### PR TITLE
feat(missions): gate hidden runtime

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -882,6 +882,7 @@
 		9159297D87B2AA9B7A03F072 /* ACPSessionAgentStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2A5B37528AD21CAD5ED051 /* ACPSessionAgentStateTests.swift */; };
 		9169618F36666AED9DA0B10D /* MissionPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E740A01C784A24F01F79BC3 /* MissionPresentationTests.swift */; };
 		91BA613AFD278AF56168EB22 /* LSPURI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C69060B922A729DD807920 /* LSPURI.swift */; };
+		92337647F73072ED37DF56E3 /* MissionFeatureRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0DB69D5FB91038BA8D17E97 /* MissionFeatureRuntimeTests.swift */; };
 		92845FA01F7A57EB8508C2CF /* AppKitDiffScrollerReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3384E5FA341561735906B9EF /* AppKitDiffScrollerReconcilerTests.swift */; };
 		929C2E12D6178FF3728365A2 /* ACPStdioTerminalDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DB2EFD475B2D7D5D75B06A /* ACPStdioTerminalDispatchTests.swift */; };
 		92BDCA81E566BF56CFE87AFB /* NewRunScriptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3A201BB87075FB20E88FBC /* NewRunScriptDialog.swift */; };
@@ -1144,6 +1145,7 @@
 		B9F3258E4AE2DB1E7481690A /* SubprocessRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E06BA06E4A620EEE773E1672 /* SubprocessRunner.swift */; };
 		B9F75C605157BA01FD10DEE5 /* AppKitDiffRowSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E9E696C1C8F5817524752F /* AppKitDiffRowSpec.swift */; };
 		BA43C3AE340673902EC7CDA9 /* MissionReadinessEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03FE562E9CFD25618944D2B8 /* MissionReadinessEvaluatorTests.swift */; };
+		BA9D9498AFEB47636D9F2820 /* MissionsFeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F869FE1727BFCD06CD374DF /* MissionsFeatureFlag.swift */; };
 		BACDEEE3791E66405294B328 /* ACPFirstRunConnectingPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6EDDD4D22267C26B496A6FF /* ACPFirstRunConnectingPolicyTests.swift */; };
 		BAE4D422FC3950E61FEE1D15 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
 		BAE6B1D93387807ADD7ED0CC /* ACPImageThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E1462C85D0E49127BCED81 /* ACPImageThumbnail.swift */; };
@@ -1451,6 +1453,7 @@
 		E89811545A8AD0ED03655AA3 /* RecommendedLanguageCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77927262BEAF31E39CE6698 /* RecommendedLanguageCatalogTests.swift */; };
 		E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */; };
 		E8CD4B9C918E2A9A83FA637A /* ProjectIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56C7878101DA7532B9850D13 /* ProjectIconView.swift */; };
+		E8F2D41CACB5211CEB1A9B45 /* MissionsFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8DE5C81B31A06C188438A7 /* MissionsFeatureFlagTests.swift */; };
 		E8F4E5FAC73026DAC29FDEF7 /* DiffDisplayModelBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F66827E8BFF9AB51D76A96 /* DiffDisplayModelBuilder.swift */; };
 		E9507AB389CE47A6A48C049B /* ACPProcessLiveness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA695BB3D2901435BFF6C0E /* ACPProcessLiveness.swift */; };
 		E982387DB4C0EF18291C68FB /* ACPTranscriptScrollerReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81D94695C26A2270165EC820 /* ACPTranscriptScrollerReconciler.swift */; };
@@ -1874,6 +1877,7 @@
 		2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexInstallerTests.swift; sourceTree = "<group>"; };
 		2F74F721E41ADB3EC7906DC1 /* GGServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGServiceTests.swift; sourceTree = "<group>"; };
 		2F7E37886988A6F285BEA163 /* ReviewSessionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionModels.swift; sourceTree = "<group>"; };
+		2F869FE1727BFCD06CD374DF /* MissionsFeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionsFeatureFlag.swift; sourceTree = "<group>"; };
 		2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadReaderTests.swift; sourceTree = "<group>"; };
 		2FACC9A36AFADFB92DC240BD /* ACPTranscriptRowContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptRowContent.swift; sourceTree = "<group>"; };
 		2FD28E0005DE3A33A974A511 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
@@ -2178,6 +2182,7 @@
 		5F128D8543DA5FC5C39C22E9 /* ACPPermissionDecisionLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionDecisionLog.swift; sourceTree = "<group>"; };
 		5F30C23C9CD0842373F29D1F /* BuildIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildIdentity.swift; sourceTree = "<group>"; };
 		5F77AE52695B7B19A9F11B89 /* RemotePairingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePairingService.swift; sourceTree = "<group>"; };
+		5F8DE5C81B31A06C188438A7 /* MissionsFeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionsFeatureFlagTests.swift; sourceTree = "<group>"; };
 		5F931B1EEA7F04855BAE5A43 /* WorkingTreeStageAllActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeStageAllActionTests.swift; sourceTree = "<group>"; };
 		5F9F77CC231E1131962F5A43 /* ProviderReviewActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewActions.swift; sourceTree = "<group>"; };
 		6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeInstallerTests.swift; sourceTree = "<group>"; };
@@ -2942,6 +2947,7 @@
 		E09A66AE390C7748A8847C8E /* MarkdownTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTabView.swift; sourceTree = "<group>"; };
 		E0CD4F3AC6DD83BC45459475 /* CompletionEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionEngineTests.swift; sourceTree = "<group>"; };
 		E0D0F48B60A75972D3A8DBED /* ReviewTargetPaletteEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewTargetPaletteEnvironment.swift; sourceTree = "<group>"; };
+		E0DB69D5FB91038BA8D17E97 /* MissionFeatureRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionFeatureRuntimeTests.swift; sourceTree = "<group>"; };
 		E0E1BF90CB3BE5BFDFA2EC7C /* ACPSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStore.swift; sourceTree = "<group>"; };
 		E0E5107A10052A150DD8DE02 /* ZmxSunPathBudgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSunPathBudgetTests.swift; sourceTree = "<group>"; };
 		E0F10B6B1311831E53DA45C0 /* DiffReviewStagedMutationActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewStagedMutationActionsTests.swift; sourceTree = "<group>"; };
@@ -4820,6 +4826,7 @@
 				DBB784CA59AB7163DF7B96A6 /* MissionPersistence.swift */,
 				ACAFC463DDFFF41E0E1B52A9 /* MissionPromptBuilder.swift */,
 				450A13855438B606F539AEB5 /* MissionReadinessEvaluator.swift */,
+				2F869FE1727BFCD06CD374DF /* MissionsFeatureFlag.swift */,
 				829A799BCFC9BB7F0A3A8B63 /* MissionSidebarSection.swift */,
 				1A235176E6DBEA7A68FEFAED /* MissionSourceProvider.swift */,
 				6B256E5E263B92DA3BB65807 /* MissionSourceResolver.swift */,
@@ -5034,11 +5041,13 @@
 				AA6A933FA317E1B2F15EEEC4 /* AddMissionLegModelTests.swift */,
 				2A64277DCFB5D4A9C2691C50 /* EditMissionSourceDialogTests.swift */,
 				50D6CBC43AD597B23E365A85 /* MissionCoordinatorTests.swift */,
+				E0DB69D5FB91038BA8D17E97 /* MissionFeatureRuntimeTests.swift */,
 				A1322C73D6479228960B9D76 /* MissionIntegrationTests.swift */,
 				B54AC1E309BF3848797FA62F /* MissionLegPromptBuilderTests.swift */,
 				2E740A01C784A24F01F79BC3 /* MissionPresentationTests.swift */,
 				78B20E30E45C7EBE078A54F9 /* MissionPromptBuilderTests.swift */,
 				03FE562E9CFD25618944D2B8 /* MissionReadinessEvaluatorTests.swift */,
+				5F8DE5C81B31A06C188438A7 /* MissionsFeatureFlagTests.swift */,
 				4B89757CB3A518B333C56DC8 /* MissionSidebarTests.swift */,
 				A3F58759D9622ED1C33D0B20 /* MissionSourceResolverTests.swift */,
 				C465B80387939C91778E1AF7 /* MissionStoreTests.swift */,
@@ -6617,6 +6626,7 @@
 				A76E0F76155E024132484DC1 /* MissionSourceResolver.swift in Sources */,
 				F4D23F9C68A6102EADD3613F /* MissionStore.swift in Sources */,
 				8180F4CA434F434D7476F91C /* MissionTabView.swift in Sources */,
+				BA9D9498AFEB47636D9F2820 /* MissionsFeatureFlag.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
 				44743D5298D6988CE6DCA947 /* NewMissionDialog.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
@@ -7350,6 +7360,7 @@
 				5ABD7DF29A68C38C8AA9EF37 /* MermaidRenderServiceTests.swift in Sources */,
 				4F6177806CEB8E50F0D70F7B /* MermaidViewerStateTests.swift in Sources */,
 				6574E0F5D8FC2144ECA324B1 /* MissionCoordinatorTests.swift in Sources */,
+				92337647F73072ED37DF56E3 /* MissionFeatureRuntimeTests.swift in Sources */,
 				149D2CA127DE63DB6B57044D /* MissionIntegrationTests.swift in Sources */,
 				D1B2658DE3025F4541A70194 /* MissionLegPromptBuilderTests.swift in Sources */,
 				9169618F36666AED9DA0B10D /* MissionPresentationTests.swift in Sources */,
@@ -7360,6 +7371,7 @@
 				82FFFB6C174B8F1069772800 /* MissionStoreTests.swift in Sources */,
 				D84B41639E0AC0533E37A9E6 /* MissionTabTests.swift in Sources */,
 				199BE03E36D7202143D7547A /* MissionTestFixtures.swift in Sources */,
+				E8F2D41CACB5211CEB1A9B45 /* MissionsFeatureFlagTests.swift in Sources */,
 				B0571620ECDFDC0CC84F6707 /* NewMissionDialogTests.swift in Sources */,
 				1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */,
 				3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1,5 +1,6 @@
-import Foundation
 import AppKit
+import Combine
+import Foundation
 import Observation
 import os
 
