### PR TITLE
fix(editor): pair dead-key delimiters and reachable field pairing

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -398,6 +398,7 @@
 		40345C2068BFBF42B5C629B0 /* StashesSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E8D8B829B3A7B0327CAFA1 /* StashesSectionView.swift */; };
 		40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */; };
 		4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */; };
+		407C480A97251F3D342D84F7 /* PairedDelimiterDeadKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D9C87FA802239BCCC9F4F4 /* PairedDelimiterDeadKeyTests.swift */; };
 		40A21E55EB86B5F3D42AEFF2 /* InlineDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */; };
 		40C56ABCF57F6F3F7D40E020 /* RemoteHelperInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE8745F3A4C6F0645D1D44A /* RemoteHelperInstaller.swift */; };
 		40D9FD39D36ADE353B9971E8 /* MergeRegionVisualLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256257983A4B1E1E674DF5B8 /* MergeRegionVisualLayoutTests.swift */; };
@@ -2874,6 +2875,7 @@
 		D5825E49F6DC54DC35132D2F /* MergeConflictTabModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabModelTests.swift; sourceTree = "<group>"; };
 		D5AA350F5909E28954C623B7 /* ProcessMemoryProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMemoryProbe.swift; sourceTree = "<group>"; };
 		D5BAC2BE2CEAFDD462D9116F /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		D5D9C87FA802239BCCC9F4F4 /* PairedDelimiterDeadKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedDelimiterDeadKeyTests.swift; sourceTree = "<group>"; };
 		D5DAD29A75E3651CA720017D /* RemoteAccessPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteAccessPolicy.swift; sourceTree = "<group>"; };
 		D60051A6C7BEE35773F3FBB9 /* tool-call-content-terminal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tool-call-content-terminal.json"; sourceTree = "<group>"; };
 		D6128B044F59DB08F2383F7B /* RunScriptCreationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptCreationTests.swift; sourceTree = "<group>"; };
@@ -3586,6 +3588,7 @@
 				DEFCC9CAC7B3254708748815 /* OpenSessionsTests.swift */,
 				DDBB557833D3939208D75FB7 /* PairedAuthoredContentSurfaceTests.swift */,
 				2E984007859E2721356CAF8A /* PairedComposerTextControlsTests.swift */,
+				D5D9C87FA802239BCCC9F4F4 /* PairedDelimiterDeadKeyTests.swift */,
 				8A1B501810079EB9A18E70D3 /* PairedDelimiterEditingTests.swift */,
 				F89DAC6A8A16FADF8D614D0A /* PairedPrimaryComposerSurfaceTests.swift */,
 				6F88DEFC78E8D8AF65CB740A /* PairedReviewComposerSurfaceTests.swift */,
@@ -7367,6 +7370,7 @@
 				BC0EC69E1BC62514BBE129E7 /* OpenSessionsTests.swift in Sources */,
 				D36A33178D064DBD5DFD9B6D /* PairedAuthoredContentSurfaceTests.swift in Sources */,
 				7EB1A9415AE49BBB694946AC /* PairedComposerTextControlsTests.swift in Sources */,
