### PR TITLE
feat(textinput): Add paired delimiters to authored composers

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -625,6 +625,7 @@
 		664EEC1B4A18A02A49897FBA /* ACPTerminalCRLFTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF798A386DD56B4127D5272A /* ACPTerminalCRLFTests.swift */; };
 		6682233134C258D81E22D7AD /* ACPTranscriptMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5069EF396F2CB8E81B2AD11 /* ACPTranscriptMarkdownTests.swift */; };
 		66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */; };
+		66DCE2D5A6D886BAE5A6B9A0 /* PairedComposerTextControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B8003F90C5FD770A293717 /* PairedComposerTextControls.swift */; };
 		671F28D6A18DD75EB912596B /* PersistenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A17A797374500E1FDD2382C /* PersistenceStore.swift */; };
 		67683DB8DF67CCAEF6DEF9A8 /* ACPSessionForkPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A2AA9654545DAB044C5DA7 /* ACPSessionForkPresentationTests.swift */; };
 		676C9F2E4246D5E383F83F72 /* GitStatusCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4261E417947C1A21E77C1587 /* GitStatusCache.swift */; };
@@ -756,6 +757,7 @@
 		7E2E0B87C53DBAAE4AEF81E9 /* GGStackModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A948C5D9B5EB13DBAC21E538 /* GGStackModelsTests.swift */; };
 		7E56D356C235F59E1CE24210 /* AgentBuiltinsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */; };
 		7E5819BACB71C38AA2B3A80E /* ChangesTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA0432FB3F35FC9780718C8 /* ChangesTabViewTests.swift */; };
+		7EB1A9415AE49BBB694946AC /* PairedComposerTextControlsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E984007859E2721356CAF8A /* PairedComposerTextControlsTests.swift */; };
 		7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */; };
 		7F2D2A9180110871CFF58192 /* ProjectIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141C4CAF1B49032EDF0FF404 /* ProjectIconTests.swift */; };
 		7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */; };
@@ -1854,6 +1856,7 @@
 		2E669FEBE09BC250B477B335 /* ACPLaunchCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchCatalog.swift; sourceTree = "<group>"; };
 		2E740A01C784A24F01F79BC3 /* MissionPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionPresentationTests.swift; sourceTree = "<group>"; };
 		2E7E61C3BD4AD4AE3828A6F0 /* InstallSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallSource.swift; sourceTree = "<group>"; };
+		2E984007859E2721356CAF8A /* PairedComposerTextControlsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedComposerTextControlsTests.swift; sourceTree = "<group>"; };
 		2EB39DE3614B5BEC4D3EBF13 /* ACPSessionLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionLifecycleTests.swift; sourceTree = "<group>"; };
 		2EC0311F5824C51F14EC4278 /* ReviewDraftCommentActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentActions.swift; sourceTree = "<group>"; };
 		2EF18448EDA0DCC8B171F11D /* CommitDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDiffView.swift; sourceTree = "<group>"; };
@@ -1906,6 +1909,7 @@
 		3659703F6EB9AD2454C2898B /* ACPChatTypographyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatTypographyTests.swift; sourceTree = "<group>"; };
 		36992F601C8EB6C3D45B584F /* SearchKbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKbd.swift; sourceTree = "<group>"; };
 		36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKind.swift; sourceTree = "<group>"; };
+		36B8003F90C5FD770A293717 /* PairedComposerTextControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedComposerTextControls.swift; sourceTree = "<group>"; };
 		36F875ED8D44E6C298588E60 /* AgentAutoLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAutoLaunchTests.swift; sourceTree = "<group>"; };
 		37011506F459800FFF6D12A9 /* RemoteSessionGatewayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSessionGatewayTests.swift; sourceTree = "<group>"; };
 		3708552C2BF0E70F10C76B63 /* ACPTranscriptMarkdownCacheEvictionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMarkdownCacheEvictionTests.swift; sourceTree = "<group>"; };
@@ -3567,6 +3571,7 @@
 				5D89087B3506E3F54F29C718 /* OpenBinaryRoutingTests.swift */,
 				292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */,
 				DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */,
+				2E984007859E2721356CAF8A /* PairedComposerTextControlsTests.swift */,
 				8A1B501810079EB9A18E70D3 /* PairedDelimiterEditingTests.swift */,
 				6FD359E5712BE30FF37251EE /* PaneDragMathTests.swift */,
 				4DA7089B238D285A1A2040CA /* PaneLeafEncodeTests.swift */,
@@ -3958,6 +3963,7 @@
 				5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */,
 				7BEC4E033DB3BA44C825D453 /* EmojiPickerButton.swift */,
 				16CA8FEE64D73BDEBAF74878 /* Kbd.swift */,
+				36B8003F90C5FD770A293717 /* PairedComposerTextControls.swift */,
 				9C4B3503EDFD4AAEAA6894FE /* PairedDelimiterEditing.swift */,
 				7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */,
 				EECB91379591DA21D216A894 /* RelativeTime.swift */,
@@ -6603,6 +6609,7 @@
 				84103C99FE430DB2B36982D1 /* OpenSessionsSection.swift in Sources */,
 				082582F4BBA9DCFF0EAB9588 /* OperationCard.swift in Sources */,
 				ACB0AD03C9DFD88A431E6BC5 /* OutdatedThreadsDrawer.swift in Sources */,
+				66DCE2D5A6D886BAE5A6B9A0 /* PairedComposerTextControls.swift in Sources */,
 				7962F21EA05595E2182ECF6E /* PairedDelimiterEditing.swift in Sources */,
 				6635C1BBE700E46738D5648F /* PaneDragMath.swift in Sources */,
 				86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */,
@@ -7337,6 +7344,7 @@
 				E2FA5B84915EC84D8640701E /* OpenBinaryRoutingTests.swift in Sources */,
 				1ECA2C8485DB484C5C687F3D /* OpenCodeInstallerTests.swift in Sources */,
 				BC0EC69E1BC62514BBE129E7 /* OpenSessionsTests.swift in Sources */,
+				7EB1A9415AE49BBB694946AC /* PairedComposerTextControlsTests.swift in Sources */,
 				DCF52CA0F7607995402CED3D /* PairedDelimiterEditingTests.swift in Sources */,
 				439761195191FAC857E78705 /* PaneDragMathTests.swift in Sources */,
 				4BDE8C92734D3A60645C0500 /* PaneLeafEncodeTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -722,6 +722,7 @@
 		792C4398DB584C1C56D8C23E /* GGSplitPreviewRowPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A811C3D697D29CF9267F2C5 /* GGSplitPreviewRowPlan.swift */; };
 		7950F5765E0B95EB1CB5B818 /* ACPNewChatEmptyStatePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF80D59C3200AD3215D1E140 /* ACPNewChatEmptyStatePolicy.swift */; };
 		79575F0DA597D2C2DFCDC9E2 /* LSPMessagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */; };
+		7962F21EA05595E2182ECF6E /* PairedDelimiterEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4B3503EDFD4AAEAA6894FE /* PairedDelimiterEditing.swift */; };
 		79FC7259C8ABAF2A9D031E88 /* ACPWorktreeSessionBootstrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C66CE5C7DDA561C0970A50 /* ACPWorktreeSessionBootstrapperTests.swift */; };
 		7A0D3E122F34EF1A2A04984F /* EnvBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159FE807399835B0821E1CAB /* EnvBuilder.swift */; };
 		7A2C912B677A34391361B720 /* AdvancedSettingsVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B123596E047E4CE0FAFE3E /* AdvancedSettingsVisibility.swift */; };
@@ -1356,6 +1357,7 @@
 		DC86127564ACE3337640D0AD /* PendingStashDrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = F748F06725644571785BF658 /* PendingStashDrop.swift */; };
 		DC93AED5844A56C6BA012CC3 /* ProviderReviewActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327D6F0E386398E6A512ADDF /* ProviderReviewActionsTests.swift */; };
 		DCACB5B624BFFE7C50DA6C61 /* RightPaneStateSyncStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */; };
+		DCF52CA0F7607995402CED3D /* PairedDelimiterEditingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1B501810079EB9A18E70D3 /* PairedDelimiterEditingTests.swift */; };
 		DD18C5FF006D18BC66964D94 /* TerminalTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */; };
 		DD2553E3635BFE3B15355E08 /* ACPLaunchPathResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D911D138AF8A0E99191C862 /* ACPLaunchPathResolverTests.swift */; };
 		DDAA1FF54466B7F5424D315E /* TreeSitterMarkdown in Frameworks */ = {isa = PBXBuildFile; productRef = 49F7F27A9183521F9997AF49 /* TreeSitterMarkdown */; };
@@ -2408,6 +2410,7 @@
 		89B2725002A4349D9E5D1432 /* AppKitDiffTilingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffTilingController.swift; sourceTree = "<group>"; };
 		89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowControllerTests.swift; sourceTree = "<group>"; };
 		89D180B7FCAA9DD1F7D7D2E4 /* AppState+RunScripts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+RunScripts.swift"; sourceTree = "<group>"; };
+		8A1B501810079EB9A18E70D3 /* PairedDelimiterEditingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedDelimiterEditingTests.swift; sourceTree = "<group>"; };
 		8A811C3D697D29CF9267F2C5 /* GGSplitPreviewRowPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGSplitPreviewRowPlan.swift; sourceTree = "<group>"; };
 		8AD22187C951174C9ECEC4C4 /* ACPContextUsageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextUsageButton.swift; sourceTree = "<group>"; };
 		8B4BB6C10F3718F7D0A50BAE /* ACPFirstRunConnectingPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFirstRunConnectingPolicy.swift; sourceTree = "<group>"; };
@@ -2509,6 +2512,7 @@
 		9B44E54236211F972F3D1C24 /* RemoteFileOps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileOps.swift; sourceTree = "<group>"; };
 		9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneTransitionalView.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
+		9C4B3503EDFD4AAEAA6894FE /* PairedDelimiterEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedDelimiterEditing.swift; sourceTree = "<group>"; };
 		9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRecents.swift; sourceTree = "<group>"; };
 		9CAED428443C9A7FE55E9A31 /* ReviewTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewTabViewTests.swift; sourceTree = "<group>"; };
 		9D1D9C02088B9B4C15D88D57 /* RemoteHelperClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperClientTests.swift; sourceTree = "<group>"; };
@@ -3563,6 +3567,7 @@
 				5D89087B3506E3F54F29C718 /* OpenBinaryRoutingTests.swift */,
 				292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */,
 				DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */,
+				8A1B501810079EB9A18E70D3 /* PairedDelimiterEditingTests.swift */,
 				6FD359E5712BE30FF37251EE /* PaneDragMathTests.swift */,
 				4DA7089B238D285A1A2040CA /* PaneLeafEncodeTests.swift */,
 				16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */,
@@ -3953,6 +3958,7 @@
 				5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */,
 				7BEC4E033DB3BA44C825D453 /* EmojiPickerButton.swift */,
 				16CA8FEE64D73BDEBAF74878 /* Kbd.swift */,
+				9C4B3503EDFD4AAEAA6894FE /* PairedDelimiterEditing.swift */,
 				7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */,
 				EECB91379591DA21D216A894 /* RelativeTime.swift */,
 				489C9B383554D7DAB170C2F8 /* Seg.swift */,
@@ -6597,6 +6603,7 @@
 				84103C99FE430DB2B36982D1 /* OpenSessionsSection.swift in Sources */,
 				082582F4BBA9DCFF0EAB9588 /* OperationCard.swift in Sources */,
 				ACB0AD03C9DFD88A431E6BC5 /* OutdatedThreadsDrawer.swift in Sources */,
+				7962F21EA05595E2182ECF6E /* PairedDelimiterEditing.swift in Sources */,
 				6635C1BBE700E46738D5648F /* PaneDragMath.swift in Sources */,
 				86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */,
 				78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */,
@@ -7330,6 +7337,7 @@
 				E2FA5B84915EC84D8640701E /* OpenBinaryRoutingTests.swift in Sources */,
 				1ECA2C8485DB484C5C687F3D /* OpenCodeInstallerTests.swift in Sources */,
 				BC0EC69E1BC62514BBE129E7 /* OpenSessionsTests.swift in Sources */,
+				DCF52CA0F7607995402CED3D /* PairedDelimiterEditingTests.swift in Sources */,
 				439761195191FAC857E78705 /* PaneDragMathTests.swift in Sources */,
 				4BDE8C92734D3A60645C0500 /* PaneLeafEncodeTests.swift in Sources */,
 				CAE7524F4289A256FF1069FC /* PaneTreeTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1415,6 +1415,7 @@
 		E433BB79E6D79DAF4532172A /* Kbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CA8FEE64D73BDEBAF74878 /* Kbd.swift */; };
 		E44EBD2F2F9A398207E55C6D /* ACPTerminal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0594E7E039B5FC403783C6E8 /* ACPTerminal.swift */; };
 		E468E95C778E0C9BE6F1EDED /* LegacyHookSweep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE0FF00CB2F81000FB09A72 /* LegacyHookSweep.swift */; };
+		E4BE423D04F69D25C520A80B /* PairedReviewComposerSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F88DEFC78E8D8AF65CB740A /* PairedReviewComposerSurfaceTests.swift */; };
 		E4C6E2BE1C7F20AD29C66DF0 /* ACPPermissionDecisionLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F128D8543DA5FC5C39C22E9 /* ACPPermissionDecisionLog.swift */; };
 		E4E04048352D9CBC77D954C5 /* RightPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE66950F2226F1182DCDD39A /* RightPaneView.swift */; };
 		E4EAC28F55CBE987E0AB1F85 /* WorktreeWatcherFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */; };
@@ -2257,6 +2258,7 @@
 		6EC184A7BDBFF2156FD2AD44 /* ACPOrchestrationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPOrchestrationModels.swift; sourceTree = "<group>"; };
 		6F0AE27D70E34430C71AAF84 /* ProviderReviewMutationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewMutationController.swift; sourceTree = "<group>"; };
 		6F4D0EAA4C7CB45617BDD3FE /* ReadonlyTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadonlyTextView.swift; sourceTree = "<group>"; };
+		6F88DEFC78E8D8AF65CB740A /* PairedReviewComposerSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedReviewComposerSurfaceTests.swift; sourceTree = "<group>"; };
 		6FD359E5712BE30FF37251EE /* PaneDragMathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDragMathTests.swift; sourceTree = "<group>"; };
 		6FF766C79A3F9F004A513D4D /* UpdateProgressSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProgressSheet.swift; sourceTree = "<group>"; };
 		6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsSectionView.swift; sourceTree = "<group>"; };
@@ -3578,6 +3580,7 @@
 				2E984007859E2721356CAF8A /* PairedComposerTextControlsTests.swift */,
 				8A1B501810079EB9A18E70D3 /* PairedDelimiterEditingTests.swift */,
 				F89DAC6A8A16FADF8D614D0A /* PairedPrimaryComposerSurfaceTests.swift */,
+				6F88DEFC78E8D8AF65CB740A /* PairedReviewComposerSurfaceTests.swift */,
 				6FD359E5712BE30FF37251EE /* PaneDragMathTests.swift */,
 				4DA7089B238D285A1A2040CA /* PaneLeafEncodeTests.swift */,
 				16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */,
@@ -7354,6 +7357,7 @@
 				7EB1A9415AE49BBB694946AC /* PairedComposerTextControlsTests.swift in Sources */,
 				DCF52CA0F7607995402CED3D /* PairedDelimiterEditingTests.swift in Sources */,
 				DDE5BE847DFFF54429D61D4E /* PairedPrimaryComposerSurfaceTests.swift in Sources */,
+				E4BE423D04F69D25C520A80B /* PairedReviewComposerSurfaceTests.swift in Sources */,
 				439761195191FAC857E78705 /* PaneDragMathTests.swift in Sources */,
 				4BDE8C92734D3A60645C0500 /* PaneLeafEncodeTests.swift in Sources */,
 				CAE7524F4289A256FF1069FC /* PaneTreeTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1295,6 +1295,7 @@
 		D28EE6309DBB51EFEDCEAC18 /* ACPSessionManagerLeaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C13707B79B7A4F4BB2608E /* ACPSessionManagerLeaseTests.swift */; };
 		D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */; };
 		D2D5D79EE8DE82FC44C2D36A /* CompletionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D510DACCD80A328B2DFABDC0 /* CompletionFeature.swift */; };
+		D36A33178D064DBD5DFD9B6D /* PairedAuthoredContentSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBB557833D3939208D75FB7 /* PairedAuthoredContentSurfaceTests.swift */; };
 		D397C3E94E3F00F012CBE5AE /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27595490B7D883CF5D9FFD5 /* Tab.swift */; };
 		D3C333539943019DB3439AE6 /* DiffReviewRenderBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34971259AB0FE69892952670 /* DiffReviewRenderBudget.swift */; };
 		D3EAFAA986CE4441B7F103F9 /* HookCommandShellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */; };
@@ -2912,6 +2913,7 @@
 		DC76F9150CC29A324D785C29 /* ACPDelayedHoverVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDelayedHoverVisibilityTests.swift; sourceTree = "<group>"; };
 		DCD333CD0765908F6657E824 /* WorktreePathTemplateRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreePathTemplateRenderer.swift; sourceTree = "<group>"; };
 		DD1F34E025D235A5CECCE36E /* ACPSessionUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUpdate.swift; sourceTree = "<group>"; };
+		DDBB557833D3939208D75FB7 /* PairedAuthoredContentSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedAuthoredContentSurfaceTests.swift; sourceTree = "<group>"; };
 		DDE8B45ECF898B83A616586D /* SubHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubHeader.swift; sourceTree = "<group>"; };
 		DE28FBD8A093452150901B6F /* MissionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionCoordinator.swift; sourceTree = "<group>"; };
 		DE2AC16E9220C05F670BE3EB /* ACPMarkdownText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownText.swift; sourceTree = "<group>"; };
@@ -3577,6 +3579,7 @@
 				5D89087B3506E3F54F29C718 /* OpenBinaryRoutingTests.swift */,
 				292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */,
 				DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */,
+				DDBB557833D3939208D75FB7 /* PairedAuthoredContentSurfaceTests.swift */,
 				2E984007859E2721356CAF8A /* PairedComposerTextControlsTests.swift */,
 				8A1B501810079EB9A18E70D3 /* PairedDelimiterEditingTests.swift */,
 				F89DAC6A8A16FADF8D614D0A /* PairedPrimaryComposerSurfaceTests.swift */,
@@ -7354,6 +7357,7 @@
 				E2FA5B84915EC84D8640701E /* OpenBinaryRoutingTests.swift in Sources */,
 				1ECA2C8485DB484C5C687F3D /* OpenCodeInstallerTests.swift in Sources */,
 				BC0EC69E1BC62514BBE129E7 /* OpenSessionsTests.swift in Sources */,
+				D36A33178D064DBD5DFD9B6D /* PairedAuthoredContentSurfaceTests.swift in Sources */,
 				7EB1A9415AE49BBB694946AC /* PairedComposerTextControlsTests.swift in Sources */,
 				DCF52CA0F7607995402CED3D /* PairedDelimiterEditingTests.swift in Sources */,
 				DDE5BE847DFFF54429D61D4E /* PairedPrimaryComposerSurfaceTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1235,6 +1235,7 @@
 		C9BC01285F80FB20F665A765 /* CodeTextViewMultiCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */; };
 		C9C01E8A89C6767524FAC63B /* RemoteHTTPResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85AC3FB0255285382EF24D8D /* RemoteHTTPResponder.swift */; };
 		C9DAC0F907752F6D3B955DD8 /* HoverFeatureRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1D8FEB5416139D8B2BA780 /* HoverFeatureRenderingTests.swift */; };
+		CA4A81EE17E955229258DBB6 /* ACPComposerPairedDelimiterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8A1143A53C09FD0B4D5CF6 /* ACPComposerPairedDelimiterTests.swift */; };
 		CA4CE5E97DB02330A1151245 /* ACPSetupCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8E722C16FFBEEEC43337D5 /* ACPSetupCheck.swift */; };
 		CA7269D9237C925D7C1358D7 /* RemoteWorktreePollTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EEB37C08A315D65558B273 /* RemoteWorktreePollTests.swift */; };
 		CA73C930734C839D8EA9088D /* GGStackReadinessModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DCBE3FBD88DC56C81B8FDB /* GGStackReadinessModelTests.swift */; };
@@ -1669,6 +1670,7 @@
 		0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeature.swift; sourceTree = "<group>"; };
 		0E1B5714AB51C0D1E7B6DB66 /* GGWorktreeContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGWorktreeContextTests.swift; sourceTree = "<group>"; };
 		0E6600436B01C75D85C01FFA /* Clipboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clipboard.swift; sourceTree = "<group>"; };
+		0E8A1143A53C09FD0B4D5CF6 /* ACPComposerPairedDelimiterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerPairedDelimiterTests.swift; sourceTree = "<group>"; };
 		0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCHTests.swift; sourceTree = "<group>"; };
 		0EE8745F3A4C6F0645D1D44A /* RemoteHelperInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperInstaller.swift; sourceTree = "<group>"; };
 		0EE97D2D6875CD6A1DBF4DE9 /* GitService+ReviewRequestDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+ReviewRequestDraft.swift"; sourceTree = "<group>"; };
@@ -4204,6 +4206,7 @@
 				B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */,
 				98CA6A0F4862D9A29E4151B5 /* ACPComposerFocusPolicyTests.swift */,
 				A637073E5D65DAA4E0CF6EA4 /* ACPComposerImageExtractTests.swift */,
+				0E8A1143A53C09FD0B4D5CF6 /* ACPComposerPairedDelimiterTests.swift */,
 				85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */,
 				ECD9419E685AD7EED286006B /* ACPContextRingTests.swift */,
 				DC76F9150CC29A324D785C29 /* ACPDelayedHoverVisibilityTests.swift */,
@@ -6879,6 +6882,7 @@
 				3518735F0614C32919E3FC27 /* ACPComposerDraftTests.swift in Sources */,
 				B430895772AC7AA84932905E /* ACPComposerFocusPolicyTests.swift in Sources */,
 				84E96EB0EF4267784462B866 /* ACPComposerImageExtractTests.swift in Sources */,
+				CA4A81EE17E955229258DBB6 /* ACPComposerPairedDelimiterTests.swift in Sources */,
 				3FCC4EDA31A96BE121F45D44 /* ACPComposerPlaceholderTests.swift in Sources */,
 				FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */,
 				30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1365,6 +1365,7 @@
 		DD2553E3635BFE3B15355E08 /* ACPLaunchPathResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D911D138AF8A0E99191C862 /* ACPLaunchPathResolverTests.swift */; };
 		DDAA1FF54466B7F5424D315E /* TreeSitterMarkdown in Frameworks */ = {isa = PBXBuildFile; productRef = 49F7F27A9183521F9997AF49 /* TreeSitterMarkdown */; };
 		DDBEA2D41ECA8F0F28CF5DF6 /* RemoteRepoValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27192411BB5CB8F8F7AD09B2 /* RemoteRepoValidatorTests.swift */; };
+		DDE5BE847DFFF54429D61D4E /* PairedPrimaryComposerSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F89DAC6A8A16FADF8D614D0A /* PairedPrimaryComposerSurfaceTests.swift */; };
 		DDEFEBB152E6AE1B0BB4D3EE /* ACPSessionOrchestrationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89034A1968C6BC371826314D /* ACPSessionOrchestrationCoordinatorTests.swift */; };
 		DE207C4CFA1A45866FCB4E22 /* RemoteFileOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B44E54236211F972F3D1C24 /* RemoteFileOps.swift */; };
 		DE33366A35436471AE0DAE96 /* DiffReviewRenderBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE54F0320B9F40BEF46FB85 /* DiffReviewRenderBudgetTests.swift */; };
@@ -3081,6 +3082,7 @@
 		F8393DE75ACFA27C6B581B5E /* MissionLegCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionLegCoordinator.swift; sourceTree = "<group>"; };
 		F84BC1A10866A165EA321719 /* ACPTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptTests.swift; sourceTree = "<group>"; };
 		F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterPaneView.swift; sourceTree = "<group>"; };
+		F89DAC6A8A16FADF8D614D0A /* PairedPrimaryComposerSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedPrimaryComposerSurfaceTests.swift; sourceTree = "<group>"; };
 		F8A5D091F06D7B2D02072492 /* ACPTranscriptScrollerReconcilerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollerReconcilerTests.swift; sourceTree = "<group>"; };
 		F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerAttachRestoreTests.swift; sourceTree = "<group>"; };
 		F90F265EBA9431630D56836C /* MissionTestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionTestFixtures.swift; sourceTree = "<group>"; };
@@ -3575,6 +3577,7 @@
 				DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */,
 				2E984007859E2721356CAF8A /* PairedComposerTextControlsTests.swift */,
 				8A1B501810079EB9A18E70D3 /* PairedDelimiterEditingTests.swift */,
+				F89DAC6A8A16FADF8D614D0A /* PairedPrimaryComposerSurfaceTests.swift */,
 				6FD359E5712BE30FF37251EE /* PaneDragMathTests.swift */,
 				4DA7089B238D285A1A2040CA /* PaneLeafEncodeTests.swift */,
 				16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */,
@@ -7350,6 +7353,7 @@
 				BC0EC69E1BC62514BBE129E7 /* OpenSessionsTests.swift in Sources */,
 				7EB1A9415AE49BBB694946AC /* PairedComposerTextControlsTests.swift in Sources */,
 				DCF52CA0F7607995402CED3D /* PairedDelimiterEditingTests.swift in Sources */,