@@ -89,6 +90,7 @@ final class AppState {
     private var unpersistedGGWorktreeModes: [String: [String: GGWorktreeMode]] = [:]
     var spacesManager: SpacesManager
     var selectedWorktreeId: String?
+    private(set) var missionsEnabled: Bool
     private(set) var isRefreshingProjectTopologies = false
     private(set) var missingMissionTab: MissionTabState?
     private var missingMissionRecoveryTarget: MissingMissionRecoveryTarget?
@@ -597,7 +599,18 @@ final class AppState {
     @ObservationIgnored
     private let missionArchiveRecorder: MissionArchiveRecorder?
     @ObservationIgnored
-    private(set) lazy var missions = makeMissionController()
+    private var missionController: MissionController?
+    var missions: MissionController {
+        if let missionController { return missionController }
+        let controller = makeMissionController()
+        if !missionsEnabled { controller.suspend() }
+        missionController = controller
+        return controller
+    }
+    @ObservationIgnored
+    private var missionFeatureTransition: Task<Void, Never>?
+    @ObservationIgnored
+    private var missionsFeatureFlagSubscription: AnyCancellable?
     @ObservationIgnored
     private let persistenceErrorHandler: (String, String) -> Void
     @ObservationIgnored
@@ -633,11 +646,15 @@ final class AppState {
         missionStartupReviewSnapshot: MissionStartupReviewSnapshot? = nil,
         missionBranchTipOverride: MissionBranchTip? = nil,
         missionArchiveRecorder: MissionArchiveRecorder? = nil,
-        globalTabs: GlobalTabsManager = GlobalTabsManager()
+        missionsEnabled: Bool = MissionsFeatureFlag.isEnabled,
+        missionsFeatureUpdates: AnyPublisher<Bool, Never> = MissionsFeatureFlag.updates(),
+        globalTabs: GlobalTabsManager = GlobalTabsManager(),
+        tabsManager: TabsManager? = nil
     ) {
         self.store = store
         self.missionPersistence = missionPersistence
         self.globalTabs = globalTabs
+        _tabs = tabsManager
         self.persistenceErrorHandler = persistenceErrorHandler ?? { title, message in
             AppState.showWarningAlert(title: title, message: message)
         }
@@ -652,6 +669,7 @@ final class AppState {
         self.missionStartupReviewSnapshot = missionStartupReviewSnapshot
         self.missionBranchTipOverride = missionBranchTipOverride
         self.missionArchiveRecorder = missionArchiveRecorder
+        self.missionsEnabled = missionsEnabled
         let config = (try? store.readIfExists(AppConfig.self, from: Paths.appConfigFile)) ?? AppConfig.defaults
         let projectsFile = (try? store.readIfExists(ProjectsFile.self, from: Paths.projectsFile)) ?? ProjectsFile(projects: [])
         let spacesFile = try? store.readIfExists(SpacesFile.self, from: Paths.spacesFile)
@@ -699,7 +717,7 @@ final class AppState {
         rightPaneStore.appState = self
         rightPaneStore.reviewSnapshotDidChange = { [weak self] worktreeID, baseRef, snapshot in
             Task { @MainActor [weak self] in
-                guard let self else { return }
+                guard let self, missionsEnabled else { return }
                 let missionBaseRef = Self.missionCallbackBaseRef(
                     worktreeID: worktreeID,
                     paneBaseRef: baseRef,
@@ -739,6 +757,68 @@ final class AppState {
             await GGAvailability.shared.probe()
             self?.rightPaneStore.reevaluateGGGates()
         }
+
+        missionsFeatureFlagSubscription = missionsFeatureUpdates
+            .removeDuplicates()
+            .sink { enabled in
+                Task { @MainActor [weak self] in
+                    self?.setMissionsEnabled(enabled)
+                }
+            }
+    }
+
+    func setMissionsEnabled(_ enabled: Bool) {
+        guard missionsEnabled != enabled else { return }
+        missionsEnabled = enabled
+        MissionsFeatureFlag.setEnabled(enabled)
+        missionFeatureTransition?.cancel()
+
+        if enabled {
+            missions.resume()
+            let selection = selectedWorktreeId
+            missionFeatureTransition = Task { @MainActor [weak self] in
+                guard let self else { return }
+                do {
+                    try globalTabs.loadAndMigrate(
+                        worktreeTabs: tabs,
+                        selectedWorktreeID: selection ?? resolvedSelectionForActiveSpaceForStartup()
+                    )
+                } catch {
+                    persistenceErrorHandler("Mission Tabs Save Failed", error.localizedDescription)
+                }
+                await missions.load()
+                guard !Task.isCancelled, missionsEnabled else { return }
+                let selectionBeforeReconcile = selectedWorktreeId
+                await reconcileLoadedMissionsForStartup()
+                guard !Task.isCancelled, missionsEnabled else { return }
+                if selectedWorktreeId != selectionBeforeReconcile {
+                    selectWorktree(id: selectionBeforeReconcile)
+                }
+            }
+        } else {
+            missionController?.suspend()
+            globalTabs.clearActiveTab()
+            missingMissionTab = nil
+            missingMissionRecoveryTarget = nil
+            let currentVisibleInActiveSpace = selectedWorktreeId.flatMap { selectedId in
+                activeSpaceProjects.contains { project in
+                    projectsManager.visibleWorktrees(projectId: project.id).contains { $0.id == selectedId }
+                } ? selectedId : nil
+            }
+            selectWorktree(id: currentVisibleInActiveSpace ?? resolvedSelectionForActiveSpaceForStartup())
+        }
+    }
+
+    func loadMissionsIfEnabledForStartup() async {
+        guard missionsEnabled else { return }
+        restoreGlobalTabsForStartup()
+        await missions.load()
+        guard missionsEnabled, !Task.isCancelled else { return }
+        await reconcileLoadedMissionsForStartup()
+    }
+
+    func waitForMissionFeatureTransitionForTesting() async {
+        await missionFeatureTransition?.value
     }
 
     private func makeMissionController() -> MissionController {
@@ -747,7 +827,7 @@ final class AppState {
             now: { Date() },
             makeID: { UUID().uuidString },
             plannedWorktreeID: { [weak self] leg in
-                guard let self,
+                guard let self, missionsEnabled,
                       let project = self.projects.first(where: { $0.id == leg.projectId })
                 else {
                     return .failure(.init(message: "The Mission project is no longer available."))
@@ -766,7 +846,7 @@ final class AppState {
                 self?.missionWorktreeAtDestination(projectID: projectID, destinationPath: destinationPath)
             },
             createWorktree: { [weak self] leg in
-                guard let self else {
+                guard let self, missionsEnabled else {
                     return .failure(.init(message: "Alas is no longer available."))
                 }
                 return await self.createWorktreeAndWait(
@@ -778,7 +858,7 @@ final class AppState {
                 )
             },
             startACP: { [weak self] leg, worktree in
-                guard let self else {
+                guard let self, missionsEnabled else {
                     return .failure(.init(message: "Alas is no longer available."))
                 }
                 guard let sessionID = leg.acpSessionId else {
@@ -804,7 +884,7 @@ final class AppState {
                 }
             },
             notifyChanged: { [weak self] aggregate in
-                guard let self else { return }
+                guard let self, missionsEnabled else { return }
                 globalTabs.updateMissionTitle(
                     missionID: aggregate.mission.id,
                     title: aggregate.mission.title
@@ -814,12 +894,12 @@ final class AppState {
                 }
             }
         ), sourceRefresh: { [weak self] source, projectID in
-            guard let self else {
+            guard let self, missionsEnabled else {
                 throw CodeHostProviderError.malformedOutput("Alas is no longer available.")
             }
             return try await self.refreshMissionSource(source, projectID: projectID)
         }, reviewRepositoryMatches: { [weak self] projectID, baseRef, baseRemoteName, request in
-            guard let self,
+            guard let self, missionsEnabled,
                   let project = self.projectsManager.projects.first(where: { $0.id == projectID }),
                   let remotes = try? await GitService().remotes(
                       worktreePath: URL(fileURLWithPath: project.path)
@@ -837,15 +917,17 @@ final class AppState {
                 remotes: remotes
             ) != nil
         }, linkedReviewRequest: { [weak self] identity, projectID, baseRef in
-            await self?.refreshMissionReview(identity: identity, projectID: projectID, baseRef: baseRef)
+            guard self?.missionsEnabled == true else { return nil }
+            return await self?.refreshMissionReview(identity: identity, projectID: projectID, baseRef: baseRef)
         }, branchTip: { [weak self] projectID, branch in
-            guard let self else { return nil }
+            guard let self, missionsEnabled else { return nil }
             if let missionBranchTipOverride = self.missionBranchTipOverride {
                 return await missionBranchTipOverride(projectID, branch)
             }
             return await self.missionBranchTip(projectID: projectID, branch: branch)
         }, branchOwner: { [weak self] projectID, branch, baseRef in
-            await self?.missionBranchOwner(
+            guard self?.missionsEnabled == true else { return nil }
+            return await self?.missionBranchOwner(
                 projectID: projectID,
                 branch: branch,
                 baseRef: baseRef
@@ -862,7 +944,7 @@ final class AppState {
         }, reviewSnapshot: { [weak self] worktreeID, baseRef in
             self?.rightPaneStore.reviewSnapshot(worktreeId: worktreeID, baseBranch: baseRef)
         }, startupReviewSnapshot: { [weak self] worktree, baseRef in
-            guard let self else { return nil }
+            guard let self, missionsEnabled else { return nil }
             let paneBaseRef: String
             if let match = missions.aggregates.lazy.compactMap({ aggregate -> (MissionAggregate, MissionLeg)? in
                 guard aggregate.mission.state != .completed,
@@ -887,7 +969,8 @@ final class AppState {
                 comparisonMode: self.config.changes.comparisonMode
             )
         }, discoverReviewRequest: { [weak self] projectID, branch, baseRef, headSHA, headOwner in
-            await self?.discoverMissionReview(
+            guard self?.missionsEnabled == true else { return nil }
+            return await self?.discoverMissionReview(
                 projectID: projectID,
                 branch: branch,
                 baseRef: baseRef,
@@ -895,11 +978,13 @@ final class AppState {
                 headOwner: headOwner
             )
         }, openMission: { [weak self] missionID in
+            guard self?.missionsEnabled == true else { return }
             _ = self?.openMission(id: missionID)
         })
     }
 
     func restoreGlobalTabsForStartup() {
+        guard missionsEnabled else { return }
         do {
             try globalTabs.loadPersistedTabs()
         } catch {
@@ -908,11 +993,13 @@ final class AppState {
     }
 
     func reconcileMissionsForStartup() async {
+        guard missionsEnabled else { return }
         await missions.load()
         await reconcileLoadedMissionsForStartup()
     }
 
     func reconcileLoadedMissionsForStartup() async {
+        guard missionsEnabled else { return }
         await refreshRenamedMissionRepositories()
         await missions.resolveLegacyBaseRemoteNames { [weak self] projectID, baseRef in
             await self?.resolveLegacyMissionBaseRemoteName(projectID: projectID, baseRef: baseRef)
@@ -922,6 +1009,7 @@ final class AppState {
     }
 
     private func refreshRenamedMissionRepositories() async {
+        guard missionsEnabled else { return }
         for aggregate in missions.aggregates where aggregate.mission.state != .completed {
             guard let leg = aggregate.primaryLeg,
                   let locator = aggregate.source.repositoryLocator,
@@ -964,6 +1052,7 @@ final class AppState {
 
     @discardableResult
     func openMission(id: MissionID) -> Result<Tab, MissionOpenError> {
+        guard missionsEnabled else { return .failure(.missionUnavailable(id)) }
         guard let aggregate = missions.aggregate(id: id),
               let leg = aggregate.primaryLeg
         else {
@@ -1007,6 +1096,7 @@ final class AppState {
         missionID: MissionID,
         legID: MissionLegID
     ) async {
+        guard missionsEnabled else { return }
         guard let aggregate = missions.aggregate(id: missionID),
               let leg = aggregate.legs.first(where: { $0.id == legID }),
               missionWorktree(worktree, for: leg, aggregate: aggregate)?.id == worktree.id
@@ -1056,6 +1146,7 @@ final class AppState {
 
     @discardableResult
     func refreshMission(_ id: MissionID) async -> MissionSourceRefreshResult {
+        guard missionsEnabled else { return .unavailable }
         guard missions.aggregate(id: id) != nil else { return .unavailable }
 
         let sourceResult = await missions.refreshSource(id)
@@ -1127,6 +1218,7 @@ final class AppState {
     }
 
     func activateMissionRightPane(worktree: Worktree, aggregate: MissionAggregate) async {
+        guard missionsEnabled else { return }
         let paneBaseRef = await missionPaneBaseRef(for: aggregate, worktree: worktree)
         _ = missionRightPaneState(for: worktree, baseRef: paneBaseRef)
     }
@@ -1521,6 +1613,7 @@ final class AppState {
     }
 
     func reconcileDeletedMissionWorktree(_ worktreeID: String) async {
+        guard missionsEnabled else { return }
         let missionLegs = missions.aggregates.flatMap { aggregate in
             aggregate.legs.compactMap { leg in
                 leg.worktreeId == worktreeID ? (aggregate.mission.id, leg.id) : nil
@@ -1732,6 +1825,10 @@ final class AppState {
     func cleanupMissingWorktrees(beforeIds: Set<String>) async {
         let afterIds = allWorktreeIds()
         let disappeared = beforeIds.subtracting(afterIds)
+        guard missionsEnabled else {
+            cleanupMissingWorktreeState(beforeIds: beforeIds, afterIds: afterIds)
+            return
+        }
         let missingMissionLegs = missions.aggregates.flatMap { aggregate in
             aggregate.legs.compactMap { leg -> (MissionID, MissionLegID)? in
                 guard leg.setupCheckpoint != .creatingWorktree,
@@ -1832,6 +1929,7 @@ final class AppState {
     }
 
     private func presentMissingMissionRecoveryIfNeeded() {
+        guard missionsEnabled else { return }
         let activeProjectIDs = Set(activeSpaceProjects.map(\.id))
         guard missingMissionTab == nil,
               globalTabs.activeMissionTab() == nil,
@@ -1857,11 +1955,13 @@ final class AppState {
             projectsManager.worktrees(projectId: $0.id).map(\.id)
         }
         tabs.loadAll(worktreeIds: allWorktreeIds)
-        do {
-            let migrationWorktreeID = selectedWorktreeId ?? resolvedSelectionForActiveSpaceForStartup()
-            try globalTabs.migrateLegacyMissionTabs(worktreeTabs: tabs, selectedWorktreeID: migrationWorktreeID)
-        } catch {
-            persistenceErrorHandler("Mission Tabs Save Failed", error.localizedDescription)
+        if missionsEnabled {
+            do {
+                let migrationWorktreeID = selectedWorktreeId ?? resolvedSelectionForActiveSpaceForStartup()
+                try globalTabs.loadAndMigrate(worktreeTabs: tabs, selectedWorktreeID: migrationWorktreeID)
+            } catch {
+                persistenceErrorHandler("Mission Tabs Save Failed", error.localizedDescription)
+            }
         }
         // When cross-quit persistence is disabled, drop every persisted
         // terminal tab right after load — across all worktrees, before
@@ -2099,6 +2199,22 @@ final class AppState {
     func activateWorktreeCenterTab(worktreeId: String, tabId: TabID) {
         activateWorktreeTabPresentation()
         tabs.activate(worktreeId: worktreeId, tabId: tabId)
+    }
+
+    func synchronizeVisibleWorktreeCenterTabIfNeeded(
+        worktreeId: String,
+        activeTabId: TabID?,
+        missionsEnabled: Bool
+    ) {
+        guard !missionsEnabled else { return }
+        if let activeTabId {
+            guard tabs.activeTabId(forWorktree: worktreeId) != activeTabId,
+                  tabs.tabs(forWorktree: worktreeId).contains(where: { $0.id == activeTabId })
+            else { return }
+            activateWorktreeCenterTab(worktreeId: worktreeId, tabId: activeTabId)
+        } else {
+            tabs.clearActiveTab(worktreeId: worktreeId)
+        }
     }
 
     private func activateWorktreeTabPresentation() {
@@ -2781,6 +2897,7 @@ final class AppState {
     }
 
     func preparedMissionDraft(_ draft: MissionDraft) async throws -> MissionDraft {
+        guard missionsEnabled else { throw CancellationError() }
         guard let project = projects.first(where: { $0.id == draft.projectId }) else {
             throw CodeHostProviderError.malformedOutput("The selected repository is no longer available.")
         }
@@ -2807,6 +2924,7 @@ final class AppState {
     }
 
     func preparedMissionLegDraft(_ draft: MissionLegDraft) async throws -> MissionLegDraft {
+        guard missionsEnabled else { throw CancellationError() }
         guard let project = projects.first(where: { $0.id == draft.projectId }) else {
             throw CodeHostProviderError.malformedOutput("The selected repository is no longer available.")
         }
@@ -3082,7 +3200,8 @@ final class AppState {
         let removedIds = beforeIds.subtracting(afterIds)
         cleanupMissingWorktreeState(beforeIds: beforeIds, afterIds: afterIds)
         Task { @MainActor [weak self] in
-            await self?.missions.recordMissingWorktree(projectId: id, projectRemoved: true)
+            guard let self, missionsEnabled else { return }
+            await missions.recordMissingWorktree(projectId: id, projectRemoved: true)
         }
         for root in remoteRootsToUnregister {
             RemoteHostRegistry.shared.unregister(root: root)
@@ -3887,10 +4006,11 @@ final class AppState {
             hidden: true
         )
         saveProjects()
-        if projectsManager.isWorktreeHidden(projectId: worktree.projectId, path: worktree.path),
+        if missionsEnabled,
+           projectsManager.isWorktreeHidden(projectId: worktree.projectId, path: worktree.path),
            missions.hasActiveMission(worktreeId: worktree.id) {
             Task { @MainActor [weak self] in
-                guard let self else { return }
+                guard let self, missionsEnabled else { return }
                 if let missionArchiveRecorder = self.missionArchiveRecorder {
                     await missionArchiveRecorder(worktree.id)
                 }
@@ -4845,12 +4965,14 @@ final class AppState {
     }
 
     func deleteMission(id: MissionID) async {
+        guard missionsEnabled else { return }
         await missions.delete(id)
         guard missions.aggregate(id: id) == nil else { return }
         discardMissionUI(id: id)
     }
 
     func deleteCompletedMissions(ids: [MissionID]) async {
+        guard missionsEnabled else { return }
         for id in await missions.deleteCompleted(ids: ids) {
             discardMissionUI(id: id)
         }
@@ -4873,6 +4995,7 @@ final class AppState {
     }
 
     func requestCloseGlobalTab(tabID: TabID) {
+        guard missionsEnabled else { return }
         guard let tab = globalTabs.tabs.first(where: { $0.id == tabID }) else { return }
         closedTabHistory.record(ClosedTabEntry(
             snapshot: .global(tab),
@@ -4889,7 +5012,8 @@ final class AppState {
             globalTabs: globalTabs.tabs,
             worktreeTabs: worktreeTabs,
             activeGlobalMissionTab: globalTabs.activeMissionTab(),
-            activeWorktreeTabId: worktreeId.flatMap { tabs.activeTabId(forWorktree: $0) }
+            activeWorktreeTabId: worktreeId.flatMap { tabs.activeTabId(forWorktree: $0) },
+            missionsEnabled: missionsEnabled
         )
         let index = number - 1
         guard composition.tabs.indices.contains(index) else { return nil }
@@ -4906,7 +5030,8 @@ final class AppState {
             globalTabs: globalTabs.tabs,
             worktreeTabs: worktreeTabs,
             activeGlobalMissionTab: globalTabs.activeMissionTab(),
-            activeWorktreeTabId: worktreeId.flatMap { tabs.activeTabId(forWorktree: $0) }
+            activeWorktreeTabId: worktreeId.flatMap { tabs.activeTabId(forWorktree: $0) },
+            missionsEnabled: missionsEnabled
         )
         guard let tabID = composition.adjacentTabID(in: direction) else { return nil }
         return activateCenterTab(tabID, worktreeId: worktreeId)
@@ -5616,6 +5741,10 @@ final class AppState {
         while let entry = closedTabHistory.last {
             switch entry.snapshot {
             case .global(let tab):
+                guard missionsEnabled else {
+                    closedTabHistory.remove(id: entry.id)
+                    continue
+                }
                 _ = globalTabs.restore(tab: tab, placement: entry.placement)
                 closedTabHistory.remove(id: entry.id)
                 return
@@ -6683,7 +6812,12 @@ final class AppState {
         force: Bool,
         removedIndex: Int
     ) async {
-        let missionAllowsBranchDeletion = await missions.refreshReviewBeforeWorktreeRemoval(worktree.id)
+        let missionAllowsBranchDeletion: Bool
+        if missionsEnabled {
+            missionAllowsBranchDeletion = await missions.refreshReviewBeforeWorktreeRemoval(worktree.id)
+        } else {
+            missionAllowsBranchDeletion = true
+        }
         do {
             try await Self.performRemoveWorktree(
                 repoPath: repoPath,

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -14,10 +14,11 @@ private struct CommitReviewSessionLaunchError: Identifiable, Equatable {
 enum RootWorkspaceVisibilityPolicy {
     static func showsWorkspace(
         hasProjects: Bool,
+        missionsEnabled: Bool,
         hasMissions: Bool,
         hasActiveMissionTab: Bool
     ) -> Bool {
-        hasProjects || hasMissions || hasActiveMissionTab
+        hasProjects || (missionsEnabled && (hasMissions || hasActiveMissionTab))
     }
 }
 
@@ -79,11 +80,7 @@ struct RootView: View {
             }
             .task {
                 state.startHarness()
-                state.restoreGlobalTabsForStartup()
-                async let topologyRefresh: Bool = state.refreshAllProjectTopologies()
-                async let missionLoad: Void = state.missions.load()
-
-                _ = await topologyRefresh
+                _ = await state.refreshAllProjectTopologies()
                 guard !Task.isCancelled else { return }
                 // Worktrees now exist — load any persisted tab files for them. Init
                 // can't do this because refreshAll runs async after init.
@@ -95,10 +92,7 @@ struct RootView: View {
                 }
                 state.startAllProjectGitWatchers()
                 state.rescanAgents()
-
-                await missionLoad
-                guard !Task.isCancelled else { return }
-                await state.reconcileLoadedMissionsForStartup()
+                await state.loadMissionsIfEnabledForStartup()
             }
     }
 
@@ -117,8 +111,9 @@ struct RootView: View {
     private var mainContent: some View {
         if !RootWorkspaceVisibilityPolicy.showsWorkspace(
             hasProjects: !state.projects.isEmpty,
-            hasMissions: !state.missions.aggregates.isEmpty,
-            hasActiveMissionTab: state.globalTabs.activeMissionTab() != nil
+            missionsEnabled: state.missionsEnabled,
+            hasMissions: state.missionsEnabled && !state.missions.aggregates.isEmpty,
+            hasActiveMissionTab: state.missionsEnabled && state.globalTabs.activeMissionTab() != nil
         ) {
             EmptyState(
                 canCreateWorktree: false,
@@ -139,7 +134,7 @@ struct RootView: View {
                 sidebarVisible: state.config.sidebarVisible,
                 rightVisible: state.config.rightPaneVisible
                     && rightPaneSelection.showsRightPane
-                    && state.globalTabs.activeMissionTab() == nil,
+                    && (!state.missionsEnabled || state.globalTabs.activeMissionTab() == nil),
                 onWidthsChanged: { state.saveConfig() },
                 sidebar: { sidebarContent },
                 center: { centerContent() },
@@ -170,6 +165,7 @@ struct RootView: View {
                 newWorktreePresentation = NewWorktreePresentation(projectId: projectId)
             },
             onNewMission: {
+                guard state.missionsEnabled else { return }
                 newMissionPresentation = NewMissionPresentation()
             },
             onHideSidebar: {
@@ -237,7 +233,7 @@ struct RootView: View {
             projects: state.activeSpaceProjects,
             projectsManager: state.projectsManager,
             isRefreshingProjectTopologies: state.isRefreshingProjectTopologies,
-            activeGlobalMissionTab: state.globalTabs.activeMissionTab(),
+            activeGlobalMissionTab: state.missionsEnabled ? state.globalTabs.activeMissionTab() : nil,
             allowsHiddenSelectedWorktree: allowsHiddenSelectedWorktreeForMission
         )
         switch resolver.resolve() {
@@ -247,9 +243,10 @@ struct RootView: View {
                     state: state,
                     worktree: worktree,
                     activeGlobalMissionTab: tabState,
+                    missionsEnabled: state.missionsEnabled,
                     allowsPaneFocus: !state.isKeyboardOverlayOpen
                 )
-            } else {
+            } else if state.missionsEnabled {
                 VStack(spacing: 0) {
                     GlobalMissionTabBarView(
                         tabs: state.globalTabs.tabs,
@@ -270,7 +267,8 @@ struct RootView: View {
             CenterPaneView(
                 state: state,
                 worktree: wt,
-                activeGlobalMissionTab: state.globalTabs.activeMissionTab(),
+                activeGlobalMissionTab: state.missionsEnabled ? state.globalTabs.activeMissionTab() : nil,
+                missionsEnabled: state.missionsEnabled,
                 allowsPaneFocus: !state.isKeyboardOverlayOpen
             )
         case .deleting(let wt):
@@ -292,7 +290,7 @@ struct RootView: View {
         case .loadingProject:
             LoadingProjectView()
         case .empty:
-            if let tabState = state.missingMissionTab {
+            if state.missionsEnabled, let tabState = state.missingMissionTab {
                 MissionTabView(state: state, worktree: nil, tabState: tabState)
             } else {
                 EmptyTabView(
@@ -308,7 +306,8 @@ struct RootView: View {
     }
 
     private var allowsHiddenSelectedWorktreeForMission: Bool {
-        guard let worktreeID = state.selectedWorktreeId,
+        guard state.missionsEnabled,
+              let worktreeID = state.selectedWorktreeId,
               let tab = state.globalTabs.activeMissionTab(),
               state.missions.aggregate(id: tab.missionID)?.primaryLeg?.worktreeId == worktreeID
         else { return false }
@@ -532,7 +531,10 @@ private struct RootPresentationHandlers: ViewModifier {
                 presetProjectId: presentation.projectId
             )
         }
-        .sheet(item: $newMissionPresentation) { _ in
+        .sheet(item: Binding(
+            get: { state.missionsEnabled ? newMissionPresentation : nil },
+            set: { newMissionPresentation = $0 }
+        )) { _ in
             NewMissionDialog(
                 presented: Binding(
                     get: { newMissionPresentation != nil },
@@ -541,6 +543,9 @@ private struct RootPresentationHandlers: ViewModifier {
                 projects: state.projects,
                 environment: .live(state: state)
             )
+        }
+        .onChange(of: state.missionsEnabled) { _, enabled in
+            if !enabled { newMissionPresentation = nil }
         }
         .sheet(item: $state.pendingRunScriptCreation) { presentation in
             NewRunScriptDialog(

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -14,13 +14,25 @@ struct CenterTabComposition {
         globalTabs: [GlobalTab],
         worktreeTabs: [Tab],
         activeGlobalMissionTab: MissionTabState?,
-        activeWorktreeTabId: TabID?
+        activeWorktreeTabId: TabID?,
+        missionsEnabled: Bool = true
     ) {
-        tabs = globalTabs.compactMap { tab -> Tab? in
+        let missionTabs = missionsEnabled ? globalTabs.compactMap { tab -> Tab? in
             guard case .mission(let mission) = tab else { return nil }
             return .mission(mission)
-        } + worktreeTabs
-        activeId = activeGlobalMissionTab?.id ?? activeWorktreeTabId
+        } : []
+        let visibleWorktreeTabs = missionsEnabled ? worktreeTabs : worktreeTabs.filter { tab in
+            if case .mission = tab { return false }
+            return true
+        }
+        tabs = missionTabs + visibleWorktreeTabs
+        if missionsEnabled {
+            activeId = activeGlobalMissionTab?.id ?? activeWorktreeTabId
+        } else if visibleWorktreeTabs.contains(where: { $0.id == activeWorktreeTabId }) {
+            activeId = activeWorktreeTabId
+        } else {
+            activeId = visibleWorktreeTabs.first?.id
+        }
     }
 
     func adjacentTabID(in direction: CenterTabNavigationDirection) -> TabID? {
@@ -63,6 +75,7 @@ struct CenterPaneView: View {
     @Bindable var state: AppState
     let worktree: Worktree
     var activeGlobalMissionTab: MissionTabState? = nil
+    var missionsEnabled = true
     var allowsPaneFocus: Bool = true
     @Environment(\.theme) var theme
 
@@ -73,7 +86,8 @@ struct CenterPaneView: View {
                 globalTabs: state.globalTabs.tabs,
                 worktreeTabs: worktreeTabs,
                 activeGlobalMissionTab: activeGlobalMissionTab,
-                activeWorktreeTabId: state.tabs.activeTabId(forWorktree: worktree.id)
+                activeWorktreeTabId: state.tabs.activeTabId(forWorktree: worktree.id),
+                missionsEnabled: missionsEnabled
             )
             let tabs = composition.tabs
             let closurePlan = CenterTabClosurePlan(orderedTabIDs: tabs.map(\.id))
@@ -298,6 +312,20 @@ struct CenterPaneView: View {
                         ?? AgentBuiltins.entry(id: session.agentId)
                 }
             )
+            .onAppear {
+                state.synchronizeVisibleWorktreeCenterTabIfNeeded(
+                    worktreeId: worktree.id,
+                    activeTabId: composition.activeId,
+                    missionsEnabled: missionsEnabled
+                )
+            }
+            .onChange(of: composition.activeId) { _, activeId in
+                state.synchronizeVisibleWorktreeCenterTabIfNeeded(
+                    worktreeId: worktree.id,
+                    activeTabId: activeId,
+                    missionsEnabled: missionsEnabled
+                )
+            }
             Group {
                 if tabs.isEmpty, !state.tabs.hasLoaded {
                     Spinner()

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -1408,6 +1408,15 @@ final class TabsManager {
         persist(worktreeId)
     }
 
+    func clearActiveTab(worktreeId: String) {
+        guard var file = byWorktree[worktreeId],
+              file.activeTabId != nil
+        else { return }
+        file.activeTabId = nil
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+    }
+
     @discardableResult
     func restore(tab: Tab, worktreeID: String, placement: ClosedTabPlacement) -> TabID {
         var file = byWorktree[worktreeID] ?? TabsFile(tabs: [], activeTabId: nil)

--- a/Alas/Sources/Missions/MissionController.swift
+++ b/Alas/Sources/Missions/MissionController.swift
@@ -117,6 +117,8 @@ final class MissionController {
     @ObservationIgnored
     private var sourceRefreshGenerations: [MissionID: Int] = [:]
     @ObservationIgnored
+    private var isSuspended = false
+    @ObservationIgnored
     private lazy var coordinator = MissionCoordinator(environment: .init(
         persistence: environment.persistence,
         now: environment.now,
@@ -171,18 +173,36 @@ final class MissionController {
         self.openMission = openMission
     }
 
+    func resume() {
+        guard isSuspended else { return }
+        isSuspended = false
+        coordinator.resume()
+    }
+
+    func suspend() {
+        guard !isSuspended else { return }
+        isSuspended = true
+        sourceRefreshGenerations = sourceRefreshGenerations.mapValues { $0 &+ 1 }
+        for waiters in lifecycleWaiters.values {
+            for waiter in waiters { waiter.resume() }
+        }
+        lifecycleWaiters.removeAll()
+        coordinator.suspend()
+    }
+
     func load() async {
+        guard !isSuspended else { return }
         loadState = .loading
         loadError = nil
         do {
             let loaded = try await persistence.list(includeCompleted: true)
-            guard !Task.isCancelled else { return }
+            guard !isSuspended, !Task.isCancelled else { return }
             // A delete(_:) that completes while this load is in flight must not have
             // its result overwritten by a snapshot read before the deletion committed.
             aggregates = Self.sorted(loaded.filter { !deletedMissionIDs.contains($0.mission.id) })
             loadState = .loaded
         } catch {
-            guard !Task.isCancelled else { return }
+            guard !isSuspended, !Task.isCancelled else { return }
             let message = error.localizedDescription
             loadError = message
             loadState = .failed(message)
@@ -190,11 +210,16 @@ final class MissionController {
     }
 
     func resolveLegacyBaseRemoteNames(using resolver: MissionLegacyBaseRemoteResolver) async {
+        guard !isSuspended else { return }
         do {
             var didChange = false
-            for aggregate in try await persistence.list(includeCompleted: true) {
+            let aggregates = try await persistence.list(includeCompleted: true)
+            guard !isSuspended, !Task.isCancelled else { return }
+            for aggregate in aggregates {
+                guard !isSuspended, !Task.isCancelled else { return }
                 for var leg in aggregate.legs where leg.baseRemoteName == nil {
                     guard let resolvedRemoteName = await resolver(leg.projectId, leg.baseRef) else { continue }
+                    guard !isSuspended, !Task.isCancelled else { return }
                     leg.baseRemoteName = resolvedRemoteName
                     try await persistence.updateLeg(leg, event: nil)
                     didChange = true
@@ -207,23 +232,27 @@ final class MissionController {
     }
 
     func create(_ draft: MissionDraft, allowDuplicate: Bool) async throws -> MissionID {
+        guard !isSuspended else { throw CancellationError() }
         let id = try await coordinator.create(draft, allowDuplicate: allowDuplicate)
         loadError = nil
         return id
     }
 
     func addLeg(_ draft: MissionLegDraft, to missionID: MissionID) async throws -> MissionLegID {
+        guard !isSuspended else { throw CancellationError() }
         let legID = try await coordinator.addLeg(missionID: missionID, draft: draft)
         loadError = nil
         return legID
     }
 
     func retry(_ id: MissionID, agentId: String? = nil) async {
+        guard !isSuspended else { return }
         guard let legID = aggregate(id: id)?.mission.primaryLegID else { return }
         await retry(id, legID: legID, agentId: agentId)
     }
 
     func retry(_ id: MissionID, legID: MissionLegID, agentId: String? = nil) async {
+        guard !isSuspended else { return }
         await withLifecycleMutation(id: id) { [weak self] in
             guard let self else { return }
             do {
@@ -267,12 +296,14 @@ final class MissionController {
     }
 
     func reconcileInterrupted() async {
+        guard !isSuspended else { return }
         loadError = nil
         await coordinator.reconcileInterrupted()
         await reconcileReadinessAtStartup()
     }
 
     func observeReview(worktreeId: String, baseRef: String, snapshot: ReviewLoopSnapshot) async {
+        guard !isSuspended else { return }
         loadError = nil
         do {
             let active = try await persistence.list(includeCompleted: false)
@@ -352,6 +383,7 @@ final class MissionController {
     }
 
     func discoverMergedReview(worktreeId: String, baseRef: String, snapshot: ReviewLoopSnapshot) async {
+        guard !isSuspended else { return }
         loadError = nil
         do {
             let active = try await persistence.list(includeCompleted: false)
@@ -386,11 +418,13 @@ final class MissionController {
     }
 
     func refreshReviewSnapshot(worktreeId: String, baseRef: String, snapshot: ReviewLoopSnapshot) async {
+        guard !isSuspended else { return }
         await observeReview(worktreeId: worktreeId, baseRef: baseRef, snapshot: snapshot)
         await discoverMergedReview(worktreeId: worktreeId, baseRef: baseRef, snapshot: snapshot)
     }
 
     func recordArchive(worktreeId: String) async {
+        guard !isSuspended else { return }
         loadError = nil
         do {
             let active = try await persistence.list(includeCompleted: false)
@@ -412,11 +446,13 @@ final class MissionController {
     }
 
     func recordMissingWorktree(_ id: MissionID, projectRemoved: Bool = false) async {
+        guard !isSuspended else { return }
         guard let legID = aggregate(id: id)?.mission.primaryLegID else { return }
         await recordMissingWorktree(id, legID: legID, projectRemoved: projectRemoved)
     }
 
     func recordMissingWorktree(_ id: MissionID, legID: MissionLegID, projectRemoved: Bool = false) async {
+        guard !isSuspended else { return }
         await apply(
             signal: projectRemoved ? .projectRemoved : .worktreeMissing,
             to: id,
@@ -425,14 +461,17 @@ final class MissionController {
     }
 
     func recordAvailableWorktree(_ id: MissionID) async {
+        guard !isSuspended else { return }
         await restoreReappearedWorktreeIfNeeded(id)
     }
 
     func recordAvailableWorktree(_ id: MissionID, legID: MissionLegID) async {
+        guard !isSuspended else { return }
         await restoreReappearedWorktreeIfNeeded(id, legID: legID)
     }
 
     func recordMissingWorktree(projectId: String, projectRemoved: Bool) async {
+        guard !isSuspended else { return }
         loadError = nil
         do {
             let active = try await persistence.list(includeCompleted: false)
@@ -452,6 +491,7 @@ final class MissionController {
 
     @discardableResult
     func refreshSource(_ id: MissionID) async -> MissionSourceRefreshResult {
+        guard !isSuspended else { return .unavailable }
         sourceRefreshGenerations[id, default: 0] &+= 1
         let generation = sourceRefreshGenerations[id, default: 0]
         do {
@@ -463,11 +503,11 @@ final class MissionController {
             do {
                 refreshed = try await sourceRefresh(loaded.source, leg.projectId)
             } catch {
-                guard sourceRefreshGenerations[id] == generation else { return .unavailable }
+                guard !isSuspended, sourceRefreshGenerations[id] == generation else { return .unavailable }
                 await persistRefreshFailure(error, aggregate: loaded)
                 return .failed(Self.sanitized(error.localizedDescription))
             }
-            guard sourceRefreshGenerations[id] == generation else { return .unavailable }
+            guard !isSuspended, sourceRefreshGenerations[id] == generation else { return .unavailable }
             if loaded.source.contentOrigin == .manual || refreshed.contentOrigin == .manual {
                 loadError = nil
                 return .confirmationRequired(.init(
@@ -493,7 +533,7 @@ final class MissionController {
             loadError = nil
             return .applied
         } catch {
-            guard sourceRefreshGenerations[id] == generation else { return .unavailable }
+            guard !isSuspended, sourceRefreshGenerations[id] == generation else { return .unavailable }
             loadError = error.localizedDescription
             return .failed(error.localizedDescription)
         }
@@ -501,8 +541,10 @@ final class MissionController {
 
     @discardableResult
     func confirmSourceRefresh(_ proposal: MissionSourceRefreshProposal) async -> Bool {
+        guard !isSuspended else { return false }
         do {
             guard let loaded = try await persistence.aggregate(id: proposal.missionID),
+                  !isSuspended,
                   loaded.source.identity == proposal.expectedIdentity,
                   loaded.source.capturedAt == proposal.expectedCapturedAt
             else {
@@ -532,8 +574,10 @@ final class MissionController {
 
     @discardableResult
     func updateManualSource(id: MissionID, title: String, body: String) async -> Bool {
+        guard !isSuspended else { return false }
         do {
             guard let aggregate = try await persistence.aggregate(id: id) else { return false }
+            guard !isSuspended else { return false }
             let event = makeEvent(
                 aggregate: aggregate,
                 kind: .sourceRefreshed,
@@ -555,6 +599,7 @@ final class MissionController {
     }
 
     func refreshLinkedReview(_ id: MissionID) async {
+        guard !isSuspended else { return }
         do {
             guard let aggregate = try await persistence.aggregate(id: id) else { return }
             for leg in aggregate.legs where leg.reviewIdentity != nil {
@@ -566,6 +611,7 @@ final class MissionController {
     }
 
     func refreshLinkedReview(_ id: MissionID, legID: MissionLegID) async {
+        guard !isSuspended else { return }
         do {
             guard let aggregate = try await persistence.aggregate(id: id),
                   let leg = aggregate.legs.first(where: { $0.id == legID }),
@@ -589,6 +635,7 @@ final class MissionController {
     }
 
     func refreshReviewWithoutWorktree(_ id: MissionID) async {
+        guard !isSuspended else { return }
         do {
             guard let aggregate = try await persistence.aggregate(id: id) else { return }
             for leg in aggregate.legs {
@@ -600,6 +647,7 @@ final class MissionController {
     }
 
     func refreshReviewWithoutWorktree(_ id: MissionID, legID: MissionLegID) async {
+        guard !isSuspended else { return }
         do {
             guard let aggregate = try await persistence.aggregate(id: id),
                   let leg = aggregate.legs.first(where: { $0.id == legID })
@@ -611,6 +659,7 @@ final class MissionController {
     }
 
     func refreshReviewBeforeWorktreeRemoval(_ worktreeID: String) async -> Bool {
+        guard !isSuspended else { return true }
         loadError = nil
         do {
             let active = try await persistence.list(includeCompleted: false)
@@ -630,6 +679,7 @@ final class MissionController {
     }
 
     func complete(_ id: MissionID) async {
+        guard !isSuspended else { return }
         await withLifecycleMutation(id: id) { [weak self] in
             guard let self else { return }
             do {
@@ -669,6 +719,7 @@ final class MissionController {
     }
 
     func delete(_ id: MissionID) async {
+        guard !isSuspended else { return }
         await withLifecycleMutation(id: id) { [weak self] in
             guard let self else { return }
             do {
@@ -685,6 +736,7 @@ final class MissionController {
     // skips the per-Mission lifecycle gate and deletes them in one transaction.
     @discardableResult
     func deleteCompleted(ids: [MissionID]) async -> [MissionID] {
+        guard !isSuspended else { return [] }
         let completed = ids.filter { aggregate(id: $0)?.mission.state == .completed }
         guard !completed.isEmpty else { return [] }
         do {
@@ -699,11 +751,13 @@ final class MissionController {
     }
 
     func aggregate(id: MissionID) -> MissionAggregate? {
-        aggregates.first { $0.mission.id == id }
+        guard !isSuspended else { return nil }
+        return aggregates.first { $0.mission.id == id }
     }
 
     func hasActiveMission(worktreeId: String) -> Bool {
-        aggregates.contains { aggregate in
+        guard !isSuspended else { return false }
+        return aggregates.contains { aggregate in
             aggregate.mission.state != .completed
                 && aggregate.legs.contains { $0.worktreeId == worktreeId }
         }
@@ -714,7 +768,15 @@ final class MissionController {
         existingProjectIds: [String],
         knownWorktreeIds: Set<String>
     ) -> MissionSidebarModel {
-        MissionSidebarModel.make(
+        guard !isSuspended else {
+            return MissionSidebarModel.make(
+                aggregates: [],
+                activeProjectIds: activeProjectIds,
+                existingProjectIds: existingProjectIds,
+                knownWorktreeIds: knownWorktreeIds
+            )
+        }
+        return MissionSidebarModel.make(
             aggregates: aggregates,
             activeProjectIds: activeProjectIds,
             existingProjectIds: existingProjectIds,
@@ -967,6 +1029,7 @@ final class MissionController {
         legID: MissionLegID? = nil,
         replaceReviewIdentity: Bool = false
     ) async {
+        guard !isSuspended else { return }
         await apply(
             signal: .review(state: request.state, identity: identity),
             to: id,
@@ -990,6 +1053,7 @@ final class MissionController {
     }
 
     private func applyArchive(to id: MissionID, legID: MissionLegID? = nil) async {
+        guard !isSuspended else { return }
         await apply(
             signal: .worktreeArchived,
             to: id,
@@ -1019,8 +1083,9 @@ final class MissionController {
         replaceReviewIdentity: Bool = false,
         validate: @escaping @MainActor (MissionAggregate) async -> Bool = { _ in true }
     ) async {
+        guard !isSuspended else { return }
         await withLifecycleMutation(id: id) { [weak self] in
-            guard let self else { return }
+            guard let self, !isSuspended else { return }
             do {
                 guard var aggregate = try await persistence.aggregate(id: id) else { return }
                 guard aggregate.mission.state != .completed else { return }
@@ -1033,7 +1098,7 @@ final class MissionController {
                     else { return }
                     aggregate = settled
                 }
-                guard await validate(aggregate) else { return }
+                guard await validate(aggregate), !isSuspended else { return }
                 guard let targetLeg = aggregate.legs.first(where: { $0.id == targetLegID }) else { return }
                 let decision = MissionReadinessEvaluator.evaluate(
                     currentState: targetLeg.state,
@@ -1136,6 +1201,7 @@ final class MissionController {
         _ error: Error,
         aggregate: MissionAggregate
     ) async {
+        guard !isSuspended else { return }
         let message = Self.sanitized(error.localizedDescription)
         let event = makeEvent(
             aggregate: aggregate,
@@ -1163,7 +1229,9 @@ final class MissionController {
     }
 
     private func publish(id: MissionID) async throws {
+        guard !isSuspended else { return }
         if let aggregate = try await persistence.aggregate(id: id) {
+            guard !isSuspended else { return }
             environment.notifyChanged(aggregate)
             replace(aggregate)
         }
@@ -1173,6 +1241,7 @@ final class MissionController {
         id: MissionID,
         operation: @escaping @MainActor () async -> Void
     ) async {
+        guard !isSuspended else { return }
         guard lifecycleMutations.insert(id).inserted else {
             await withCheckedContinuation { continuation in
                 lifecycleWaiters[id, default: []].append(continuation)
@@ -1275,6 +1344,7 @@ final class MissionController {
     // tombstone guard against a real MissionController without fabricating
     // real concurrency.
     func replace(_ aggregate: MissionAggregate) {
+        guard !isSuspended else { return }
         guard !deletedMissionIDs.contains(aggregate.mission.id) else { return }
         if let index = aggregates.firstIndex(where: { $0.mission.id == aggregate.mission.id }) {
             aggregates[index] = aggregate

--- a/Alas/Sources/Missions/MissionCoordinator.swift
+++ b/Alas/Sources/Missions/MissionCoordinator.swift
@@ -55,13 +55,32 @@ final class MissionCoordinator {
     private let legCoordinator: MissionLegCoordinator
     private var addingLegs: Set<MissionID> = []
     private var addLegWaiters: [MissionID: [CheckedContinuation<Void, Never>]] = [:]
+    private var scheduledAdvances: [MissionLegID: Task<Void, Never>] = [:]
+    private var isSuspended = false
 
     init(environment: Environment) {
         self.environment = environment
         legCoordinator = MissionLegCoordinator(environment: environment)
     }
 
+    func resume() {
+        isSuspended = false
+        legCoordinator.resume()
+    }
+
+    func suspend() {
+        isSuspended = true
+        scheduledAdvances.values.forEach { $0.cancel() }
+        scheduledAdvances.removeAll()
+        for waiters in addLegWaiters.values {
+            for waiter in waiters { waiter.resume() }
+        }
+        addLegWaiters.removeAll()
+        legCoordinator.suspend()
+    }
+
     func create(_ draft: MissionDraft, allowDuplicate: Bool = false) async throws -> MissionID {
+        guard !isSuspended else { throw CancellationError() }
         let missionID = MissionID(rawValue: environment.makeID())
         let legID = MissionLegID(rawValue: environment.makeID())
         let now = environment.now()
@@ -109,13 +128,12 @@ final class MissionCoordinator {
 
         try await environment.persistence.insert(aggregate, allowDuplicate: allowDuplicate)
         environment.notifyChanged(aggregate)
-        Task { @MainActor [weak self] in
-            await self?.legCoordinator.advance(missionID: missionID, legID: legID)
-        }
+        scheduleAdvance(missionID: missionID, legID: legID)
         return missionID
     }
 
     func addLeg(missionID: MissionID, draft: MissionLegDraft) async throws -> MissionLegID {
+        guard !isSuspended else { throw CancellationError() }
         guard addingLegs.insert(missionID).inserted else {
             await withCheckedContinuation { continuation in
                 addLegWaiters[missionID, default: []].append(continuation)
@@ -167,13 +185,12 @@ final class MissionCoordinator {
         if let changed = try await environment.persistence.aggregate(id: missionID) {
             environment.notifyChanged(changed)
         }
-        Task { @MainActor [weak self] in
-            await self?.legCoordinator.advance(missionID: missionID, legID: legID)
-        }
+        scheduleAdvance(missionID: missionID, legID: legID)
         return legID
     }
 
     func advance(id: MissionID) async {
+        guard !isSuspended else { return }
         do {
             guard let aggregate = try await environment.persistence.aggregate(id: id) else { return }
             await legCoordinator.advance(missionID: id, legID: aggregate.mission.primaryLegID)
@@ -183,10 +200,12 @@ final class MissionCoordinator {
     }
 
     func advance(id: MissionID, legID: MissionLegID) async {
+        guard !isSuspended else { return }
         await legCoordinator.advance(missionID: id, legID: legID)
     }
 
     func retry(id: MissionID, recreateWorktree: Bool = false) async {
+        guard !isSuspended else { return }
         do {
             guard let aggregate = try await environment.persistence.aggregate(id: id) else { return }
             await retry(id: id, legID: aggregate.mission.primaryLegID, recreateWorktree: recreateWorktree)
@@ -196,6 +215,7 @@ final class MissionCoordinator {
     }
 
     func retry(id: MissionID, legID: MissionLegID, recreateWorktree: Bool = false) async {
+        guard !isSuspended else { return }
         await legCoordinator.retry(
             missionID: id,
             legID: legID,
@@ -204,7 +224,18 @@ final class MissionCoordinator {
     }
 
     func reconcileInterrupted() async {
+        guard !isSuspended else { return }
         await legCoordinator.reconcileInterrupted()
+    }
+
+    private func scheduleAdvance(missionID: MissionID, legID: MissionLegID) {
+        guard !isSuspended else { return }
+        scheduledAdvances[legID]?.cancel()
+        scheduledAdvances[legID] = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await legCoordinator.advance(missionID: missionID, legID: legID)
+            scheduledAdvances.removeValue(forKey: legID)
+        }
     }
 
     private func event(

--- a/Alas/Sources/Missions/MissionLegCoordinator.swift
+++ b/Alas/Sources/Missions/MissionLegCoordinator.swift
@@ -5,16 +5,31 @@ final class MissionLegCoordinator {
     private let environment: MissionCoordinator.Environment
     private var advancing: Set<MissionLegID> = []
     private var advanceWaiters: [MissionLegID: [CheckedContinuation<Void, Never>]] = [:]
+    private var isSuspended = false
 
     init(environment: MissionCoordinator.Environment) {
         self.environment = environment
     }
 
+    func resume() {
+        isSuspended = false
+    }
+
+    func suspend() {
+        isSuspended = true
+        for waiters in advanceWaiters.values {
+            for waiter in waiters { waiter.resume() }
+        }
+        advanceWaiters.removeAll()
+    }
+
     func advance(missionID: MissionID, legID: MissionLegID) async {
+        guard !isSuspended else { return }
         guard advancing.insert(legID).inserted else {
             await withCheckedContinuation { continuation in
                 advanceWaiters[legID, default: []].append(continuation)
             }
+            await advance(missionID: missionID, legID: legID)
             return
         }
 
@@ -27,6 +42,7 @@ final class MissionLegCoordinator {
     }
 
     func retry(missionID: MissionID, legID: MissionLegID, recreateWorktree: Bool = false) async {
+        guard !isSuspended else { return }
         let aggregate: MissionAggregate
         let leg: MissionLeg
         do {
@@ -77,6 +93,7 @@ final class MissionLegCoordinator {
     }
 
     func reconcileInterrupted() async {
+        guard !isSuspended else { return }
         let aggregates: [MissionAggregate]
         do {
             aggregates = try await environment.persistence.list(includeCompleted: false)
@@ -86,7 +103,9 @@ final class MissionLegCoordinator {
         }
 
         for aggregate in aggregates {
+            guard !isSuspended else { return }
             for leg in aggregate.legs where setupLeg(in: aggregate, legID: leg.id)?.state == .needsAttention {
+                guard !isSuspended else { return }
                 await reconcileArtifacts(missionID: aggregate.mission.id, legID: leg.id)
             }
         }
@@ -110,6 +129,7 @@ final class MissionLegCoordinator {
 
     private func performAdvance(missionID: MissionID, legID: MissionLegID) async {
         while true {
+            guard !isSuspended, !Task.isCancelled else { return }
             let aggregate: MissionAggregate
             let leg: MissionLeg
             do {
@@ -134,6 +154,7 @@ final class MissionLegCoordinator {
             case .running:
                 didAdvance = await settleRunning(aggregate: aggregate, leg: leg)
             }
+            guard !isSuspended, !Task.isCancelled else { return }
             if !didAdvance { return }
         }
     }
@@ -155,6 +176,7 @@ final class MissionLegCoordinator {
         } else {
             if leg.worktreeId == nil {
                 let planningResult = await environment.plannedWorktreeID(leg)
+                guard !isSuspended, !Task.isCancelled else { return false }
                 guard !(await missionIsCompleted(aggregate.mission.id)) else { return false }
                 switch planningResult {
                 case .success(let worktreeID):
@@ -179,6 +201,7 @@ final class MissionLegCoordinator {
                 }
             }
             let creationResult = await environment.createWorktree(leg)
+            guard !isSuspended, !Task.isCancelled else { return false }
             guard !(await missionIsCompleted(aggregate.mission.id)) else { return false }
             switch creationResult {
             case .success(let created):
@@ -276,6 +299,7 @@ final class MissionLegCoordinator {
         guard !(await missionIsCompleted(aggregate.mission.id)) else { return false }
 
         let startupResult = await environment.startACP(leg, worktree)
+        guard !isSuspended, !Task.isCancelled else { return false }
         guard !(await missionIsCompleted(aggregate.mission.id)) else { return false }
         switch startupResult {
         case .success:
@@ -378,8 +402,10 @@ final class MissionLegCoordinator {
         event: MissionEvent?,
         failureCheckpoint: MissionSetupCheckpoint? = nil
     ) async -> Bool {
+        guard !isSuspended, !Task.isCancelled else { return false }
         do {
             try await environment.persistence.updateLegSetup(missionID: missionID, leg: leg, event: event)
+            guard !isSuspended, !Task.isCancelled else { return false }
             await notify(id: missionID)
             return true
         } catch MissionStore.Error.missionCompleted {

--- a/Alas/Sources/Missions/MissionsFeatureFlag.swift
+++ b/Alas/Sources/Missions/MissionsFeatureFlag.swift
@@ -1,0 +1,30 @@
+import Combine
+import Foundation
+
+enum MissionsFeatureFlag {
+    static let defaultsKey = "alas.features.missions"
+    static let didChangeNotification = Notification.Name(
+        "alas.missions-feature-flag-did-change"
+    )
+
+    static var isEnabled: Bool { isEnabled(in: .standard) }
+
+    nonisolated static func isEnabled(in defaults: UserDefaults) -> Bool {
+        defaults.object(forKey: defaultsKey) as? Bool ?? false
+    }
+
+    static func updates(
+        in defaults: UserDefaults = .standard,
+        notificationCenter: NotificationCenter = .default
+    ) -> AnyPublisher<Bool, Never> {
+        notificationCenter.publisher(for: UserDefaults.didChangeNotification, object: defaults)
+            .map { _ in isEnabled(in: defaults) }
+            .eraseToAnyPublisher()
+    }
+
+    static func setEnabled(_ enabled: Bool, in defaults: UserDefaults = .standard) {
+        guard isEnabled(in: defaults) != enabled else { return }
+        defaults.set(enabled, forKey: defaultsKey)
+        NotificationCenter.default.post(name: didChangeNotification, object: nil)
+    }
+}

--- a/Alas/Sources/Settings/AdvancedPane.swift
+++ b/Alas/Sources/Settings/AdvancedPane.swift
@@ -22,6 +22,15 @@ struct AdvancedPane: View {
 
                 SettingsGroup(title: "Experiments") {
                     SettingsRow(
+                        name: "Missions",
+                        desc: "Shows the experimental Missions interface and resumes its background coordination."
+                    ) {
+                        AlasToggle(on: Binding(
+                            get: { state.missionsEnabled },
+                            set: { state.setMissionsEnabled($0) }
+                        ))
+                    }
+                    SettingsRow(
                         name: "AppKit diff scrollers",
                         desc: "Replaces vertical scrolling in diff and review panes with an AppKit-backed scroller. Toggling this re-creates open diff views, so their scroll positions are lost."
                     ) {

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -35,20 +35,22 @@ struct SidebarView: View {
                 )
                 ScrollView(.vertical, showsIndicators: true) {
                     VStack(alignment: .leading, spacing: 8) {
-                        MissionSidebarSection(
-                            model: missionSidebarModel,
-                            selectedMissionID: selectedMissionID,
-                            onOpenMission: { missionID in
-                                _ = state.openMission(id: missionID)
-                            },
-                            onNewMission: onNewMission,
-                            onDeleteMission: { missionID in
-                                Task { await state.deleteMission(id: missionID) }
-                            },
-                            onDeleteCompleted: { missionIDs in
-                                Task { await state.deleteCompletedMissions(ids: missionIDs) }
-                            }
-                        )
+                        if state.missionsEnabled {
+                            MissionSidebarSection(
+                                model: missionSidebarModel,
+                                selectedMissionID: selectedMissionID,
+                                onOpenMission: { missionID in
+                                    _ = state.openMission(id: missionID)
+                                },
+                                onNewMission: onNewMission,
+                                onDeleteMission: { missionID in
+                                    Task { await state.deleteMission(id: missionID) }
+                                },
+                                onDeleteCompleted: { missionIDs in
+                                    Task { await state.deleteCompletedMissions(ids: missionIDs) }
+                                }
+                            )
+                        }
                         ForEach(state.activeSpaceProjects) { project in
                             RepoGroupView(
                                 project: project,
@@ -62,7 +64,9 @@ struct SidebarView: View {
                                 ),
                                 selectedWorktreeId: Self.effectiveSelectedWorktreeId(
                                     selectedWorktreeId: state.selectedWorktreeId,
-                                    activeMissionTab: state.globalTabs.activeMissionTab()
+                                    activeMissionTab: state.missionsEnabled
+                                        ? state.globalTabs.activeMissionTab()
+                                        : nil
                                 ),
                                 isMain: { wt in state.projectsManager.isMain(wt, in: project) },
                                 operationState: { wt in
@@ -287,7 +291,15 @@ struct SidebarView: View {
     }
 
     private var missionSidebarModel: MissionSidebarModel {
-        state.missions.sidebarModel(
+        guard state.missionsEnabled else {
+            return MissionSidebarModel.make(
+                aggregates: [],
+                activeProjectIds: [],
+                existingProjectIds: [],
+                knownWorktreeIds: []
+            )
+        }
+        return state.missions.sidebarModel(
             activeProjectIds: state.spacesManager.activeSpace?.projectIds ?? state.projects.map(\.id),
             existingProjectIds: state.projects.map(\.id),
             knownWorktreeIds: state.allWorktreeIds()
@@ -295,6 +307,7 @@ struct SidebarView: View {
     }
 
     private var selectedMissionID: MissionID? {
+        guard state.missionsEnabled else { return nil }
         if let tabState = state.globalTabs.activeMissionTab() {
             return tabState.missionID
         }

--- a/AlasTests/AppStateCreateWorktreeSymlinkTests.swift
+++ b/AlasTests/AppStateCreateWorktreeSymlinkTests.swift
@@ -102,7 +102,7 @@ struct AppStateCreateWorktreeSymlinkTests {
 
         let state = AppState(missionPersistence: MissionPersistence(
             path: persistenceDirectory.appendingPathComponent("missions.sqlite").path
-        ))
+        ), missionsEnabled: true)
         let project = try await state.projectsManager.addProject(
             path: realRepo,
             displayName: "mission-symlink-repo",

--- a/AlasTests/AppStatePersistenceTests.swift
+++ b/AlasTests/AppStatePersistenceTests.swift
@@ -834,7 +834,8 @@ struct AppStatePersistenceTests {
         let persistence = try Self.makeMissionPersistence()
         let state = AppState(
             store: RecordingStore(initialProjectsFile: .init(projects: [project])),
-            missionPersistence: persistence
+            missionPersistence: persistence,
+            missionsEnabled: true
         )
         let worktree = Self.worktree
         state.projectsManager.insertOptimisticWorktree(worktree)
@@ -853,7 +854,8 @@ struct AppStatePersistenceTests {
         let persistence = try Self.makeMissionPersistence()
         let state = AppState(
             store: RecordingStore(initialProjectsFile: .init(projects: [project])),
-            missionPersistence: persistence
+            missionPersistence: persistence,
+            missionsEnabled: true
         )
         let worktree = Self.worktree
         state.projectsManager.insertOptimisticWorktree(worktree)
@@ -876,7 +878,8 @@ struct AppStatePersistenceTests {
         let state = AppState(
             store: RecordingStore(initialProjectsFile: .init(projects: [project])),
             missionPersistence: persistence,
-            missionArchiveRecorder: { _ in await recorder.waitForRelease() }
+            missionArchiveRecorder: { _ in await recorder.waitForRelease() },
+            missionsEnabled: true
         )
         let worktree = Self.worktree
         let other = Self.otherWorktree
@@ -903,7 +906,8 @@ struct AppStatePersistenceTests {
         let state = AppState(
             store: RecordingStore(initialProjectsFile: .init(projects: [project])),
             missionPersistence: persistence,
-            missionArchiveRecorder: { _ in await recorder.waitForRelease() }
+            missionArchiveRecorder: { _ in await recorder.waitForRelease() },
+            missionsEnabled: true
         )
         let worktree = Self.worktree
         state.projectsManager.insertOptimisticWorktree(worktree)
@@ -965,7 +969,8 @@ struct AppStatePersistenceTests {
                 #expect(projectID == project.id)
                 #expect(branch == worktree.branch)
                 return "abc123"
-            }
+            },
+            missionsEnabled: true
         )
         state.projectsManager.insertOptimisticWorktree(worktree)
 
@@ -985,7 +990,8 @@ struct AppStatePersistenceTests {
         let persistence = try Self.makeMissionPersistence()
         let state = AppState(
             store: RecordingStore(initialProjectsFile: .init(projects: [project])),
-            missionPersistence: persistence
+            missionPersistence: persistence,
+            missionsEnabled: true
         )
         await state.missions.load()
 
@@ -1170,6 +1176,7 @@ private struct MissionGlobalNavigationFixture {
         let appState = AppState(
             store: NavigationStore(projectsFile: ProjectsFile(projects: [project])),
             missionPersistence: MissionPersistence(path: databaseURL.path),
+            missionsEnabled: true,
             globalTabs: GlobalTabsManager(
                 fileURL: FileManager.default.temporaryDirectory
                     .appendingPathComponent("mission-global-navigation-\(UUID().uuidString).json")
@@ -1311,6 +1318,7 @@ private struct MissionCrossSpaceNavigationFixture {
         let state = AppState(
             store: Store(projectsFile: projectsFile, spacesFile: spacesFile),
             missionPersistence: MissionPersistence(path: missionDatabaseURL.path),
+            missionsEnabled: true,
             globalTabs: globalTabs
         )
         state.projectsManager.insertOptimisticWorktree(appWorktree)

--- a/AlasTests/CenterSelectionStateResolverTests.swift
+++ b/AlasTests/CenterSelectionStateResolverTests.swift
@@ -17,11 +17,52 @@ struct CenterSelectionStateResolverTests {
             globalTabs: [.mission(mission)],
             worktreeTabs: [terminal],
             activeGlobalMissionTab: mission,
-            activeWorktreeTabId: terminal.id
+            activeWorktreeTabId: terminal.id,
+            missionsEnabled: true
         )
 
         #expect(composition.tabs == [.mission(mission), terminal])
         #expect(composition.activeId == mission.id)
+    }
+
+    @Test func disabledMissionsAreExcludedFromCenterComposition() {
+        let mission = MissionTabState.fixture
+        let terminal = Tab.terminal(TerminalTabState(
+            id: "terminal-1",
+            title: "Terminal",
+            sessionId: "session-1"
+        ))
+
+        let composition = CenterTabComposition(
+            globalTabs: [.mission(mission)],
+            worktreeTabs: [terminal],
+            activeGlobalMissionTab: mission,
+            activeWorktreeTabId: terminal.id,
+            missionsEnabled: false
+        )
+
+        #expect(composition.tabs == [terminal])
+        #expect(composition.activeId == terminal.id)
+    }
+
+    @Test func disabledMissionsExcludeLegacyWorktreeMissionAndKeepARegularTabActive() {
+        let mission = MissionTabState.fixture
+        let terminal = Tab.terminal(TerminalTabState(
+            id: "terminal-1",
+            title: "Terminal",
+            sessionId: "session-1"
+        ))
+
+        let composition = CenterTabComposition(
+            globalTabs: [],
+            worktreeTabs: [.mission(mission), terminal],
+            activeGlobalMissionTab: nil,
+            activeWorktreeTabId: mission.id,
+            missionsEnabled: false
+        )
+
+        #expect(composition.tabs == [terminal])
+        #expect(composition.activeId == terminal.id)
     }
 
     @Test func adjacentTabsFollowVisualOrderAndWrap() {

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -50,7 +50,9 @@ struct ClosedTabAppStateTests {
         let second: Worktree
     }
 
-    private func makeFixture(state: AppState = AppState(store: MemoryStore())) -> Fixture {
+    private func makeFixture(
+        state: AppState = AppState(store: MemoryStore(), missionsEnabled: true)
+    ) -> Fixture {
         let project = ProjectConfig(
             id: "closed-tabs-project",
             name: "Closed Tabs",
@@ -125,6 +127,28 @@ struct ClosedTabAppStateTests {
 
         #expect(fixture.state.globalTabs.activeTabId == tab.id)
         #expect(fixture.state.globalTabs.tabs.count == 1)
+    }
+
+    @Test func disabledMissionsSkipClosedGlobalTabsWhenReopeningEarlierWorktreeTab() async {
+        let fixture = makeFixture()
+        let local = fixture.state.tabs.appendEditor(
+            worktreeId: fixture.second.id,
+            title: "README.md",
+            relativePath: "README.md"
+        )
+        fixture.state.requestCloseTab(worktreeId: fixture.second.id, tabId: local.id)
+        let mission = fixture.state.globalTabs.openOrFocusMission(
+            missionID: MissionID(rawValue: "closed-tabs-disabled-mission"),
+            title: "Mission"
+        )
+        fixture.state.requestCloseGlobalTab(tabID: mission.id)
+        fixture.state.setMissionsEnabled(false)
+
+        await fixture.state.reopenLastClosedTab()
+
+        #expect(fixture.state.selectedWorktreeId == fixture.second.id)
+        #expect(fixture.state.tabs.activeTabId(forWorktree: fixture.second.id) == local.id)
+        #expect(fixture.state.closedTabHistory.entries.isEmpty)
     }
 
     @Test func reopenFocusesManuallyRestoredGlobalTabWithoutDuplication() async {
@@ -524,7 +548,7 @@ struct ClosedTabAppStateTests {
         let completedID = MissionID(rawValue: "closed-tabs-completed-mission")
         let runningID = MissionID(rawValue: "closed-tabs-running-mission")
         let persistence = try Self.makeMixedMissionPersistence(completedID: completedID, runningID: runningID)
-        let state = AppState(store: MemoryStore(), missionPersistence: persistence)
+        let state = AppState(store: MemoryStore(), missionPersistence: persistence, missionsEnabled: true)
         let fixture = makeFixture(state: state)
         await fixture.state.missions.load()
 

--- a/AlasTests/Missions/AddMissionLegDialogTests.swift
+++ b/AlasTests/Missions/AddMissionLegDialogTests.swift
@@ -238,7 +238,8 @@ private struct DialogFixture {
         ]
         state = AppState(
             store: DialogStore(projects: projects),
-            missionPersistence: persistence
+            missionPersistence: persistence,
+            missionsEnabled: true
         )
         self.aggregate = aggregate
     }

--- a/AlasTests/Missions/MissionFeatureRuntimeTests.swift
+++ b/AlasTests/Missions/MissionFeatureRuntimeTests.swift
@@ -1,0 +1,461 @@
+import Combine
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Mission feature runtime", .serialized)
+@MainActor
+struct MissionFeatureRuntimeTests {
+    @Test("AppState observes Mission feature flag updates without Settings pane")
+    func appStateObservesFeatureFlagUpdatesWithoutSettingsPane() async {
+        let updates = PassthroughSubject<Bool, Never>()
+        let state = AppState(
+            store: MemoryStore(),
+            missionPersistence: MissionPersistence(path: "/tmp/unused-missions.sqlite"),
+            missionsEnabled: true,
+            missionsFeatureUpdates: updates.eraseToAnyPublisher()
+        )
+        defer { state.setMissionsEnabled(false) }
+
+        updates.send(false)
+        for _ in 0..<20 where state.missionsEnabled {
+            await Task.yield()
+        }
+
+        #expect(!state.missionsEnabled)
+    }
+
+    @Test("disabled tab reload preserves legacy Mission tabs without migration writes")
+    func disabledTabReloadPreservesLegacyMissionTabs() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("disabled-mission-tab-reload-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let tabsDirectory = root.appendingPathComponent("tabs", isDirectory: true)
+        let worktreeID = "worktree-1"
+        let tabsFile = tabsDirectory.appendingPathComponent("\(worktreeID).json")
+        let globalTabsFile = root.appendingPathComponent("global-tabs.json")
+        let mission = MissionTabState(
+            missionID: MissionID(rawValue: "mission-1"),
+            title: "Fix issue 42"
+        )
+        try PersistenceStore().write(
+            TabsFile(tabs: [.mission(mission)], activeTabId: mission.id),
+            to: tabsFile
+        )
+        let persistedBeforeReload = try Data(contentsOf: tabsFile)
+        let project = ProjectConfig(
+            id: "project-1",
+            name: "Alas",
+            path: "/tmp/alas",
+            color: "#5fb7c4",
+            addedAt: Date(timeIntervalSince1970: 0)
+        )
+        let worktree = Worktree(
+            id: worktreeID,
+            projectId: project.id,
+            name: "fix-42",
+            branch: "fix-42",
+            path: URL(fileURLWithPath: "/tmp/alas-fix-42"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+        let worktreeTabs = TabsManager(tabsDirectory: tabsDirectory)
+        let globalTabs = GlobalTabsManager(fileURL: globalTabsFile)
+        let state = AppState(
+            store: ProjectStore(project: project),
+            missionsEnabled: false,
+            globalTabs: globalTabs,
+            tabsManager: worktreeTabs
+        )
+        state.projectsManager.insertOptimisticWorktree(worktree)
+
+        state.reloadTabs()
+
+        #expect(worktreeTabs.tabs(forWorktree: worktreeID) == [.mission(mission)])
+        #expect(worktreeTabs.activeTabId(forWorktree: worktreeID) == mission.id)
+        #expect(try Data(contentsOf: tabsFile) == persistedBeforeReload)
+        #expect(!FileManager.default.fileExists(atPath: globalTabsFile.path))
+        #expect(globalTabs.tabs.isEmpty)
+    }
+
+    @Test("enabled tab reload restores persisted global Mission tabs before migration")
+    func enabledTabReloadRestoresPersistedGlobalTabsBeforeMigration() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("enabled-global-mission-reload-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let tabsDirectory = root.appendingPathComponent("tabs", isDirectory: true)
+        let globalTabsFile = root.appendingPathComponent("global-tabs.json")
+        let mission = MissionTabState(
+            missionID: MissionID(rawValue: "persisted-mission"),
+            title: "Persisted mission"
+        )
+        try PersistenceStore().write(
+            GlobalTabsFile(
+                migrationVersion: 1,
+                tabs: [.mission(mission)],
+                activeTabId: mission.id
+            ),
+            to: globalTabsFile
+        )
+        let project = ProjectConfig(
+            id: "project-1",
+            name: "Alas",
+            path: "/tmp/alas",
+            color: "#5fb7c4",
+            addedAt: Date(timeIntervalSince1970: 0)
+        )
+        let worktree = Worktree(
+            id: "worktree-1",
+            projectId: project.id,
+            name: "main",
+            branch: "main",
+            path: URL(fileURLWithPath: "/tmp/alas"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+        let globalTabs = GlobalTabsManager(fileURL: globalTabsFile)
+        let state = AppState(
+            store: ProjectStore(project: project),
+            missionsEnabled: true,
+            globalTabs: globalTabs,
+            tabsManager: TabsManager(tabsDirectory: tabsDirectory)
+        )
+        state.projectsManager.insertOptimisticWorktree(worktree)
+
+        state.reloadTabs()
+
+        #expect(globalTabs.tabs == [.mission(mission)])
+        #expect(globalTabs.activeTabId == mission.id)
+    }
+
+    @Test("enabling at runtime migrates legacy worktree Mission tabs")
+    func enablingAtRuntimeMigratesLegacyWorktreeMissionTabs() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("enable-runtime-mission-migration-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let tabsDirectory = root.appendingPathComponent("tabs", isDirectory: true)
+        let worktreeID = "worktree-1"
+        let tabsFile = tabsDirectory.appendingPathComponent("\(worktreeID).json")
+        let globalTabsFile = root.appendingPathComponent("global-tabs.json")
+        let mission = MissionTabState(
+            missionID: MissionID(rawValue: "runtime-mission"),
+            title: "Runtime mission"
+        )
+        try PersistenceStore().write(
+            TabsFile(tabs: [.mission(mission)], activeTabId: mission.id),
+            to: tabsFile
+        )
+        let project = ProjectConfig(
+            id: "project-1",
+            name: "Alas",
+            path: "/tmp/alas",
+            color: "#5fb7c4",
+            addedAt: Date(timeIntervalSince1970: 0)
+        )
+        let worktree = Worktree(
+            id: worktreeID,
+            projectId: project.id,
+            name: "main",
+            branch: "main",
+            path: URL(fileURLWithPath: "/tmp/alas"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+        let worktreeTabs = TabsManager(tabsDirectory: tabsDirectory)
+        let globalTabs = GlobalTabsManager(fileURL: globalTabsFile)
+        let state = AppState(
+            store: ProjectStore(project: project),
+            missionPersistence: MissionPersistence(path: root.appendingPathComponent("missions.sqlite").path),
+            missionsEnabled: false,
+            globalTabs: globalTabs,
+            tabsManager: worktreeTabs
+        )
+        state.projectsManager.insertOptimisticWorktree(worktree)
+        state.selectedWorktreeId = worktreeID
+        state.reloadTabs()
+
+        state.setMissionsEnabled(true)
+        await state.waitForMissionFeatureTransitionForTesting()
+        defer { state.setMissionsEnabled(false) }
+
+        #expect(globalTabs.tabs == [.mission(mission)])
+        #expect(globalTabs.activeTabId == mission.id)
+        #expect(worktreeTabs.tabs(forWorktree: worktreeID).isEmpty)
+    }
+
+    @Test("disabled startup does not open Mission persistence")
+    func disabledStartupDoesNotOpenPersistence() async {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("disabled-missions-\(UUID().uuidString).sqlite")
+        let state = AppState(
+            store: MemoryStore(),
+            missionPersistence: MissionPersistence(path: databaseURL.path),
+            missionsEnabled: false,
+            globalTabs: GlobalTabsManager(
+                store: MemoryStore(),
+                fileURL: databaseURL.deletingPathExtension().appendingPathExtension("tabs.json")
+            )
+        )
+
+        await state.loadMissionsIfEnabledForStartup()
+
+        #expect(!FileManager.default.fileExists(atPath: databaseURL.path))
+    }
+
+    @Test("enabling loads once without replacing worktree selection")
+    func enablingLoadsWithoutReplacingSelection() async {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("enabled-missions-\(UUID().uuidString).sqlite")
+        let tabsStore = RecordingStore()
+        let state = AppState(
+            store: MemoryStore(),
+            missionPersistence: MissionPersistence(path: databaseURL.path),
+            missionsEnabled: false,
+            globalTabs: GlobalTabsManager(
+                store: tabsStore,
+                fileURL: databaseURL.deletingPathExtension().appendingPathExtension("tabs.json")
+            )
+        )
+        defer { state.setMissionsEnabled(false) }
+        state.selectedWorktreeId = "selected-before-enable"
+
+        state.setMissionsEnabled(true)
+        state.setMissionsEnabled(true)
+        await state.waitForMissionFeatureTransitionForTesting()
+
+        #expect(FileManager.default.fileExists(atPath: databaseURL.path))
+        #expect(tabsStore.readIfExistsCalls == 1)
+        #expect(state.missions.loadState == .loaded)
+        #expect(state.selectedWorktreeId == "selected-before-enable")
+    }
+
+    @Test("disabling clears Mission focus without deleting persisted tabs")
+    func disablingPreservesMissionTabs() {
+        let tabs = GlobalTabsManager(store: MemoryStore(), fileURL: URL(fileURLWithPath: "/tmp/unused-tabs.json"))
+        let missionID = MissionID(rawValue: "mission-1")
+        tabs.openOrFocusMission(missionID: missionID, title: "Fix issue 42")
+        let state = AppState(
+            store: MemoryStore(),
+            missionPersistence: MissionPersistence(path: "/tmp/unused-missions.sqlite"),
+            missionsEnabled: true,
+            globalTabs: tabs
+        )
+
+        state.setMissionsEnabled(false)
+
+        #expect(tabs.activeTabId == nil)
+        #expect(tabs.tabs == [.mission(MissionTabState(missionID: missionID, title: "Fix issue 42"))])
+    }
+
+    @Test("disabling reselects a visible worktree when the selected worktree is hidden")
+    func disablingSelectsVisibleWorktreeWhenCurrentSelectionIsHidden() {
+        let project = ProjectConfig(
+            id: "project-1",
+            name: "Alas",
+            path: "/tmp/alas",
+            color: "#5fb7c4",
+            addedAt: Date(timeIntervalSince1970: 0)
+        )
+        let visible = Worktree(
+            id: "visible-worktree",
+            projectId: project.id,
+            name: "main",
+            branch: "main",
+            path: URL(fileURLWithPath: "/tmp/alas"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+        let hidden = Worktree(
+            id: "hidden-worktree",
+            projectId: project.id,
+            name: "mission",
+            branch: "mission",
+            path: URL(fileURLWithPath: "/tmp/alas-mission"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 1)
+        )
+        let state = AppState(
+            store: ProjectStore(project: project),
+            missionPersistence: MissionPersistence(path: "/tmp/unused-missions.sqlite"),
+            missionsEnabled: true
+        )
+        state.spacesManager.addProject(project.id, toSpace: state.spacesManager.activeSpaceId)
+        state.projectsManager.insertOptimisticWorktree(visible)
+        state.projectsManager.insertOptimisticWorktree(hidden)
+        state.projectsManager.setWorktreeHidden(projectId: project.id, path: hidden.path, hidden: true)
+        state.selectWorktree(id: hidden.id)
+
+        state.setMissionsEnabled(false)
+
+        #expect(state.selectedWorktreeId == visible.id)
+    }
+
+    @Test("disabled center fallback synchronizes the active worktree tab")
+    func disabledCenterFallbackSynchronizesActiveWorktreeTab() {
+        let worktreeID = "worktree-center-fallback"
+        let tabsManager = TabsManager()
+        let mission = tabsManager.openOrFocusMission(
+            worktreeId: worktreeID,
+            missionID: MissionID(rawValue: "mission-center-fallback"),
+            title: "Hidden Mission"
+        )
+        let terminal = tabsManager.appendTerminal(
+            worktreeId: worktreeID,
+            title: "Terminal",
+            sessionId: "session-center-fallback"
+        )
+        tabsManager.activate(worktreeId: worktreeID, tabId: mission.id)
+        let state = AppState(
+            store: MemoryStore(),
+            missionPersistence: MissionPersistence(path: "/tmp/unused-missions.sqlite"),
+            missionsEnabled: false,
+            tabsManager: tabsManager
+        )
+
+        state.synchronizeVisibleWorktreeCenterTabIfNeeded(
+            worktreeId: worktreeID,
+            activeTabId: terminal.id,
+            missionsEnabled: false
+        )
+
+        #expect(state.tabs.activeTabId(forWorktree: worktreeID) == terminal.id)
+    }
+
+    @Test("disabled center fallback clears hidden active Mission when no visible tab remains")
+    func disabledCenterFallbackClearsHiddenMissionWhenNoVisibleTabRemains() {
+        let worktreeID = "worktree-center-empty"
+        let tabsManager = TabsManager()
+        let mission = tabsManager.openOrFocusMission(
+            worktreeId: worktreeID,
+            missionID: MissionID(rawValue: "mission-center-empty"),
+            title: "Hidden Mission"
+        )
+        tabsManager.activate(worktreeId: worktreeID, tabId: mission.id)
+        let state = AppState(
+            store: MemoryStore(),
+            missionPersistence: MissionPersistence(path: "/tmp/unused-missions.sqlite"),
+            missionsEnabled: false,
+            tabsManager: tabsManager
+        )
+
+        state.synchronizeVisibleWorktreeCenterTabIfNeeded(
+            worktreeId: worktreeID,
+            activeTabId: nil,
+            missionsEnabled: false
+        )
+
+        let persistedTabs = state.tabs.tabs(forWorktree: worktreeID)
+        #expect(persistedTabs.count == 1)
+        if case .mission(let missionState)? = persistedTabs.first {
+            #expect(missionState.id == mission.id)
+        } else {
+            Issue.record("Expected Mission tab to remain persisted")
+        }
+        #expect(state.tabs.activeTabId(forWorktree: worktreeID) == nil)
+    }
+
+    @Test("suspending during Git prevents the next durable checkpoint")
+    func suspendingDuringGitPreventsNextCheckpoint() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("suspended-missions-\(UUID().uuidString).sqlite")
+        let persistence = MissionPersistence(path: databaseURL.path)
+        let gate = WorktreeGate()
+        var startACPCalls = 0
+        let worktree = Worktree(
+            id: "worktree-1",
+            projectId: "project-1",
+            name: "fix-42",
+            branch: "fix-42",
+            path: URL(fileURLWithPath: "/tmp/fix-42"),
+            status: .clean,
+            lastActivity: .now,
+            lineageID: "lineage-1"
+        )
+        var ids = ["mission-1", "leg-1", "created-event"]
+        let coordinator = MissionCoordinator(environment: .init(
+            persistence: persistence,
+            now: Date.init,
+            makeID: { ids.removeFirst() },
+            worktreeAtDestination: { _, _ in nil },
+            createWorktree: { _ in await gate.wait() },
+            startACP: { leg, _ in
+                startACPCalls += 1
+                return .success(leg.acpSessionId ?? "session-1")
+            },
+            notifyChanged: { _ in }
+        ))
+        let draft = MissionDraft(
+            source: MissionSourceSnapshot(issue: MissionFixtures.issue()),
+            projectId: "project-1",
+            baseRef: "origin/main",
+            baseRemoteName: "origin",
+            branch: "fix-42",
+            destinationPath: "/tmp/fix-42",
+            agentId: "codex",
+            initialPromptId: UUID(),
+            initialPrompt: "Fix issue 42."
+        )
+
+        let missionID = try await coordinator.create(draft)
+        await gate.waitUntilStarted()
+        coordinator.suspend()
+        gate.resume(with: .success(worktree))
+        for _ in 0..<20 { await Task.yield() }
+
+        let aggregate = try #require(try await persistence.aggregate(id: missionID))
+        #expect(aggregate.primaryLeg?.setupCheckpoint == .creatingWorktree)
+        #expect(!aggregate.events.contains { $0.kind == .worktreeCreated })
+        #expect(startACPCalls == 0)
+    }
+}
+
+@MainActor
+private final class WorktreeGate {
+    private var continuation: CheckedContinuation<Result<Worktree, WorktreeCreationFailure>, Never>?
+    private var started = false
+
+    func wait() async -> Result<Worktree, WorktreeCreationFailure> {
+        started = true
+        return await withCheckedContinuation { continuation = $0 }
+    }
+
+    func waitUntilStarted() async {
+        while !started { await Task.yield() }
+    }
+
+    func resume(with result: Result<Worktree, WorktreeCreationFailure>) {
+        continuation?.resume(returning: result)
+        continuation = nil
+    }
+}
+
+private struct MemoryStore: PersistenceStoreProtocol {
+    func read<T: Decodable>(_: T.Type, from _: URL) throws -> T { throw CocoaError(.fileNoSuchFile) }
+    func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    func write<T: Encodable>(_: T, to _: URL) throws {}
+}
+
+private struct ProjectStore: PersistenceStoreProtocol {
+    let project: ProjectConfig
+
+    func read<T: Decodable>(_: T.Type, from _: URL) throws -> T { throw CocoaError(.fileNoSuchFile) }
+
+    func readIfExists<T: Decodable>(_ type: T.Type, from _: URL) throws -> T? {
+        type == ProjectsFile.self ? ProjectsFile(projects: [project]) as? T : nil
+    }
+
+    func write<T: Encodable>(_: T, to _: URL) throws {}
+}
+
+private final class RecordingStore: PersistenceStoreProtocol, @unchecked Sendable {
+    private(set) var readIfExistsCalls = 0
+
+    func read<T: Decodable>(_: T.Type, from _: URL) throws -> T { throw CocoaError(.fileNoSuchFile) }
+
+    func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? {
+        readIfExistsCalls += 1
+        return nil
+    }
+
+    func write<T: Encodable>(_: T, to _: URL) throws {}
+}

--- a/AlasTests/Missions/MissionSidebarTests.swift
+++ b/AlasTests/Missions/MissionSidebarTests.swift
@@ -6,6 +6,7 @@ struct MissionSidebarTests {
     @Test func orphanedMissionsKeepTheWorkspaceVisibleWithoutProjects() {
         #expect(RootWorkspaceVisibilityPolicy.showsWorkspace(
             hasProjects: false,
+            missionsEnabled: true,
             hasMissions: true,
             hasActiveMissionTab: false
         ))
@@ -14,7 +15,17 @@ struct MissionSidebarTests {
     @Test func activePersistedMissionTabKeepsTheWorkspaceVisibleWithoutProjectsOrMissions() {
         #expect(RootWorkspaceVisibilityPolicy.showsWorkspace(
             hasProjects: false,
+            missionsEnabled: true,
             hasMissions: false,
+            hasActiveMissionTab: true
+        ))
+    }
+
+    @Test func disabledMissionsDoNotKeepAnEmptyWorkspaceVisible() {
+        #expect(!RootWorkspaceVisibilityPolicy.showsWorkspace(
+            hasProjects: false,
+            missionsEnabled: false,
+            hasMissions: true,
             hasActiveMissionTab: true
         ))
     }

--- a/AlasTests/Missions/MissionTabTests.swift
+++ b/AlasTests/Missions/MissionTabTests.swift
@@ -890,6 +890,7 @@ struct MissionTabTests {
                 spacesFile: SpacesFile(activeSpaceId: "default", spaces: [])
             ),
             missionPersistence: MissionPersistence(path: "/dev/null/missions.sqlite"),
+            missionsEnabled: true,
             globalTabs: GlobalTabsManager(
                 fileURL: FileManager.default.temporaryDirectory
                     .appendingPathComponent("mission-failed-load-tabs-\(UUID().uuidString).json")
@@ -1235,6 +1236,7 @@ private struct MissionNavigationFixture {
                 spacesFile: spaces
             ),
             missionPersistence: persistence,
+            missionsEnabled: true,
             globalTabs: GlobalTabsManager(
                 fileURL: FileManager.default.temporaryDirectory
                     .appendingPathComponent("mission-global-tabs-\(UUID().uuidString).json")

--- a/AlasTests/Missions/MissionsFeatureFlagTests.swift
+++ b/AlasTests/Missions/MissionsFeatureFlagTests.swift
@@ -1,0 +1,64 @@
+import Combine
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+struct MissionsFeatureFlagTests {
+    @Test func unsetDefaultsAreDisabled() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        #expect(!MissionsFeatureFlag.isEnabled(in: defaults))
+    }
+
+    @Test func explicitValuePersistsAndPostsOneNotification() {
+        let suite = #function
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        var notifications = 0
+        let token = NotificationCenter.default.addObserver(
+            forName: MissionsFeatureFlag.didChangeNotification,
+            object: nil,
+            queue: nil
+        ) { _ in notifications += 1 }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        MissionsFeatureFlag.setEnabled(true, in: defaults)
+
+        #expect(MissionsFeatureFlag.isEnabled(in: defaults))
+        #expect(notifications == 1)
+    }
+
+    @Test func settingSameValueIsIdempotent() {
+        let suite = #function
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        MissionsFeatureFlag.setEnabled(false, in: defaults)
+        var notifications = 0
+        let token = NotificationCenter.default.addObserver(
+            forName: MissionsFeatureFlag.didChangeNotification,
+            object: nil,
+            queue: nil
+        ) { _ in notifications += 1 }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        MissionsFeatureFlag.setEnabled(false, in: defaults)
+        #expect(notifications == 0)
+    }
+
+    @Test func directDefaultsWritesPublishUpdatedValue() async {
+        let suite = #function
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        await confirmation { updated in
+            let subscription = MissionsFeatureFlag.updates(in: defaults).sink { isEnabled in
+                #expect(isEnabled)
+                updated()
+            }
+
+            defaults.set(true, forKey: MissionsFeatureFlag.defaultsKey)
+            withExtendedLifetime(subscription) {}
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Hides Missions behind a debug-only feature flag that defaults off.
- Prevents hidden Mission UI from appearing in the sidebar, center tabs, and startup restoration paths.
- Suspends Mission runtime work while the feature is disabled, while preserving existing Mission state for users who re-enable it.

### Reviewer notes

- The feature flag lives in debug settings and propagates through `AppState` so UI and runtime behavior use the same source of truth.
- Mission-specific tests opt in explicitly where they need the legacy enabled behavior.

### Verification

- `rtk xcodebuild ... -only-testing:AlasTests/MissionsFeatureFlagTests -only-testing:AlasTests/MissionFeatureRuntimeTests`
- Included in the final Stack A focused suite and full-suite run before sync.

<!-- gg:managed:start -->
Part of stack `missions`

Commit: 60fbeb8
<!-- gg:managed:end -->