+				407C480A97251F3D342D84F7 /* PairedDelimiterDeadKeyTests.swift in Sources */,
 				DCF52CA0F7607995402CED3D /* PairedDelimiterEditingTests.swift in Sources */,
 				DDE5BE847DFFF54429D61D4E /* PairedPrimaryComposerSurfaceTests.swift in Sources */,
 				E4BE423D04F69D25C520A80B /* PairedReviewComposerSurfaceTests.swift in Sources */,

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -28,6 +28,14 @@ final class CodeTextView: NSTextView, FontSizeResponder {
 
     var autoPairDisabled: Bool = false
 
+    /// Text that the in-flight marked composition swallowed, kept so a dead-key
+    /// delimiter can still wrap the selection the user had before pressing it.
+    private var selectionReplacedByMarkedText: String?
+    /// `NSTextView.unmarkText()` finalizes a composition by re-inserting the
+    /// marked characters through `insertText`, so pairing has to stay suppressed
+    /// while we replace them or the placeholder pairs with itself.
+    private var isCommittingMarkedText = false
+
     /// Set by `CodeEditorCoordinator.attach`. Each closure mutates the shared
     /// `code.fontSize` config in response to the matching menu command.
     var increaseFontSizeHandler: (() -> Void)?
@@ -265,10 +273,37 @@ final class CodeTextView: NSTextView, FontSizeResponder {
         return shouldChange
     }
 
+    override func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
+        if !hasMarkedText() {
+            let replaced = replacementRange.location == NSNotFound ? self.selectedRange() : replacementRange
+            let nsString = self.string as NSString
+            selectionReplacedByMarkedText = replaced.length > 0 && NSMaxRange(replaced) <= nsString.length
+                ? nsString.substring(with: replaced)
+                : nil
+        }
+        super.setMarkedText(string, selectedRange: selectedRange, replacementRange: replacementRange)
+    }
+
+    override func unmarkText() {
+        selectionReplacedByMarkedText = nil
+        super.unmarkText()
+    }
+
     override func insertText(_ insertString: Any, replacementRange: NSRange) {
         guard isEditable else { return }
+        guard !isCommittingMarkedText else {
+            insertTextAfterTextEdit(insertString, replacementRange: replacementRange)
+            return
+        }
+        let replacedSelection = selectionReplacedByMarkedText
+        selectionReplacedByMarkedText = nil
         guard let text = Self.string(from: insertString) else {
             insertTextAfterTextEdit(insertString, replacementRange: replacementRange)
+            return
+        }
+
+        if !autoPairDisabled, !hasMultipleSelections, hasMarkedText(),
+           insertPairedDelimiterCommittingMarkedText(text, replacedSelection: replacedSelection) {
             return
         }
 
@@ -878,6 +913,59 @@ final class CodeTextView: NSTextView, FontSizeResponder {
         } else {
             setSelectedRangeAfterTextEdit(NSRange(location: range.location + 1, length: 0))
         }
+    }
+
+    /// Pairs a delimiter that arrived as a dead-key composition — layouts such as
+    /// "U.S. International – PC" install `"`, `'` and `` ` `` as marked text and
+    /// only commit the literal character on the next keystroke. Returns `false`
+    /// for accented results and IME candidates so they insert natively.
+    private func insertPairedDelimiterCommittingMarkedText(
+        _ text: String,
+        replacedSelection: String?
+    ) -> Bool {
+        let marked = markedRange()
+        let nsString = string as NSString
+        guard text.count == 1,
+              marked.location != NSNotFound,
+              marked.length > 0,
+              NSMaxRange(marked) <= nsString.length,
+              nsString.substring(with: marked) == text,
+              let context = PairedDelimiterEditing.preCompositionContext(
+                  text: string,
+                  markedRange: marked,
+                  replacedSelection: replacedSelection ?? ""
+              )
+        else { return false }
+
+        switch PairedDelimiterEditing.resolve(
+            insertedText: text,
+            in: context.text,
+            selectedRange: context.selectedRange
+        ) {
+        case let .wrap(opening, closing), let .insertPair(opening, closing):
+            let wrapped = (context.text as NSString).substring(with: context.selectedRange)
+            replaceMarkedText(with: "\(opening)\(wrapped)\(closing)", markedRange: marked)
+            setSelectedRangeAfterTextEdit(NSRange(
+                location: marked.location + 1,
+                length: context.selectedRange.length
+            ))
+            return true
+
+        case .stepOver:
+            replaceMarkedText(with: "", markedRange: marked)
+            setSelectedRangeAfterTextEdit(NSRange(location: marked.location + 1, length: 0))
+            return true
+
+        case .native:
+            return false
+        }
+    }
+
+    private func replaceMarkedText(with replacement: String, markedRange: NSRange) {
+        isCommittingMarkedText = true
+        defer { isCommittingMarkedText = false }
+        unmarkText()
+        insertTextAfterTextEdit(replacement, replacementRange: markedRange)
     }
 
     private func previousCharacter(before location: Int) -> Character? {

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -4,14 +4,41 @@ import SwiftUI
 class PairedDelimiterTextView: NSTextView {
     private var bypassesPairedDelimiterResolution = false
     private var appliesPairedDelimiterResolutionForKeyboardInput = false
+    /// Text that the in-flight marked composition swallowed, kept so a dead-key
+    /// delimiter can still wrap the selection the user had before pressing it.
+    private var selectionReplacedByMarkedText: NSAttributedString?
+
+    override func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
+        if !hasMarkedText() {
+            let replaced = replacementRange.location == NSNotFound ? self.selectedRange() : replacementRange
+            selectionReplacedByMarkedText = textStorage.flatMap { storage in
+                replaced.length > 0 && Self.isValid(replaced, in: storage)
+                    ? storage.attributedSubstring(from: replaced)
+                    : nil
+            }
+        }
+        super.setMarkedText(string, selectedRange: selectedRange, replacementRange: replacementRange)
+    }
 
     override func insertText(_ insertString: Any, replacementRange: NSRange) {
+        let replacedSelection = selectionReplacedByMarkedText
+        selectionReplacedByMarkedText = nil
+
         guard !bypassesPairedDelimiterResolution,
               appliesPairedDelimiterResolutionForKeyboardInput,
-              !hasMarkedText(),
               let insertedText = Self.plainText(from: insertString)
         else {
             super.insertText(insertString, replacementRange: replacementRange)
+            return
+        }
+
+        if hasMarkedText() {
+            commitMarkedText(
+                insertString,
+                insertedText: insertedText,
+                replacementRange: replacementRange,
+                replacedSelection: replacedSelection
+            )
             return
         }
 
@@ -48,6 +75,92 @@ class PairedDelimiterTextView: NSTextView {
 
         case .native:
             super.insertText(insertString, replacementRange: replacementRange)
+        }
+    }
+
+    override func unmarkText() {
+        selectionReplacedByMarkedText = nil
+        super.unmarkText()
+    }
+
+    /// Handles the keystroke that commits a marked composition. Only a
+    /// single-character commit that matches the marked text itself is treated as
+    /// a dead-key delimiter — an accented result (`"` then `o` → `ö`) or a
+    /// multi-character IME candidate falls through to native insertion.
+    private func commitMarkedText(
+        _ insertString: Any,
+        insertedText: String,
+        replacementRange: NSRange,
+        replacedSelection: NSAttributedString?
+    ) {
+        let marked = markedRange()
+        let nsString = string as NSString
+        guard insertedText.count == 1,
+              Self.isValid(marked, in: nsString),
+              marked.length > 0,
+              nsString.substring(with: marked) == insertedText,
+              let context = PairedDelimiterEditing.preCompositionContext(
+                  text: string,
+                  markedRange: marked,
+                  replacedSelection: replacedSelection?.string ?? ""
+              )
+        else {
+            super.insertText(insertString, replacementRange: replacementRange)
+            return
+        }
+
+        switch PairedDelimiterEditing.resolve(
+            insertedText: insertedText,
+            in: context.text,
+            selectedRange: context.selectedRange
+        ) {
+        case let .wrap(opening, closing):
+            let replacement = NSMutableAttributedString(
+                string: String(opening),
+                attributes: typingAttributes
+            )
+            if let replacedSelection {
+                replacement.append(replacedSelection)
+            }
+            replacement.append(NSAttributedString(
+                string: String(closing),
+                attributes: typingAttributes
+            ))
+            replaceMarkedText(with: replacement, markedRange: marked)
+            setSelectedRange(NSRange(
+                location: marked.location + 1,
+                length: context.selectedRange.length
+            ))
+
+        case let .insertPair(opening, closing):
+            replaceMarkedText(
+                with: NSAttributedString(
+                    string: String(opening) + String(closing),
+                    attributes: typingAttributes
+                ),
+                markedRange: marked
+            )
+            setSelectedRange(NSRange(location: marked.location + 1, length: 0))
+
+        case .stepOver:
+            replaceMarkedText(
+                with: NSAttributedString(string: "", attributes: typingAttributes),
+                markedRange: marked
+            )
+            setSelectedRange(NSRange(location: marked.location + 1, length: 0))
+
+        case .native:
+            super.insertText(insertString, replacementRange: replacementRange)
+        }
+    }
+
+    /// `NSTextView.unmarkText()` finalizes the composition by re-inserting the
+    /// marked characters through `insertText`, so the whole replacement has to
+    /// run with pairing suppressed or the placeholder pairs with itself.
+    private func replaceMarkedText(with replacement: NSAttributedString, markedRange: NSRange) {
+        performNativeTextInsertion {
+            unmarkText()
+            super.insertText(replacement, replacementRange: markedRange)
         }
     }
 
@@ -98,11 +211,19 @@ class PairedDelimiterTextView: NSTextView {
     }
 
     private static func isValid(_ range: NSRange, in storage: NSTextStorage) -> Bool {
+        isValid(range, length: storage.length)
+    }
+
+    private static func isValid(_ range: NSRange, in string: NSString) -> Bool {
+        isValid(range, length: string.length)
+    }
+
+    private static func isValid(_ range: NSRange, length: Int) -> Bool {
         range.location != NSNotFound
             && range.location >= 0
             && range.length >= 0
-            && range.location <= storage.length
-            && range.length <= storage.length - range.location
+            && range.location <= length
+            && range.length <= length - range.location
     }
 }
 