+				DDE5BE847DFFF54429D61D4E /* PairedPrimaryComposerSurfaceTests.swift in Sources */,
 				439761195191FAC857E78705 /* PaneDragMathTests.swift in Sources */,
 				4BDE8C92734D3A60645C0500 /* PaneLeafEncodeTests.swift in Sources */,
 				CAE7524F4289A256FF1069FC /* PaneTreeTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -563,7 +563,7 @@ extension NSAttributedString.Key {
     static let imageAttachmentMime = NSAttributedString.Key("alas.acp.imageAttachmentMime")
 }
 
-final class ACPNSTextView: NSTextView {
+final class ACPNSTextView: PairedDelimiterTextView {
     weak var coordinator: ACPInputField.Coordinator?
     private var chatTypography: ACPChatTypography = .default
 

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -1048,7 +1048,9 @@ final class ACPNSTextView: PairedDelimiterTextView {
         )
         let attrs = baseTypingAttributes
         typingAttributes = attrs
-        insertText(text, replacementRange: boundedRange)
+        performNativeTextInsertion {
+            insertText(text, replacementRange: boundedRange)
+        }
         typingAttributes = attrs
         return true
     }

--- a/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
+++ b/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct CommitMessageEditorView: View {
@@ -108,9 +109,20 @@ struct CommitMessageEditorView: View {
     }
 
     private var subjectField: some View {
-        TextField("Subject", text: $subject)
-            .textFieldStyle(.plain)
-            .font(.system(size: 12.5, weight: .medium))
+        PairedTextField(
+            text: $subject,
+            placeholder: "Subject",
+            font: .systemFont(ofSize: 12.5, weight: .medium),
+            textColor: NSColor(theme.color("fg")),
+            isEnabled: !(busy || editorDisabled),
+            isFocused: Binding(
+                get: { focused == .subject },
+                set: { value in
+                    if value { focused = .subject }
+                    else if focused == .subject { focused = nil }
+                }
+            )
+        )
             .foregroundColor(theme.color("fg"))
             .padding(.horizontal, 10)
             .frame(height: 30)
@@ -131,15 +143,23 @@ struct CommitMessageEditorView: View {
                     .padding(-2)
             )
             .clipShape(RoundedRectangle(cornerRadius: 6))
-            .focused($focused, equals: .subject)
-            .disabled(busy || editorDisabled)
     }
 
     private var bodyField: some View {
-        TextEditor(text: $bodyText)
-            .font(.system(size: 12, design: .monospaced))
+        PairedTextEditor(
+            text: $bodyText,
+            font: .monospacedSystemFont(ofSize: 12, weight: .regular),
+            textColor: NSColor(theme.color("fg")),
+            isEnabled: !(busy || editorDisabled),
+            isFocused: Binding(
+                get: { focused == .body },
+                set: { value in
+                    if value { focused = .body }
+                    else if focused == .body { focused = nil }
+                }
+            )
+        )
             .frame(minHeight: 70, maxHeight: 150)
-            .scrollContentBackground(.hidden)
             .padding(.horizontal, 6).padding(.vertical, 4)
             .background(theme.color("field-bg"))
             .overlay(
@@ -158,8 +178,6 @@ struct CommitMessageEditorView: View {
                     .padding(-2)
             )
             .clipShape(RoundedRectangle(cornerRadius: 6))
-            .focused($focused, equals: .body)
-            .disabled(busy || editorDisabled)
     }
 
     /// Render the modifier + key glyphs of a `KeyboardShortcut` for display

--- a/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
+++ b/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
@@ -115,6 +115,7 @@ struct CommitMessageEditorView: View {
             font: .systemFont(ofSize: 12.5, weight: .medium),
             textColor: NSColor(theme.color("fg")),
             isEnabled: !(busy || editorDisabled),
+            focusRingType: .none,
             isFocused: Binding(
                 get: { focused == .subject },
                 set: { value in

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -2433,11 +2433,24 @@ struct DiffReviewInlineFeedbackCard: View {
                 PairedTextEditor(
                     text: replyEditorBinding.body,
                     font: .systemFont(ofSize: 11.5),
-                    textColor: NSColor(theme.color("fg"))
+                    textColor: NSColor(theme.color("fg")),
+                    placeholder: "Reply"
                 )
+                    .frame(minHeight: 32, maxHeight: 96)
                     .padding(7)
                     .background(theme.color("bg-1"))
                     .clipShape(RoundedRectangle(cornerRadius: 5))
+                    .overlay(alignment: .topLeading) {
+                        if replyEditorBinding.wrappedValue.body.isEmpty {
+                            Text("Reply")
+                                .font(.system(size: 11.5))
+                                .foregroundColor(theme.color("fg-muted"))
+                                .padding(.horizontal, 11)
+                                .padding(.vertical, 9)
+                                .allowsHitTesting(false)
+                        }
+                    }
+                    .accessibilityLabel("Reply")
                     .accessibilityIdentifier("diff-review-inline-feedback-reply-\(item.id)")
 
                 HStack(spacing: 6) {

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -1253,7 +1253,7 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
     }
 }
 
-private final class ReviewDraftComposerNSTextView: NSTextView {
+private final class ReviewDraftComposerNSTextView: PairedDelimiterTextView {
     var onKeyboardAction: (@MainActor (ReviewDraftComposerKeyboardAction) -> Void)?
     var onWindowChanged: (@MainActor () -> Void)?
 
@@ -2430,10 +2430,11 @@ struct DiffReviewInlineFeedbackCard: View {
         let availability = actions.availability(item, file)
         if replyEditorBinding.wrappedValue.isReplying {
             VStack(alignment: .leading, spacing: 6) {
-                TextField("Reply", text: replyEditorBinding.body, axis: .vertical)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 11.5))
-                    .foregroundColor(theme.color("fg"))
+                PairedTextEditor(
+                    text: replyEditorBinding.body,
+                    font: .systemFont(ofSize: 11.5),
+                    textColor: NSColor(theme.color("fg"))
+                )
                     .padding(7)
                     .background(theme.color("bg-1"))
                     .clipShape(RoundedRectangle(cornerRadius: 5))

--- a/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
+++ b/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
@@ -171,9 +171,14 @@ struct DiffInlineCommentCard: View {
                         .font(.system(size: 11))
                         .foregroundColor(.accentColor)
                     }
-                    TextEditor(text: editorStateBinding.replyDraft)
-                        .font(.system(size: 11))
-                        .focused($focusedEditor, equals: .reply)
+                    PairedTextEditor(
+                        text: editorStateBinding.replyDraft,
+                        font: .systemFont(ofSize: 11),
+                        isFocused: Binding(
+                            get: { focusedEditor == .reply },
+                            set: { focusedEditor = $0 ? .reply : nil }
+                        )
+                    )
                         .frame(minHeight: 60)
                         .overlay(
                             RoundedRectangle(cornerRadius: 4)
@@ -267,9 +272,14 @@ struct DiffInlineCommentCard: View {
                 Text(comment.author)
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundColor(.primary)
-                TextEditor(text: editorStateBinding.editDraft)
-                    .font(.system(size: 11))
-                    .focused($focusedEditor, equals: .edit(comment.id))
+                PairedTextEditor(
+                    text: editorStateBinding.editDraft,
+                    font: .systemFont(ofSize: 11),
+                    isFocused: Binding(
+                        get: { focusedEditor == .edit(comment.id) },
+                        set: { focusedEditor = $0 ? .edit(comment.id) : nil }
+                    )
+                )
                     .frame(minHeight: 60)
                     .overlay(
                         RoundedRectangle(cornerRadius: 4)

--- a/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
+++ b/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
@@ -176,7 +176,13 @@ struct DiffInlineCommentCard: View {
                         font: .systemFont(ofSize: 11),
                         isFocused: Binding(
                             get: { focusedEditor == .reply },
-                            set: { focusedEditor = $0 ? .reply : nil }
+                            set: { value in
+                                if value {
+                                    focusedEditor = .reply
+                                } else if focusedEditor == .reply {
+                                    focusedEditor = nil
+                                }
+                            }
                         )
                     )
                         .frame(minHeight: 60)
@@ -274,12 +280,18 @@ struct DiffInlineCommentCard: View {
                     .foregroundColor(.primary)
                 PairedTextEditor(
                     text: editorStateBinding.editDraft,
-                    font: .systemFont(ofSize: 11),
-                    isFocused: Binding(
-                        get: { focusedEditor == .edit(comment.id) },
-                        set: { focusedEditor = $0 ? .edit(comment.id) : nil }
+                        font: .systemFont(ofSize: 11),
+                        isFocused: Binding(
+                            get: { focusedEditor == .edit(comment.id) },
+                            set: { value in
+                                if value {
+                                    focusedEditor = .edit(comment.id)
+                                } else if focusedEditor == .edit(comment.id) {
+                                    focusedEditor = nil
+                                }
+                            }
+                        )
                     )
-                )
                     .frame(minHeight: 60)
                     .overlay(
                         RoundedRectangle(cornerRadius: 4)

--- a/Alas/Sources/Center/Review/VerdictSheet.swift
+++ b/Alas/Sources/Center/Review/VerdictSheet.swift
@@ -22,8 +22,12 @@ struct VerdictSheet: View {
         _verdict = State(initialValue: initialVerdict)
     }
 
-    private var canSubmit: Bool {
+    static func canSubmit(verdict: ReviewVerdict, summaryBody: String) -> Bool {
         verdict != .requestChanges || !summaryBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var canSubmit: Bool {
+        Self.canSubmit(verdict: verdict, summaryBody: summaryBody)
     }
 
     var body: some View {
@@ -62,15 +66,7 @@ struct VerdictSheet: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.regular)
-                .background(
-                    VerdictSheetPressMarker(
-                        identifier: "verdict-submit-review",
-                        label: "Submit review",
-                        isEnabled: canSubmit
-                    ) {
-                        onSubmit(verdict, summaryBody)
-                    }
-                )
+                .accessibilityIdentifier("verdict-submit-review")
                 .disabled(!canSubmit)
 
                 Button("Cancel") {
@@ -120,45 +116,5 @@ struct VerdictSheet: View {
         }
         .buttonStyle(.plain)
         .help(label)
-    }
-}
-
-private struct VerdictSheetPressMarker: NSViewRepresentable {
-    let identifier: String
-    let label: String
-    let isEnabled: Bool
-    let action: () -> Void
-
-    func makeNSView(context: Context) -> VerdictSheetPressView {
-        let view = VerdictSheetPressView(frame: .zero)
-        view.setAccessibilityElement(true)
-        view.setAccessibilityIdentifier(identifier)
-        view.setAccessibilityLabel(label)
-        view.setAccessibilityRole(.button)
-        view.setAccessibilityEnabled(isEnabled)
-        view.isPressEnabled = isEnabled
-        view.action = action
-        return view
-    }
-
-    func updateNSView(_ view: VerdictSheetPressView, context: Context) {
-        view.setAccessibilityElement(true)
-        view.setAccessibilityIdentifier(identifier)
-        view.setAccessibilityLabel(label)
-        view.setAccessibilityRole(.button)
-        view.setAccessibilityEnabled(isEnabled)
-        view.isPressEnabled = isEnabled
-        view.action = action
-    }
-}
-
-private final class VerdictSheetPressView: NSView {
-    var isPressEnabled = true
-    var action: () -> Void = {}
-
-    override func accessibilityPerformPress() -> Bool {
-        guard isPressEnabled else { return false }
-        action()
-        return true
     }
 }

--- a/Alas/Sources/Center/Review/VerdictSheet.swift
+++ b/Alas/Sources/Center/Review/VerdictSheet.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct VerdictSheet: View {
@@ -8,6 +9,22 @@ struct VerdictSheet: View {
     @State private var verdict: ReviewVerdict = .comment
     @State private var summaryBody = ""
     @Environment(\.theme) private var theme
+
+    init(
+        pendingCount: Int,
+        initialVerdict: ReviewVerdict = .comment,
+        onSubmit: @escaping (ReviewVerdict, String) -> Void = { _, _ in },
+        onCancel: @escaping () -> Void = {}
+    ) {
+        self.pendingCount = pendingCount
+        self.onSubmit = onSubmit
+        self.onCancel = onCancel
+        _verdict = State(initialValue: initialVerdict)
+    }
+
+    private var canSubmit: Bool {
+        verdict != .requestChanges || !summaryBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -26,9 +43,11 @@ struct VerdictSheet: View {
                 Text(verdict == .requestChanges ? "Summary (required)" : "Summary (optional)")
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundColor(theme.color("fg-dim"))
-                TextEditor(text: $summaryBody)
-                    .font(.system(size: 12))
-                    .scrollContentBackground(.hidden)
+                PairedTextEditor(
+                    text: $summaryBody,
+                    font: .systemFont(ofSize: 12),
+                    textColor: NSColor(theme.color("fg"))
+                )
                     .frame(minHeight: 80)
                     .background(theme.color("bg-1"))
                     .overlay(
@@ -43,7 +62,16 @@ struct VerdictSheet: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.regular)
-                .disabled(verdict == .requestChanges && summaryBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .background(
+                    VerdictSheetPressMarker(
+                        identifier: "verdict-submit-review",
+                        label: "Submit review",
+                        isEnabled: canSubmit
+                    ) {
+                        onSubmit(verdict, summaryBody)
+                    }
+                )
+                .disabled(!canSubmit)
 
                 Button("Cancel") {
                     onCancel()
@@ -92,5 +120,45 @@ struct VerdictSheet: View {
         }
         .buttonStyle(.plain)
         .help(label)
+    }
+}
+
+private struct VerdictSheetPressMarker: NSViewRepresentable {
+    let identifier: String
+    let label: String
+    let isEnabled: Bool
+    let action: () -> Void
+
+    func makeNSView(context: Context) -> VerdictSheetPressView {
+        let view = VerdictSheetPressView(frame: .zero)
+        view.setAccessibilityElement(true)
+        view.setAccessibilityIdentifier(identifier)
+        view.setAccessibilityLabel(label)
+        view.setAccessibilityRole(.button)
+        view.setAccessibilityEnabled(isEnabled)
+        view.isPressEnabled = isEnabled
+        view.action = action
+        return view
+    }
+
+    func updateNSView(_ view: VerdictSheetPressView, context: Context) {
+        view.setAccessibilityElement(true)
+        view.setAccessibilityIdentifier(identifier)
+        view.setAccessibilityLabel(label)
+        view.setAccessibilityRole(.button)
+        view.setAccessibilityEnabled(isEnabled)
+        view.isPressEnabled = isEnabled
+        view.action = action
+    }
+}
+
+private final class VerdictSheetPressView: NSView {
+    var isPressEnabled = true
+    var action: () -> Void = {}
+
+    override func accessibilityPerformPress() -> Bool {
+        guard isPressEnabled else { return false }
+        action()
+        return true
     }
 }

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -298,9 +298,20 @@ struct DraftReviewRequestTabView: View {
     }
 
     private var titleField: some View {
-        TextField("Title", text: $title)
-            .textFieldStyle(.plain)
-            .font(.system(size: 12.5, weight: .medium))
+        PairedTextField(
+            text: $title,
+            placeholder: "Title",
+            font: .systemFont(ofSize: 12.5, weight: .medium),
+            textColor: NSColor(theme.color("fg")),
+            isEnabled: !(busy || tabState.createdURL != nil),
+            isFocused: Binding(
+                get: { focused == .title },
+                set: { value in
+                    if value { focused = .title }
+                    else if focused == .title { focused = nil }
+                }
+            )
+        )
             .foregroundColor(theme.color("fg"))
             .padding(.horizontal, 10)
             .frame(height: 30)
@@ -321,15 +332,23 @@ struct DraftReviewRequestTabView: View {
                     .padding(-2)
             )
             .clipShape(RoundedRectangle(cornerRadius: 6))
-            .focused($focused, equals: .title)
-            .disabled(busy || tabState.createdURL != nil)
     }
 
     private var bodyEditor: some View {
-        TextEditor(text: $bodyText)
-            .font(.system(size: 12, design: .monospaced))
+        PairedTextEditor(
+            text: $bodyText,
+            font: .monospacedSystemFont(ofSize: 12, weight: .regular),
+            textColor: NSColor(theme.color("fg")),
+            isEnabled: !(busy || tabState.createdURL != nil),
+            isFocused: Binding(
+                get: { focused == .body },
+                set: { value in
+                    if value { focused = .body }
+                    else if focused == .body { focused = nil }
+                }
+            )
+        )
             .frame(minHeight: 90, maxHeight: 180)
-            .scrollContentBackground(.hidden)
             .padding(.horizontal, 6)
             .padding(.vertical, 4)
             .background(theme.color("field-bg"))
@@ -349,8 +368,6 @@ struct DraftReviewRequestTabView: View {
                     .padding(-2)
             )
             .clipShape(RoundedRectangle(cornerRadius: 6))
-            .focused($focused, equals: .body)
-            .disabled(busy || tabState.createdURL != nil)
     }
 
     private var contextBrowser: some View {

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -153,11 +153,11 @@ struct DraftReviewRequestTabView: View {
 
     private var reviewRequestEditor: some View {
         VStack(spacing: 0) {
-            CommitMessageEditorView(
-                subject: $title,
+            ReviewRequestMessageEditor(
+                title: $title,
                 bodyText: $bodyText,
                 aiToolId: appState.bind(\.changes.aiToolId),
-                title: editorTitle,
+                editorTitle: editorTitle,
                 busy: busy,
                 error: error,
                 availableAgents: appState.agentRegistry.enabled(),
@@ -168,7 +168,6 @@ struct DraftReviewRequestTabView: View {
                     showSavedState: false,
                     handler: createReviewRequest
                 ),
-                iconName: "branch",
                 editorDisabled: tabState.createdURL != nil,
                 onDismissError: { self.error = nil },
                 accessory: AnyView(
@@ -238,136 +237,6 @@ struct DraftReviewRequestTabView: View {
             )
         )
         .overlay(Divider().opacity(0.5), alignment: .bottom)
-    }
-
-    private var headerRow: some View {
-        HStack(spacing: 8) {
-            Icon(name: "branch", size: 12, color: theme.color("accent"))
-            Text("\(tabState.provider.displayName) \(tabState.provider.reviewRequestLabel)")
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundColor(theme.color("fg"))
-            Text(tabState.repositorySlug.isEmpty ? "Unknown repository" : tabState.repositorySlug)
-                .font(.system(size: 11))
-                .foregroundColor(theme.color("fg-dim"))
-            Text("\(tabState.branchName) -> \(tabState.baseBranch)")
-                .font(.system(size: 11))
-                .foregroundColor(theme.color("fg-faint"))
-                .lineLimit(1)
-                .truncationMode(.middle)
-            Spacer()
-            Toggle(isOn: $createAsDraft) {
-                Text("Draft")
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.color("fg-dim"))
-            }
-            .toggleStyle(.checkbox)
-            .disabled(busy || tabState.createdURL != nil)
-            AiSplitButton(
-                availableAgents: appState.agentRegistry.enabled(),
-                selectedToolId: appState.bind(\.changes.aiToolId),
-                busy: busy,
-                onGenerate: handleGenerate
-            )
-            createButton
-            if let createdURL = tabState.createdURL {
-                AlasButton(title: "Open \(tabState.provider.reviewRequestLabel)", icon: "arrow.up.right.square") {
-                    NSWorkspace.shared.open(createdURL)
-                }
-            }
-        }
-    }
-
-    private var createButton: some View {
-        Button(action: createReviewRequest) {
-            HStack(spacing: 8) {
-                if busy {
-                    Spinner(lineWidth: 1.5, duration: 0.7)
-                        .frame(width: 12, height: 12)
-                }
-                Text("Create \(tabState.provider.reviewRequestLabel)")
-                    .font(.system(size: 12, weight: .semibold))
-            }
-            .padding(.horizontal, 14)
-            .frame(height: 28)
-            .foregroundColor(.white)
-            .background(canCreate ? theme.color("accent") : theme.color("accent").opacity(0.4))
-            .clipShape(RoundedRectangle(cornerRadius: 6))
-        }
-        .buttonStyle(.plain)
-        .disabled(!canCreate)
-    }
-
-    private var titleField: some View {
-        PairedTextField(
-            text: $title,
-            placeholder: "Title",
-            font: .systemFont(ofSize: 12.5, weight: .medium),
-            textColor: NSColor(theme.color("fg")),
-            isEnabled: !(busy || tabState.createdURL != nil),
-            isFocused: Binding(
-                get: { focused == .title },
-                set: { value in
-                    if value { focused = .title }
-                    else if focused == .title { focused = nil }
-                }
-            )
-        )
-            .foregroundColor(theme.color("fg"))
-            .padding(.horizontal, 10)
-            .frame(height: 30)
-            .background(theme.color("field-bg"))
-            .overlay(
-                RoundedRectangle(cornerRadius: 6)
-                    .strokeBorder(
-                        focused == .title ? theme.color("accent") : theme.color("line"),
-                        lineWidth: focused == .title ? 1 : 0.5
-                    )
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .strokeBorder(
-                        focused == .title ? theme.color("accent-glow-soft") : .clear,
-                        lineWidth: 2
-                    )
-                    .padding(-2)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 6))
-    }
-
-    private var bodyEditor: some View {
-        PairedTextEditor(
-            text: $bodyText,
-            font: .monospacedSystemFont(ofSize: 12, weight: .regular),
-            textColor: NSColor(theme.color("fg")),
-            isEnabled: !(busy || tabState.createdURL != nil),
-            isFocused: Binding(
-                get: { focused == .body },
-                set: { value in
-                    if value { focused = .body }
-                    else if focused == .body { focused = nil }
-                }
-            )
-        )
-            .frame(minHeight: 90, maxHeight: 180)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 4)
-            .background(theme.color("field-bg"))
-            .overlay(
-                RoundedRectangle(cornerRadius: 6)
-                    .strokeBorder(
-                        focused == .body ? theme.color("accent") : theme.color("line"),
-                        lineWidth: focused == .body ? 1 : 0.5
-                    )
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .strokeBorder(
-                        focused == .body ? theme.color("accent-glow-soft") : .clear,
-                        lineWidth: 2
-                    )
-                    .padding(-2)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 6))
     }
 
     private var contextBrowser: some View {
@@ -882,5 +751,38 @@ struct DraftReviewRequestTabView: View {
         } catch {
             // The controller keeps the non-blocking error state for the review rail.
         }
+    }
+}
+
+struct ReviewRequestMessageEditor: View {
+    @Binding var title: String
+    @Binding var bodyText: String
+    @Binding var aiToolId: String
+    let editorTitle: String
+    let busy: Bool
+    let error: String?
+    let availableAgents: [AgentDefinition]
+    let onGenerate: () -> Void
+    let primaryAction: CommitPrimaryAction
+    let editorDisabled: Bool
+    let onDismissError: () -> Void
+    let accessory: AnyView?
+
+    var body: some View {
+        CommitMessageEditorView(
+            subject: $title,
+            bodyText: $bodyText,
+            aiToolId: $aiToolId,
+            title: editorTitle,
+            busy: busy,
+            error: error,
+            availableAgents: availableAgents,
+            onGenerate: onGenerate,
+            primaryAction: primaryAction,
+            iconName: "branch",
+            editorDisabled: editorDisabled,
+            onDismissError: onDismissError,
+            accessory: accessory
+        )
     }
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift
@@ -49,10 +49,12 @@ struct ProviderReviewPublishConfirmationView: View {
                     Text("Review summary")
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundColor(theme.color("fg-muted"))
-                    TextEditor(text: $summaryBody)
-                        .font(.system(size: 12))
-                        .foregroundColor(theme.color("fg"))
-                        .scrollContentBackground(.hidden)
+                    PairedTextEditor(
+                        text: $summaryBody,
+                        font: .systemFont(ofSize: 12),
+                        textColor: NSColor(theme.color("fg")),
+                        isEnabled: !isPublishing
+                    )
                         .frame(minHeight: 72)
                         .padding(6)
                         .background(theme.color("bg-0"))
@@ -61,7 +63,6 @@ struct ProviderReviewPublishConfirmationView: View {
                             RoundedRectangle(cornerRadius: 6)
                                 .stroke(theme.color("line"), lineWidth: 0.75)
                         )
-                        .disabled(isPublishing)
                         .accessibilityIdentifier("provider-review-publish-summary")
                 }
                 .background(

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -678,14 +678,10 @@ struct ReviewDraftSummaryRail: View {
             }
 
             if editingCommentID == comment.id {
-                TextEditor(text: $editingBody)
-                    .font(.system(size: 11.5))
-                    .foregroundColor(theme.color("fg"))
-                    .scrollContentBackground(.hidden)
-                    .frame(minHeight: 62)
-                    .background(theme.color("bg-2"))
-                    .clipShape(RoundedRectangle(cornerRadius: 5))
-                    .accessibilityIdentifier("review-draft-summary-editor-\(comment.id)")
+                ReviewDraftSummaryCommentEditor(
+                    text: $editingBody,
+                    accessibilityIdentifier: "review-draft-summary-editor-\(comment.id)"
+                )
             } else {
                 DiffReviewInlineFeedbackMarkdown.view(comment.bodyMarkdown)
                     .frame(maxHeight: 80, alignment: .top)
@@ -790,6 +786,25 @@ struct ReviewDraftSummaryRail: View {
         case .dismissed:
             theme.color("fg-muted")
         }
+    }
+}
+
+struct ReviewDraftSummaryCommentEditor: View {
+    @Binding var text: String
+    let accessibilityIdentifier: String
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        PairedTextEditor(
+            text: $text,
+            font: .systemFont(ofSize: 11.5),
+            textColor: NSColor(theme.color("fg"))
+        )
+        .frame(minHeight: 62)
+        .background(theme.color("bg-2"))
+        .clipShape(RoundedRectangle(cornerRadius: 5))
+        .accessibilityIdentifier(accessibilityIdentifier)
     }
 }
 

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -886,7 +886,6 @@ final class CodeTextView: NSTextView, FontSizeResponder {
         guard location <= nsString.length else { return nil }
         return Character(nsString.substring(with: NSRange(location: location - 1, length: 1)))
     }
-
 }
 
 extension CodeTextView {

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -13,16 +13,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
         case dismiss
     }
 
-    private static let pairedDelimiters: [Character: Character] = [
-        "(": ")",
-        "[": "]",
-        "{": "}",
-        "\"": "\"",
-        "'": "'",
-        "`": "`"
-    ]
-
-    private static let closingDelimiters: Set<Character> = [")", "]", "}"]
+    private static let indentationClosingDelimiters: Set<Character> = [")", "]", "}"]
 
     var hoverHandler: ((NSPoint) -> Void)?
     var commandClickHandler: ((NSPoint) -> Void)?
@@ -235,7 +226,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
 
     private func editForCharacter(_ character: Character, at range: NSRange) -> MultiCursorEdit? {
         // Closing delimiter dedent
-        if Self.closingDelimiters.contains(character),
+        if Self.indentationClosingDelimiters.contains(character),
            indentationMode == .bracketAware,
            let edit = IndentationHelper.closingDelimiterEdit(in: string, selectedRange: range, delimiter: character, mode: indentationMode) {
             return MultiCursorEdit(
@@ -245,31 +236,20 @@ final class CodeTextView: NSTextView, FontSizeResponder {
             )
         }
 
-        // Paired delimiter
-        if let closing = Self.pairedDelimiters[character] {
-            if shouldInsertPair(opening: character, closing: closing, range: range) {
-                let current = string as NSString
-                let selectedText = range.length > 0 ? current.substring(with: range) : ""
-                let replacement = "\(character)\(selectedText)\(closing)"
-                let resultingSelection: NSRange
-                if range.length > 0 {
-                    resultingSelection = NSRange(location: range.location + 1, length: range.length)
-                } else {
-                    resultingSelection = NSRange(location: range.location + 1, length: 0)
-                }
-                return MultiCursorEdit(originalRange: range, replacement: replacement, resultingSelection: resultingSelection)
-            }
-            if character == closing, range.length == 0, nextCharacter(at: range.location) == character {
-                return MultiCursorEdit(originalRange: range, replacement: "", resultingSelection: NSRange(location: range.location + 1, length: 0))
-            }
-        }
-
-        // Closing delimiter step-over (non-paired)
-        if Self.closingDelimiters.contains(character), range.length == 0, nextCharacter(at: range.location) == character {
+        switch PairedDelimiterEditing.resolve(insertedText: String(character), in: string, selectedRange: range) {
+        case let .wrap(opening, closing), let .insertPair(opening, closing):
+            let current = string as NSString
+            let selectedText = range.length > 0 ? current.substring(with: range) : ""
+            return MultiCursorEdit(
+                originalRange: range,
+                replacement: "\(opening)\(selectedText)\(closing)",
+                resultingSelection: NSRange(location: range.location + 1, length: range.length)
+            )
+        case .stepOver:
             return MultiCursorEdit(originalRange: range, replacement: "", resultingSelection: NSRange(location: range.location + 1, length: 0))
+        case .native:
+            return nil
         }
-
-        return nil
     }
 
     // MARK: - Text insertion overrides
@@ -327,7 +307,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
         }
 
         // NEW: Closing delimiter dedent for whitespace-only lines
-        if Self.closingDelimiters.contains(character),
+        if Self.indentationClosingDelimiters.contains(character),
            indentationMode == .bracketAware,
            let edit = IndentationHelper.closingDelimiterEdit(in: string, selectedRange: range, delimiter: character, mode: indentationMode) {
             insertTextAfterTextEdit(edit.replacement, replacementRange: edit.replacementRange)
@@ -335,20 +315,15 @@ final class CodeTextView: NSTextView, FontSizeResponder {
             return
         }
 
-        if let closing = Self.pairedDelimiters[character] {
-            if shouldInsertPair(opening: character, closing: closing, range: range) {
-                insertPairedDelimiter(opening: character, closing: closing, replacementRange: range)
-                return
-            }
-            if character == closing, range.length == 0, nextCharacter(at: range.location) == character {
-                setSelectedRange(NSRange(location: range.location + 1, length: 0))
-                return
-            }
-        }
-
-        if Self.closingDelimiters.contains(character), range.length == 0, nextCharacter(at: range.location) == character {
+        switch PairedDelimiterEditing.resolve(insertedText: text, in: string, selectedRange: range) {
+        case let .wrap(opening, closing), let .insertPair(opening, closing):
+            insertPairedDelimiter(opening: opening, closing: closing, replacementRange: range)
+            return
+        case .stepOver:
             setSelectedRange(NSRange(location: range.location + 1, length: 0))
             return
+        case .native:
+            break
         }
 
         insertTextAfterTextEdit(insertString, replacementRange: replacementRange)
@@ -894,11 +869,6 @@ final class CodeTextView: NSTextView, FontSizeResponder {
 
     private func insertPairedDelimiter(opening: Character, closing: Character, replacementRange range: NSRange) {
         let current = string as NSString
-        if opening == closing, range.length == 0, nextCharacter(at: range.location) == closing {
-            setSelectedRange(NSRange(location: range.location + 1, length: 0))
-            return
-        }
-
         let selectedText = range.length > 0 ? current.substring(with: range) : ""
         let replacement = "\(opening)\(selectedText)\(closing)"
         insertTextAfterTextEdit(replacement, replacementRange: range)
@@ -910,22 +880,6 @@ final class CodeTextView: NSTextView, FontSizeResponder {
         }
     }
 
-    private func shouldInsertPair(opening: Character, closing: Character, range: NSRange) -> Bool {
-        guard opening == closing, range.length == 0 else { return true }
-
-        if isEscapedByBackslash(at: range.location) { return false }
-        if isIdentifierLike(characterBefore: range.location) { return false }
-        if isIdentifierLike(characterAfter: range.location) { return false }
-
-        return true
-    }
-
-    private func nextCharacter(at location: Int) -> Character? {
-        let nsString = string as NSString
-        guard location < nsString.length else { return nil }
-        return Character(nsString.substring(with: NSRange(location: location, length: 1)))
-    }
-
     private func previousCharacter(before location: Int) -> Character? {
         guard location > 0 else { return nil }
         let nsString = string as NSString
@@ -933,25 +887,6 @@ final class CodeTextView: NSTextView, FontSizeResponder {
         return Character(nsString.substring(with: NSRange(location: location - 1, length: 1)))
     }
 
-    private func isIdentifierLike(characterBefore location: Int) -> Bool {
-        guard let character = previousCharacter(before: location) else { return false }
-        return character.isLetter || character.isNumber || character == "_"
-    }
-
-    private func isIdentifierLike(characterAfter location: Int) -> Bool {
-        guard let character = nextCharacter(at: location) else { return false }
-        return character.isLetter || character.isNumber || character == "_"
-    }
-
-    private func isEscapedByBackslash(at location: Int) -> Bool {
-        var cursor = location
-        var backslashCount = 0
-        while previousCharacter(before: cursor) == "\\" {
-            backslashCount += 1
-            cursor -= 1
-        }
-        return backslashCount % 2 == 1
-    }
 }
 
 extension CodeTextView {

--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -507,14 +507,10 @@ private struct ProjectDialog: View {
                     .foregroundColor(theme.color("fg"))
                 Seg(value: $sessionOpenMode, options: startupOptions)
                 if sessionOpenMode == .appendToGlobal || sessionOpenMode == .overrideGlobal {
-                    TextEditor(text: $sessionOpenScript)
-                        .font(.system(size: 12, design: .monospaced))
-                        .foregroundColor(theme.color("fg"))
-                        .scrollContentBackground(.hidden)
-                        .frame(minHeight: 60)
-                        .padding(8)
-                        .background(theme.color("bg-0"))
-                        .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line"), lineWidth: 0.5))
+                    ProjectStartupScriptEditor(
+                        text: $sessionOpenScript,
+                        minHeight: 60
+                    )
                 }
             }
             VStack(alignment: .leading, spacing: 8) {
@@ -523,14 +519,10 @@ private struct ProjectDialog: View {
                     .foregroundColor(theme.color("fg"))
                 Seg(value: $worktreeCreateMode, options: startupOptions)
                 if worktreeCreateMode == .appendToGlobal || worktreeCreateMode == .overrideGlobal {
-                    TextEditor(text: $worktreeCreateScript)
-                        .font(.system(size: 12, design: .monospaced))
-                        .foregroundColor(theme.color("fg"))
-                        .scrollContentBackground(.hidden)
-                        .frame(minHeight: 60)
-                        .padding(8)
-                        .background(theme.color("bg-0"))
-                        .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line"), lineWidth: 0.5))
+                    ProjectStartupScriptEditor(
+                        text: $worktreeCreateScript,
+                        minHeight: 60
+                    )
                 }
             }
         }
@@ -822,6 +814,24 @@ private struct ProjectDialog: View {
         if sshSetupStatus == .verifying {
             sshSetupStatus = .connecting
         }
+    }
+}
+
+struct ProjectStartupScriptEditor: View {
+    @Binding var text: String
+    let minHeight: CGFloat
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        PairedTextEditor(
+            text: $text,
+            font: .monospacedSystemFont(ofSize: 12, weight: .regular),
+            textColor: NSColor(theme.color("fg"))
+        )
+        .frame(minHeight: minHeight)
+        .padding(8)
+        .background(theme.color("bg-0"))
+        .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line"), lineWidth: 0.5))
     }
 }
 

--- a/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct GGSplitCommitTabView: View {
@@ -310,8 +311,21 @@ struct GGSplitCommitTabView: View {
             .accessibilityValue(isActive ? "Selected" : "Not selected")
             .accessibilityIdentifier("gg-split-commit-card-\(destination.previewID)")
 
-            TextField("Commit message", text: message)
-                .textFieldStyle(.roundedBorder)
+            PairedTextField(
+                text: message,
+                placeholder: "Commit message",
+                font: .systemFont(ofSize: NSFont.systemFontSize),
+                textColor: NSColor(theme.color("fg")),
+                isEnabled: !isApplying
+            )
+                .padding(.horizontal, 6)
+                .frame(height: 22)
+                .background(theme.color("field-bg"))
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .strokeBorder(theme.color("border"), lineWidth: 1)
+                )
                 .onChange(of: message.wrappedValue) { draftDidChange() }
         }
         .padding(10)

--- a/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
@@ -311,22 +311,10 @@ struct GGSplitCommitTabView: View {
             .accessibilityValue(isActive ? "Selected" : "Not selected")
             .accessibilityIdentifier("gg-split-commit-card-\(destination.previewID)")
 
-            PairedTextField(
-                text: message,
-                placeholder: "Commit message",
-                font: .systemFont(ofSize: NSFont.systemFontSize),
-                textColor: NSColor(theme.color("fg")),
-                isEnabled: !isApplying
+            GGSplitCommitMessageEditor(
+                message: message,
+                onDraftChange: draftDidChange
             )
-                .padding(.horizontal, 6)
-                .frame(height: 22)
-                .background(theme.color("field-bg"))
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 4)
-                        .strokeBorder(theme.color("border"), lineWidth: 1)
-                )
-                .onChange(of: message.wrappedValue) { draftDidChange() }
         }
         .padding(10)
         .frame(maxWidth: .infinity)
@@ -604,6 +592,27 @@ struct GGSplitCommitTabView: View {
                 errorMessage = GGErrorPresentation.message(for: error)
             }
         }
+    }
+}
+
+struct GGSplitCommitMessageEditor: View {
+    @Binding var message: String
+    let onDraftChange: () -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        PairedTextField(
+            text: $message,
+            placeholder: "Commit message",
+            font: .systemFont(ofSize: NSFont.systemFontSize),
+            textColor: NSColor(theme.color("fg")),
+            isBordered: true,
+            isBezeled: true,
+            drawsBackground: true,
+            bezelStyle: .roundedBezel
+        )
+        .onChange(of: message) { onDraftChange() }
     }
 }
 

--- a/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
@@ -11,6 +11,7 @@ struct GGSplitCommitTabView: View {
     let codeFontSize: CGFloat
     let onCancel: () -> Void
     let onDraftChange: (GGSplitCommitDraft) -> Void
+    let loadsOnAppear: Bool
 
     @Environment(\.theme) private var theme
     @State private var model: GGSplitCommitModel
@@ -52,6 +53,7 @@ struct GGSplitCommitTabView: View {
         self.codeFontSize = codeFontSize
         self.onCancel = onCancel
         self.onDraftChange = onDraftChange
+        self.loadsOnAppear = true
         _model = State(initialValue: GGSplitCommitModel(
             service: rightPaneState,
             target: GGSplitCommitTarget(
@@ -63,6 +65,32 @@ struct GGSplitCommitTabView: View {
             workflowAvailable: workflowAvailable && !hasBlockingGitOperation,
             initialDraft: initialDraft
         ))
+    }
+
+    init(
+        tabState: GGSplitCommitTabState,
+        worktreePath: URL,
+        capabilities: GGCapabilities,
+        workflowAvailable: Bool,
+        hasBlockingGitOperation: Bool,
+        model: GGSplitCommitModel,
+        codeFontFamily: String,
+        codeFontSize: CGFloat,
+        onCancel: @escaping () -> Void,
+        onDraftChange: @escaping (GGSplitCommitDraft) -> Void
+    ) {
+        self.tabState = tabState
+        self.worktreePath = worktreePath
+        self.capabilities = capabilities
+        self.workflowAvailable = workflowAvailable
+        self.hasBlockingGitOperation = hasBlockingGitOperation
+        self.codeFontFamily = codeFontFamily
+        self.codeFontSize = codeFontSize
+        self.onCancel = onCancel
+        self.onDraftChange = onDraftChange
+        self.loadsOnAppear = false
+        _model = State(initialValue: model)
+        _isLoading = State(initialValue: false)
     }
 
     var body: some View {
@@ -80,7 +108,11 @@ struct GGSplitCommitTabView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(theme.color("bg-1"))
-        .task(id: tabState.id) { await load() }
+        .task(id: tabState.id) {
+            if loadsOnAppear {
+                await load()
+            }
+        }
         .onReceive(
             NotificationCenter.default.publisher(for: AppKitDiffScrollerFlag.overrideDidChangeNotification)
         ) { _ in

--- a/Alas/Sources/Missions/AddMissionLegDialog.swift
+++ b/Alas/Sources/Missions/AddMissionLegDialog.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AppKit
 import Observation
 import SwiftUI
 
@@ -159,10 +160,12 @@ struct AddMissionLegDialog: View {
                         agentPicker
                     }
                     DialogField(label: "Repository instructions") {
-                        TextEditor(text: $instructions)
-                            .font(.system(size: 12, design: .monospaced))
-                            .foregroundStyle(theme.color("fg"))
-                            .scrollContentBackground(.hidden)
+                        PairedTextEditor(
+                            text: $instructions,
+                            font: .monospacedSystemFont(ofSize: 12, weight: .regular),
+                            textColor: NSColor(theme.color("fg")),
+                            isEnabled: !actions.isSubmitting
+                        )
                             .frame(minHeight: 110, maxHeight: 170)
                             .padding(8)
                             .background(theme.color("bg-0"))
@@ -170,7 +173,6 @@ struct AddMissionLegDialog: View {
                                 RoundedRectangle(cornerRadius: 6)
                                     .strokeBorder(theme.color("line"), lineWidth: 0.5)
                             )
-                            .disabled(actions.isSubmitting)
                     }
                     if actions.isSubmitting {
                         progressRow("Adding Mission leg…")

--- a/Alas/Sources/Missions/EditMissionSourceDialog.swift
+++ b/Alas/Sources/Missions/EditMissionSourceDialog.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 @Observable
@@ -55,8 +56,11 @@ struct EditMissionSourceDialog: View {
                 .textSelection(.enabled)
             TextField("Title", text: $model.title)
                 .textFieldStyle(.roundedBorder)
-            TextEditor(text: $model.body)
-                .font(.system(size: 12))
+            PairedTextEditor(
+                text: $model.body,
+                font: .systemFont(ofSize: 12),
+                textColor: NSColor(theme.color("fg"))
+            )
                 .frame(minHeight: 140)
                 .overlay {
                     RoundedRectangle(cornerRadius: 6)

--- a/Alas/Sources/Missions/NewMissionDialog.swift
+++ b/Alas/Sources/Missions/NewMissionDialog.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AppKit
 import Observation
 import SwiftUI
 
@@ -680,10 +681,12 @@ struct NewMissionDialog: View {
                                 .disabled(model.phase == .creating)
                         }
                         DialogField(label: "Work-item context") {
-                            TextEditor(text: $model.sourceBody)
-                                .font(.system(size: 12))
-                                .foregroundStyle(theme.color("fg"))
-                                .scrollContentBackground(.hidden)
+                            PairedTextEditor(
+                                text: $model.sourceBody,
+                                font: .systemFont(ofSize: 12),
+                                textColor: NSColor(theme.color("fg")),
+                                isEnabled: model.phase != .creating
+                            )
                                 .frame(minHeight: 80, maxHeight: 140)
                                 .padding(8)
                                 .background(theme.color("bg-0"))
@@ -691,7 +694,6 @@ struct NewMissionDialog: View {
                                     RoundedRectangle(cornerRadius: 6)
                                         .strokeBorder(theme.color("line"), lineWidth: 0.5)
                                 )
-                                .disabled(model.phase == .creating)
                         }
                     }
                 }
@@ -720,10 +722,12 @@ struct NewMissionDialog: View {
                     agentPicker
                 }
                 DialogField(label: "Initial prompt") {
-                    TextEditor(text: actions.prompt)
-                        .font(.system(size: 12, design: .monospaced))
-                        .foregroundStyle(theme.color("fg"))
-                        .scrollContentBackground(.hidden)
+                    PairedTextEditor(
+                        text: actions.prompt,
+                        font: .monospacedSystemFont(ofSize: 12, weight: .regular),
+                        textColor: NSColor(theme.color("fg")),
+                        isEnabled: model.phase != .creating
+                    )
                         .frame(minHeight: 130, maxHeight: 190)
                         .padding(8)
                         .background(theme.color("bg-0"))
@@ -731,7 +735,6 @@ struct NewMissionDialog: View {
                             RoundedRectangle(cornerRadius: 6)
                                 .strokeBorder(theme.color("line"), lineWidth: 0.5)
                         )
-                        .disabled(model.phase == .creating)
                 }
                 if model.phase == .creating {
                     HStack(spacing: 8) {

--- a/Alas/Sources/Settings/PromptEditorBody.swift
+++ b/Alas/Sources/Settings/PromptEditorBody.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Shared layout for prompt-editor windows (Commit, Merge Resolve all,
@@ -25,9 +26,10 @@ struct PromptEditorBody: View {
                         .font(.system(size: 12.5))
                         .foregroundColor(theme.color("fg-dim"))
                 }
-                TextEditor(text: $draftPrompt)
-                    .font(.system(size: 12, design: .monospaced))
-                    .scrollContentBackground(.hidden)
+                PairedTextEditor(
+                    text: $draftPrompt,
+                    font: .monospacedSystemFont(ofSize: 12, weight: .regular)
+                )
                     .background(theme.color("bg-2"))
                     .overlay(
                         RoundedRectangle(cornerRadius: 6)

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct TerminalPane: View {
@@ -49,10 +50,11 @@ struct TerminalPane: View {
                 SettingsGroup(title: "Startup scripts") {
                     SettingsRow(name: "Run on session open",
                                 desc: "Executed in every new terminal pane after the shell starts.") {
-                        TextEditor(text: state.bind(\.terminal.startupScript))
-                            .font(.system(size: 12, design: .monospaced))
-                            .foregroundColor(theme.color("fg"))
-                            .scrollContentBackground(.hidden)
+                        PairedTextEditor(
+                            text: state.bind(\.terminal.startupScript),
+                            font: .monospacedSystemFont(ofSize: 12, weight: .regular),
+                            textColor: NSColor(theme.color("fg"))
+                        )
                             .frame(minHeight: 80)
                             .padding(8)
                             .background(theme.color("bg-0"))
@@ -60,10 +62,11 @@ struct TerminalPane: View {
                     }
                     SettingsRow(name: "Run on worktree create",
                                 desc: "Executed once after a worktree is created.") {
-                        TextEditor(text: state.bind(\.terminal.worktreeCreateScript))
-                            .font(.system(size: 12, design: .monospaced))
-                            .foregroundColor(theme.color("fg"))
-                            .scrollContentBackground(.hidden)
+                        PairedTextEditor(
+                            text: state.bind(\.terminal.worktreeCreateScript),
+                            font: .monospacedSystemFont(ofSize: 12, weight: .regular),
+                            textColor: NSColor(theme.color("fg"))
+                        )
                             .frame(minHeight: 60)
                             .padding(8)
                             .background(theme.color("bg-0"))

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -3,9 +3,11 @@ import SwiftUI
 
 class PairedDelimiterTextView: NSTextView {
     private var bypassesPairedDelimiterResolution = false
+    private var appliesPairedDelimiterResolutionForKeyboardInput = false
 
     override func insertText(_ insertString: Any, replacementRange: NSRange) {
         guard !bypassesPairedDelimiterResolution,
+              appliesPairedDelimiterResolutionForKeyboardInput,
               !hasMarkedText(),
               let insertedText = Self.plainText(from: insertString)
         else {
@@ -49,6 +51,12 @@ class PairedDelimiterTextView: NSTextView {
         }
     }
 
+    override func keyDown(with event: NSEvent) {
+        performKeyboardTextInsertion {
+            super.keyDown(with: event)
+        }
+    }
+
     override func paste(_ sender: Any?) {
         performNativeTextInsertion {
             super.paste(sender)
@@ -65,6 +73,12 @@ class PairedDelimiterTextView: NSTextView {
         performNativeTextInsertion {
             super.pasteAsRichText(sender)
         }
+    }
+
+    func performKeyboardTextInsertion(_ insert: () -> Void) {
+        appliesPairedDelimiterResolutionForKeyboardInput = true
+        defer { appliesPairedDelimiterResolutionForKeyboardInput = false }
+        insert()
     }
 
     func performNativeTextInsertion(_ insert: () -> Void) {
@@ -214,6 +228,7 @@ struct PairedTextField: NSViewRepresentable {
         var parent: PairedTextField
         private var isApplyingPairedEdit = false
         private var isApplyingNativePaste = false
+        private var isApplyingKeyboardTextInput = false
         private weak var observedUndoManager: UndoManager?
         private var undoObservers: [NSObjectProtocol] = []
 
@@ -249,12 +264,9 @@ struct PairedTextField: NSViewRepresentable {
                   !isApplyingNativePaste,
                   parent.isEnabled,
                   !textView.hasMarkedText(),
-                  let replacementString
+                  let replacementString,
+                  shouldApplyPairedDelimiterResolution(for: replacementString)
             else { return true }
-
-            if shouldUseNativePaste(for: replacementString) {
-                return true
-            }
 
             switch PairedDelimiterEditing.resolve(
                 insertedText: replacementString,
@@ -313,19 +325,23 @@ struct PairedTextField: NSViewRepresentable {
             return true
         }
 
-        private func shouldUseNativePaste(for replacementString: String) -> Bool {
-            guard replacementString.count == 1,
-                  NSPasteboard.general.string(forType: .string) == replacementString
-            else { return false }
+        func performKeyboardTextInsertion(_ insert: () -> Bool) -> Bool {
+            isApplyingKeyboardTextInput = true
+            defer { isApplyingKeyboardTextInput = false }
+            return insert()
+        }
 
-            guard let event = NSApp.currentEvent, event.type == .keyDown else {
+        private func shouldApplyPairedDelimiterResolution(for replacementString: String) -> Bool {
+            if isApplyingKeyboardTextInput {
                 return true
+            }
+            guard let event = NSApp.currentEvent, event.type == .keyDown else {
+                return false
             }
 
             let textInputModifiers: NSEvent.ModifierFlags = [.command, .control, .option]
-            let isPlainMatchingKeyDown = event.modifierFlags.intersection(textInputModifiers).isEmpty
+            return event.modifierFlags.intersection(textInputModifiers).isEmpty
                 && (event.charactersIgnoringModifiers ?? event.characters) == replacementString
-            return !isPlainMatchingKeyDown
         }
 
         private static let nativePasteSelectors: Set<Selector> = [

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -2,8 +2,13 @@ import AppKit
 import SwiftUI
 
 class PairedDelimiterTextView: NSTextView {
+    private var bypassesPairedDelimiterResolution = false
+
     override func insertText(_ insertString: Any, replacementRange: NSRange) {
-        guard !hasMarkedText(), let insertedText = Self.plainText(from: insertString) else {
+        guard !bypassesPairedDelimiterResolution,
+              !hasMarkedText(),
+              let insertedText = Self.plainText(from: insertString)
+        else {
             super.insertText(insertString, replacementRange: replacementRange)
             return
         }
@@ -42,6 +47,18 @@ class PairedDelimiterTextView: NSTextView {
         case .native:
             super.insertText(insertString, replacementRange: replacementRange)
         }
+    }
+
+    override func paste(_ sender: Any?) {
+        performNativeTextInsertion {
+            super.paste(sender)
+        }
+    }
+
+    func performNativeTextInsertion(_ insert: () -> Void) {
+        bypassesPairedDelimiterResolution = true
+        defer { bypassesPairedDelimiterResolution = false }
+        insert()
     }
 
     private static func plainText(from value: Any) -> String? {

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -55,6 +55,18 @@ class PairedDelimiterTextView: NSTextView {
         }
     }
 
+    override func pasteAsPlainText(_ sender: Any?) {
+        performNativeTextInsertion {
+            super.pasteAsPlainText(sender)
+        }
+    }
+
+    override func pasteAsRichText(_ sender: Any?) {
+        performNativeTextInsertion {
+            super.pasteAsRichText(sender)
+        }
+    }
+
     func performNativeTextInsertion(_ insert: () -> Void) {
         bypassesPairedDelimiterResolution = true
         defer { bypassesPairedDelimiterResolution = false }
@@ -291,7 +303,7 @@ struct PairedTextField: NSViewRepresentable {
         }
 
         func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
-            guard commandSelector == #selector(NSText.paste(_:)) else { return false }
+            guard Self.nativePasteSelectors.contains(commandSelector) else { return false }
             isApplyingNativePaste = true
             defer {
                 isApplyingNativePaste = false
@@ -315,6 +327,12 @@ struct PairedTextField: NSViewRepresentable {
                 && (event.charactersIgnoringModifiers ?? event.characters) == replacementString
             return !isPlainMatchingKeyDown
         }
+
+        private static let nativePasteSelectors: Set<Selector> = [
+            #selector(NSText.paste(_:)),
+            #selector(NSTextView.pasteAsPlainText(_:)),
+            #selector(NSTextView.pasteAsRichText(_:)),
+        ]
 
         func synchronizeFocus(for field: NSTextField) {
             guard let binding = parent.isFocused, let window = field.window else { return }

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -121,9 +121,15 @@ struct PairedTextField: NSViewRepresentable {
     }
 
     static func dismantleNSView(_ field: PairedTextFieldBackingView, coordinator: Coordinator) {
+        let window = field.window
+        let editor = field.currentEditor()
+        coordinator.stopObservingUndoManager()
         field.onWindowChanged = nil
         field.delegate = nil
         field.target = nil
+        if let editor, window?.firstResponder === editor {
+            window?.makeFirstResponder(nil)
+        }
     }
 
     private func applyConfiguration(to field: NSTextField, coordinator: Coordinator) {
@@ -160,6 +166,8 @@ struct PairedTextField: NSViewRepresentable {
     final class Coordinator: NSObject, NSTextFieldDelegate {
         var parent: PairedTextField
         private var isApplyingPairedEdit = false
+        private weak var observedUndoManager: UndoManager?
+        private var undoObservers: [NSObjectProtocol] = []
 
         init(_ parent: PairedTextField) {
             self.parent = parent
@@ -214,6 +222,7 @@ struct PairedTextField: NSViewRepresentable {
                     string: String(closing),
                     attributes: textView.typingAttributes
                 ))
+                observeUndoChanges(for: control as? NSTextField, textView: textView)
                 apply(replacement, to: textView, range: affectedCharRange)
                 textView.setSelectedRange(NSRange(
                     location: affectedCharRange.location + 1,
@@ -226,6 +235,7 @@ struct PairedTextField: NSViewRepresentable {
                     string: String(opening) + String(closing),
                     attributes: textView.typingAttributes
                 )
+                observeUndoChanges(for: control as? NSTextField, textView: textView)
                 apply(replacement, to: textView, range: affectedCharRange)
                 textView.setSelectedRange(NSRange(location: affectedCharRange.location + 1, length: 0))
                 return false
@@ -253,10 +263,37 @@ struct PairedTextField: NSViewRepresentable {
         }
 
         func fieldEditor(for field: NSTextField) -> NSTextView? {
-            guard let window = field.window,
-                  window.firstResponder === field || window.firstResponder === window.fieldEditor(false, for: field)
-            else { return nil }
-            return window.fieldEditor(false, for: field) as? NSTextView
+            field.currentEditor() as? NSTextView
+        }
+
+        func stopObservingUndoManager() {
+            for observer in undoObservers {
+                NotificationCenter.default.removeObserver(observer)
+            }
+            undoObservers.removeAll()
+            observedUndoManager = nil
+        }
+
+        private func observeUndoChanges(for field: NSTextField?, textView: NSTextView) {
+            guard let field, let undoManager = textView.undoManager,
+                  observedUndoManager !== undoManager
+            else { return }
+
+            stopObservingUndoManager()
+            observedUndoManager = undoManager
+            for name in [Notification.Name.NSUndoManagerDidUndoChange, .NSUndoManagerDidRedoChange] {
+                undoObservers.append(NotificationCenter.default.addObserver(
+                    forName: name,
+                    object: undoManager,
+                    queue: .main
+                ) { [weak self, weak field] _ in
+                    MainActor.assumeIsolated {
+                        guard let self, let field else { return }
+                        let value = (field.currentEditor() as? NSTextView)?.string ?? field.stringValue
+                        self.updateText(value)
+                    }
+                })
+            }
         }
 
         private func apply(_ replacement: NSAttributedString, to textView: NSTextView, range: NSRange) {
@@ -361,9 +398,13 @@ struct PairedTextEditor: NSViewRepresentable {
 
     static func dismantleNSView(_ scrollView: NSScrollView, coordinator: Coordinator) {
         guard let textView = scrollView.documentView as? PairedTextEditorBackingView else { return }
+        let window = textView.window
         textView.onWindowChanged = nil
         textView.delegate = nil
         coordinator.textView = nil
+        if window?.firstResponder === textView {
+            window?.makeFirstResponder(nil)
+        }
     }
 
     private func applyConfiguration(to textView: PairedDelimiterTextView) {

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -240,6 +240,10 @@ struct PairedTextField: NSViewRepresentable {
                   let replacementString
             else { return true }
 
+            if shouldUseNativePaste(for: replacementString) {
+                return true
+            }
+
             switch PairedDelimiterEditing.resolve(
                 insertedText: replacementString,
                 in: textView.string,
@@ -295,6 +299,21 @@ struct PairedTextField: NSViewRepresentable {
             }
             textView.paste(nil)
             return true
+        }
+
+        private func shouldUseNativePaste(for replacementString: String) -> Bool {
+            guard replacementString.count == 1,
+                  NSPasteboard.general.string(forType: .string) == replacementString
+            else { return false }
+
+            guard let event = NSApp.currentEvent, event.type == .keyDown else {
+                return true
+            }
+
+            let textInputModifiers: NSEvent.ModifierFlags = [.command, .control, .option]
+            let isPlainMatchingKeyDown = event.modifierFlags.intersection(textInputModifiers).isEmpty
+                && (event.charactersIgnoringModifiers ?? event.characters) == replacementString
+            return !isPlainMatchingKeyDown
         }
 
         func synchronizeFocus(for field: NSTextField) {

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -1,0 +1,451 @@
+import AppKit
+import SwiftUI
+
+class PairedDelimiterTextView: NSTextView {
+    override func insertText(_ insertString: Any, replacementRange: NSRange) {
+        guard !hasMarkedText(), let insertedText = Self.plainText(from: insertString) else {
+            super.insertText(insertString, replacementRange: replacementRange)
+            return
+        }
+
+        let range = replacementRange.location == NSNotFound ? selectedRange() : replacementRange
+        switch PairedDelimiterEditing.resolve(insertedText: insertedText, in: string, selectedRange: range) {
+        case let .wrap(opening, closing):
+            guard let textStorage, Self.isValid(range, in: textStorage) else {
+                super.insertText(insertString, replacementRange: replacementRange)
+                return
+            }
+
+            let replacement = NSMutableAttributedString(
+                string: String(opening),
+                attributes: typingAttributes
+            )
+            replacement.append(textStorage.attributedSubstring(from: range))
+            replacement.append(NSAttributedString(
+                string: String(closing),
+                attributes: typingAttributes
+            ))
+            super.insertText(replacement, replacementRange: range)
+            setSelectedRange(NSRange(location: range.location + 1, length: range.length))
+
+        case let .insertPair(opening, closing):
+            let replacement = NSAttributedString(
+                string: String(opening) + String(closing),
+                attributes: typingAttributes
+            )
+            super.insertText(replacement, replacementRange: range)
+            setSelectedRange(NSRange(location: range.location + 1, length: 0))
+
+        case .stepOver:
+            setSelectedRange(NSRange(location: range.location + 1, length: 0))
+
+        case .native:
+            super.insertText(insertString, replacementRange: replacementRange)
+        }
+    }
+
+    private static func plainText(from value: Any) -> String? {
+        if let string = value as? String {
+            return string
+        }
+        if let attributedString = value as? NSAttributedString {
+            return attributedString.string
+        }
+        return nil
+    }
+
+    private static func isValid(_ range: NSRange, in storage: NSTextStorage) -> Bool {
+        range.location != NSNotFound
+            && range.location >= 0
+            && range.length >= 0
+            && range.location <= storage.length
+            && range.length <= storage.length - range.location
+    }
+}
+
+struct PairedTextField: NSViewRepresentable {
+    @Binding var text: String
+    var placeholder: String
+    var font: NSFont
+    var textColor: NSColor
+    var isEnabled: Bool
+    var isFocused: Binding<Bool>?
+    var onSubmit: (() -> Void)?
+
+    init(
+        text: Binding<String>,
+        placeholder: String = "",
+        font: NSFont = .systemFont(ofSize: NSFont.systemFontSize),
+        textColor: NSColor = .labelColor,
+        isEnabled: Bool = true,
+        isFocused: Binding<Bool>? = nil,
+        onSubmit: (() -> Void)? = nil
+    ) {
+        _text = text
+        self.placeholder = placeholder
+        self.font = font
+        self.textColor = textColor
+        self.isEnabled = isEnabled
+        self.isFocused = isFocused
+        self.onSubmit = onSubmit
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeNSView(context: Context) -> PairedTextFieldBackingView {
+        let field = PairedTextFieldBackingView()
+        field.isBordered = false
+        field.isBezeled = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.usesSingleLineMode = true
+        field.cell?.wraps = false
+        field.cell?.isScrollable = true
+        field.delegate = context.coordinator
+        field.target = context.coordinator
+        field.action = #selector(Coordinator.submit(_:))
+        field.onWindowChanged = { [weak coordinator = context.coordinator, weak field] in
+            guard let field else { return }
+            coordinator?.synchronizeFocus(for: field)
+        }
+        applyConfiguration(to: field, coordinator: context.coordinator)
+        return field
+    }
+
+    func updateNSView(_ field: PairedTextFieldBackingView, context: Context) {
+        context.coordinator.parent = self
+        applyConfiguration(to: field, coordinator: context.coordinator)
+        context.coordinator.synchronizeFocus(for: field)
+    }
+
+    static func dismantleNSView(_ field: PairedTextFieldBackingView, coordinator: Coordinator) {
+        field.onWindowChanged = nil
+        field.delegate = nil
+        field.target = nil
+    }
+
+    private func applyConfiguration(to field: NSTextField, coordinator: Coordinator) {
+        field.placeholderString = placeholder
+        field.font = font
+        field.textColor = textColor
+        field.isEnabled = isEnabled
+        field.isEditable = isEnabled
+        field.isSelectable = isEnabled
+
+        let fieldEditor = coordinator.fieldEditor(for: field)
+        if field.stringValue != text {
+            field.stringValue = text
+        }
+        if let fieldEditor, fieldEditor.string != text {
+            let selection = fieldEditor.selectedRange()
+            fieldEditor.string = text
+            fieldEditor.setSelectedRange(Self.clamped(selection, in: text))
+        }
+        fieldEditor?.font = font
+        fieldEditor?.textColor = textColor
+    }
+
+    private static func clamped(_ range: NSRange, in text: String) -> NSRange {
+        let length = (text as NSString).length
+        guard range.location != NSNotFound else {
+            return NSRange(location: length, length: 0)
+        }
+        let location = min(max(0, range.location), length)
+        return NSRange(location: location, length: min(max(0, range.length), length - location))
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var parent: PairedTextField
+        private var isApplyingPairedEdit = false
+
+        init(_ parent: PairedTextField) {
+            self.parent = parent
+        }
+
+        @objc func submit(_ sender: NSTextField) {
+            updateText(sender.stringValue)
+            parent.onSubmit?()
+        }
+
+        func controlTextDidChange(_ notification: Notification) {
+            guard let field = notification.object as? NSTextField else { return }
+            updateText(field.stringValue)
+        }
+
+        func controlTextDidBeginEditing(_ notification: Notification) {
+            updateFocus(true)
+        }
+
+        func controlTextDidEndEditing(_ notification: Notification) {
+            updateFocus(false)
+        }
+
+        func control(
+            _ control: NSControl,
+            textView: NSTextView,
+            shouldChangeCharactersIn affectedCharRange: NSRange,
+            replacementString: String?
+        ) -> Bool {
+            guard !isApplyingPairedEdit,
+                  parent.isEnabled,
+                  !textView.hasMarkedText(),
+                  let replacementString
+            else { return true }
+
+            switch PairedDelimiterEditing.resolve(
+                insertedText: replacementString,
+                in: textView.string,
+                selectedRange: affectedCharRange
+            ) {
+            case let .wrap(opening, closing):
+                guard let textStorage = textView.textStorage,
+                      Self.isValid(affectedCharRange, in: textStorage)
+                else { return true }
+
+                let replacement = NSMutableAttributedString(
+                    string: String(opening),
+                    attributes: textView.typingAttributes
+                )
+                replacement.append(textStorage.attributedSubstring(from: affectedCharRange))
+                replacement.append(NSAttributedString(
+                    string: String(closing),
+                    attributes: textView.typingAttributes
+                ))
+                apply(replacement, to: textView, range: affectedCharRange)
+                textView.setSelectedRange(NSRange(
+                    location: affectedCharRange.location + 1,
+                    length: affectedCharRange.length
+                ))
+                return false
+
+            case let .insertPair(opening, closing):
+                let replacement = NSAttributedString(
+                    string: String(opening) + String(closing),
+                    attributes: textView.typingAttributes
+                )
+                apply(replacement, to: textView, range: affectedCharRange)
+                textView.setSelectedRange(NSRange(location: affectedCharRange.location + 1, length: 0))
+                return false
+
+            case .stepOver:
+                textView.setSelectedRange(NSRange(location: affectedCharRange.location + 1, length: 0))
+                return false
+
+            case .native:
+                return true
+            }
+        }
+
+        func synchronizeFocus(for field: NSTextField) {
+            guard let binding = parent.isFocused, let window = field.window else { return }
+            let editor = fieldEditor(for: field)
+            let ownsFocus = window.firstResponder === field || window.firstResponder === editor
+            let wantsFocus = binding.wrappedValue && parent.isEnabled
+
+            if wantsFocus, !ownsFocus {
+                window.makeFirstResponder(field)
+            } else if !wantsFocus, ownsFocus {
+                window.makeFirstResponder(nil)
+            }
+        }
+
+        func fieldEditor(for field: NSTextField) -> NSTextView? {
+            guard let window = field.window,
+                  window.firstResponder === field || window.firstResponder === window.fieldEditor(false, for: field)
+            else { return nil }
+            return window.fieldEditor(false, for: field) as? NSTextView
+        }
+
+        private func apply(_ replacement: NSAttributedString, to textView: NSTextView, range: NSRange) {
+            isApplyingPairedEdit = true
+            defer { isApplyingPairedEdit = false }
+            textView.insertText(replacement, replacementRange: range)
+        }
+
+        private func updateText(_ value: String) {
+            if parent.text != value {
+                parent.text = value
+            }
+        }
+
+        private func updateFocus(_ value: Bool) {
+            if let binding = parent.isFocused, binding.wrappedValue != value {
+                binding.wrappedValue = value
+            }
+        }
+
+        private static func isValid(_ range: NSRange, in storage: NSTextStorage) -> Bool {
+            range.location != NSNotFound
+                && range.location >= 0
+                && range.length >= 0
+                && range.location <= storage.length
+                && range.length <= storage.length - range.location
+        }
+    }
+}
+
+struct PairedTextEditor: NSViewRepresentable {
+    @Binding var text: String
+    var font: NSFont
+    var textColor: NSColor
+    var isEnabled: Bool
+    var isFocused: Binding<Bool>?
+    var textContainerInset: NSSize
+
+    init(
+        text: Binding<String>,
+        font: NSFont = .systemFont(ofSize: NSFont.systemFontSize),
+        textColor: NSColor = .labelColor,
+        isEnabled: Bool = true,
+        isFocused: Binding<Bool>? = nil,
+        textContainerInset: NSSize = .zero
+    ) {
+        _text = text
+        self.font = font
+        self.textColor = textColor
+        self.isEnabled = isEnabled
+        self.isFocused = isFocused
+        self.textContainerInset = textContainerInset
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+
+        let textView = PairedTextEditorBackingView()
+        textView.delegate = context.coordinator
+        textView.isRichText = false
+        textView.importsGraphics = false
+        textView.allowsUndo = true
+        textView.drawsBackground = false
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(
+            width: scrollView.contentSize.width,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.minSize = .zero
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.onWindowChanged = { [weak coordinator = context.coordinator, weak textView] in
+            guard let textView else { return }
+            coordinator?.synchronizeFocus(for: textView)
+        }
+        scrollView.documentView = textView
+        context.coordinator.textView = textView
+        applyConfiguration(to: textView)
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        context.coordinator.parent = self
+        guard let textView = scrollView.documentView as? PairedDelimiterTextView else { return }
+        applyConfiguration(to: textView)
+        context.coordinator.synchronizeFocus(for: textView)
+    }
+
+    static func dismantleNSView(_ scrollView: NSScrollView, coordinator: Coordinator) {
+        guard let textView = scrollView.documentView as? PairedTextEditorBackingView else { return }
+        textView.onWindowChanged = nil
+        textView.delegate = nil
+        coordinator.textView = nil
+    }
+
+    private func applyConfiguration(to textView: PairedDelimiterTextView) {
+        if textView.string != text {
+            let selection = textView.selectedRange()
+            textView.string = text
+            textView.setSelectedRange(Self.clamped(selection, in: text))
+        }
+        textView.font = font
+        textView.textColor = textColor
+        textView.isEditable = isEnabled
+        textView.isSelectable = isEnabled
+        textView.textContainerInset = textContainerInset
+    }
+
+    private static func clamped(_ range: NSRange, in text: String) -> NSRange {
+        let length = (text as NSString).length
+        guard range.location != NSNotFound else {
+            return NSRange(location: length, length: 0)
+        }
+        let location = min(max(0, range.location), length)
+        return NSRange(location: location, length: min(max(0, range.length), length - location))
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: PairedTextEditor
+        weak var textView: PairedDelimiterTextView?
+
+        init(_ parent: PairedTextEditor) {
+            self.parent = parent
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView,
+                  parent.text != textView.string
+            else { return }
+            parent.text = textView.string
+        }
+
+        func textDidBeginEditing(_ notification: Notification) {
+            updateFocus(true)
+        }
+
+        func textDidEndEditing(_ notification: Notification) {
+            updateFocus(false)
+        }
+
+        func synchronizeFocus(for textView: NSTextView) {
+            guard let binding = parent.isFocused, let window = textView.window else { return }
+            let ownsFocus = window.firstResponder === textView
+            let wantsFocus = binding.wrappedValue && parent.isEnabled
+
+            if wantsFocus, !ownsFocus {
+                window.makeFirstResponder(textView)
+            } else if !wantsFocus, ownsFocus {
+                window.makeFirstResponder(nil)
+            }
+        }
+
+        private func updateFocus(_ value: Bool) {
+            if let binding = parent.isFocused, binding.wrappedValue != value {
+                binding.wrappedValue = value
+            }
+        }
+    }
+}
+
+final class PairedTextFieldBackingView: NSTextField {
+    var onWindowChanged: (() -> Void)?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        onWindowChanged?()
+    }
+}
+
+private final class PairedTextEditorBackingView: PairedDelimiterTextView {
+    var onWindowChanged: (() -> Void)?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        onWindowChanged?()
+    }
+}

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -392,7 +392,6 @@ struct PairedTextEditor: NSViewRepresentable {
             width: scrollView.contentSize.width,
             height: CGFloat.greatestFiniteMagnitude
         )
-        textView.minSize = .zero
         textView.maxSize = NSSize(
             width: CGFloat.greatestFiniteMagnitude,
             height: CGFloat.greatestFiniteMagnitude
@@ -406,6 +405,7 @@ struct PairedTextEditor: NSViewRepresentable {
         }
         scrollView.documentView = textView
         context.coordinator.textView = textView
+        synchronizeLayout(of: textView, in: scrollView)
         applyConfiguration(to: textView)
         return scrollView
     }
@@ -413,6 +413,7 @@ struct PairedTextEditor: NSViewRepresentable {
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         context.coordinator.parent = self
         guard let textView = scrollView.documentView as? PairedDelimiterTextView else { return }
+        synchronizeLayout(of: textView, in: scrollView)
         applyConfiguration(to: textView)
         context.coordinator.synchronizeFocus(for: textView)
     }
@@ -440,6 +441,21 @@ struct PairedTextEditor: NSViewRepresentable {
         textView.isSelectable = isEnabled
         textView.textContainerInset = textContainerInset
         textView.setAccessibilityPlaceholderValue(placeholder)
+    }
+
+    private func synchronizeLayout(of textView: PairedDelimiterTextView, in scrollView: NSScrollView) {
+        let viewport = scrollView.contentView.bounds.size
+        let width = max(viewport.width, scrollView.contentSize.width, textView.frame.width)
+        let height = max(viewport.height, scrollView.contentSize.height)
+        textView.minSize = NSSize(width: 0, height: height)
+        textView.textContainer?.containerSize = NSSize(
+            width: width,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.frame.size = NSSize(
+            width: width,
+            height: max(textView.frame.height, height)
+        )
     }
 
     private static func clamped(_ range: NSRange, in text: String) -> NSRange {

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -265,7 +265,7 @@ struct PairedTextField: NSViewRepresentable {
                   parent.isEnabled,
                   !textView.hasMarkedText(),
                   let replacementString,
-                  shouldApplyPairedDelimiterResolution(for: replacementString)
+                  shouldApplyPairedDelimiterResolution(for: replacementString, event: NSApp.currentEvent)
             else { return true }
 
             switch PairedDelimiterEditing.resolve(
@@ -331,17 +331,17 @@ struct PairedTextField: NSViewRepresentable {
             return insert()
         }
 
-        private func shouldApplyPairedDelimiterResolution(for replacementString: String) -> Bool {
+        func shouldApplyPairedDelimiterResolution(for replacementString: String, event: NSEvent?) -> Bool {
             if isApplyingKeyboardTextInput {
                 return true
             }
-            guard let event = NSApp.currentEvent, event.type == .keyDown else {
+            guard let event, event.type == .keyDown else {
                 return false
             }
 
-            let textInputModifiers: NSEvent.ModifierFlags = [.command, .control, .option]
-            return event.modifierFlags.intersection(textInputModifiers).isEmpty
-                && (event.charactersIgnoringModifiers ?? event.characters) == replacementString
+            let commandModifiers: NSEvent.ModifierFlags = [.command, .control]
+            return event.modifierFlags.intersection(commandModifiers).isEmpty
+                && event.characters == replacementString
         }
 
         private static let nativePasteSelectors: Set<Selector> = [

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -73,6 +73,7 @@ struct PairedTextField: NSViewRepresentable {
     var isBezeled: Bool
     var drawsBackground: Bool
     var bezelStyle: NSTextField.BezelStyle?
+    var focusRingType: NSFocusRingType
     var isFocused: Binding<Bool>?
     var onSubmit: (() -> Void)?
 
@@ -86,6 +87,7 @@ struct PairedTextField: NSViewRepresentable {
         isBezeled: Bool = false,
         drawsBackground: Bool = false,
         bezelStyle: NSTextField.BezelStyle? = nil,
+        focusRingType: NSFocusRingType = .default,
         isFocused: Binding<Bool>? = nil,
         onSubmit: (() -> Void)? = nil
     ) {
@@ -98,6 +100,7 @@ struct PairedTextField: NSViewRepresentable {
         self.isBezeled = isBezeled
         self.drawsBackground = drawsBackground
         self.bezelStyle = bezelStyle
+        self.focusRingType = focusRingType
         self.isFocused = isFocused
         self.onSubmit = onSubmit
     }
@@ -108,7 +111,6 @@ struct PairedTextField: NSViewRepresentable {
 
     func makeNSView(context: Context) -> PairedTextFieldBackingView {
         let field = PairedTextFieldBackingView()
-        field.focusRingType = .none
         field.usesSingleLineMode = true
         field.cell?.wraps = false
         field.cell?.isScrollable = true
@@ -148,6 +150,7 @@ struct PairedTextField: NSViewRepresentable {
         field.isBordered = isBordered
         field.isBezeled = isBezeled
         field.drawsBackground = drawsBackground
+        field.focusRingType = focusRingType
         if let bezelStyle {
             field.bezelStyle = bezelStyle
         }
@@ -346,6 +349,7 @@ struct PairedTextEditor: NSViewRepresentable {
     var isEnabled: Bool
     var isFocused: Binding<Bool>?
     var textContainerInset: NSSize
+    var placeholder: String?
 
     init(
         text: Binding<String>,
@@ -353,7 +357,8 @@ struct PairedTextEditor: NSViewRepresentable {
         textColor: NSColor = .labelColor,
         isEnabled: Bool = true,
         isFocused: Binding<Bool>? = nil,
-        textContainerInset: NSSize = .zero
+        textContainerInset: NSSize = .zero,
+        placeholder: String? = nil
     ) {
         _text = text
         self.font = font
@@ -361,6 +366,7 @@ struct PairedTextEditor: NSViewRepresentable {
         self.isEnabled = isEnabled
         self.isFocused = isFocused
         self.textContainerInset = textContainerInset
+        self.placeholder = placeholder
     }
 
     func makeCoordinator() -> Coordinator {
@@ -433,6 +439,7 @@ struct PairedTextEditor: NSViewRepresentable {
         textView.isEditable = isEnabled
         textView.isSelectable = isEnabled
         textView.textContainerInset = textContainerInset
+        textView.setAccessibilityPlaceholderValue(placeholder)
     }
 
     private static func clamped(_ range: NSRange, in text: String) -> NSRange {

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -201,6 +201,7 @@ struct PairedTextField: NSViewRepresentable {
     final class Coordinator: NSObject, NSTextFieldDelegate {
         var parent: PairedTextField
         private var isApplyingPairedEdit = false
+        private var isApplyingNativePaste = false
         private weak var observedUndoManager: UndoManager?
         private var undoObservers: [NSObjectProtocol] = []
 
@@ -233,6 +234,7 @@ struct PairedTextField: NSViewRepresentable {
             replacementString: String?
         ) -> Bool {
             guard !isApplyingPairedEdit,
+                  !isApplyingNativePaste,
                   parent.isEnabled,
                   !textView.hasMarkedText(),
                   let replacementString
@@ -282,6 +284,17 @@ struct PairedTextField: NSViewRepresentable {
             case .native:
                 return true
             }
+        }
+
+        func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            guard commandSelector == #selector(NSText.paste(_:)) else { return false }
+            isApplyingNativePaste = true
+            defer {
+                isApplyingNativePaste = false
+                updateText(textView.string)
+            }
+            textView.paste(nil)
+            return true
         }
 
         func synchronizeFocus(for field: NSTextField) {

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -69,6 +69,10 @@ struct PairedTextField: NSViewRepresentable {
     var font: NSFont
     var textColor: NSColor
     var isEnabled: Bool
+    var isBordered: Bool
+    var isBezeled: Bool
+    var drawsBackground: Bool
+    var bezelStyle: NSTextField.BezelStyle?
     var isFocused: Binding<Bool>?
     var onSubmit: (() -> Void)?
 
@@ -78,6 +82,10 @@ struct PairedTextField: NSViewRepresentable {
         font: NSFont = .systemFont(ofSize: NSFont.systemFontSize),
         textColor: NSColor = .labelColor,
         isEnabled: Bool = true,
+        isBordered: Bool = false,
+        isBezeled: Bool = false,
+        drawsBackground: Bool = false,
+        bezelStyle: NSTextField.BezelStyle? = nil,
         isFocused: Binding<Bool>? = nil,
         onSubmit: (() -> Void)? = nil
     ) {
@@ -86,6 +94,10 @@ struct PairedTextField: NSViewRepresentable {
         self.font = font
         self.textColor = textColor
         self.isEnabled = isEnabled
+        self.isBordered = isBordered
+        self.isBezeled = isBezeled
+        self.drawsBackground = drawsBackground
+        self.bezelStyle = bezelStyle
         self.isFocused = isFocused
         self.onSubmit = onSubmit
     }
@@ -96,9 +108,6 @@ struct PairedTextField: NSViewRepresentable {
 
     func makeNSView(context: Context) -> PairedTextFieldBackingView {
         let field = PairedTextFieldBackingView()
-        field.isBordered = false
-        field.isBezeled = false
-        field.drawsBackground = false
         field.focusRingType = .none
         field.usesSingleLineMode = true
         field.cell?.wraps = false
@@ -136,6 +145,12 @@ struct PairedTextField: NSViewRepresentable {
         field.placeholderString = placeholder
         field.font = font
         field.textColor = textColor
+        field.isBordered = isBordered
+        field.isBezeled = isBezeled
+        field.drawsBackground = drawsBackground
+        if let bezelStyle {
+            field.bezelStyle = bezelStyle
+        }
         field.isEnabled = isEnabled
         field.isEditable = isEnabled
         field.isSelectable = isEnabled

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -528,17 +528,29 @@ struct PairedTextEditor: NSViewRepresentable {
 
     private func synchronizeLayout(of textView: PairedDelimiterTextView, in scrollView: NSScrollView) {
         let viewport = scrollView.contentView.bounds.size
-        let width = max(viewport.width, scrollView.contentSize.width, textView.frame.width)
-        let height = max(viewport.height, scrollView.contentSize.height)
-        textView.minSize = NSSize(width: 0, height: height)
+        let width = max(viewport.width, scrollView.contentSize.width)
+        let viewportHeight = max(viewport.height, scrollView.contentSize.height)
         textView.textContainer?.containerSize = NSSize(
             width: width,
             height: CGFloat.greatestFiniteMagnitude
         )
+        let contentHeight = Self.laidOutContentHeight(of: textView)
+        let height = max(viewportHeight, contentHeight)
+        textView.minSize = NSSize(width: 0, height: height)
         textView.frame.size = NSSize(
             width: width,
-            height: max(textView.frame.height, height)
+            height: height
         )
+    }
+
+    private static func laidOutContentHeight(of textView: PairedDelimiterTextView) -> CGFloat {
+        guard let layoutManager = textView.layoutManager,
+              let textContainer = textView.textContainer
+        else { return 0 }
+
+        layoutManager.ensureLayout(for: textContainer)
+        let usedRect = layoutManager.usedRect(for: textContainer)
+        return ceil(usedRect.height + textView.textContainerInset.height * 2)
     }
 
     private static func clamped(_ range: NSRange, in text: String) -> NSRange {

--- a/Alas/Sources/UI/PairedDelimiterEditing.swift
+++ b/Alas/Sources/UI/PairedDelimiterEditing.swift
@@ -49,7 +49,11 @@ enum PairedDelimiterEditing {
     }
 
     private static func isValid(_ range: NSRange, in string: NSString) -> Bool {
-        range.location != NSNotFound && range.location <= string.length && range.length <= string.length - range.location
+        range.location != NSNotFound
+            && range.location >= 0
+            && range.length >= 0
+            && range.location <= string.length
+            && range.length <= string.length - range.location
     }
 
     private static func shouldInsertSymmetricPair(at location: Int, in string: NSString) -> Bool {

--- a/Alas/Sources/UI/PairedDelimiterEditing.swift
+++ b/Alas/Sources/UI/PairedDelimiterEditing.swift
@@ -64,7 +64,7 @@ enum PairedDelimiterEditing {
 
     private static func character(at location: Int, in string: NSString) -> Character? {
         guard location >= 0, location < string.length else { return nil }
-        return Character(string.substring(with: NSRange(location: location, length: 1)))
+        return Character(string.substring(with: string.rangeOfComposedCharacterSequence(at: location)))
     }
 
     private static func character(before location: Int, in string: NSString) -> Character? {

--- a/Alas/Sources/UI/PairedDelimiterEditing.swift
+++ b/Alas/Sources/UI/PairedDelimiterEditing.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+enum PairedDelimiterEditAction: Equatable {
+    case wrap(opening: Character, closing: Character)
+    case insertPair(opening: Character, closing: Character)
+    case stepOver
+    case native
+}
+
+enum PairedDelimiterEditing {
+    static let pairs: [Character: Character] = [
+        "(": ")", "[": "]", "{": "}", "\"": "\"", "'": "'", "`": "`",
+    ]
+
+    static func resolve(
+        insertedText: String,
+        in text: String,
+        selectedRange: NSRange
+    ) -> PairedDelimiterEditAction {
+        let nsString = text as NSString
+        guard isValid(selectedRange, in: nsString), insertedText.count == 1,
+              let insertedCharacter = insertedText.first else {
+            return .native
+        }
+
+        if let closing = pairs[insertedCharacter] {
+            if selectedRange.length > 0 {
+                return .wrap(opening: insertedCharacter, closing: closing)
+            }
+
+            if insertedCharacter == closing,
+               character(at: selectedRange.location, in: nsString) == insertedCharacter {
+                return .stepOver
+            }
+
+            if insertedCharacter != closing || shouldInsertSymmetricPair(at: selectedRange.location, in: nsString) {
+                return .insertPair(opening: insertedCharacter, closing: closing)
+            }
+
+            return .native
+        }
+
+        if pairs.values.contains(insertedCharacter), selectedRange.length == 0,
+           character(at: selectedRange.location, in: nsString) == insertedCharacter {
+            return .stepOver
+        }
+
+        return .native
+    }
+
+    private static func isValid(_ range: NSRange, in string: NSString) -> Bool {
+        range.location != NSNotFound && range.location <= string.length && range.length <= string.length - range.location
+    }
+
+    private static func shouldInsertSymmetricPair(at location: Int, in string: NSString) -> Bool {
+        !isEscapedByBackslash(at: location, in: string)
+            && !isIdentifierLike(character(before: location, in: string))
+            && !isIdentifierLike(character(at: location, in: string))
+    }
+
+    private static func character(at location: Int, in string: NSString) -> Character? {
+        guard location >= 0, location < string.length else { return nil }
+        return Character(string.substring(with: NSRange(location: location, length: 1)))
+    }
+
+    private static func character(before location: Int, in string: NSString) -> Character? {
+        guard location > 0, location <= string.length else { return nil }
+        return character(at: location - 1, in: string)
+    }
+
+    private static func isIdentifierLike(_ character: Character?) -> Bool {
+        guard let character else { return false }
+        return character.isLetter || character.isNumber || character == "_"
+    }
+
+    private static func isEscapedByBackslash(at location: Int, in string: NSString) -> Bool {
+        var cursor = location
+        var backslashCount = 0
+        while character(before: cursor, in: string) == "\\" {
+            backslashCount += 1
+            cursor -= 1
+        }
+        return backslashCount % 2 == 1
+    }
+}

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -548,6 +548,17 @@ struct ACPComposerDraftBridgeTests {
         #expect(typingFont.pointSize == 13)
     }
 
+    @Test("plain paste insertion bypasses single delimiter pairing")
+    func plainPasteInsertionBypassesSingleDelimiterPairing() {
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 40))
+
+        let inserted = textView.insertPlainText("(")
+
+        #expect(inserted)
+        #expect(textView.string == "(")
+        #expect(textView.selectedRange() == NSRange(location: 1, length: 0))
+    }
+
     @Test("plain paste insertion replaces selected text with normalized styling")
     func plainPasteInsertionReplacesSelectionWithNormalizedStyling() throws {
         let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 40))

--- a/AlasTests/ACP/UI/ACPComposerPairedDelimiterTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerPairedDelimiterTests.swift
@@ -1,0 +1,64 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@Suite("ACP composer paired delimiters")
+@MainActor
+struct ACPComposerPairedDelimiterTests {
+    @Test("backticks wrap selected styled text without losing attributes")
+    func backticksWrapStyledSelection() throws {
+        let customAttribute = NSAttributedString.Key("alas.tests.customStyle")
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 120))
+        textView.textStorage?.setAttributedString(NSAttributedString(
+            string: "value",
+            attributes: [customAttribute: "keep-me"]
+        ))
+        textView.setSelectedRange(NSRange(location: 0, length: 5))
+
+        textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "`value`")
+        let storage = try #require(textView.textStorage)
+        #expect(storage.attribute(customAttribute, at: 1, effectiveRange: nil) as? String == "keep-me")
+        #expect(textView.selectedRange() == NSRange(location: 1, length: 5))
+    }
+
+    @Test("backticks wrap a mention attachment without losing its URI")
+    func backticksWrapMentionAttachment() throws {
+        let uri = "file:///tmp/File.swift"
+        let attachment = NSMutableAttributedString(attachment: NSTextAttachment())
+        attachment.addAttribute(.attachmentURI, value: uri, range: NSRange(location: 0, length: 1))
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 120))
+        textView.textStorage?.setAttributedString(attachment)
+        textView.setSelectedRange(NSRange(location: 0, length: 1))
+
+        textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "`\u{fffc}`")
+        let storage = try #require(textView.textStorage)
+        #expect(storage.attribute(.attachmentURI, at: 1, effectiveRange: nil) as? String == uri)
+        #expect(textView.selectedRange() == NSRange(location: 1, length: 1))
+    }
+
+    @Test("opening delimiter inserts an empty pair")
+    func openingDelimiterInsertsEmptyPair() {
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 120))
+
+        textView.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "()")
+        #expect(textView.selectedRange() == NSRange(location: 1, length: 0))
+    }
+
+    @Test("typing an existing closer steps over it")
+    func existingCloserStepsOver() {
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 120))
+        textView.string = "()"
+        textView.setSelectedRange(NSRange(location: 1, length: 0))
+
+        textView.insertText(")", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "()")
+        #expect(textView.selectedRange() == NSRange(location: 2, length: 0))
+    }
+}

--- a/AlasTests/ACP/UI/ACPComposerPairedDelimiterTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerPairedDelimiterTests.swift
@@ -15,7 +15,9 @@ struct ACPComposerPairedDelimiterTests {
         ))
         textView.setSelectedRange(NSRange(location: 0, length: 5))
 
-        textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        textView.performKeyboardTextInsertion {
+            textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
 
         #expect(textView.string == "`value`")
         let storage = try #require(textView.textStorage)
@@ -32,7 +34,9 @@ struct ACPComposerPairedDelimiterTests {
         textView.textStorage?.setAttributedString(attachment)
         textView.setSelectedRange(NSRange(location: 0, length: 1))
 
-        textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        textView.performKeyboardTextInsertion {
+            textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
 
         #expect(textView.string == "`\u{fffc}`")
         let storage = try #require(textView.textStorage)
@@ -44,7 +48,9 @@ struct ACPComposerPairedDelimiterTests {
     func openingDelimiterInsertsEmptyPair() {
         let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 120))
 
-        textView.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
+        textView.performKeyboardTextInsertion {
+            textView.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
 
         #expect(textView.string == "()")
         #expect(textView.selectedRange() == NSRange(location: 1, length: 0))
@@ -56,7 +62,9 @@ struct ACPComposerPairedDelimiterTests {
         textView.string = "()"
         textView.setSelectedRange(NSRange(location: 1, length: 0))
 
-        textView.insertText(")", replacementRange: NSRange(location: NSNotFound, length: 0))
+        textView.performKeyboardTextInsertion {
+            textView.insertText(")", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
 
         #expect(textView.string == "()")
         #expect(textView.selectedRange() == NSRange(location: 2, length: 0))

--- a/AlasTests/CodeTextViewAutoPairTests.swift
+++ b/AlasTests/CodeTextViewAutoPairTests.swift
@@ -93,6 +93,15 @@ struct CodeTextViewAutoPairTests {
         #expect(textView.selectedRange() == NSRange(location: 2, length: 0))
     }
 
+    @Test func evenlyEscapedQuoteInsertsPair() {
+        let textView = makeTextView("\\\\")
+
+        textView.insertText("\"", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "\\\\\"\"")
+        #expect(textView.selectedRange() == NSRange(location: 3, length: 0))
+    }
+
     @Test func multiCharacterInsertionFallsBackToNormalTextInsertion() {
         let textView = makeTextView()
 

--- a/AlasTests/CommitMessageEditorViewTests.swift
+++ b/AlasTests/CommitMessageEditorViewTests.swift
@@ -91,17 +91,21 @@ struct CommitMessageEditorViewTests {
         let subjectEditor = try #require(window.fieldEditor(false, for: subject) as? NSTextView)
         let coordinator = try #require(subject.delegate as? PairedTextField.Coordinator)
         subjectEditor.setSelectedRange(NSRange(location: 0, length: 7))
-        #expect(!coordinator.control(
-            subject,
-            textView: subjectEditor,
-            shouldChangeCharactersIn: NSRange(location: 0, length: 7),
-            replacementString: "`")
-        )
+        #expect(!coordinator.performKeyboardTextInsertion {
+            coordinator.control(
+                subject,
+                textView: subjectEditor,
+                shouldChangeCharactersIn: NSRange(location: 0, length: 7),
+                replacementString: "`"
+            )
+        })
         #expect(model.subject == "`subject`")
 
         let body = try #require(firstSubview(of: PairedDelimiterTextView.self, in: controller.view))
         body.setSelectedRange(NSRange(location: 0, length: 4))
-        body.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        body.performKeyboardTextInsertion {
+            body.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
         #expect(model.body == "`body`")
 
         window.orderOut(nil)

--- a/AlasTests/CommitMessageEditorViewTests.swift
+++ b/AlasTests/CommitMessageEditorViewTests.swift
@@ -79,4 +79,89 @@ struct CommitMessageEditorViewTests {
         controller.view.layoutSubtreeIfNeeded()
         #expect(controller.view != nil)
     }
+
+    @Test func pairedSubjectAndBodyWrapSelectedText() async throws {
+        let model = CommitComposerModel(subject: "subject", body: "body")
+        let controller = NSHostingController(rootView: CommitComposerHarness(model: model, theme: currentTheme()))
+        let window = attach(controller)
+        await drain(controller.view)
+
+        let subject = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
+        #expect(window.makeFirstResponder(subject))
+        let subjectEditor = try #require(window.fieldEditor(false, for: subject) as? NSTextView)
+        let coordinator = try #require(subject.delegate as? PairedTextField.Coordinator)
+        subjectEditor.setSelectedRange(NSRange(location: 0, length: 7))
+        #expect(!coordinator.control(
+            subject,
+            textView: subjectEditor,
+            shouldChangeCharactersIn: NSRange(location: 0, length: 7),
+            replacementString: "`")
+        )
+        #expect(model.subject == "`subject`")
+
+        let body = try #require(firstSubview(of: PairedDelimiterTextView.self, in: controller.view))
+        body.setSelectedRange(NSRange(location: 0, length: 4))
+        body.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(model.body == "`body`")
+
+        window.orderOut(nil)
+    }
+
+    private func attach<Content: View>(_ controller: NSHostingController<Content>) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 240),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentViewController = controller
+        window.makeKeyAndOrderFront(nil)
+        return window
+    }
+
+    private func drain(_ view: NSView) async {
+        view.layoutSubtreeIfNeeded()
+        await Task.yield()
+        view.layoutSubtreeIfNeeded()
+    }
+
+    private func firstSubview<T: NSView>(of type: T.Type, in view: NSView) -> T? {
+        if let match = view as? T { return match }
+        for subview in view.subviews {
+            if let match = firstSubview(of: type, in: subview) { return match }
+        }
+        return nil
+    }
+}
+
+@MainActor
+private final class CommitComposerModel: ObservableObject {
+    @Published var subject: String
+    @Published var body: String
+
+    init(subject: String, body: String) {
+        self.subject = subject
+        self.body = body
+    }
+}
+
+@MainActor
+private struct CommitComposerHarness: View {
+    @ObservedObject var model: CommitComposerModel
+    let theme: Theme
+
+    var body: some View {
+        CommitMessageEditorView(
+            subject: $model.subject,
+            bodyText: $model.body,
+            aiToolId: .constant(""),
+            title: "Edit abc1234",
+            busy: false,
+            error: nil,
+            availableAgents: [],
+            onGenerate: {},
+            primaryAction: CommitPrimaryAction(label: "Save", isEnabled: true, handler: {})
+        )
+        .environment(\.theme, theme)
+    }
 }

--- a/AlasTests/PairedAuthoredContentSurfaceTests.swift
+++ b/AlasTests/PairedAuthoredContentSurfaceTests.swift
@@ -115,7 +115,13 @@ struct PairedAuthoredContentSurfaceTests {
 
     private func wrapSelection(in textView: NSTextView) {
         textView.setSelectedRange(NSRange(location: 0, length: textView.string.utf16.count))
-        textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        if let pairedTextView = textView as? PairedDelimiterTextView {
+            pairedTextView.performKeyboardTextInsertion {
+                pairedTextView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+            }
+        } else {
+            textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
     }
 }
 

--- a/AlasTests/PairedAuthoredContentSurfaceTests.swift
+++ b/AlasTests/PairedAuthoredContentSurfaceTests.swift
@@ -1,0 +1,179 @@
+import AppKit
+import Combine
+import SwiftUI
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct PairedAuthoredContentSurfaceTests {
+    @Test func missionSourceBodyBindingWrapsSelectedCommand() async throws {
+        let model = EditMissionSourceDialogModel(source: missionSource(body: "mission command")) { _, _ in true }
+        let controller = NSHostingController(rootView: EditMissionSourceDialog(
+            presented: .constant(true),
+            model: model,
+            sourceURL: URL(string: "https://example.com/issues/42")!
+        )
+        .environment(\.theme, try! ThemeStore().current))
+        let window = attach(controller)
+        await drain(controller.view)
+
+        wrapSelection(in: try #require(textView(containing: "mission command", in: controller.view)))
+
+        #expect(model.body == "`mission command`")
+        window.orderOut(nil)
+    }
+
+    @Test func promptEditorDraftBindingWrapsSelectedCommand() async throws {
+        let model = PromptDraftCapture(text: "prompt command")
+        let controller = NSHostingController(rootView: PromptEditorHarness(model: model))
+        let window = attach(controller)
+        await drain(controller.view)
+
+        wrapSelection(in: try #require(textView(containing: "prompt command", in: controller.view)))
+
+        #expect(model.text == "`prompt command`")
+        window.orderOut(nil)
+    }
+
+    @Test func terminalStartupScriptBindingWrapsSelectedCommand() async throws {
+        let state = AppState(store: MemoryStore())
+        state.config.terminal.startupScript = "terminal command"
+        let controller = NSHostingController(rootView: TerminalPane(state: state)
+            .environment(\.theme, try! ThemeStore().current))
+        let window = attach(controller, height: 620)
+        await drain(controller.view)
+
+        wrapSelection(in: try #require(textView(containing: "terminal command", in: controller.view)))
+
+        #expect(state.config.terminal.startupScript == "`terminal command`")
+        window.orderOut(nil)
+    }
+
+    @Test func projectStartupScriptBindingWrapsSelectedCommandBeforeSave() async throws {
+        let model = ProjectStartupScriptCapture(text: "project command")
+        let controller = NSHostingController(rootView: ProjectStartupScriptHarness(model: model))
+        let window = attach(controller)
+        await drain(controller.view)
+
+        wrapSelection(in: try #require(textView(containing: "project command", in: controller.view)))
+
+        #expect(model.text == "`project command`")
+        window.orderOut(nil)
+    }
+
+    private func missionSource(body: String) -> MissionSourceSnapshot {
+        MissionSourceSnapshot(
+            identity: MissionSourceIdentity(providerID: .manual, stableID: "manual:42"),
+            canonicalURL: URL(string: "https://example.com/issues/42")!,
+            providerLabel: "Manual",
+            displayReference: nil,
+            repositoryLocator: nil,
+            title: "Mission source",
+            body: body,
+            state: .open,
+            labels: [],
+            assignees: [],
+            providerUpdatedAt: nil,
+            capturedAt: .now,
+            refreshError: nil,
+            contentOrigin: .manual,
+            isEditable: true,
+            isRefreshable: false
+        )
+    }
+
+    private func attach<Content: View>(
+        _ controller: NSHostingController<Content>,
+        height: CGFloat = 320
+    ) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 760, height: height),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentViewController = controller
+        window.makeKeyAndOrderFront(nil)
+        return window
+    }
+
+    private func drain(_ view: NSView) async {
+        for _ in 0..<6 {
+            view.layoutSubtreeIfNeeded()
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.001))
+            await Task.yield()
+        }
+    }
+
+    private func textView(containing text: String, in view: NSView) -> NSTextView? {
+        if let textView = view as? NSTextView, textView.string == text {
+            return textView
+        }
+        return view.subviews.lazy.compactMap { textView(containing: text, in: $0) }.first
+    }
+
+    private func wrapSelection(in textView: NSTextView) {
+        textView.setSelectedRange(NSRange(location: 0, length: textView.string.utf16.count))
+        textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+    }
+}
+
+@MainActor
+private final class PromptDraftCapture: ObservableObject {
+    @Published var text: String
+
+    init(text: String) {
+        self.text = text
+    }
+}
+
+@MainActor
+private struct PromptEditorHarness: View {
+    @ObservedObject var model: PromptDraftCapture
+
+    var body: some View {
+        PromptEditorBody(
+            windowTitle: "Prompt",
+            title: "Prompt title",
+            description: "Prompt description",
+            draftPrompt: $model.text,
+            onReset: {},
+            onCancel: {},
+            onSave: {},
+            theme: try! ThemeStore().current
+        )
+    }
+}
+
+@MainActor
+private final class ProjectStartupScriptCapture: ObservableObject {
+    @Published var text: String
+
+    init(text: String) {
+        self.text = text
+    }
+}
+
+@MainActor
+private struct ProjectStartupScriptHarness: View {
+    @ObservedObject var model: ProjectStartupScriptCapture
+
+    var body: some View {
+        ProjectStartupScriptEditor(text: $model.text, minHeight: 60)
+            .environment(\.theme, try! ThemeStore().current)
+    }
+}
+
+private struct MemoryStore: PersistenceStoreProtocol {
+    var projectsFile: ProjectsFile? = nil
+
+    func write<T: Encodable>(_: T, to _: URL) throws {}
+
+    func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? {
+        if T.self == ProjectsFile.self {
+            return projectsFile as? T
+        }
+        return nil
+    }
+}

--- a/AlasTests/PairedComposerTextControlsTests.swift
+++ b/AlasTests/PairedComposerTextControlsTests.swift
@@ -312,6 +312,29 @@ struct PairedComposerTextControlsTests {
         await dismantle(model: model, controller: controller, window: window)
     }
 
+    @Test func textEditorEmptyDocumentShrinksWithViewport() async throws {
+        let model = ComposerControlModel(text: "", isFocused: false)
+        model.editorHeight = 220
+        let controller = NSHostingController(rootView: PairedTextEditorHarness(model: model))
+        let window = attach(controller, size: NSSize(width: 360, height: 300))
+        await drain(controller.view)
+
+        let textView = try #require(firstSubview(of: PairedDelimiterTextView.self, in: controller.view))
+        let scrollView = try #require(textView.enclosingScrollView)
+        let tallDocumentHeight = textView.frame.height
+        #expect(tallDocumentHeight >= scrollView.contentView.bounds.height)
+
+        model.editorHeight = 48
+        await drain(controller.view)
+
+        let shrunkenViewportHeight = scrollView.contentView.bounds.height
+        #expect(shrunkenViewportHeight < tallDocumentHeight)
+        #expect(textView.frame.height <= shrunkenViewportHeight + 1)
+        #expect(textView.frame.height >= shrunkenViewportHeight)
+
+        await dismantle(model: model, controller: controller, window: window)
+    }
+
     @Test func textFieldUpdatesExternalConfigurationAndDisabledState() async throws {
         let model = ComposerControlModel(text: "initial", isFocused: false)
         let controller = NSHostingController(rootView: PairedTextFieldHarness(model: model, onSubmit: {}))
@@ -461,6 +484,7 @@ private final class ComposerControlModel: ObservableObject {
     @Published var fontSize: CGFloat = 13
     @Published var textColor = NSColor.labelColor
     @Published var isPresented = true
+    @Published var editorHeight: CGFloat = 100
 
     init(text: String, isFocused: Bool) {
         self.text = text
@@ -507,7 +531,7 @@ private struct PairedTextEditorHarness: View {
                     isFocused: $model.isFocused,
                     textContainerInset: NSSize(width: 7, height: 9)
                 )
-                .frame(height: 100)
+                .frame(height: model.editorHeight)
             }
             ComposerFocusSinkRepresentable()
         }

--- a/AlasTests/PairedComposerTextControlsTests.swift
+++ b/AlasTests/PairedComposerTextControlsTests.swift
@@ -143,6 +143,10 @@ struct PairedComposerTextControlsTests {
         await drain(controller.view)
 
         let textView = try #require(firstSubview(of: PairedDelimiterTextView.self, in: controller.view))
+        let scrollView = try #require(textView.enclosingScrollView)
+        #expect(textView.minSize.height >= scrollView.contentView.bounds.height)
+        #expect(textView.frame.height >= scrollView.contentView.bounds.height)
+
         textView.setSelectedRange(NSRange(location: 5, length: 0))
         textView.insertText("{", replacementRange: NSRange(location: NSNotFound, length: 0))
 

--- a/AlasTests/PairedComposerTextControlsTests.swift
+++ b/AlasTests/PairedComposerTextControlsTests.swift
@@ -1,0 +1,311 @@
+import AppKit
+import Combine
+import SwiftUI
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct PairedComposerTextControlsTests {
+    @Test func wrapsPlainSelectionAndKeepsItSelected() {
+        let textView = makePairedTextView(text: "value")
+        textView.setSelectedRange(NSRange(location: 0, length: 5))
+
+        textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "`value`")
+        #expect(textView.selectedRange() == NSRange(location: 1, length: 5))
+    }
+
+    @Test func wrappingPreservesAttributedSelection() {
+        let storage = NSTextStorage(attributedString: NSAttributedString(
+            string: "value",
+            attributes: [.toolTip: "keep-me"]
+        ))
+        let textView = makePairedTextView(storage: storage)
+        textView.setSelectedRange(NSRange(location: 0, length: 5))
+
+        textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "`value`")
+        #expect(textView.textStorage?.attribute(.toolTip, at: 1, effectiveRange: nil) as? String == "keep-me")
+        #expect(textView.selectedRange() == NSRange(location: 1, length: 5))
+    }
+
+    @Test func insertsEmptyPairAndStepsOverCloser() {
+        let textView = makePairedTextView()
+
+        textView.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "()")
+        #expect(textView.selectedRange() == NSRange(location: 1, length: 0))
+
+        textView.insertText(")", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "()")
+        #expect(textView.selectedRange() == NSRange(location: 2, length: 0))
+    }
+
+    @Test func multiCharacterAndMarkedTextUseNativeInsertion() {
+        let pastedTextView = makePairedTextView()
+
+        pastedTextView.insertText("paste", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(pastedTextView.string == "paste")
+
+        let markedTextView = makePairedTextView()
+        markedTextView.setMarkedText(
+            "candidate",
+            selectedRange: NSRange(location: 9, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        #expect(markedTextView.hasMarkedText())
+
+        markedTextView.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(markedTextView.string == "(")
+    }
+
+    @Test func pairedInsertionIsOneUndoableEdit() {
+        let textView = makePairedTextView(text: "value")
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 120),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = textView
+        #expect(window.makeFirstResponder(textView))
+        textView.allowsUndo = true
+        textView.setSelectedRange(NSRange(location: 0, length: 5))
+
+        textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "`value`")
+        #expect(textView.undoManager?.canUndo == true)
+        textView.undoManager?.undo()
+        #expect(textView.string == "value")
+    }
+
+    @Test func textFieldSynchronizesBindingFocusAndSubmit() async throws {
+        let model = ComposerControlModel(text: "value", isFocused: true)
+        var submitCount = 0
+        let controller = NSHostingController(rootView: PairedTextFieldHarness(model: model) {
+            submitCount += 1
+        })
+        let window = attach(controller, size: NSSize(width: 360, height: 120))
+        defer { ComposerControlRetainer.retain(window, controller) }
+        await drain(controller.view)
+
+        let field = try #require(firstSubview(of: NSTextField.self, in: controller.view))
+        let editor = try #require(window.fieldEditor(false, for: field) as? NSTextView)
+        let coordinator = try #require(field.delegate as? PairedTextField.Coordinator)
+        #expect(window.firstResponder === editor)
+        editor.setSelectedRange(NSRange(location: 0, length: 5))
+
+        let shouldUseNativeInsertion = coordinator.control(
+            field,
+            textView: editor,
+            shouldChangeCharactersIn: NSRange(location: 0, length: 5),
+            replacementString: "`"
+        )
+
+        #expect(shouldUseNativeInsertion == false)
+        #expect(field.stringValue == "`value`")
+        #expect(model.text == "`value`")
+        #expect(editor.selectedRange() == NSRange(location: 1, length: 5))
+
+        field.sendAction(field.action, to: field.target)
+        #expect(submitCount == 1)
+
+        let sink = try #require(firstSubview(of: ComposerFocusSink.self, in: controller.view))
+        #expect(window.makeFirstResponder(sink))
+        await drain(controller.view)
+        #expect(model.isFocused == false)
+
+        model.isFocused = true
+        await drain(controller.view)
+        #expect(window.firstResponder === window.fieldEditor(false, for: field))
+    }
+
+    @Test func textEditorSynchronizesExternalConfigurationAndDisabledState() async throws {
+        let model = ComposerControlModel(text: "start", isFocused: false)
+        let controller = NSHostingController(rootView: PairedTextEditorHarness(model: model))
+        let window = attach(controller, size: NSSize(width: 360, height: 180))
+        defer { ComposerControlRetainer.retain(window, controller) }
+        await drain(controller.view)
+
+        let textView = try #require(firstSubview(of: PairedDelimiterTextView.self, in: controller.view))
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+        textView.insertText("{", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(model.text == "start{}")
+        #expect(textView.textContainerInset == NSSize(width: 7, height: 9))
+
+        model.text = "external"
+        model.fontSize = 16
+        model.textColor = .systemRed
+        model.isEnabled = false
+        await drain(controller.view)
+
+        #expect(textView.string == "external")
+        #expect(textView.font?.pointSize == 16)
+        #expect(textView.textColor == .systemRed)
+        #expect(textView.isEditable == false)
+        #expect(textView.isSelectable == false)
+
+        model.isEnabled = true
+        model.isFocused = true
+        await drain(controller.view)
+        #expect(window.firstResponder === textView)
+
+        let sink = try #require(firstSubview(of: ComposerFocusSink.self, in: controller.view))
+        #expect(window.makeFirstResponder(sink))
+        await drain(controller.view)
+        #expect(model.isFocused == false)
+    }
+
+    @Test func textFieldUpdatesExternalConfigurationAndDisabledState() async throws {
+        let model = ComposerControlModel(text: "initial", isFocused: false)
+        let controller = NSHostingController(rootView: PairedTextFieldHarness(model: model, onSubmit: {}))
+        let window = attach(controller, size: NSSize(width: 360, height: 120))
+        defer { ComposerControlRetainer.retain(window, controller) }
+        await drain(controller.view)
+
+        let field = try #require(firstSubview(of: NSTextField.self, in: controller.view))
+        #expect(field.placeholderString == "Compose")
+
+        model.text = "external"
+        model.fontSize = 16
+        model.textColor = .systemBlue
+        model.isEnabled = false
+        await drain(controller.view)
+
+        #expect(field.stringValue == "external")
+        #expect(field.font?.pointSize == 16)
+        #expect(field.textColor == .systemBlue)
+        #expect(field.isEnabled == false)
+    }
+
+    private func makePairedTextView(text: String = "") -> PairedDelimiterTextView {
+        makePairedTextView(storage: NSTextStorage(string: text))
+    }
+
+    private func makePairedTextView(storage: NSTextStorage) -> PairedDelimiterTextView {
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(width: 320, height: 120))
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+        let textView = PairedDelimiterTextView(
+            frame: NSRect(x: 0, y: 0, width: 320, height: 120),
+            textContainer: container
+        )
+        textView.setSelectedRange(NSRange(location: (textView.string as NSString).length, length: 0))
+        return textView
+    }
+
+    private func attach<Content: View>(
+        _ controller: NSHostingController<Content>,
+        size: NSSize
+    ) -> NSWindow {
+        let frame = NSRect(origin: .zero, size: size)
+        let window = NSWindow(contentRect: frame, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentViewController = controller
+        controller.view.frame = frame
+        controller.view.layoutSubtreeIfNeeded()
+        return window
+    }
+
+    private func drain(_ view: NSView) async {
+        for _ in 0..<6 {
+            view.layoutSubtreeIfNeeded()
+            try? await Task.sleep(nanoseconds: 1_000_000)
+            await Task.yield()
+        }
+    }
+
+    private func firstSubview<T: NSView>(of type: T.Type, in view: NSView) -> T? {
+        if let match = view as? T { return match }
+        for subview in view.subviews {
+            if let match = firstSubview(of: type, in: subview) { return match }
+        }
+        return nil
+    }
+}
+
+@MainActor
+private final class ComposerControlRetainer {
+    private static var retainedObjects: [AnyObject] = []
+
+    static func retain(_ objects: AnyObject...) {
+        retainedObjects.append(contentsOf: objects)
+    }
+}
+
+@MainActor
+private final class ComposerControlModel: ObservableObject {
+    @Published var text: String
+    @Published var isFocused: Bool
+    @Published var isEnabled = true
+    @Published var fontSize: CGFloat = 13
+    @Published var textColor = NSColor.labelColor
+
+    init(text: String, isFocused: Bool) {
+        self.text = text
+        self.isFocused = isFocused
+    }
+}
+
+@MainActor
+private struct PairedTextFieldHarness: View {
+    @ObservedObject var model: ComposerControlModel
+    let onSubmit: () -> Void
+
+    var body: some View {
+        VStack {
+            PairedTextField(
+                text: $model.text,
+                placeholder: "Compose",
+                font: .systemFont(ofSize: model.fontSize),
+                textColor: model.textColor,
+                isEnabled: model.isEnabled,
+                isFocused: $model.isFocused,
+                onSubmit: onSubmit
+            )
+            .frame(height: 28)
+            ComposerFocusSinkRepresentable()
+        }
+    }
+}
+
+@MainActor
+private struct PairedTextEditorHarness: View {
+    @ObservedObject var model: ComposerControlModel
+
+    var body: some View {
+        VStack {
+            PairedTextEditor(
+                text: $model.text,
+                font: .systemFont(ofSize: model.fontSize),
+                textColor: model.textColor,
+                isEnabled: model.isEnabled,
+                isFocused: $model.isFocused,
+                textContainerInset: NSSize(width: 7, height: 9)
+            )
+            .frame(height: 100)
+            ComposerFocusSinkRepresentable()
+        }
+    }
+}
+
+private struct ComposerFocusSinkRepresentable: NSViewRepresentable {
+    func makeNSView(context: Context) -> ComposerFocusSink {
+        ComposerFocusSink(frame: NSRect(x: 0, y: 0, width: 20, height: 20))
+    }
+
+    func updateNSView(_ nsView: ComposerFocusSink, context: Context) {}
+}
+
+private final class ComposerFocusSink: NSView {
+    override var acceptsFirstResponder: Bool { true }
+}

--- a/AlasTests/PairedComposerTextControlsTests.swift
+++ b/AlasTests/PairedComposerTextControlsTests.swift
@@ -66,6 +66,23 @@ struct PairedComposerTextControlsTests {
         #expect(markedTextView.string == "(")
     }
 
+    @Test func nativeTextInsertionBypassesSingleDelimiterPairing() {
+        let emptyInsertion = makePairedTextView()
+        emptyInsertion.performNativeTextInsertion {
+            emptyInsertion.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+        #expect(emptyInsertion.string == "(")
+        #expect(emptyInsertion.selectedRange() == NSRange(location: 1, length: 0))
+
+        let selectedInsertion = makePairedTextView(text: "value")
+        selectedInsertion.setSelectedRange(NSRange(location: 0, length: 5))
+        selectedInsertion.performNativeTextInsertion {
+            selectedInsertion.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+        #expect(selectedInsertion.string == "`")
+        #expect(selectedInsertion.selectedRange() == NSRange(location: 1, length: 0))
+    }
+
     @Test func pairedInsertionIsOneUndoableEdit() {
         let textView = makePairedTextView(text: "value")
         let window = NSWindow(

--- a/AlasTests/PairedComposerTextControlsTests.swift
+++ b/AlasTests/PairedComposerTextControlsTests.swift
@@ -81,6 +81,14 @@ struct PairedComposerTextControlsTests {
         }
         #expect(selectedInsertion.string == "`")
         #expect(selectedInsertion.selectedRange() == NSRange(location: 1, length: 0))
+
+        let pasteAndMatchStyleInsertion = makePairedTextView()
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString("(", forType: .string)
+        defer { NSPasteboard.general.clearContents() }
+        pasteAndMatchStyleInsertion.pasteAsPlainText(nil)
+        #expect(pasteAndMatchStyleInsertion.string == "(")
+        #expect(pasteAndMatchStyleInsertion.selectedRange() == NSRange(location: 1, length: 0))
     }
 
     @Test func pairedInsertionIsOneUndoableEdit() {
@@ -174,6 +182,32 @@ struct PairedComposerTextControlsTests {
         ))
 
         #expect(coordinator.control(field, textView: editor, doCommandBy: #selector(NSText.paste(_:))))
+
+        #expect(field.stringValue == "(")
+        #expect(model.text == "(")
+        #expect(editor.selectedRange() == NSRange(location: 1, length: 0))
+
+        await dismantle(model: model, controller: controller, window: window)
+    }
+
+    @Test func textFieldPasteAndMatchStyleBypassesSingleDelimiterPairing() async throws {
+        let model = ComposerControlModel(text: "", isFocused: true)
+        let controller = NSHostingController(rootView: PairedTextFieldHarness(model: model, onSubmit: {}))
+        let window = attach(controller, size: NSSize(width: 360, height: 120))
+        await drain(controller.view)
+
+        let field = try #require(firstSubview(of: NSTextField.self, in: controller.view))
+        let editor = try #require(window.fieldEditor(false, for: field) as? NSTextView)
+        let coordinator = try #require(field.delegate as? PairedTextField.Coordinator)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString("(", forType: .string)
+        defer { NSPasteboard.general.clearContents() }
+
+        #expect(coordinator.control(
+            field,
+            textView: editor,
+            doCommandBy: #selector(NSTextView.pasteAsPlainText(_:))
+        ))
 
         #expect(field.stringValue == "(")
         #expect(model.text == "(")

--- a/AlasTests/PairedComposerTextControlsTests.swift
+++ b/AlasTests/PairedComposerTextControlsTests.swift
@@ -242,6 +242,27 @@ struct PairedComposerTextControlsTests {
         await dismantle(model: model, controller: controller, window: window)
     }
 
+    @Test func textFieldOptionGeneratedDelimiterUsesKeyboardPairing() async throws {
+        let model = ComposerControlModel(text: "", isFocused: true)
+        let controller = NSHostingController(rootView: PairedTextFieldHarness(model: model, onSubmit: {}))
+        let window = attach(controller, size: NSSize(width: 360, height: 120))
+        await drain(controller.view)
+
+        let field = try #require(firstSubview(of: NSTextField.self, in: controller.view))
+        let coordinator = try #require(field.delegate as? PairedTextField.Coordinator)
+
+        #expect(coordinator.shouldApplyPairedDelimiterResolution(
+            for: "{",
+            event: try keyEvent(characters: "{", modifiers: .option)
+        ))
+        #expect(!coordinator.shouldApplyPairedDelimiterResolution(
+            for: "{",
+            event: try keyEvent(characters: "{", modifiers: [.command, .option])
+        ))
+
+        await dismantle(model: model, controller: controller, window: window)
+    }
+
     @Test func textFieldPasteAndMatchStyleBypassesSingleDelimiterPairing() async throws {
         let model = ComposerControlModel(text: "", isFocused: true)
         let controller = NSHostingController(rootView: PairedTextFieldHarness(model: model, onSubmit: {}))
@@ -473,6 +494,21 @@ struct PairedComposerTextControlsTests {
         var matches = view.subviews.compactMap { $0 as? T }
         matches.append(contentsOf: view.subviews.flatMap { subviews(of: type, in: $0) })
         return matches
+    }
+
+    private func keyEvent(characters: String, modifiers: NSEvent.ModifierFlags) throws -> NSEvent {
+        try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: 0
+        ))
     }
 }
 

--- a/AlasTests/PairedComposerTextControlsTests.swift
+++ b/AlasTests/PairedComposerTextControlsTests.swift
@@ -153,6 +153,28 @@ struct PairedComposerTextControlsTests {
         await dismantle(model: model, controller: controller, window: window)
     }
 
+    @Test func textFieldPasteBypassesSingleDelimiterPairing() async throws {
+        let model = ComposerControlModel(text: "", isFocused: true)
+        let controller = NSHostingController(rootView: PairedTextFieldHarness(model: model, onSubmit: {}))
+        let window = attach(controller, size: NSSize(width: 360, height: 120))
+        await drain(controller.view)
+
+        let field = try #require(firstSubview(of: NSTextField.self, in: controller.view))
+        let editor = try #require(window.fieldEditor(false, for: field) as? NSTextView)
+        let coordinator = try #require(field.delegate as? PairedTextField.Coordinator)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString("(", forType: .string)
+        defer { NSPasteboard.general.clearContents() }
+
+        #expect(coordinator.control(field, textView: editor, doCommandBy: #selector(NSText.paste(_:))))
+
+        #expect(field.stringValue == "(")
+        #expect(model.text == "(")
+        #expect(editor.selectedRange() == NSRange(location: 1, length: 0))
+
+        await dismantle(model: model, controller: controller, window: window)
+    }
+
     @Test func textEditorSynchronizesExternalConfigurationAndDisabledState() async throws {
         let model = ComposerControlModel(text: "start", isFocused: false)
         let controller = NSHostingController(rootView: PairedTextEditorHarness(model: model))

--- a/AlasTests/PairedComposerTextControlsTests.swift
+++ b/AlasTests/PairedComposerTextControlsTests.swift
@@ -94,7 +94,6 @@ struct PairedComposerTextControlsTests {
             submitCount += 1
         })
         let window = attach(controller, size: NSSize(width: 360, height: 120))
-        defer { ComposerControlRetainer.retain(window, controller) }
         await drain(controller.view)
 
         let field = try #require(firstSubview(of: NSTextField.self, in: controller.view))
@@ -114,6 +113,13 @@ struct PairedComposerTextControlsTests {
         #expect(field.stringValue == "`value`")
         #expect(model.text == "`value`")
         #expect(editor.selectedRange() == NSRange(location: 1, length: 5))
+        #expect(editor.undoManager?.canUndo == true)
+
+        editor.undoManager?.undo()
+        await drain(controller.view)
+
+        #expect(editor.string == "value")
+        #expect(model.text == "value")
 
         field.sendAction(field.action, to: field.target)
         #expect(submitCount == 1)
@@ -126,13 +132,14 @@ struct PairedComposerTextControlsTests {
         model.isFocused = true
         await drain(controller.view)
         #expect(window.firstResponder === window.fieldEditor(false, for: field))
+
+        await dismantle(model: model, controller: controller, window: window)
     }
 
     @Test func textEditorSynchronizesExternalConfigurationAndDisabledState() async throws {
         let model = ComposerControlModel(text: "start", isFocused: false)
         let controller = NSHostingController(rootView: PairedTextEditorHarness(model: model))
         let window = attach(controller, size: NSSize(width: 360, height: 180))
-        defer { ComposerControlRetainer.retain(window, controller) }
         await drain(controller.view)
 
         let textView = try #require(firstSubview(of: PairedDelimiterTextView.self, in: controller.view))
@@ -163,13 +170,14 @@ struct PairedComposerTextControlsTests {
         #expect(window.makeFirstResponder(sink))
         await drain(controller.view)
         #expect(model.isFocused == false)
+
+        await dismantle(model: model, controller: controller, window: window)
     }
 
     @Test func textFieldUpdatesExternalConfigurationAndDisabledState() async throws {
         let model = ComposerControlModel(text: "initial", isFocused: false)
         let controller = NSHostingController(rootView: PairedTextFieldHarness(model: model, onSubmit: {}))
         let window = attach(controller, size: NSSize(width: 360, height: 120))
-        defer { ComposerControlRetainer.retain(window, controller) }
         await drain(controller.view)
 
         let field = try #require(firstSubview(of: NSTextField.self, in: controller.view))
@@ -185,6 +193,62 @@ struct PairedComposerTextControlsTests {
         #expect(field.font?.pointSize == 16)
         #expect(field.textColor == .systemBlue)
         #expect(field.isEnabled == false)
+
+        await dismantle(model: model, controller: controller, window: window)
+    }
+
+    @Test func updatingInactiveFieldDoesNotTouchSiblingFieldEditor() async throws {
+        let firstModel = ComposerControlModel(text: "alpha", isFocused: false)
+        let secondModel = ComposerControlModel(text: "bravo", isFocused: true)
+        let controller = NSHostingController(rootView: TwoPairedTextFieldsHarness(
+            firstModel: firstModel,
+            secondModel: secondModel
+        ))
+        let window = attach(controller, size: NSSize(width: 360, height: 120))
+        await drain(controller.view)
+
+        let fields = subviews(of: PairedTextFieldBackingView.self, in: controller.view)
+        #expect(fields.count == 2)
+        let firstField = try #require(fields.first { $0.stringValue == "alpha" })
+        let secondField = try #require(fields.first { $0.stringValue == "bravo" })
+        let secondEditor = try #require(secondField.currentEditor() as? NSTextView)
+        #expect(window.firstResponder === secondEditor)
+        secondEditor.setSelectedRange(NSRange(location: 1, length: 3))
+
+        firstModel.text = "alpha updated"
+        firstModel.fontSize = 17
+        await drain(controller.view)
+
+        #expect(firstField.stringValue == "alpha updated")
+        #expect(secondField.currentEditor() === secondEditor)
+        #expect(window.firstResponder === secondEditor)
+        #expect(secondEditor.string == "bravo")
+        #expect(secondEditor.selectedRange() == NSRange(location: 1, length: 3))
+        #expect(secondModel.isFocused)
+
+        firstModel.isPresented = false
+        secondModel.isPresented = false
+        await drain(controller.view)
+        #expect(firstField.delegate == nil)
+        #expect(secondField.delegate == nil)
+        #expect(window.firstResponder !== secondEditor)
+    }
+
+    @Test func representablesDismantleWithoutRetainingHost() async throws {
+        let model = ComposerControlModel(text: "lifecycle", isFocused: false)
+        let controller = NSHostingController(rootView: PairedControlLifecycleHarness(model: model))
+        await drain(controller.view)
+
+        let field = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
+        let editor = try #require(firstSubview(of: PairedDelimiterTextView.self, in: controller.view))
+
+        model.isPresented = false
+        await drain(controller.view)
+
+        #expect(field.delegate == nil)
+        #expect(editor.delegate == nil)
+        #expect(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view) == nil)
+        #expect(firstSubview(of: PairedDelimiterTextView.self, in: controller.view) == nil)
     }
 
     private func makePairedTextView(text: String = "") -> PairedDelimiterTextView {
@@ -216,8 +280,20 @@ struct PairedComposerTextControlsTests {
         return window
     }
 
+    private func dismantle<Content: View>(
+        model: ComposerControlModel,
+        controller: NSHostingController<Content>,
+        window: NSWindow
+    ) async {
+        model.isPresented = false
+        await drain(controller.view)
+        #expect(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view) == nil)
+        #expect(firstSubview(of: PairedDelimiterTextView.self, in: controller.view) == nil)
+        withExtendedLifetime(window) {}
+    }
+
     private func drain(_ view: NSView) async {
-        for _ in 0..<6 {
+        for _ in 0..<12 {
             view.layoutSubtreeIfNeeded()
             try? await Task.sleep(nanoseconds: 1_000_000)
             await Task.yield()
@@ -231,14 +307,11 @@ struct PairedComposerTextControlsTests {
         }
         return nil
     }
-}
 
-@MainActor
-private final class ComposerControlRetainer {
-    private static var retainedObjects: [AnyObject] = []
-
-    static func retain(_ objects: AnyObject...) {
-        retainedObjects.append(contentsOf: objects)
+    private func subviews<T: NSView>(of type: T.Type, in view: NSView) -> [T] {
+        var matches = view.subviews.compactMap { $0 as? T }
+        matches.append(contentsOf: view.subviews.flatMap { subviews(of: type, in: $0) })
+        return matches
     }
 }
 
@@ -249,6 +322,7 @@ private final class ComposerControlModel: ObservableObject {
     @Published var isEnabled = true
     @Published var fontSize: CGFloat = 13
     @Published var textColor = NSColor.labelColor
+    @Published var isPresented = true
 
     init(text: String, isFocused: Bool) {
         self.text = text
@@ -263,16 +337,18 @@ private struct PairedTextFieldHarness: View {
 
     var body: some View {
         VStack {
-            PairedTextField(
-                text: $model.text,
-                placeholder: "Compose",
-                font: .systemFont(ofSize: model.fontSize),
-                textColor: model.textColor,
-                isEnabled: model.isEnabled,
-                isFocused: $model.isFocused,
-                onSubmit: onSubmit
-            )
-            .frame(height: 28)
+            if model.isPresented {
+                PairedTextField(
+                    text: $model.text,
+                    placeholder: "Compose",
+                    font: .systemFont(ofSize: model.fontSize),
+                    textColor: model.textColor,
+                    isEnabled: model.isEnabled,
+                    isFocused: $model.isFocused,
+                    onSubmit: onSubmit
+                )
+                .frame(height: 28)
+            }
             ComposerFocusSinkRepresentable()
         }
     }
@@ -284,16 +360,63 @@ private struct PairedTextEditorHarness: View {
 
     var body: some View {
         VStack {
-            PairedTextEditor(
+            if model.isPresented {
+                PairedTextEditor(
+                    text: $model.text,
+                    font: .systemFont(ofSize: model.fontSize),
+                    textColor: model.textColor,
+                    isEnabled: model.isEnabled,
+                    isFocused: $model.isFocused,
+                    textContainerInset: NSSize(width: 7, height: 9)
+                )
+                .frame(height: 100)
+            }
+            ComposerFocusSinkRepresentable()
+        }
+    }
+}
+
+@MainActor
+private struct TwoPairedTextFieldsHarness: View {
+    let firstModel: ComposerControlModel
+    let secondModel: ComposerControlModel
+
+    var body: some View {
+        VStack {
+            PairedTextFieldLeaf(model: firstModel)
+            PairedTextFieldLeaf(model: secondModel)
+        }
+    }
+}
+
+@MainActor
+private struct PairedControlLifecycleHarness: View {
+    @ObservedObject var model: ComposerControlModel
+
+    var body: some View {
+        if model.isPresented {
+            VStack {
+                PairedTextField(text: $model.text)
+                PairedTextEditor(text: $model.text)
+            }
+        }
+    }
+}
+
+@MainActor
+private struct PairedTextFieldLeaf: View {
+    @ObservedObject var model: ComposerControlModel
+
+    var body: some View {
+        if model.isPresented {
+            PairedTextField(
                 text: $model.text,
                 font: .systemFont(ofSize: model.fontSize),
                 textColor: model.textColor,
                 isEnabled: model.isEnabled,
-                isFocused: $model.isFocused,
-                textContainerInset: NSSize(width: 7, height: 9)
+                isFocused: $model.isFocused
             )
-            .frame(height: 100)
-            ComposerFocusSinkRepresentable()
+            .frame(height: 28)
         }
     }
 }

--- a/AlasTests/PairedComposerTextControlsTests.swift
+++ b/AlasTests/PairedComposerTextControlsTests.swift
@@ -166,6 +166,13 @@ struct PairedComposerTextControlsTests {
         NSPasteboard.general.setString("(", forType: .string)
         defer { NSPasteboard.general.clearContents() }
 
+        #expect(coordinator.control(
+            field,
+            textView: editor,
+            shouldChangeCharactersIn: NSRange(location: 0, length: 0),
+            replacementString: "("
+        ))
+
         #expect(coordinator.control(field, textView: editor, doCommandBy: #selector(NSText.paste(_:))))
 
         #expect(field.stringValue == "(")

--- a/AlasTests/PairedComposerTextControlsTests.swift
+++ b/AlasTests/PairedComposerTextControlsTests.swift
@@ -11,7 +11,9 @@ struct PairedComposerTextControlsTests {
         let textView = makePairedTextView(text: "value")
         textView.setSelectedRange(NSRange(location: 0, length: 5))
 
-        textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        textView.performKeyboardTextInsertion {
+            textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
 
         #expect(textView.string == "`value`")
         #expect(textView.selectedRange() == NSRange(location: 1, length: 5))
@@ -25,7 +27,9 @@ struct PairedComposerTextControlsTests {
         let textView = makePairedTextView(storage: storage)
         textView.setSelectedRange(NSRange(location: 0, length: 5))
 
-        textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        textView.performKeyboardTextInsertion {
+            textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
 
         #expect(textView.string == "`value`")
         #expect(textView.textStorage?.attribute(.toolTip, at: 1, effectiveRange: nil) as? String == "keep-me")
@@ -35,12 +39,16 @@ struct PairedComposerTextControlsTests {
     @Test func insertsEmptyPairAndStepsOverCloser() {
         let textView = makePairedTextView()
 
-        textView.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
+        textView.performKeyboardTextInsertion {
+            textView.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
 
         #expect(textView.string == "()")
         #expect(textView.selectedRange() == NSRange(location: 1, length: 0))
 
-        textView.insertText(")", replacementRange: NSRange(location: NSNotFound, length: 0))
+        textView.performKeyboardTextInsertion {
+            textView.insertText(")", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
 
         #expect(textView.string == "()")
         #expect(textView.selectedRange() == NSRange(location: 2, length: 0))
@@ -49,7 +57,9 @@ struct PairedComposerTextControlsTests {
     @Test func multiCharacterAndMarkedTextUseNativeInsertion() {
         let pastedTextView = makePairedTextView()
 
-        pastedTextView.insertText("paste", replacementRange: NSRange(location: NSNotFound, length: 0))
+        pastedTextView.performKeyboardTextInsertion {
+            pastedTextView.insertText("paste", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
 
         #expect(pastedTextView.string == "paste")
 
@@ -61,9 +71,20 @@ struct PairedComposerTextControlsTests {
         )
         #expect(markedTextView.hasMarkedText())
 
-        markedTextView.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
+        markedTextView.performKeyboardTextInsertion {
+            markedTextView.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
 
         #expect(markedTextView.string == "(")
+    }
+
+    @Test func directSingleDelimiterInsertionBypassesPairing() {
+        let dictationInsertion = makePairedTextView()
+
+        dictationInsertion.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(dictationInsertion.string == "(")
+        #expect(dictationInsertion.selectedRange() == NSRange(location: 1, length: 0))
     }
 
     @Test func nativeTextInsertionBypassesSingleDelimiterPairing() {
@@ -104,7 +125,9 @@ struct PairedComposerTextControlsTests {
         textView.allowsUndo = true
         textView.setSelectedRange(NSRange(location: 0, length: 5))
 
-        textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        textView.performKeyboardTextInsertion {
+            textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
 
         #expect(textView.string == "`value`")
         #expect(textView.undoManager?.canUndo == true)
@@ -127,12 +150,14 @@ struct PairedComposerTextControlsTests {
         #expect(window.firstResponder === editor)
         editor.setSelectedRange(NSRange(location: 0, length: 5))
 
-        let shouldUseNativeInsertion = coordinator.control(
-            field,
-            textView: editor,
-            shouldChangeCharactersIn: NSRange(location: 0, length: 5),
-            replacementString: "`"
-        )
+        let shouldUseNativeInsertion = coordinator.performKeyboardTextInsertion {
+            coordinator.control(
+                field,
+                textView: editor,
+                shouldChangeCharactersIn: NSRange(location: 0, length: 5),
+                replacementString: "`"
+            )
+        }
 
         #expect(shouldUseNativeInsertion == false)
         #expect(field.stringValue == "`value`")
@@ -190,6 +215,33 @@ struct PairedComposerTextControlsTests {
         await dismantle(model: model, controller: controller, window: window)
     }
 
+    @Test func textFieldDirectSingleDelimiterInsertionBypassesPairing() async throws {
+        let model = ComposerControlModel(text: "", isFocused: true)
+        let controller = NSHostingController(rootView: PairedTextFieldHarness(model: model, onSubmit: {}))
+        let window = attach(controller, size: NSSize(width: 360, height: 120))
+        await drain(controller.view)
+
+        let field = try #require(firstSubview(of: NSTextField.self, in: controller.view))
+        let editor = try #require(window.fieldEditor(false, for: field) as? NSTextView)
+        let coordinator = try #require(field.delegate as? PairedTextField.Coordinator)
+
+        #expect(coordinator.control(
+            field,
+            textView: editor,
+            shouldChangeCharactersIn: NSRange(location: 0, length: 0),
+            replacementString: "("
+        ))
+
+        editor.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
+        await drain(controller.view)
+
+        #expect(field.stringValue == "(")
+        #expect(model.text == "(")
+        #expect(editor.selectedRange() == NSRange(location: 1, length: 0))
+
+        await dismantle(model: model, controller: controller, window: window)
+    }
+
     @Test func textFieldPasteAndMatchStyleBypassesSingleDelimiterPairing() async throws {
         let model = ComposerControlModel(text: "", isFocused: true)
         let controller = NSHostingController(rootView: PairedTextFieldHarness(model: model, onSubmit: {}))
@@ -228,7 +280,9 @@ struct PairedComposerTextControlsTests {
         #expect(textView.frame.height >= scrollView.contentView.bounds.height)
 
         textView.setSelectedRange(NSRange(location: 5, length: 0))
-        textView.insertText("{", replacementRange: NSRange(location: NSNotFound, length: 0))
+        textView.performKeyboardTextInsertion {
+            textView.insertText("{", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
 
         #expect(model.text == "start{}")
         #expect(textView.textContainerInset == NSSize(width: 7, height: 9))

--- a/AlasTests/PairedDelimiterEditingTests.swift
+++ b/AlasTests/PairedDelimiterEditingTests.swift
@@ -1,0 +1,102 @@
+import AppKit
+import Testing
+@testable import Alas
+
+struct PairedDelimiterEditingTests {
+    @Test(arguments: [
+        ("(", "value", NSRange(location: 0, length: 5), PairedDelimiterEditAction.wrap(opening: "(", closing: ")")),
+        ("[", "", NSRange(location: 0, length: 0), PairedDelimiterEditAction.insertPair(opening: "[", closing: "]")),
+        (")", "()", NSRange(location: 1, length: 0), PairedDelimiterEditAction.stepOver),
+        ("`", "word", NSRange(location: 4, length: 0), PairedDelimiterEditAction.native),
+        ("paste", "", NSRange(location: 0, length: 0), PairedDelimiterEditAction.native),
+    ])
+    func resolvesRepresentativeEdits(
+        input: String,
+        text: String,
+        range: NSRange,
+        expected: PairedDelimiterEditAction
+    ) {
+        #expect(PairedDelimiterEditing.resolve(insertedText: input, in: text, selectedRange: range) == expected)
+    }
+
+    @Test(arguments: [
+        ("(", ")"),
+        ("[", "]"),
+        ("{", "}"),
+        ("\"", "\""),
+        ("'", "'"),
+        ("`", "`"),
+    ])
+    func insertsEverySupportedPair(opening: Character, closing: Character) {
+        #expect(
+            PairedDelimiterEditing.resolve(
+                insertedText: String(opening),
+                in: "",
+                selectedRange: NSRange(location: 0, length: 0)
+            ) == .insertPair(opening: opening, closing: closing)
+        )
+    }
+
+    @Test(arguments: [
+        ("\\", PairedDelimiterEditAction.native),
+        ("\\\\", PairedDelimiterEditAction.insertPair(opening: "\"", closing: "\"")),
+    ])
+    func countsBackslashesBeforeSymmetricDelimiter(text: String, expected: PairedDelimiterEditAction) {
+        #expect(
+            PairedDelimiterEditing.resolve(
+                insertedText: "\"",
+                in: text,
+                selectedRange: NSRange(location: (text as NSString).length, length: 0)
+            ) == expected
+        )
+    }
+
+    @Test(arguments: [
+        ("word", 4),
+        ("word", 0),
+    ])
+    func symmetricDelimiterAdjacentToIdentifierUsesNativeInsertion(text: String, location: Int) {
+        #expect(
+            PairedDelimiterEditing.resolve(
+                insertedText: "'",
+                in: text,
+                selectedRange: NSRange(location: location, length: 0)
+            ) == .native
+        )
+    }
+
+    @Test func selectedSymmetricDelimiterWrapsSelection() {
+        #expect(
+            PairedDelimiterEditing.resolve(
+                insertedText: "`",
+                in: "value",
+                selectedRange: NSRange(location: 0, length: 5)
+            ) == .wrap(opening: "`", closing: "`")
+        )
+    }
+
+    @Test func closerOnlyStepsOverItsMatchingCharacter() {
+        #expect(
+            PairedDelimiterEditing.resolve(
+                insertedText: ")",
+                in: "]",
+                selectedRange: NSRange(location: 0, length: 0)
+            ) == .native
+        )
+    }
+
+    @Test(arguments: [
+        NSRange(location: NSNotFound, length: 0),
+        NSRange(location: 6, length: 0),
+        NSRange(location: 4, length: 2),
+    ])
+    func invalidSelectionRangesUseNativeInsertion(range: NSRange) {
+        #expect(
+            PairedDelimiterEditing.resolve(
+                insertedText: "(",
+                in: "word",
+                selectedRange: range
+            ) == .native
+        )
+    }
+}

--- a/AlasTests/PairedDelimiterEditingTests.swift
+++ b/AlasTests/PairedDelimiterEditingTests.swift
@@ -65,6 +65,20 @@ struct PairedDelimiterEditingTests {
         )
     }
 
+    @Test(arguments: [
+        0,
+        ("𝒙" as NSString).length,
+    ])
+    func symmetricDelimiterAdjacentToSupplementaryPlaneIdentifierUsesNativeInsertion(location: Int) {
+        #expect(
+            PairedDelimiterEditing.resolve(
+                insertedText: "'",
+                in: "𝒙",
+                selectedRange: NSRange(location: location, length: 0)
+            ) == .native
+        )
+    }
+
     @Test func selectedSymmetricDelimiterWrapsSelection() {
         #expect(
             PairedDelimiterEditing.resolve(

--- a/AlasTests/PairedDelimiterEditingTests.swift
+++ b/AlasTests/PairedDelimiterEditingTests.swift
@@ -87,6 +87,8 @@ struct PairedDelimiterEditingTests {
 
     @Test(arguments: [
         NSRange(location: NSNotFound, length: 0),
+        NSRange(location: -1, length: 0),
+        NSRange(location: 0, length: -1),
         NSRange(location: 6, length: 0),
         NSRange(location: 4, length: 2),
     ])

--- a/AlasTests/PairedPrimaryComposerSurfaceTests.swift
+++ b/AlasTests/PairedPrimaryComposerSurfaceTests.swift
@@ -17,17 +17,21 @@ struct PairedPrimaryComposerSurfaceTests {
         let titleEditor = try #require(window.fieldEditor(false, for: title) as? NSTextView)
         let coordinator = try #require(title.delegate as? PairedTextField.Coordinator)
         titleEditor.setSelectedRange(NSRange(location: 0, length: model.title.utf16.count))
-        #expect(!coordinator.control(
-            title,
-            textView: titleEditor,
-            shouldChangeCharactersIn: NSRange(location: 0, length: model.title.utf16.count),
-            replacementString: "`")
-        )
+        #expect(!coordinator.performKeyboardTextInsertion {
+            coordinator.control(
+                title,
+                textView: titleEditor,
+                shouldChangeCharactersIn: NSRange(location: 0, length: model.title.utf16.count),
+                replacementString: "`"
+            )
+        })
         #expect(model.title == "`Review title`")
 
         let body = try #require(firstSubview(of: PairedDelimiterTextView.self, in: controller.view))
         body.setSelectedRange(NSRange(location: 0, length: model.body.utf16.count))
-        body.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        body.performKeyboardTextInsertion {
+            body.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
         #expect(model.body == "`Review body`")
 
         window.orderOut(nil)
@@ -67,12 +71,14 @@ struct PairedPrimaryComposerSurfaceTests {
         let editor = try #require(window.fieldEditor(false, for: field) as? NSTextView)
         let coordinator = try #require(field.delegate as? PairedTextField.Coordinator)
         editor.setSelectedRange(NSRange(location: 0, length: 12))
-        #expect(!coordinator.control(
-            field,
-            textView: editor,
-            shouldChangeCharactersIn: NSRange(location: 0, length: 12),
-            replacementString: "`")
-        )
+        #expect(!coordinator.performKeyboardTextInsertion {
+            coordinator.control(
+                field,
+                textView: editor,
+                shouldChangeCharactersIn: NSRange(location: 0, length: 12),
+                replacementString: "`"
+            )
+        })
         await drain(controller.view)
 
         #expect(model.firstMessage == "`First commit`")

--- a/AlasTests/PairedPrimaryComposerSurfaceTests.swift
+++ b/AlasTests/PairedPrimaryComposerSurfaceTests.swift
@@ -62,6 +62,7 @@ struct PairedPrimaryComposerSurfaceTests {
         draftChanges.removeAll()
 
         let field = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
+        #expect(field.focusRingType == .default)
         #expect(window.makeFirstResponder(field))
         let editor = try #require(window.fieldEditor(false, for: field) as? NSTextView)
         let coordinator = try #require(field.delegate as? PairedTextField.Coordinator)

--- a/AlasTests/PairedPrimaryComposerSurfaceTests.swift
+++ b/AlasTests/PairedPrimaryComposerSurfaceTests.swift
@@ -36,14 +36,15 @@ struct PairedPrimaryComposerSurfaceTests {
     @Test func ggSplitMessageInvokesDraftChangeAfterPairedEdit() async throws {
         let model = GGSplitMessageModel(message: "split")
         var draftChanges: [String] = []
-        let controller = NSHostingController(rootView: GGSplitMessageHarness(model: model) {
+        let controller = NSHostingController(rootView: GGSplitMessageHarness(model: model, theme: try! ThemeStore().current) {
             draftChanges.append(model.message)
         })
         let window = attach(controller)
         await drain(controller.view)
 
         let field = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
-        let editor = try #require(field.currentEditor() as? NSTextView)
+        #expect(window.makeFirstResponder(field))
+        let editor = try #require(window.fieldEditor(false, for: field) as? NSTextView)
         let coordinator = try #require(field.delegate as? PairedTextField.Coordinator)
         editor.setSelectedRange(NSRange(location: 0, length: 5))
         #expect(!coordinator.control(
@@ -103,17 +104,19 @@ private struct ReviewRequestComposerHarness: View {
     let theme: Theme
 
     var body: some View {
-        CommitMessageEditorView(
-            subject: $model.title,
+        ReviewRequestMessageEditor(
+            title: $model.title,
             bodyText: $model.body,
             aiToolId: .constant(""),
-            title: "GitHub Pull Request",
+            editorTitle: "GitHub Pull Request",
             busy: false,
             error: nil,
             availableAgents: [],
             onGenerate: {},
             primaryAction: CommitPrimaryAction(label: "Create Pull Request", isEnabled: true, handler: {}),
-            iconName: "branch"
+            editorDisabled: false,
+            onDismissError: {},
+            accessory: nil
         )
         .environment(\.theme, theme)
     }
@@ -131,15 +134,11 @@ private final class GGSplitMessageModel: ObservableObject {
 @MainActor
 private struct GGSplitMessageHarness: View {
     @ObservedObject var model: GGSplitMessageModel
+    let theme: Theme
     let draftDidChange: () -> Void
 
     var body: some View {
-        PairedTextField(
-            text: $model.message,
-            placeholder: "Commit message",
-            isFocused: .constant(true)
-        )
-        .frame(height: 22)
-        .onChange(of: model.message) { draftDidChange() }
+        GGSplitCommitMessageEditor(message: $model.message, onDraftChange: draftDidChange)
+            .environment(\.theme, theme)
     }
 }

--- a/AlasTests/PairedPrimaryComposerSurfaceTests.swift
+++ b/AlasTests/PairedPrimaryComposerSurfaceTests.swift
@@ -1,0 +1,145 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct PairedPrimaryComposerSurfaceTests {
+    @Test func reviewRequestTitleAndBodyUsePairedBindings() async throws {
+        let model = ReviewRequestComposerModel(title: "Review title", body: "Review body")
+        let controller = NSHostingController(rootView: ReviewRequestComposerHarness(model: model, theme: try! ThemeStore().current))
+        let window = attach(controller)
+        await drain(controller.view)
+
+        let title = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
+        #expect(window.makeFirstResponder(title))
+        let titleEditor = try #require(window.fieldEditor(false, for: title) as? NSTextView)
+        let coordinator = try #require(title.delegate as? PairedTextField.Coordinator)
+        titleEditor.setSelectedRange(NSRange(location: 0, length: model.title.utf16.count))
+        #expect(!coordinator.control(
+            title,
+            textView: titleEditor,
+            shouldChangeCharactersIn: NSRange(location: 0, length: model.title.utf16.count),
+            replacementString: "`")
+        )
+        #expect(model.title == "`Review title`")
+
+        let body = try #require(firstSubview(of: PairedDelimiterTextView.self, in: controller.view))
+        body.setSelectedRange(NSRange(location: 0, length: model.body.utf16.count))
+        body.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(model.body == "`Review body`")
+
+        window.orderOut(nil)
+    }
+
+    @Test func ggSplitMessageInvokesDraftChangeAfterPairedEdit() async throws {
+        let model = GGSplitMessageModel(message: "split")
+        var draftChanges: [String] = []
+        let controller = NSHostingController(rootView: GGSplitMessageHarness(model: model) {
+            draftChanges.append(model.message)
+        })
+        let window = attach(controller)
+        await drain(controller.view)
+
+        let field = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
+        let editor = try #require(field.currentEditor() as? NSTextView)
+        let coordinator = try #require(field.delegate as? PairedTextField.Coordinator)
+        editor.setSelectedRange(NSRange(location: 0, length: 5))
+        #expect(!coordinator.control(
+            field,
+            textView: editor,
+            shouldChangeCharactersIn: NSRange(location: 0, length: 5),
+            replacementString: "`")
+        )
+        await drain(controller.view)
+
+        #expect(model.message == "`split`")
+        #expect(draftChanges == ["`split`"])
+        window.orderOut(nil)
+    }
+
+    private func attach<Content: View>(_ controller: NSHostingController<Content>) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 240),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentViewController = controller
+        window.makeKeyAndOrderFront(nil)
+        return window
+    }
+
+    private func drain(_ view: NSView) async {
+        view.layoutSubtreeIfNeeded()
+        await Task.yield()
+        view.layoutSubtreeIfNeeded()
+    }
+
+    private func firstSubview<T: NSView>(of type: T.Type, in view: NSView) -> T? {
+        if let match = view as? T { return match }
+        for subview in view.subviews {
+            if let match = firstSubview(of: type, in: subview) { return match }
+        }
+        return nil
+    }
+}
+
+@MainActor
+private final class ReviewRequestComposerModel: ObservableObject {
+    @Published var title: String
+    @Published var body: String
+
+    init(title: String, body: String) {
+        self.title = title
+        self.body = body
+    }
+}
+
+@MainActor
+private struct ReviewRequestComposerHarness: View {
+    @ObservedObject var model: ReviewRequestComposerModel
+    let theme: Theme
+
+    var body: some View {
+        CommitMessageEditorView(
+            subject: $model.title,
+            bodyText: $model.body,
+            aiToolId: .constant(""),
+            title: "GitHub Pull Request",
+            busy: false,
+            error: nil,
+            availableAgents: [],
+            onGenerate: {},
+            primaryAction: CommitPrimaryAction(label: "Create Pull Request", isEnabled: true, handler: {}),
+            iconName: "branch"
+        )
+        .environment(\.theme, theme)
+    }
+}
+
+@MainActor
+private final class GGSplitMessageModel: ObservableObject {
+    @Published var message: String
+
+    init(message: String) {
+        self.message = message
+    }
+}
+
+@MainActor
+private struct GGSplitMessageHarness: View {
+    @ObservedObject var model: GGSplitMessageModel
+    let draftDidChange: () -> Void
+
+    var body: some View {
+        PairedTextField(
+            text: $model.message,
+            placeholder: "Commit message",
+            isFocused: .constant(true)
+        )
+        .frame(height: 22)
+        .onChange(of: model.message) { draftDidChange() }
+    }
+}

--- a/AlasTests/PairedPrimaryComposerSurfaceTests.swift
+++ b/AlasTests/PairedPrimaryComposerSurfaceTests.swift
@@ -33,30 +33,49 @@ struct PairedPrimaryComposerSurfaceTests {
         window.orderOut(nil)
     }
 
-    @Test func ggSplitMessageInvokesDraftChangeAfterPairedEdit() async throws {
-        let model = GGSplitMessageModel(message: "split")
+    @Test func ggSplitCardInvokesDraftChangeAfterPairedEdit() async throws {
+        let service = GGSplitSurfaceService()
+        let model = GGSplitCommitModel(
+            service: service,
+            target: GGSplitCommitTarget(worktreeId: "wt", targetGGID: "change-2", targetSHA: "abc123"),
+            capabilities: GGCapabilities(structuredSplit: true, keepCurrentUnstack: true),
+            workflowAvailable: true
+        )
+        try await model.load()
         var draftChanges: [String] = []
-        let controller = NSHostingController(rootView: GGSplitMessageHarness(model: model, theme: try! ThemeStore().current) {
-            draftChanges.append(model.message)
-        })
+        let controller = NSHostingController(rootView: GGSplitCommitTabView(
+            tabState: GGSplitCommitTabState(worktreeId: "wt", targetGGID: "change-2", targetSHA: "abc123"),
+            worktreePath: URL(fileURLWithPath: "/tmp"),
+            capabilities: GGCapabilities(structuredSplit: true, keepCurrentUnstack: true),
+            workflowAvailable: true,
+            hasBlockingGitOperation: false,
+            model: model,
+            codeFontFamily: "Menlo",
+            codeFontSize: 12,
+            onCancel: {},
+            onDraftChange: { draft in draftChanges.append(draft.firstMessage) }
+        )
+        .environment(\.theme, try! ThemeStore().current))
         let window = attach(controller)
         await drain(controller.view)
+        await drain(controller.view)
+        draftChanges.removeAll()
 
         let field = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
         #expect(window.makeFirstResponder(field))
         let editor = try #require(window.fieldEditor(false, for: field) as? NSTextView)
         let coordinator = try #require(field.delegate as? PairedTextField.Coordinator)
-        editor.setSelectedRange(NSRange(location: 0, length: 5))
+        editor.setSelectedRange(NSRange(location: 0, length: 12))
         #expect(!coordinator.control(
             field,
             textView: editor,
-            shouldChangeCharactersIn: NSRange(location: 0, length: 5),
+            shouldChangeCharactersIn: NSRange(location: 0, length: 12),
             replacementString: "`")
         )
         await drain(controller.view)
 
-        #expect(model.message == "`split`")
-        #expect(draftChanges == ["`split`"])
+        #expect(model.firstMessage == "`First commit`")
+        #expect(draftChanges == ["`First commit`"])
         window.orderOut(nil)
     }
 
@@ -123,22 +142,28 @@ private struct ReviewRequestComposerHarness: View {
 }
 
 @MainActor
-private final class GGSplitMessageModel: ObservableObject {
-    @Published var message: String
+private final class GGSplitSurfaceService: GGSplitCommitServicing {
+    private let description = GGSplitDescription(
+        version: 1,
+        planToken: "split-v1-token",
+        target: GGSplitTargetIdentity(ggID: "change-2", sha: "abc123", tree: "tree123"),
+        hunks: [GGSplitHunk(id: "h-1", path: "Sources/A.swift", header: "@@ -1 +1 @@", patch: "-old\n+new\n")],
+        nonTextualFiles: [],
+        firstMessage: "First commit",
+        remainderMessage: "Remainder commit"
+    )
 
-    init(message: String) {
-        self.message = message
+    func loadDescription(target: GGSplitCommitTarget) async throws -> GGSplitLoadedDescription {
+        GGSplitLoadedDescription(
+            description: description,
+            stackIdentity: GGStackIdentity(stackName: "stack", base: "main", headSHA: "head", operationID: nil)
+        )
     }
-}
 
-@MainActor
-private struct GGSplitMessageHarness: View {
-    @ObservedObject var model: GGSplitMessageModel
-    let theme: Theme
-    let draftDidChange: () -> Void
-
-    var body: some View {
-        GGSplitCommitMessageEditor(message: $model.message, onDraftChange: draftDidChange)
-            .environment(\.theme, theme)
-    }
+    func applySplit(
+        planURL: URL,
+        target: GGSplitTargetIdentity,
+        planToken: String,
+        confirmedAgainst identity: GGStackIdentity
+    ) async throws {}
 }

--- a/AlasTests/PairedReviewComposerSurfaceTests.swift
+++ b/AlasTests/PairedReviewComposerSurfaceTests.swift
@@ -14,9 +14,11 @@ struct PairedReviewComposerSurfaceTests {
         let window = attach(controller)
         await drain(controller.view)
 
-        let composer = try #require(textView(containing: model.text, in: controller.view))
+        let composer = try #require(textView(containing: model.text, in: controller.view) as? PairedDelimiterTextView)
         composer.setSelectedRange(NSRange(location: 0, length: model.text.utf16.count))
-        composer.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        composer.performKeyboardTextInsertion {
+            composer.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
         #expect(model.text == "`review body`")
 
         composer.keyDown(with: try keyEvent(characters: "\r", modifiers: .command))
@@ -170,7 +172,13 @@ struct PairedReviewComposerSurfaceTests {
 
     private func wrapSelection(in textView: NSTextView) {
         textView.setSelectedRange(NSRange(location: 0, length: textView.string.utf16.count))
-        textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        if let pairedTextView = textView as? PairedDelimiterTextView {
+            pairedTextView.performKeyboardTextInsertion {
+                pairedTextView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+            }
+        } else {
+            textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
     }
 
     private func waitForTextView(containing text: String, in view: NSView) async throws -> NSTextView {

--- a/AlasTests/PairedReviewComposerSurfaceTests.swift
+++ b/AlasTests/PairedReviewComposerSurfaceTests.swift
@@ -1,0 +1,432 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct PairedReviewComposerSurfaceTests {
+    @Test func reviewDraftComposerWrapsSelectionAndRoutesKeyboardActions() async throws {
+        let model = ReviewDraftComposerCapture(text: "review body")
+        let controller = NSHostingController(
+            rootView: ReviewDraftComposerCaptureHarness(model: model, theme: try! ThemeStore().current)
+        )
+        let window = attach(controller)
+        await drain(controller.view)
+
+        let composer = try #require(textView(containing: model.text, in: controller.view))
+        composer.setSelectedRange(NSRange(location: 0, length: model.text.utf16.count))
+        composer.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(model.text == "`review body`")
+
+        composer.keyDown(with: try keyEvent(characters: "\r", modifiers: .command))
+        composer.keyDown(with: try keyEvent(characters: "\u{1b}", modifiers: []))
+        #expect(model.saveCount == 1)
+        #expect(model.cancelCount == 1)
+
+        window.orderOut(nil)
+    }
+
+    @Test func inlineReplyAndEditBindingsReceiveWrappedSelections() async throws {
+        let model = InlineCommentCardCapture()
+        let controller = NSHostingController(rootView: InlineCommentCardCaptureHarness(model: model))
+        let window = attach(controller, height: 520)
+        await drain(controller.view)
+
+        let replyEditor = try #require(textView(containing: "reply body", in: controller.view))
+        wrapSelection(in: replyEditor)
+        #expect(model.replyState.replyDraft == "`reply body`")
+
+        let editEditor = try #require(textView(containing: "edit body", in: controller.view))
+        wrapSelection(in: editEditor)
+        #expect(model.editState.editDraft == "`edit body`")
+
+        window.orderOut(nil)
+    }
+
+    @Test func providerReplyBindingReceivesWrappedSelection() async throws {
+        let model = ProviderReplyCapture()
+        let controller = NSHostingController(rootView: ProviderReplyCaptureHarness(model: model))
+        let window = attach(controller)
+        await drain(controller.view)
+
+        let editor = try #require(textView(containing: "provider reply", in: controller.view))
+        wrapSelection(in: editor)
+        #expect(model.editorState.body == "`provider reply`")
+
+        window.orderOut(nil)
+    }
+
+    @Test func verdictSummarySubmitReceivesWrappedSelection() async throws {
+        let capture = VerdictSubmitCapture()
+        let controller = NSHostingController(
+            rootView: VerdictSheet(
+                pendingCount: 1,
+                onSubmit: { verdict, body in
+                    capture.verdict = verdict
+                    capture.body = body
+                }
+            )
+            .environment(\.theme, try! ThemeStore().current)
+        )
+        let window = attach(controller, height: 420)
+        await drain(controller.view)
+
+        let editor = try #require(firstEditableTextView(in: controller.view))
+        editor.insertText("verdict summary", replacementRange: NSRange(location: NSNotFound, length: 0))
+        wrapSelection(in: editor)
+        try pressAccessibilityElement(
+            withIdentifier: "verdict-submit-review",
+            in: controller.view
+        )
+
+        #expect(capture.verdict == .comment)
+        #expect(capture.body == "`verdict summary`")
+        window.orderOut(nil)
+    }
+
+    @Test func verdictSummaryDisabledRequestChangesDoesNotSubmitEmptySummary() async throws {
+        let capture = VerdictSubmitCapture()
+        let controller = NSHostingController(
+            rootView: VerdictSheet(
+                pendingCount: 1,
+                initialVerdict: .requestChanges,
+                onSubmit: { verdict, body in
+                    capture.verdict = verdict
+                    capture.body = body
+                }
+            )
+            .environment(\.theme, try! ThemeStore().current)
+        )
+        let window = attach(controller, height: 420)
+        await drain(controller.view)
+
+        let didSubmit = accessibilityElementPerformsPress(
+            withIdentifier: "verdict-submit-review",
+            in: controller.view
+        )
+
+        #expect(!didSubmit)
+        #expect(capture.verdict == nil)
+        #expect(capture.body == nil)
+        window.orderOut(nil)
+    }
+
+    @Test func providerPublishSummaryBindingReceivesWrappedSelectionAndPreservesDisabledState() async throws {
+        let model = ProviderPublishCapture()
+        let controller = NSHostingController(rootView: ProviderPublishCaptureHarness(model: model))
+        let window = attach(controller, height: 420)
+        await drain(controller.view)
+
+        let editor = try #require(textView(containing: "publish summary", in: controller.view))
+        #expect(editor.isEditable)
+        wrapSelection(in: editor)
+        #expect(model.summaryBody == "`publish summary`")
+
+        model.isPublishing = true
+        await drain(controller.view)
+        #expect(!editor.isEditable)
+
+        window.orderOut(nil)
+    }
+
+    @Test func draftSummaryEditingBindingReceivesWrappedSelection() async throws {
+        let capture = DraftSummaryEditCapture(body: "draft summary")
+        let controller = NSHostingController(rootView: DraftSummaryEditCaptureHarness(capture: capture))
+        let window = attach(controller, height: 240)
+        await drain(controller.view)
+
+        let editor = try await waitForTextView(containing: "draft summary", in: controller.view)
+        wrapSelection(in: editor)
+
+        #expect(capture.body == "`draft summary`")
+        window.orderOut(nil)
+    }
+
+    private func attach<Content: View>(
+        _ controller: NSHostingController<Content>,
+        height: CGFloat = 300
+    ) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: height),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentViewController = controller
+        window.makeKeyAndOrderFront(nil)
+        return window
+    }
+
+    private func drain(_ view: NSView) async {
+        for _ in 0..<4 {
+            view.layoutSubtreeIfNeeded()
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.001))
+            await Task.yield()
+        }
+    }
+
+    private func textView(containing text: String, in view: NSView) -> NSTextView? {
+        if let textView = view as? NSTextView, textView.string == text {
+            return textView
+        }
+        for subview in view.subviews {
+            if let match = textView(containing: text, in: subview) { return match }
+        }
+        return nil
+    }
+
+    private func firstEditableTextView(in view: NSView) -> NSTextView? {
+        if let textView = view as? NSTextView, textView.isEditable {
+            return textView
+        }
+        return view.subviews.lazy.compactMap(firstEditableTextView).first
+    }
+
+    private func wrapSelection(in textView: NSTextView) {
+        textView.setSelectedRange(NSRange(location: 0, length: textView.string.utf16.count))
+        textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+    }
+
+    private func pressAccessibilityElement(withIdentifier identifier: String, in view: NSView) throws {
+        let pressed = accessibilityElementPerformsPress(withIdentifier: identifier, in: view)
+        #expect(pressed)
+        if !pressed {
+            throw SurfaceTestError.elementDidNotPress(identifier)
+        }
+    }
+
+    private func accessibilityElementPerformsPress(withIdentifier identifier: String, in view: NSView) -> Bool {
+        allSubviews(of: view)
+            .filter { $0.accessibilityIdentifier() == identifier }
+            .contains { $0.accessibilityPerformPress() }
+    }
+
+    private func allSubviews(of view: NSView) -> [NSView] {
+        [view] + view.subviews.flatMap(allSubviews)
+    }
+
+    private func waitForSubview(withAccessibilityIdentifier identifier: String, in view: NSView) async throws {
+        for _ in 0..<20 {
+            view.layoutSubtreeIfNeeded()
+            if subview(withAccessibilityIdentifier: identifier, in: view) != nil {
+                return
+            }
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+            await Task.yield()
+        }
+        try #require(subview(withAccessibilityIdentifier: identifier, in: view))
+    }
+
+    private func waitForTextView(containing text: String, in view: NSView) async throws -> NSTextView {
+        for _ in 0..<20 {
+            view.layoutSubtreeIfNeeded()
+            if let textView = textView(containing: text, in: view) {
+                return textView
+            }
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+            await Task.yield()
+        }
+        return try #require(textView(containing: text, in: view))
+    }
+
+    private func subview(withAccessibilityIdentifier identifier: String, in view: NSView) -> NSView? {
+        if view.accessibilityIdentifier() == identifier {
+            return view
+        }
+        return view.subviews.lazy.compactMap { subview(withAccessibilityIdentifier: identifier, in: $0) }.first
+    }
+
+    private func keyEvent(characters: String, modifiers: NSEvent.ModifierFlags) throws -> NSEvent {
+        try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: 0
+        ))
+    }
+}
+
+private enum SurfaceTestError: Error {
+    case elementDidNotPress(String)
+}
+
+@MainActor
+private final class ReviewDraftComposerCapture: ObservableObject {
+    @Published var text: String
+    var saveCount = 0
+    var cancelCount = 0
+
+    init(text: String) {
+        self.text = text
+    }
+}
+
+@MainActor
+private struct ReviewDraftComposerCaptureHarness: View {
+    @ObservedObject var model: ReviewDraftComposerCapture
+    @FocusState private var isFocused: Bool
+    let theme: Theme
+
+    var body: some View {
+        ReviewDraftComposerTextEditor(
+            text: $model.text,
+            theme: theme,
+            isFocused: $isFocused,
+            onSave: { model.saveCount += 1 },
+            onCancel: { model.cancelCount += 1 }
+        )
+        .frame(height: 100)
+    }
+}
+
+@MainActor
+private final class InlineCommentCardCapture: ObservableObject {
+    @Published var replyState = DiffInlineCommentCardEditorState(
+        isComposerOpen: true,
+        replyDraft: "reply body"
+    )
+    @Published var editState = DiffInlineCommentCardEditorState(
+        editingCommentID: "comment-edit",
+        editDraft: "edit body"
+    )
+}
+
+@MainActor
+private struct InlineCommentCardCaptureHarness: View {
+    @ObservedObject var model: InlineCommentCardCapture
+
+    private let thread = DiffInlineCommentThread(
+        id: "thread",
+        filePath: "Sources/App.swift",
+        newLine: 7,
+        isResolved: false,
+        isOutdated: false,
+        comments: [
+            DiffInlineComment(
+                id: "comment-edit",
+                author: "reviewer",
+                body: "original comment",
+                viewerCanUpdate: true
+            ),
+        ]
+    )
+
+    var body: some View {
+        VStack {
+            DiffInlineCommentCard(thread: thread, editorState: $model.replyState)
+            DiffInlineCommentCard(thread: thread, editorState: $model.editState)
+        }
+        .frame(width: 480)
+    }
+}
+
+@MainActor
+private final class ProviderReplyCapture: ObservableObject {
+    @Published var editorState = DiffReviewInlineFeedbackReplyEditorState(
+        isReplying: true,
+        body: "provider reply"
+    )
+}
+
+@MainActor
+private struct ProviderReplyCaptureHarness: View {
+    @ObservedObject var model: ProviderReplyCapture
+
+    private let feedback = DiffReviewInlineFeedback(
+        id: "provider-thread",
+        providerName: "GitHub",
+        author: "reviewer",
+        bodyPreview: "Please revise this.",
+        status: .actionable,
+        providerURL: nil,
+        anchor: DiffReviewInlineFeedbackAnchor(path: "Sources/App.swift", line: 7, side: .new),
+        evidenceItemID: "provider-thread"
+    )
+    private let file = DiffReviewFileSummary(
+        path: "Sources/App.swift",
+        namespace: "github",
+        groupID: nil,
+        groupTitle: nil,
+        status: .modified,
+        additions: 1,
+        deletions: 0,
+        isRenderable: true
+    )
+
+    var body: some View {
+        DiffReviewInlineFeedbackCard(
+            item: feedback,
+            file: file,
+            isFocused: false,
+            actions: DiffReviewInlineFeedbackActions(),
+            onSelect: { _ in },
+            replyEditorState: $model.editorState
+        )
+        .frame(width: 480)
+        .environment(\.theme, try! ThemeStore().current)
+    }
+}
+
+@MainActor
+private final class VerdictSubmitCapture {
+    var verdict: ReviewVerdict?
+    var body: String?
+}
+
+@MainActor
+private final class ProviderPublishCapture: ObservableObject {
+    @Published var selectedDecision = ProviderReviewDecision.requestChanges
+    @Published var summaryBody = "publish summary"
+    @Published var isPublishing = false
+}
+
+@MainActor
+private struct ProviderPublishCaptureHarness: View {
+    @ObservedObject var model: ProviderPublishCapture
+
+    var body: some View {
+        ProviderReviewPublishConfirmationView(
+            providerName: "GitHub",
+            reviewIdentity: "#42",
+            commentCount: 1,
+            unpublishableMessages: [],
+            allowedDecisions: [.comment, .approve, .requestChanges],
+            selectedDecision: $model.selectedDecision,
+            summaryBody: $model.summaryBody,
+            isPublishing: model.isPublishing,
+            errorMessage: nil,
+            onCancel: {},
+            onConfirm: {}
+        )
+        .environment(\.theme, try! ThemeStore().current)
+    }
+}
+
+@MainActor
+private final class DraftSummaryEditCapture: ObservableObject {
+    @Published var body: String
+
+    init(body: String) {
+        self.body = body
+    }
+}
+
+@MainActor
+private struct DraftSummaryEditCaptureHarness: View {
+    @ObservedObject var capture: DraftSummaryEditCapture
+
+    var body: some View {
+        ReviewDraftSummaryCommentEditor(
+            text: $capture.body,
+            accessibilityIdentifier: "review-draft-summary-editor-draft-edit"
+        )
+        .environment(\.theme, try! ThemeStore().current)
+    }
+}

--- a/AlasTests/PairedReviewComposerSurfaceTests.swift
+++ b/AlasTests/PairedReviewComposerSurfaceTests.swift
@@ -57,15 +57,24 @@ struct PairedReviewComposerSurfaceTests {
         window.orderOut(nil)
     }
 
-    @Test func verdictSummarySubmitReceivesWrappedSelection() async throws {
-        let capture = VerdictSubmitCapture()
+    @Test func providerReplyEmptyEditorPreservesReplyLabelAndMinimumHeight() async throws {
+        let model = ProviderReplyCapture(body: "")
+        let controller = NSHostingController(rootView: ProviderReplyCaptureHarness(model: model))
+        let window = attach(controller)
+        await drain(controller.view)
+
+        let replyEditor = try #require(firstEditableTextView(in: controller.view))
+        let scrollView = try #require(replyEditor.enclosingScrollView)
+
+        #expect(scrollView.frame.height >= 32)
+        #expect(replyEditor.accessibilityPlaceholderValue() == "Reply")
+        window.orderOut(nil)
+    }
+
+    @Test func verdictSummaryEditorWrapsSelectedText() async throws {
         let controller = NSHostingController(
             rootView: VerdictSheet(
-                pendingCount: 1,
-                onSubmit: { verdict, body in
-                    capture.verdict = verdict
-                    capture.body = body
-                }
+                pendingCount: 1
             )
             .environment(\.theme, try! ThemeStore().current)
         )
@@ -75,41 +84,17 @@ struct PairedReviewComposerSurfaceTests {
         let editor = try #require(firstEditableTextView(in: controller.view))
         editor.insertText("verdict summary", replacementRange: NSRange(location: NSNotFound, length: 0))
         wrapSelection(in: editor)
-        try pressAccessibilityElement(
-            withIdentifier: "verdict-submit-review",
-            in: controller.view
-        )
 
-        #expect(capture.verdict == .comment)
-        #expect(capture.body == "`verdict summary`")
+        #expect(editor.string == "`verdict summary`")
         window.orderOut(nil)
     }
 
-    @Test func verdictSummaryDisabledRequestChangesDoesNotSubmitEmptySummary() async throws {
-        let capture = VerdictSubmitCapture()
-        let controller = NSHostingController(
-            rootView: VerdictSheet(
-                pendingCount: 1,
-                initialVerdict: .requestChanges,
-                onSubmit: { verdict, body in
-                    capture.verdict = verdict
-                    capture.body = body
-                }
-            )
-            .environment(\.theme, try! ThemeStore().current)
-        )
-        let window = attach(controller, height: 420)
-        await drain(controller.view)
-
-        let didSubmit = accessibilityElementPerformsPress(
-            withIdentifier: "verdict-submit-review",
-            in: controller.view
-        )
-
-        #expect(!didSubmit)
-        #expect(capture.verdict == nil)
-        #expect(capture.body == nil)
-        window.orderOut(nil)
+    @Test func verdictSummaryRequestChangesRequiresNonEmptySummary() {
+        #expect(!VerdictSheet.canSubmit(verdict: .requestChanges, summaryBody: ""))
+        #expect(!VerdictSheet.canSubmit(verdict: .requestChanges, summaryBody: " \n\t "))
+        #expect(VerdictSheet.canSubmit(verdict: .requestChanges, summaryBody: "needs work"))
+        #expect(VerdictSheet.canSubmit(verdict: .comment, summaryBody: ""))
+        #expect(VerdictSheet.canSubmit(verdict: .approve, summaryBody: ""))
     }
 
     @Test func providerPublishSummaryBindingReceivesWrappedSelectionAndPreservesDisabledState() async throws {
@@ -188,36 +173,6 @@ struct PairedReviewComposerSurfaceTests {
         textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
     }
 
-    private func pressAccessibilityElement(withIdentifier identifier: String, in view: NSView) throws {
-        let pressed = accessibilityElementPerformsPress(withIdentifier: identifier, in: view)
-        #expect(pressed)
-        if !pressed {
-            throw SurfaceTestError.elementDidNotPress(identifier)
-        }
-    }
-
-    private func accessibilityElementPerformsPress(withIdentifier identifier: String, in view: NSView) -> Bool {
-        allSubviews(of: view)
-            .filter { $0.accessibilityIdentifier() == identifier }
-            .contains { $0.accessibilityPerformPress() }
-    }
-
-    private func allSubviews(of view: NSView) -> [NSView] {
-        [view] + view.subviews.flatMap(allSubviews)
-    }
-
-    private func waitForSubview(withAccessibilityIdentifier identifier: String, in view: NSView) async throws {
-        for _ in 0..<20 {
-            view.layoutSubtreeIfNeeded()
-            if subview(withAccessibilityIdentifier: identifier, in: view) != nil {
-                return
-            }
-            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
-            await Task.yield()
-        }
-        try #require(subview(withAccessibilityIdentifier: identifier, in: view))
-    }
-
     private func waitForTextView(containing text: String, in view: NSView) async throws -> NSTextView {
         for _ in 0..<20 {
             view.layoutSubtreeIfNeeded()
@@ -228,13 +183,6 @@ struct PairedReviewComposerSurfaceTests {
             await Task.yield()
         }
         return try #require(textView(containing: text, in: view))
-    }
-
-    private func subview(withAccessibilityIdentifier identifier: String, in view: NSView) -> NSView? {
-        if view.accessibilityIdentifier() == identifier {
-            return view
-        }
-        return view.subviews.lazy.compactMap { subview(withAccessibilityIdentifier: identifier, in: $0) }.first
     }
 
     private func keyEvent(characters: String, modifiers: NSEvent.ModifierFlags) throws -> NSEvent {
@@ -251,10 +199,6 @@ struct PairedReviewComposerSurfaceTests {
             keyCode: 0
         ))
     }
-}
-
-private enum SurfaceTestError: Error {
-    case elementDidNotPress(String)
 }
 
 @MainActor
@@ -329,10 +273,14 @@ private struct InlineCommentCardCaptureHarness: View {
 
 @MainActor
 private final class ProviderReplyCapture: ObservableObject {
-    @Published var editorState = DiffReviewInlineFeedbackReplyEditorState(
-        isReplying: true,
-        body: "provider reply"
-    )
+    @Published var editorState: DiffReviewInlineFeedbackReplyEditorState
+
+    init(body: String = "provider reply") {
+        editorState = DiffReviewInlineFeedbackReplyEditorState(
+            isReplying: true,
+            body: body
+        )
+    }
 }
 
 @MainActor
@@ -372,12 +320,6 @@ private struct ProviderReplyCaptureHarness: View {
         .frame(width: 480)
         .environment(\.theme, try! ThemeStore().current)
     }
-}
-
-@MainActor
-private final class VerdictSubmitCapture {
-    var verdict: ReviewVerdict?
-    var body: String?
 }
 
 @MainActor

--- a/docs/superpowers/plans/2026-08-10-shared-composer-paired-delimiters.md
+++ b/docs/superpowers/plans/2026-08-10-shared-composer-paired-delimiters.md
@@ -92,7 +92,7 @@ enum PairedDelimiterEditing {
 }
 ```
 
-Use `NSString` for bounds and adjacent-character reads. Check an opener before generic closer step-over so symmetric delimiters retain their current behavior.
+Use `NSString` for bounds and adjacent-character reads. When a symmetric delimiter already appears immediately after an empty caret, resolve closer step-over before empty-pair insertion so the existing editor behavior is preserved.
 
 - [ ] **Step 4: Refactor `CodeTextView` to consume semantic actions**
 

--- a/docs/superpowers/plans/2026-08-10-shared-composer-paired-delimiters.md
+++ b/docs/superpowers/plans/2026-08-10-shared-composer-paired-delimiters.md
@@ -1,0 +1,433 @@
+# Shared Composer Paired Delimiters Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every authored-content composer in Alas the code editor's selection wrapping, empty-caret delimiter pairing, and closer step-over behavior.
+
+**Architecture:** A pure `PairedDelimiterEditing` resolver owns the canonical six pairs and returns semantic actions without touching views. AppKit adapters apply those actions to plain or attributed text, while reusable SwiftUI representables migrate authored-content fields without changing utility inputs or each surface's existing chrome and focus behavior.
+
+**Tech Stack:** Swift 5.9, SwiftUI, AppKit `NSTextView`/`NSTextField`, Swift Testing, XcodeGen, macOS 15.
+
+## Global Constraints
+
+- Canonical pairs are exactly `()`, `[]`, `{}`, `""`, `''`, and a pair of single backticks.
+- Selection wrapping keeps the inner text selected; empty-pair insertion puts the caret between delimiters; an existing closer is stepped over.
+- Symmetric empty-caret pairing is disabled when escaped or directly adjacent to an identifier-like character; explicit selections always wrap.
+- Multi-character input, paste, dictation, and marked-text composition use native insertion.
+- ACP wrapping preserves attributed text, mention chips, and image attachments.
+- Every paired operation is one undoable edit and emits normal text-change notifications.
+- Include authored content only: ACP prompts; commit and review-request titles/bodies; review comments/replies/summaries; Mission instructions/prompts; reusable prompts; and scripts.
+- Exclude search/filter fields, names, paths, branches, picker queries, session titles, structured numeric/date inputs, and language-server configuration lists.
+- Preserve existing fonts, colors, chrome, sizing, scrolling, submit shortcuts, focus state, disabled/read-only state, and accessibility identifiers.
+- Keep code, comments, logs, and UI strings in English; tests use Swift Testing, not XCTest.
+
+---
+
+### Task 1: Extract the delimiter policy and retain code-editor parity
+
+**Files:**
+- Create: `Alas/Sources/UI/PairedDelimiterEditing.swift`
+- Create: `AlasTests/PairedDelimiterEditingTests.swift`
+- Modify: `Alas/Sources/Code/Editor/CodeTextView.swift:16-25,236-272,323-354,895-946`
+- Modify: `AlasTests/CodeTextViewAutoPairTests.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via `rtk xcodegen`
+
+**Interfaces:**
+- Produces: `enum PairedDelimiterEditAction: Equatable { case wrap(opening: Character, closing: Character); case insertPair(opening: Character, closing: Character); case stepOver; case native }`
+- Produces: `PairedDelimiterEditing.resolve(insertedText:in:selectedRange:) -> PairedDelimiterEditAction`
+- Consumes: UTF-16 `NSRange`, matching AppKit selection APIs.
+
+- [ ] **Step 1: Add failing resolver tests**
+
+Create table-driven Swift Testing coverage whose core assertions include:
+
+```swift
+@Test(arguments: [
+    ("(", "value", NSRange(location: 0, length: 5), .wrap(opening: "(", closing: ")")),
+    ("[", "", NSRange(location: 0, length: 0), .insertPair(opening: "[", closing: "]")),
+    (")", "()", NSRange(location: 1, length: 0), .stepOver),
+    ("`", "word", NSRange(location: 4, length: 0), .native),
+    ("paste", "", NSRange(location: 0, length: 0), .native),
+])
+func resolvesRepresentativeEdits(input: String, text: String, range: NSRange, expected: PairedDelimiterEditAction) {
+    #expect(PairedDelimiterEditing.resolve(insertedText: input, in: text, selectedRange: range) == expected)
+}
+```
+
+Add separate tests for all six pairs, odd/even backslash escaping, identifier adjacency on both sides, selected symmetric delimiters, closer mismatch, and out-of-bounds/`NSNotFound` ranges.
+
+- [ ] **Step 2: Run the new tests and verify RED**
+
+Run:
+
+```bash
+rtk xcodegen
+ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/PairedDelimiterEditingTests test
+```
+
+Expected: compilation fails because `PairedDelimiterEditing` and `PairedDelimiterEditAction` do not exist.
+
+- [ ] **Step 3: Implement the pure resolver**
+
+Implement the exact public shape below and move the current identifier/backslash rules out of `CodeTextView`:
+
+```swift
+enum PairedDelimiterEditAction: Equatable {
+    case wrap(opening: Character, closing: Character)
+    case insertPair(opening: Character, closing: Character)
+    case stepOver
+    case native
+}
+
+enum PairedDelimiterEditing {
+    static let pairs: [Character: Character] = [
+        "(": ")", "[": "]", "{": "}", "\"": "\"", "'": "'", "`": "`",
+    ]
+
+    static func resolve(
+        insertedText: String,
+        in text: String,
+        selectedRange: NSRange
+    ) -> PairedDelimiterEditAction
+}
+```
+
+Use `NSString` for bounds and adjacent-character reads. Check an opener before generic closer step-over so symmetric delimiters retain their current behavior.
+
+- [ ] **Step 4: Refactor `CodeTextView` to consume semantic actions**
+
+Replace its private pair table and symmetric helpers with the resolver. Keep editor-owned concerns in place: multi-cursor replacement calculation, closing-bracket indentation, completion notifications, and `autoPairDisabled`. Map `.wrap`/`.insertPair` to the existing replacement and selection math, `.stepOver` to caret movement, and `.native` to `super.insertText`.
+
+- [ ] **Step 5: Run focused policy and editor compatibility tests**
+
+Run:
+
+```bash
+ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/PairedDelimiterEditingTests -only-testing:AlasTests/CodeTextViewAutoPairTests -only-testing:AlasTests/CodeTextViewMultiCursorTests test
+```
+
+Expected: all selected suites pass.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add Alas/Sources/UI/PairedDelimiterEditing.swift Alas/Sources/Code/Editor/CodeTextView.swift AlasTests/PairedDelimiterEditingTests.swift AlasTests/CodeTextViewAutoPairTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "refactor(editor): share paired delimiter policy"
+```
+
+---
+
+### Task 2: Build reusable pair-aware AppKit composer controls
+
+**Files:**
+- Create: `Alas/Sources/UI/PairedComposerTextControls.swift`
+- Create: `AlasTests/PairedComposerTextControlsTests.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via `rtk xcodegen`
+
+**Interfaces:**
+- Consumes: `PairedDelimiterEditing.resolve(insertedText:in:selectedRange:)` from Task 1.
+- Produces: `class PairedDelimiterTextView: NSTextView`, usable as a superclass by specialized composers.
+- Produces: `struct PairedTextField: NSViewRepresentable` with text, placeholder, font, text color, enabled state, optional `Binding<Bool>` focus, and optional submit callback.
+- Produces: `struct PairedTextEditor: NSViewRepresentable` with text, font, text color, enabled state, optional `Binding<Bool>` focus, and configurable `textContainerInset`.
+
+- [ ] **Step 1: Add failing native-control tests**
+
+Cover plain selection wrapping, empty pairing, closer step-over, binding synchronization, disabled controls, focus round-tripping, and single-step undo. Include an attributed selection test:
+
+```swift
+let storage = NSTextStorage(attributedString: NSAttributedString(
+    string: "value",
+    attributes: [.toolTip: "keep-me"]
+))
+let textView = makePairedTextView(storage: storage)
+textView.setSelectedRange(NSRange(location: 0, length: 5))
+textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+#expect(textView.string == "`value`")
+#expect(textView.textStorage?.attribute(.toolTip, at: 1, effectiveRange: nil) as? String == "keep-me")
+#expect(textView.selectedRange() == NSRange(location: 1, length: 5))
+```
+
+- [ ] **Step 2: Run the control tests and verify RED**
+
+Run:
+
+```bash
+rtk xcodegen
+ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/PairedComposerTextControlsTests test
+```
+
+Expected: compilation fails because the reusable controls do not exist.
+
+- [ ] **Step 3: Implement `PairedDelimiterTextView`**
+
+Override `insertText(_:replacementRange:)`, normalize `String`/`NSAttributedString` input, and bypass pairing whenever `hasMarkedText()` or the resolver returns `.native`. For `.wrap`, build one attributed replacement from an opening delimiter, `textStorage.attributedSubstring(from:)`, and a closing delimiter, then call `super.insertText` once. For `.insertPair`, call `super.insertText` once with both delimiters. For `.stepOver`, move the selection without mutating storage. Set the final selection after the native edit.
+
+Delimiter attributes come from `typingAttributes`; the selected attributed substring is appended unchanged. This ensures the edit is one native undo unit and preserves attachments.
+
+- [ ] **Step 4: Implement `PairedTextField` and `PairedTextEditor`**
+
+Use AppKit coordinators that update bindings only when values differ. The text field coordinator intercepts `control(_:textView:shouldChangeCharactersIn:replacementString:)`, resolves the action, and uses a recursion guard while applying the replacement through the shared field editor. The multiline control instantiates `PairedDelimiterTextView` in an `NSScrollView`.
+
+Both controls must update font, color, enabled/editable state, external binding changes, and optional focus bindings in `updateNSView`. Do not add visual chrome inside the representables; callers retain their existing SwiftUI backgrounds, overlays, padding, frames, and accessibility identifiers.
+
+- [ ] **Step 5: Run focused tests and a build**
+
+Run:
+
+```bash
+ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/PairedComposerTextControlsTests test
+ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: tests and build pass.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add Alas/Sources/UI/PairedComposerTextControls.swift AlasTests/PairedComposerTextControlsTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(editor): add paired composer text controls"
+```
+
+---
+
+### Task 3: Add pairing to the attributed ACP composer
+
+**Files:**
+- Modify: `Alas/Sources/ACP/UI/ACPComposer.swift:562-700`
+- Create: `AlasTests/ACP/UI/ACPComposerPairedDelimiterTests.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj` via `rtk xcodegen`
+
+**Interfaces:**
+- Consumes: `PairedDelimiterTextView` from Task 2.
+- Preserves: `ACPNSTextView` slash/mention pickers, image paste, typography, attributed draft extraction, and submit shortcuts.
+
+- [ ] **Step 1: Add failing ACP attributed-content tests**
+
+Instantiate `ACPNSTextView` and prove that backticks wrap selected styled text while retaining its custom attribute and selected range. Add a second test with a one-character attachment carrying `.attachmentURI` and prove the attribute survives between the new delimiters. Add empty-pair and closer-step tests.
+
+- [ ] **Step 2: Run ACP pairing tests and verify RED**
+
+Run:
+
+```bash
+rtk xcodegen
+ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPComposerPairedDelimiterTests test
+```
+
+Expected: the wrapping assertions fail because `ACPNSTextView` still inherits directly from `NSTextView`.
+
+- [ ] **Step 3: Adopt the shared text-view superclass**
+
+Change only the superclass:
+
+```swift
+final class ACPNSTextView: PairedDelimiterTextView {
+```
+
+Keep `keyDown`, image insertion, picker reconciliation, typing attributes, and coordinator behavior unchanged. Ensure `keyDown` continues to call `super` so normal character insertion reaches the pairing override after ACP-specific shortcut handling.
+
+- [ ] **Step 4: Run ACP pairing plus composer regression suites**
+
+Run:
+
+```bash
+ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPComposerPairedDelimiterTests -only-testing:AlasTests/ACPComposerDraftBridgeTests -only-testing:AlasTests/ACPComposerImageExtractTests test
+```
+
+Expected: all selected suites pass.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add Alas/Sources/ACP/UI/ACPComposer.swift AlasTests/ACP/UI/ACPComposerPairedDelimiterTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(acp): pair delimiters in composer"
+```
+
+---
+
+### Task 4: Migrate commit and review-request message editors
+
+**Files:**
+- Modify: `Alas/Sources/Center/Commit/CommitMessageEditorView.swift:110-164`
+- Modify: `Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift:300-354`
+- Modify: `Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift:307-317`
+- Modify: `AlasTests/CommitMessageEditorViewTests.swift`
+- Create: `AlasTests/PairedPrimaryComposerSurfaceTests.swift`
+
+**Interfaces:**
+- Consumes: `PairedTextField` and `PairedTextEditor` from Task 2.
+- Preserves: enum-backed focus state in commit/review-request editors and GG draft change callbacks.
+
+- [ ] **Step 1: Add failing representative surface tests**
+
+Extend the commit-message render harness to locate the AppKit pair-aware controls and exercise backtick wrapping in both subject and body. Add a review-request harness proving the title/body bindings update. Add a GG split-message test proving the existing `draftDidChange` path still runs after a paired edit.
+
+- [ ] **Step 2: Run primary-composer tests and verify RED**
+
+Run:
+
+```bash
+ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CommitMessageEditorViewTests -only-testing:AlasTests/PairedPrimaryComposerSurfaceTests test
+```
+
+Expected: pair-aware AppKit controls are absent from these surfaces.
+
+- [ ] **Step 3: Migrate the three primary composer families**
+
+Replace only the authored fields:
+
+- commit subject/body;
+- review-request title/body;
+- GG split commit messages.
+
+Bridge enum focus to optional Boolean bindings with explicit get/set closures, for example:
+
+```swift
+Binding(
+    get: { focused == .subject },
+    set: { value in
+        if value { focused = .subject }
+        else if focused == .subject { focused = nil }
+    }
+)
+```
+
+Copy the current font, color, disabled state, padding, frame, background, overlays, and clipping exactly. Preserve GG's `.onChange` callback.
+
+- [ ] **Step 4: Run focused tests and commit**
+
+Run:
+
+```bash
+ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CommitMessageEditorViewTests -only-testing:AlasTests/PairedPrimaryComposerSurfaceTests test
+```
+
+Then:
+
+```bash
+git add Alas/Sources/Center/Commit/CommitMessageEditorView.swift Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift AlasTests/CommitMessageEditorViewTests.swift AlasTests/PairedPrimaryComposerSurfaceTests.swift
+git commit -m "feat(commit): pair delimiters in message composers"
+```
+
+---
+
+### Task 5: Migrate review feedback composers
+
+**Files:**
+- Modify: `Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift:1066-1270,2398-2425`
+- Modify: `Alas/Sources/Center/Review/DiffInlineCommentCard.swift:160-290`
+- Modify: `Alas/Sources/Center/Review/VerdictSheet.swift:20-40`
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift:44-72`
+- Modify: `Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift:672-692`
+- Modify: `AlasTests/DiffReviewSurfaceTests.swift`
+- Create: `AlasTests/PairedReviewComposerSurfaceTests.swift`
+
+**Interfaces:**
+- Consumes: `PairedDelimiterTextView` and `PairedTextEditor` from Task 2.
+- Preserves: `ReviewDraftComposerKeyboardAction`, focus generation, save/cancel shortcuts, staged reply bindings, and accessibility identifiers.
+
+- [ ] **Step 1: Add failing review-composer tests**
+
+Exercise the hosted `ReviewDraftComposerTextEditor` text view for selection wrapping and keyboard-action routing. Add representative hosting tests for inline reply/edit, verdict summary, provider publish summary, and draft-summary editing; verify their bindings receive the wrapped string.
+
+- [ ] **Step 2: Run review-composer tests and verify RED**
+
+Run:
+
+```bash
+ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/PairedReviewComposerSurfaceTests -only-testing:AlasTests/DiffReviewSurfaceTests test
+```
+
+Expected: wrapping is missing from at least the existing `ReviewDraftComposerNSTextView` and SwiftUI-only editors.
+
+- [ ] **Step 3: Migrate review feedback controls**
+
+Make `ReviewDraftComposerNSTextView` inherit `PairedDelimiterTextView`; retain its `keyDown` override and call to `super`. Replace authored SwiftUI text editors with `PairedTextEditor`, including the vertical provider-reply field currently expressed as `TextField(axis: .vertical)`. Preserve each binding, focus behavior, font, foreground color, minimum height, background, overlay, disabled state, and accessibility identifier.
+
+- [ ] **Step 4: Run review surface regression tests**
+
+Run:
+
+```bash
+ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/PairedReviewComposerSurfaceTests -only-testing:AlasTests/DiffReviewSurfaceTests -only-testing:AlasTests/ACPMarkdownInlineRendererTests test
+```
+
+Expected: all selected suites pass, including existing focus-generation coverage.
+
+- [ ] **Step 5: Commit Task 5**
+
+```bash
+git add Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift Alas/Sources/Center/Review/DiffInlineCommentCard.swift Alas/Sources/Center/Review/VerdictSheet.swift Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift AlasTests/DiffReviewSurfaceTests.swift AlasTests/PairedReviewComposerSurfaceTests.swift
+git commit -m "feat(review): pair delimiters in feedback composers"
+```
+
+---
+
+### Task 6: Migrate Mission, prompt, and script authoring surfaces
+
+**Files:**
+- Modify: `Alas/Sources/Missions/EditMissionSourceDialog.swift:56-65`
+- Modify: `Alas/Sources/Missions/AddMissionLegDialog.swift:160-177`
+- Modify: `Alas/Sources/Missions/NewMissionDialog.swift:680-739`
+- Modify: `Alas/Sources/Settings/PromptEditorBody.swift:28-36`
+- Modify: `Alas/Sources/Settings/TerminalPane.swift:50-72`
+- Modify: `Alas/Sources/Dialogs/NewProjectDialog.swift:508-536`
+- Create: `AlasTests/PairedAuthoredContentSurfaceTests.swift`
+
+**Interfaces:**
+- Consumes: `PairedTextEditor` from Task 2.
+- Preserves: Mission model bindings and validation, prompt reset/save flows, terminal config bindings, and new-project script inheritance modes.
+
+- [ ] **Step 1: Add failing authored-content surface tests**
+
+Create hosting harnesses that exercise one Mission instruction/body binding, `PromptEditorBody.draftPrompt`, one terminal startup-script binding, and one new-project script binding. Select `command`, insert backticks, and expect `` `command` `` in each backing binding.
+
+- [ ] **Step 2: Run authored-content tests and verify RED**
+
+Run:
+
+```bash
+ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/PairedAuthoredContentSurfaceTests test
+```
+
+Expected: the hosted fields are still native SwiftUI `TextEditor` instances and do not apply shared pairing.
+
+- [ ] **Step 3: Migrate the approved surfaces only**
+
+Replace Mission body/context/instructions/initial-prompt editors, the reusable prompt editor, terminal startup-script editors, and new-project script editors with `PairedTextEditor`. Keep Mission work-item title fields unchanged because they are identity inputs under the approved boundary. Keep Run Script palette search/edit query, ACP structured input forms, language-server args/root markers, and every search/filter/name/path/branch field unchanged.
+
+Copy each editor's font, foreground color, frame bounds, padding, background, overlay, disabled state, and binding exactly.
+
+- [ ] **Step 4: Run focused and full local verification**
+
+Run:
+
+```bash
+rtk xcodegen
+ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/PairedDelimiterEditingTests -only-testing:AlasTests/PairedComposerTextControlsTests -only-testing:AlasTests/ACPComposerPairedDelimiterTests -only-testing:AlasTests/PairedPrimaryComposerSurfaceTests -only-testing:AlasTests/PairedReviewComposerSurfaceTests -only-testing:AlasTests/PairedAuthoredContentSurfaceTests test
+rtk git diff --check
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: focused tests, full tests, diff check, and build all pass. A run that stops before `xctest` is incomplete and must be rerun or reported honestly.
+
+- [ ] **Step 5: Commit Task 6**
+
+```bash
+git add Alas/Sources/Missions/EditMissionSourceDialog.swift Alas/Sources/Missions/AddMissionLegDialog.swift Alas/Sources/Missions/NewMissionDialog.swift Alas/Sources/Settings/PromptEditorBody.swift Alas/Sources/Settings/TerminalPane.swift Alas/Sources/Dialogs/NewProjectDialog.swift AlasTests/PairedAuthoredContentSurfaceTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat(editor): pair delimiters across authored content"
+```
+
+---
+
+## Publication and readiness
+
+After all six tasks pass their per-task reviews and the final whole-branch review:
+
+1. Re-run `rtk git diff --check`, the full macOS test suite, and the quiet macOS build on the final tree.
+2. Rebase the branch onto current `origin/main`; resolve only task-related conflicts and rerun affected verification.
+3. Push `nacho/backticks` and create a non-draft PR against `main` with summary and verification sections.
+4. Request one fresh `@codex review` if the repository automation has not started one.
+5. Run `gh-pr-ready-loop` with the Codex gate until the current head has green required CI, a fresh positive Codex signal, no actionable unresolved review feedback, and clean mergeability.
+6. Do not merge the PR unless the user separately requests it.

--- a/docs/superpowers/specs/2026-08-10-shared-composer-paired-delimiters-design.md
+++ b/docs/superpowers/specs/2026-08-10-shared-composer-paired-delimiters-design.md
@@ -1,0 +1,92 @@
+# Shared Composer Paired Delimiters
+
+## Goal
+
+Give authored-content fields throughout Alas the code editor's paired-delimiter behavior. Typing a supported opener around selected text must wrap the selection instead of replacing it. Empty-caret pairing and closer step-over must behave consistently as well.
+
+This behavior belongs to content composition, not to every editable control.
+
+## Supported Behavior
+
+The canonical pairs remain exactly those supported by `CodeTextView`:
+
+- `(` and `)`
+- `[` and `]`
+- `{` and `}`
+- `"` and `"`
+- `'` and `'`
+- `` ` `` and `` ` ``
+
+For a non-empty selection, typing an opener wraps the selected content and keeps the inner content selected. For an empty selection, typing an opener inserts both delimiters and leaves the caret between them. Typing a closer when the same closer is immediately ahead moves the caret past the existing character.
+
+Symmetric delimiters retain the code editor's safeguards: empty-caret auto-pairing does not activate when the delimiter is escaped or directly adjacent to identifier-like text. These safeguards do not prevent wrapping an explicit selection.
+
+Paste, dictation, marked-text composition, and other multi-character input bypass pairing. If the selection or text-storage state is invalid, the control falls back to native insertion so user input is never discarded.
+
+## Surface Boundary
+
+Pair-aware editing applies to fields whose primary purpose is authoring content:
+
+- ACP prompts
+- commit subjects and bodies
+- review-request titles and descriptions
+- review comments and replies
+- Mission instructions and prompts
+- reusable prompt editors
+- script editors
+
+It does not apply to utility or identity inputs, including search and filter controls, names, paths, branches, picker queries, and session titles. The implementation plan must inventory current call sites against this rule rather than migrating every `TextField` or `TextEditor` mechanically.
+
+## Architecture
+
+### Shared decision engine
+
+Add a small, pure `PairedDelimiterEditing` component that owns the pair table and resolves a single-character insertion into one of four outcomes:
+
+1. wrap the current selection;
+2. insert an empty pair;
+3. move past an existing closer;
+4. use native insertion.
+
+The resolver accepts the typed character, selected range, and the adjacent text it needs for contextual safeguards. It does not own a view, mutate text storage, or depend on SwiftUI. This makes the behavior independently testable and keeps every surface on one canonical rule set.
+
+### AppKit adapters
+
+View-specific adapters apply the resolved action through their native editing APIs:
+
+- `CodeTextView` uses the shared rules while retaining its existing multi-cursor, indentation, completion, and edit-notification behavior.
+- `ACPNSTextView` applies wrappers directly around the selected attributed range. It inserts only the delimiter characters, preserving Markdown attributes, mention chips, image attachments, and other attributed content inside the selection.
+- Reusable AppKit-backed single-line and multiline composer controls expose SwiftUI bindings while providing pair-aware insertion to the remaining authored-content surfaces.
+
+The controls must preserve current visual chrome, typography, sizing, scrolling, focus bindings, submit shortcuts, enabled/read-only state, and accessibility identifiers. Pairing is an editing capability, not a visual redesign.
+
+### Editing semantics
+
+Each pair operation is one undoable user edit. Selection and caret updates use UTF-16 ranges, matching AppKit. Normal delegate and text-change notifications continue to fire so SwiftUI bindings, ACP draft persistence, Markdown restyling, and dirty-state tracking observe the final edit.
+
+ACP attributed selections must never be flattened to plain text. Programmatic replacements and synchronization updates do not invoke auto-pairing.
+
+## Error Handling and Compatibility
+
+The resolver returns native insertion for unsupported characters, multi-character input, invalid ranges, or insufficient context. Adapters must validate ranges against their current storage before mutation and fall back rather than swallow input.
+
+Refactoring `CodeTextView` must preserve its current behavior exactly, including multi-cursor pairing and closing-delimiter indentation. The shared component owns delimiter decisions only; editor-specific behavior remains in the editor adapter.
+
+## Testing
+
+Add focused coverage at four levels:
+
+1. Pure resolver tests cover all six pairs, selected and empty ranges, closer step-over, escaping, identifier adjacency, invalid ranges, and multi-character input.
+2. Existing `CodeTextView` tests remain compatibility coverage, including multi-cursor cases.
+3. ACP tests prove that wrapping styled text and attachment chips preserves attributes, selection, draft synchronization, and single-step undo.
+4. Reusable composer-control and representative surface tests cover binding updates, focus preservation, disabled/read-only behavior, undo, and the intended inclusion/exclusion boundary.
+
+Implementation verification proceeds from focused tests to project generation, the full macOS test suite, and a macOS build, following the repository's standard gates.
+
+## Non-Goals
+
+- Adding configurable delimiter sets or a settings toggle
+- Markdown-aware toggling that removes an existing wrapper
+- Changing the appearance or layout of composer fields
+- Adding pairing to search, naming, path, branch, picker, or session-title inputs
+- Expanding beyond the six delimiters already supported by the code editor


### PR DESCRIPTION
## Summary

- centralize paired delimiter policy and reuse it from the code editor and shared composer controls
- add AppKit-backed paired text field/editor controls for authored composer surfaces
- migrate ACP, commit/review-request, GG split, review feedback, Mission, prompt, terminal script, and project script editors
- add regression coverage for the shared policy and migrated surface families

## Verification

- `rtk xcodegen`
- `rtk git diff --check`
- `rtk swiftformat --lint` on touched source/test files
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/PairedDelimiterEditingTests -only-testing:AlasTests/PairedComposerTextControlsTests -only-testing:AlasTests/ACPComposerPairedDelimiterTests -only-testing:AlasTests/PairedPrimaryComposerSurfaceTests -only-testing:AlasTests/PairedReviewComposerSurfaceTests -only-testing:AlasTests/PairedAuthoredContentSurfaceTests test`
- `ALAS_FFF_TARGET_ARCH=arm64 rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

Full local suite note: one full run reached xctest and reported 7,889 passed / 12 skipped / 3 failures. The three failures passed immediately when rerun isolated:

- `AgentTerminalLaunchTests/acpAuthLaunchAppendsQuotedCommandAndEnvPrefix`
- `DiffReviewSurfaceTests/inlineFeedbackScrollRealizesTargetHunkWithoutEagerlyRenderingAllHunks`
- `DiffReviewSurfaceTests/surfacePassesFeedbackToMatchingFileOnly`