@@ -177,7 +298,6 @@ struct PairedTextField: NSViewRepresentable {
     static func dismantleNSView(_ field: PairedTextFieldBackingView, coordinator: Coordinator) {
         let window = field.window
         let editor = field.currentEditor()
-        coordinator.stopObservingUndoManager()
         field.onWindowChanged = nil
         field.delegate = nil
         field.target = nil
@@ -226,11 +346,6 @@ struct PairedTextField: NSViewRepresentable {
     @MainActor
     final class Coordinator: NSObject, NSTextFieldDelegate {
         var parent: PairedTextField
-        private var isApplyingPairedEdit = false
-        private var isApplyingNativePaste = false
-        private var isApplyingKeyboardTextInput = false
-        private weak var observedUndoManager: UndoManager?
-        private var undoObservers: [NSObjectProtocol] = []
 
         init(_ parent: PairedTextField) {
             self.parent = parent
@@ -254,102 +369,6 @@ struct PairedTextField: NSViewRepresentable {
             updateFocus(false)
         }
 
-        func control(
-            _ control: NSControl,
-            textView: NSTextView,
-            shouldChangeCharactersIn affectedCharRange: NSRange,
-            replacementString: String?
-        ) -> Bool {
-            guard !isApplyingPairedEdit,
-                  !isApplyingNativePaste,
-                  parent.isEnabled,
-                  !textView.hasMarkedText(),
-                  let replacementString,
-                  shouldApplyPairedDelimiterResolution(for: replacementString, event: NSApp.currentEvent)
-            else { return true }
-
-            switch PairedDelimiterEditing.resolve(
-                insertedText: replacementString,
-                in: textView.string,
-                selectedRange: affectedCharRange
-            ) {
-            case let .wrap(opening, closing):
-                guard let textStorage = textView.textStorage,
-                      Self.isValid(affectedCharRange, in: textStorage)
-                else { return true }
-
-                let replacement = NSMutableAttributedString(
-                    string: String(opening),
-                    attributes: textView.typingAttributes
-                )
-                replacement.append(textStorage.attributedSubstring(from: affectedCharRange))
-                replacement.append(NSAttributedString(
-                    string: String(closing),
-                    attributes: textView.typingAttributes
-                ))
-                observeUndoChanges(for: control as? NSTextField, textView: textView)
-                apply(replacement, to: textView, range: affectedCharRange)
-                textView.setSelectedRange(NSRange(
-                    location: affectedCharRange.location + 1,
-                    length: affectedCharRange.length
-                ))
-                return false
-
-            case let .insertPair(opening, closing):
-                let replacement = NSAttributedString(
-                    string: String(opening) + String(closing),
-                    attributes: textView.typingAttributes
-                )
-                observeUndoChanges(for: control as? NSTextField, textView: textView)
-                apply(replacement, to: textView, range: affectedCharRange)
-                textView.setSelectedRange(NSRange(location: affectedCharRange.location + 1, length: 0))
-                return false
-
-            case .stepOver:
-                textView.setSelectedRange(NSRange(location: affectedCharRange.location + 1, length: 0))
-                return false
-
-            case .native:
-                return true
-            }
-        }
-
-        func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
-            guard Self.nativePasteSelectors.contains(commandSelector) else { return false }
-            isApplyingNativePaste = true
-            defer {
-                isApplyingNativePaste = false
-                updateText(textView.string)
-            }
-            textView.paste(nil)
-            return true
-        }
-
-        func performKeyboardTextInsertion(_ insert: () -> Bool) -> Bool {
-            isApplyingKeyboardTextInput = true
-            defer { isApplyingKeyboardTextInput = false }
-            return insert()
-        }
-
-        func shouldApplyPairedDelimiterResolution(for replacementString: String, event: NSEvent?) -> Bool {
-            if isApplyingKeyboardTextInput {
-                return true
-            }
-            guard let event, event.type == .keyDown else {
-                return false
-            }
-
-            let commandModifiers: NSEvent.ModifierFlags = [.command, .control]
-            return event.modifierFlags.intersection(commandModifiers).isEmpty
-                && event.characters == replacementString
-        }
-
-        private static let nativePasteSelectors: Set<Selector> = [
-            #selector(NSText.paste(_:)),
-            #selector(NSTextView.pasteAsPlainText(_:)),
-            #selector(NSTextView.pasteAsRichText(_:)),
-        ]
-
         func synchronizeFocus(for field: NSTextField) {
             guard let binding = parent.isFocused, let window = field.window else { return }
             let editor = fieldEditor(for: field)
@@ -367,42 +386,6 @@ struct PairedTextField: NSViewRepresentable {
             field.currentEditor() as? NSTextView
         }
 
-        func stopObservingUndoManager() {
-            for observer in undoObservers {
-                NotificationCenter.default.removeObserver(observer)
-            }
-            undoObservers.removeAll()
-            observedUndoManager = nil
-        }
-
-        private func observeUndoChanges(for field: NSTextField?, textView: NSTextView) {
-            guard let field, let undoManager = textView.undoManager,
-                  observedUndoManager !== undoManager
-            else { return }
-
-            stopObservingUndoManager()
-            observedUndoManager = undoManager
-            for name in [Notification.Name.NSUndoManagerDidUndoChange, .NSUndoManagerDidRedoChange] {
-                undoObservers.append(NotificationCenter.default.addObserver(
-                    forName: name,
-                    object: undoManager,
-                    queue: .main
-                ) { [weak self, weak field] _ in
-                    MainActor.assumeIsolated {
-                        guard let self, let field else { return }
-                        let value = (field.currentEditor() as? NSTextView)?.string ?? field.stringValue
-                        self.updateText(value)
-                    }
-                })
-            }
-        }
-
-        private func apply(_ replacement: NSAttributedString, to textView: NSTextView, range: NSRange) {
-            isApplyingPairedEdit = true
-            defer { isApplyingPairedEdit = false }
-            textView.insertText(replacement, replacementRange: range)
-        }
-
         private func updateText(_ value: String) {
             if parent.text != value {
                 parent.text = value
@@ -413,14 +396,6 @@ struct PairedTextField: NSViewRepresentable {
             if let binding = parent.isFocused, binding.wrappedValue != value {
                 binding.wrappedValue = value
             }
-        }
-
-        private static func isValid(_ range: NSRange, in storage: NSTextStorage) -> Bool {
-            range.location != NSNotFound
-                && range.location >= 0
-                && range.length >= 0
-                && range.location <= storage.length
-                && range.length <= storage.length - range.location
         }
     }
 }
@@ -609,9 +584,28 @@ struct PairedTextEditor: NSViewRepresentable {
 final class PairedTextFieldBackingView: NSTextField {
     var onWindowChanged: (() -> Void)?
 
+    /// AppKit never routes a should-change-text callback to an `NSTextField`
+    /// delegate, so delimiter pairing has to live in the field editor itself.
+    override class var cellClass: AnyClass? {
+        get { PairedTextFieldCell.self }
+        set { super.cellClass = newValue }
+    }
+
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         onWindowChanged?()
+    }
+}
+
+final class PairedTextFieldCell: NSTextFieldCell {
+    private lazy var pairedFieldEditor: PairedDelimiterTextView = {
+        let editor = PairedDelimiterTextView()
+        editor.isFieldEditor = true
+        return editor
+    }()
+
+    override func fieldEditor(for controlView: NSView) -> NSTextView? {
+        pairedFieldEditor
     }
 }
 

--- a/Alas/Sources/UI/PairedDelimiterEditing.swift
+++ b/Alas/Sources/UI/PairedDelimiterEditing.swift
@@ -48,6 +48,32 @@ enum PairedDelimiterEditing {
         return .native
     }
 
+    /// Rebuilds the document as it was before a dead-key composition started.
+    ///
+    /// Layouts like "U.S. International – PC" turn `"`, `'` and `` ` `` into dead
+    /// keys: the first keystroke installs marked text — consuming any selection —
+    /// and the commit keystroke inserts the literal delimiter while that marked
+    /// text is still in the storage. Removing the marked range and restoring the
+    /// selection it swallowed gives `resolve` the context it would have seen had
+    /// the delimiter arrived as a plain keystroke.
+    static func preCompositionContext(
+        text: String,
+        markedRange: NSRange,
+        replacedSelection: String
+    ) -> (text: String, selectedRange: NSRange)? {
+        let nsString = text as NSString
+        guard isValid(markedRange, in: nsString), markedRange.length > 0 else { return nil }
+
+        let restored = nsString.replacingCharacters(in: markedRange, with: replacedSelection)
+        return (
+            text: restored,
+            selectedRange: NSRange(
+                location: markedRange.location,
+                length: (replacedSelection as NSString).length
+            )
+        )
+    }
+
     private static func isValid(_ range: NSRange, in string: NSString) -> Bool {
         range.location != NSNotFound
             && range.location >= 0

--- a/AlasTests/CommitMessageEditorViewTests.swift
+++ b/AlasTests/CommitMessageEditorViewTests.swift
@@ -88,17 +88,12 @@ struct CommitMessageEditorViewTests {
 
         let subject = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
         #expect(window.makeFirstResponder(subject))
-        let subjectEditor = try #require(window.fieldEditor(false, for: subject) as? NSTextView)
-        let coordinator = try #require(subject.delegate as? PairedTextField.Coordinator)
+        let subjectEditor = try #require(subject.currentEditor() as? PairedDelimiterTextView)
         subjectEditor.setSelectedRange(NSRange(location: 0, length: 7))
-        #expect(!coordinator.performKeyboardTextInsertion {
-            coordinator.control(
-                subject,
-                textView: subjectEditor,
-                shouldChangeCharactersIn: NSRange(location: 0, length: 7),
-                replacementString: "`"
-            )
-        })
+        subjectEditor.performKeyboardTextInsertion {
+            subjectEditor.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+        await drain(controller.view)
         #expect(model.subject == "`subject`")
 
         let body = try #require(firstSubview(of: PairedDelimiterTextView.self, in: controller.view))

--- a/AlasTests/PairedComposerTextControlsTests.swift
+++ b/AlasTests/PairedComposerTextControlsTests.swift
@@ -144,22 +144,14 @@ struct PairedComposerTextControlsTests {
         let window = attach(controller, size: NSSize(width: 360, height: 120))
         await drain(controller.view)
 
-        let field = try #require(firstSubview(of: NSTextField.self, in: controller.view))
-        let editor = try #require(window.fieldEditor(false, for: field) as? NSTextView)
-        let coordinator = try #require(field.delegate as? PairedTextField.Coordinator)
+        let field = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
+        let editor = try #require(field.currentEditor() as? PairedDelimiterTextView)
         #expect(window.firstResponder === editor)
         editor.setSelectedRange(NSRange(location: 0, length: 5))
 
-        let shouldUseNativeInsertion = coordinator.performKeyboardTextInsertion {
-            coordinator.control(
-                field,
-                textView: editor,
-                shouldChangeCharactersIn: NSRange(location: 0, length: 5),
-                replacementString: "`"
-            )
-        }
+        editor.keyDown(with: try keyEvent(characters: "`", modifiers: []))
+        await drain(controller.view)
 
-        #expect(shouldUseNativeInsertion == false)
         #expect(field.stringValue == "`value`")
         #expect(model.text == "`value`")
         #expect(editor.selectedRange() == NSRange(location: 1, length: 5))
@@ -168,9 +160,12 @@ struct PairedComposerTextControlsTests {
         editor.undoManager?.undo()
         await drain(controller.view)
 
+        // The binding catches up through `controlTextDidChange`, which AppKit only
+        // posts for a field editor inside a running app, so this harness can only
+        // assert that the paired edit is a single undoable step.
         #expect(editor.string == "value")
-        #expect(model.text == "value")
 
+        field.stringValue = editor.string
         field.sendAction(field.action, to: field.target)
         #expect(submitCount == 1)
 
@@ -181,7 +176,7 @@ struct PairedComposerTextControlsTests {
 
         model.isFocused = true
         await drain(controller.view)
-        #expect(window.firstResponder === window.fieldEditor(false, for: field))
+        #expect(window.firstResponder === field.currentEditor())
 
         await dismantle(model: model, controller: controller, window: window)
     }
@@ -192,21 +187,14 @@ struct PairedComposerTextControlsTests {
         let window = attach(controller, size: NSSize(width: 360, height: 120))
         await drain(controller.view)
 
-        let field = try #require(firstSubview(of: NSTextField.self, in: controller.view))
-        let editor = try #require(window.fieldEditor(false, for: field) as? NSTextView)
-        let coordinator = try #require(field.delegate as? PairedTextField.Coordinator)
+        let field = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
+        let editor = try #require(field.currentEditor() as? PairedDelimiterTextView)
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString("(", forType: .string)
         defer { NSPasteboard.general.clearContents() }
 
-        #expect(coordinator.control(
-            field,
-            textView: editor,
-            shouldChangeCharactersIn: NSRange(location: 0, length: 0),
-            replacementString: "("
-        ))
-
-        #expect(coordinator.control(field, textView: editor, doCommandBy: #selector(NSText.paste(_:))))
+        editor.paste(nil)
+        await drain(controller.view)
 
         #expect(field.stringValue == "(")
         #expect(model.text == "(")
@@ -221,16 +209,8 @@ struct PairedComposerTextControlsTests {
         let window = attach(controller, size: NSSize(width: 360, height: 120))
         await drain(controller.view)
 
-        let field = try #require(firstSubview(of: NSTextField.self, in: controller.view))
-        let editor = try #require(window.fieldEditor(false, for: field) as? NSTextView)
-        let coordinator = try #require(field.delegate as? PairedTextField.Coordinator)
-
-        #expect(coordinator.control(
-            field,
-            textView: editor,
-            shouldChangeCharactersIn: NSRange(location: 0, length: 0),
-            replacementString: "("
-        ))
+        let field = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
+        let editor = try #require(field.currentEditor() as? PairedDelimiterTextView)
 
         editor.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
         await drain(controller.view)
@@ -242,23 +222,24 @@ struct PairedComposerTextControlsTests {
         await dismantle(model: model, controller: controller, window: window)
     }
 
-    @Test func textFieldOptionGeneratedDelimiterUsesKeyboardPairing() async throws {
+    @Test func textFieldUsesPairedFieldEditorForKeyboardInput() async throws {
         let model = ComposerControlModel(text: "", isFocused: true)
         let controller = NSHostingController(rootView: PairedTextFieldHarness(model: model, onSubmit: {}))
         let window = attach(controller, size: NSSize(width: 360, height: 120))
         await drain(controller.view)
 
-        let field = try #require(firstSubview(of: NSTextField.self, in: controller.view))
-        let coordinator = try #require(field.delegate as? PairedTextField.Coordinator)
+        let field = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
+        #expect(field.cell is PairedTextFieldCell)
+        let editor = try #require(field.currentEditor() as? PairedDelimiterTextView)
 
-        #expect(coordinator.shouldApplyPairedDelimiterResolution(
-            for: "{",
-            event: try keyEvent(characters: "{", modifiers: .option)
-        ))
-        #expect(!coordinator.shouldApplyPairedDelimiterResolution(
-            for: "{",
-            event: try keyEvent(characters: "{", modifiers: [.command, .option])
-        ))
+        editor.performKeyboardTextInsertion {
+            editor.insertText("{", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+        await drain(controller.view)
+
+        #expect(field.stringValue == "{}")
+        #expect(model.text == "{}")
+        #expect(editor.selectedRange() == NSRange(location: 1, length: 0))
 
         await dismantle(model: model, controller: controller, window: window)
     }
@@ -269,18 +250,14 @@ struct PairedComposerTextControlsTests {
         let window = attach(controller, size: NSSize(width: 360, height: 120))
         await drain(controller.view)
 
-        let field = try #require(firstSubview(of: NSTextField.self, in: controller.view))
-        let editor = try #require(window.fieldEditor(false, for: field) as? NSTextView)
-        let coordinator = try #require(field.delegate as? PairedTextField.Coordinator)
+        let field = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
+        let editor = try #require(field.currentEditor() as? PairedDelimiterTextView)
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString("(", forType: .string)
         defer { NSPasteboard.general.clearContents() }
 
-        #expect(coordinator.control(
-            field,
-            textView: editor,
-            doCommandBy: #selector(NSTextView.pasteAsPlainText(_:))
-        ))
+        editor.pasteAsPlainText(nil)
+        await drain(controller.view)
 
         #expect(field.stringValue == "(")
         #expect(model.text == "(")

--- a/AlasTests/PairedDelimiterDeadKeyTests.swift
+++ b/AlasTests/PairedDelimiterDeadKeyTests.swift
@@ -1,0 +1,264 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+/// Layouts such as "U.S. International – PC" map `"`, `'` and `` ` `` to dead
+/// keys. Those never reach `insertText` directly: the first keystroke installs
+/// marked text (replacing any selection), and the commit keystroke inserts the
+/// literal delimiter while the marked text is still in the storage.
+@Suite(.serialized)
+@MainActor
+struct PairedDelimiterDeadKeyTests {
+    // MARK: - Pre-composition context
+
+    @Test func preCompositionContextRestoresCaret() throws {
+        let context = try #require(PairedDelimiterEditing.preCompositionContext(
+            text: "ab\"cd",
+            markedRange: NSRange(location: 2, length: 1),
+            replacedSelection: ""
+        ))
+
+        #expect(context.text == "abcd")
+        #expect(context.selectedRange == NSRange(location: 2, length: 0))
+    }
+
+    @Test func preCompositionContextRestoresReplacedSelection() throws {
+        let context = try #require(PairedDelimiterEditing.preCompositionContext(
+            text: "a\"d",
+            markedRange: NSRange(location: 1, length: 1),
+            replacedSelection: "bc"
+        ))
+
+        #expect(context.text == "abcd")
+        #expect(context.selectedRange == NSRange(location: 1, length: 2))
+    }
+
+    @Test func preCompositionContextRejectsOutOfBoundsMarkedRange() {
+        #expect(PairedDelimiterEditing.preCompositionContext(
+            text: "ab",
+            markedRange: NSRange(location: 2, length: 1),
+            replacedSelection: ""
+        ) == nil)
+        #expect(PairedDelimiterEditing.preCompositionContext(
+            text: "ab",
+            markedRange: NSRange(location: NSNotFound, length: 0),
+            replacedSelection: ""
+        ) == nil)
+    }
+
+    // MARK: - PairedDelimiterTextView
+
+    @Test func deadKeyCommitInsertsPairInEmptyDocument() {
+        for delimiter in ["\"", "'", "`"] {
+            let textView = makePairedTextView()
+            commitDeadKey(delimiter, in: textView)
+
+            #expect(textView.string == delimiter + delimiter)
+            #expect(textView.selectedRange() == NSRange(location: 1, length: 0))
+        }
+    }
+
+    @Test func deadKeyCommitWrapsSelectionConsumedByComposition() {
+        for delimiter in ["\"", "'", "`"] {
+            let textView = makePairedTextView(text: "value")
+            textView.setSelectedRange(NSRange(location: 0, length: 5))
+            commitDeadKey(delimiter, in: textView)
+
+            #expect(textView.string == "\(delimiter)value\(delimiter)")
+            #expect(textView.selectedRange() == NSRange(location: 1, length: 5))
+        }
+    }
+
+    @Test func deadKeyCommitPreservesAttributesOfWrappedSelection() {
+        let storage = NSTextStorage(attributedString: NSAttributedString(
+            string: "value",
+            attributes: [.toolTip: "keep-me"]
+        ))
+        let textView = makePairedTextView(storage: storage)
+        textView.setSelectedRange(NSRange(location: 0, length: 5))
+
+        commitDeadKey("`", in: textView)
+
+        #expect(textView.string == "`value`")
+        #expect(textView.textStorage?.attribute(.toolTip, at: 1, effectiveRange: nil) as? String == "keep-me")
+        #expect(textView.selectedRange() == NSRange(location: 1, length: 5))
+    }
+
+    @Test func deadKeyCommitStepsOverExistingCloser() {
+        let textView = makePairedTextView(text: "\"\"")
+        textView.setSelectedRange(NSRange(location: 1, length: 0))
+
+        commitDeadKey("\"", in: textView)
+
+        #expect(textView.string == "\"\"")
+        #expect(textView.selectedRange() == NSRange(location: 2, length: 0))
+    }
+
+    @Test func deadKeyCommitAfterIdentifierStaysNative() {
+        let textView = makePairedTextView(text: "don")
+        textView.setSelectedRange(NSRange(location: 3, length: 0))
+
+        commitDeadKey("'", in: textView)
+
+        #expect(textView.string == "don'")
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 0))
+    }
+
+    @Test func accentedCompositionStillReplacesMarkedText() {
+        let textView = makePairedTextView()
+        textView.setMarkedText(
+            "\"",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+
+        textView.performKeyboardTextInsertion {
+            textView.insertText("ö", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+
+        #expect(textView.string == "ö")
+        #expect(!textView.hasMarkedText())
+    }
+
+    @Test func accentedCompositionOverSelectionReplacesIt() {
+        let textView = makePairedTextView(text: "value")
+        textView.setSelectedRange(NSRange(location: 0, length: 5))
+        textView.setMarkedText(
+            "\"",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+
+        textView.performKeyboardTextInsertion {
+            textView.insertText("ö", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+
+        #expect(textView.string == "ö")
+    }
+
+    @Test func multiCharacterCandidateCommitDoesNotPair() {
+        let textView = makePairedTextView()
+        textView.setMarkedText(
+            "candidate",
+            selectedRange: NSRange(location: 9, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+
+        textView.performKeyboardTextInsertion {
+            textView.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+
+        #expect(textView.string == "(")
+    }
+
+    @Test func deadKeyCommitOutsideKeyboardInputStaysNative() {
+        let textView = makePairedTextView()
+        textView.setMarkedText(
+            "\"",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+
+        textView.insertText("\"", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "\"")
+    }
+
+    @Test func staleReplacedSelectionDoesNotLeakIntoLaterInput() {
+        let textView = makePairedTextView(text: "value")
+        textView.setSelectedRange(NSRange(location: 0, length: 5))
+        commitDeadKey("`", in: textView)
+        #expect(textView.string == "`value`")
+
+        textView.setSelectedRange(NSRange(location: 7, length: 0))
+        commitDeadKey("`", in: textView)
+
+        #expect(textView.string == "`value```")
+    }
+
+    // MARK: - CodeTextView
+
+    @Test func codeEditorDeadKeyCommitInsertsPair() {
+        let textView = makeCodeTextView()
+
+        textView.setMarkedText(
+            "\"",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        textView.insertText("\"", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "\"\"")
+        #expect(textView.selectedRange() == NSRange(location: 1, length: 0))
+    }
+
+    @Test func codeEditorDeadKeyCommitWrapsSelection() {
+        let textView = makeCodeTextView("value")
+        textView.setSelectedRange(NSRange(location: 0, length: 5))
+
+        textView.setMarkedText(
+            "`",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "`value`")
+        #expect(textView.selectedRange() == NSRange(location: 1, length: 5))
+    }
+
+    @Test func codeEditorAccentedCompositionStillReplacesMarkedText() {
+        let textView = makeCodeTextView()
+
+        textView.setMarkedText(
+            "\"",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        textView.insertText("ö", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "ö")
+    }
+
+    // MARK: - Helpers
+
+    private func commitDeadKey(_ delimiter: String, in textView: PairedDelimiterTextView) {
+        textView.setMarkedText(
+            delimiter,
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        textView.performKeyboardTextInsertion {
+            textView.insertText(delimiter, replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+    }
+
+    private func makePairedTextView(text: String = "") -> PairedDelimiterTextView {
+        makePairedTextView(storage: NSTextStorage(string: text))
+    }
+
+    private func makePairedTextView(storage: NSTextStorage) -> PairedDelimiterTextView {
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(width: 400, height: 400))
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+        let textView = PairedDelimiterTextView(
+            frame: NSRect(x: 0, y: 0, width: 400, height: 400),
+            textContainer: container
+        )
+        textView.setSelectedRange(NSRange(location: storage.length, length: 0))
+        return textView
+    }
+
+    private func makeCodeTextView(_ text: String = "") -> CodeTextView {
+        let storage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: container)
+        textView.setSelectedRange(NSRange(location: (text as NSString).length, length: 0))
+        return textView
+    }
+}

--- a/AlasTests/PairedPrimaryComposerSurfaceTests.swift
+++ b/AlasTests/PairedPrimaryComposerSurfaceTests.swift
@@ -14,17 +14,12 @@ struct PairedPrimaryComposerSurfaceTests {
 
         let title = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
         #expect(window.makeFirstResponder(title))
-        let titleEditor = try #require(window.fieldEditor(false, for: title) as? NSTextView)
-        let coordinator = try #require(title.delegate as? PairedTextField.Coordinator)
+        let titleEditor = try #require(title.currentEditor() as? PairedDelimiterTextView)
         titleEditor.setSelectedRange(NSRange(location: 0, length: model.title.utf16.count))
-        #expect(!coordinator.performKeyboardTextInsertion {
-            coordinator.control(
-                title,
-                textView: titleEditor,
-                shouldChangeCharactersIn: NSRange(location: 0, length: model.title.utf16.count),
-                replacementString: "`"
-            )
-        })
+        titleEditor.performKeyboardTextInsertion {
+            titleEditor.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+        await drain(controller.view)
         #expect(model.title == "`Review title`")
 
         let body = try #require(firstSubview(of: PairedDelimiterTextView.self, in: controller.view))
@@ -68,17 +63,11 @@ struct PairedPrimaryComposerSurfaceTests {
         let field = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
         #expect(field.focusRingType == .default)
         #expect(window.makeFirstResponder(field))
-        let editor = try #require(window.fieldEditor(false, for: field) as? NSTextView)
-        let coordinator = try #require(field.delegate as? PairedTextField.Coordinator)
+        let editor = try #require(field.currentEditor() as? PairedDelimiterTextView)
         editor.setSelectedRange(NSRange(location: 0, length: 12))
-        #expect(!coordinator.performKeyboardTextInsertion {
-            coordinator.control(
-                field,
-                textView: editor,
-                shouldChangeCharactersIn: NSRange(location: 0, length: 12),
-                replacementString: "`"
-            )
-        })
+        editor.performKeyboardTextInsertion {
+            editor.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
         await drain(controller.view)
 
         #expect(model.firstMessage == "`First commit`")


### PR DESCRIPTION
## Summary

Follow-up to #1008. Paired delimiters (auto-close/wrap on `[`, `{`, `"`, `'`, `` ` ``) didn't work at all for `"`, `'`, `` ` `` on layouts where those are dead keys (e.g. U.S. International), and never worked for the commit-message / gg-split subject fields regardless of layout.

## Root causes

**Dead-key delimiters.** On layouts like U.S. International, `"`, `'` and `` ` `` are dead keys: the first keystroke installs marked text (replacing any selection), and the commit keystroke inserts the literal character while marked text is still present. Both paired paths bailed on `hasMarkedText()`, so brackets (never dead keys) paired but these three silently fell through to native insertion.

Fix: stash the selection a composition consumes, reconstruct the pre-composition document on commit, and run the existing `PairedDelimiterEditing` policy against it. Accented results (`"` then `o` → `ö`) still fall through to native insertion untouched. Also had to guard against `NSTextView.unmarkText()` re-entering `insertText` to finalize the composition — without that guard the placeholder paired with itself.

**Unreachable field pairing.** `PairedTextField`'s coordinator hooked `control(_:textView:shouldChangeCharactersIn:replacementString:)`, but AppKit never forwards a should-change callback to an `NSTextField` delegate — only tests calling the method directly exercised it. Fixed by giving the field a custom `NSTextFieldCell` whose field editor is a `PairedDelimiterTextView`, same as every other paired surface.

## Testing

- New `PairedDelimiterDeadKeyTests` suite covering dead-key composition across the composer text view, field editor, and code editor.
- Updated field-editor tests to drive the real `PairedDelimiterTextView` field editor instead of the unreachable delegate hook.
- Verified end-to-end with real synthesized dead-key `CGEvent`s against the shipped classes (not just unit tests) on U.S. International.
- `xcodebuild build` and `xcodebuild test` both clean.