### PR TITLE
feat(worktrees): attach issues to new worktrees

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		11D58647F9E3AB8677C09493 /* ReviewScopeSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC73B8AC6AC57FB3A3253F40 /* ReviewScopeSelectionTests.swift */; };
 		1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E288FF8FA00AC18E1CDD3CA2 /* NewWorktreeDialogTests.swift */; };
 		12035048B950CE0197604F89 /* GitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CE7B4DAFDB65A79308FB63 /* GitService.swift */; };
+		1240D4046831ECB9ED93AD03 /* NewWorktreeIssueStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDED017DE2DF29C817EF178C /* NewWorktreeIssueStateTests.swift */; };
 		128B611E5324A5621897A267 /* ACPVisibleRowsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0582531788CE9D1D49769F6B /* ACPVisibleRowsCache.swift */; };
 		1298147855092677E3184AC2 /* ACPConfigOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C6356C759B509DD81EDEBB /* ACPConfigOption.swift */; };
 		12EB0B042A0225258B8A6C99 /* ACPOrchestrationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC184A7BDBFF2156FD2AD44 /* ACPOrchestrationModels.swift */; };
@@ -150,6 +151,7 @@
 		1792FECCA58D7603BD4DBDE8 /* GatekeeperRemediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C245764E69F92CBB8D31BF6 /* GatekeeperRemediator.swift */; };
 		17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */; };
 		17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */; };
+		17EA736FA0386E75D8D42B2E /* AttachIssueDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098AA369AE6B2740439CD504 /* AttachIssueDialog.swift */; };
 		188AF4E4D85149D0535251F9 /* GGInboxModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4DA46E3A858D293B9E6C34 /* GGInboxModels.swift */; };
 		188D02B853162BF4533020E2 /* ChevronStabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */; };
 		18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */; };
@@ -219,6 +221,7 @@
 		2472561EEB7160C90085B4C3 /* ACPTranscriptVisibleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46D97A89C40731455D9EC2DA /* ACPTranscriptVisibleRow.swift */; };
 		249E943D5C46A84496390B31 /* StagedDiffSelectionBridgingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3DCDC9F76F91CE1071471C /* StagedDiffSelectionBridgingTests.swift */; };
 		24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E6D61B213F3378243B4A26 /* AlasField.swift */; };
+		24F8FC4320CB8B8EA19809F6 /* IssueWorktreeLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0479721D1BC95DC664D4CB /* IssueWorktreeLaunchTests.swift */; };
 		250F0E2CB26CC16D2FFDB9DD /* DiffSelectableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FECFF5D8673A3A8E7A1431 /* DiffSelectableTextView.swift */; };
 		25311FAD068B5590F459CED9 /* ACPChatLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D8E02BB3FEB3C71AEEBBE6F /* ACPChatLayout.swift */; };
 		25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */; };
@@ -1279,6 +1282,7 @@
 		CF3567FA9501C1358D754D42 /* BlockedLanguageServerNudgeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D081C8802733D2532DBCD74D /* BlockedLanguageServerNudgeResolverTests.swift */; };
 		CF6CC4CD0C7841CA79DB0E4E /* ACPPlanPillState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDDDC4C6146165CA4C7474E /* ACPPlanPillState.swift */; };
 		CF81F0AE28C56D1DF5AD871B /* SurfaceViewShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */; };
+		CFA6B63752FF405E2BABDB48 /* NewWorktreeIssueState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E76A376D202F7144C03F221 /* NewWorktreeIssueState.swift */; };
 		D002012348D4DA7E124632BF /* SpacePagerIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9294E94F46763CC8DCD93A3 /* SpacePagerIndicator.swift */; };
 		D02BB257817B709817CAB2B6 /* ACPRemoteMCPFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB5D1C8046EF9B6A95C41CD /* ACPRemoteMCPFilter.swift */; };
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
@@ -1662,6 +1666,7 @@
 		0914F0E19514D1DF89C74B41 /* MergeConflictResolvedEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictResolvedEmptyView.swift; sourceTree = "<group>"; };
 		09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvResolverTests.swift; sourceTree = "<group>"; };
 		0934F7BB22E33263B63925B7 /* ImageDiffPair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPair.swift; sourceTree = "<group>"; };
+		098AA369AE6B2740439CD504 /* AttachIssueDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachIssueDialog.swift; sourceTree = "<group>"; };
 		09C9EEDB5A71C5FAE2D0E42B /* ReviewChangesRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesRail.swift; sourceTree = "<group>"; };
 		09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistry.swift; sourceTree = "<group>"; };
 		0A216C9D856D2A6C43964E74 /* AppConfigHarnessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigHarnessTests.swift; sourceTree = "<group>"; };
@@ -1763,6 +1768,7 @@
 		1B218326D14AA360C7476D43 /* GitServiceStashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStashTests.swift; sourceTree = "<group>"; };
 		1BB00E2F151520DC02B80BD4 /* GitServicePullTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServicePullTests.swift; sourceTree = "<group>"; };
 		1BF0C3850E43BDA96ACA24F3 /* WebPageMetadataFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageMetadataFetcherTests.swift; sourceTree = "<group>"; };
+		1C0479721D1BC95DC664D4CB /* IssueWorktreeLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueWorktreeLaunchTests.swift; sourceTree = "<group>"; };
 		1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGProjectMode.swift; sourceTree = "<group>"; };
 		1C63CBD839A151565AE577AE /* SSHIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHIntegrationTests.swift; sourceTree = "<group>"; };
 		1C8F14A2CEAE4B8404213C73 /* AlasSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasSegmentedControl.swift; sourceTree = "<group>"; };
@@ -2185,6 +2191,7 @@
 		5DEE18D06DCB7DE3C8C8D91A /* EditorBufferExternalEditableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferExternalEditableTests.swift; sourceTree = "<group>"; };
 		5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.swift; sourceTree = "<group>"; };
 		5E4EE1C8C8564C2920CC8DAF /* AppKitDiffReviewPresentationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffReviewPresentationState.swift; sourceTree = "<group>"; };
+		5E76A376D202F7144C03F221 /* NewWorktreeIssueState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorktreeIssueState.swift; sourceTree = "<group>"; };
 		5EF6536F169B7C7B2C339B1C /* ACPAdapterVersionCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterVersionCheckerTests.swift; sourceTree = "<group>"; };
 		5F128D8543DA5FC5C39C22E9 /* ACPPermissionDecisionLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionDecisionLog.swift; sourceTree = "<group>"; };
 		5F30C23C9CD0842373F29D1F /* BuildIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildIdentity.swift; sourceTree = "<group>"; };
@@ -3144,6 +3151,7 @@
 		FD2672B5B84D96BDDE9D80A0 /* AppQuitActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppQuitActionTests.swift; sourceTree = "<group>"; };
 		FDB4C80D9DD6DA28DE182955 /* InstallRecipeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallRecipeTests.swift; sourceTree = "<group>"; };
 		FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageEncodingTests.swift; sourceTree = "<group>"; };
+		FDED017DE2DF29C817EF178C /* NewWorktreeIssueStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorktreeIssueStateTests.swift; sourceTree = "<group>"; };
 		FDFF1C68250433F4B9891F1A /* PendingReviewTray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingReviewTray.swift; sourceTree = "<group>"; };
 		FE09B83A747269494B206F23 /* UpdateThrottle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateThrottle.swift; sourceTree = "<group>"; };
 		FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceUpstreamTests.swift; sourceTree = "<group>"; };
@@ -3787,12 +3795,14 @@
 			isa = PBXGroup;
 			children = (
 				413CE0B0BBC96D412D048B1D /* .gitkeep */,
+				098AA369AE6B2740439CD504 /* AttachIssueDialog.swift */,
 				C57B57158094E321BD68D224 /* AttachIssueDialogModel.swift */,
 				2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */,
 				AAEDACEB27E6AF219054496E /* DialogChrome.swift */,
 				B24ABE96ED3C62146A3CED62 /* EmptyState.swift */,
 				EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */,
 				711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */,
+				5E76A376D202F7144C03F221 /* NewWorktreeIssueState.swift */,
 				7A2B4B719D9F4EAAE84B14D1 /* ProjectAvatarPresetProvider.swift */,
 				C6B874BF8AEC4B60FC536E04 /* ProjectIconImageStaging.swift */,
 				BD456A92D66BA31E0E74B836 /* ProjectMCPServerEditor.swift */,
@@ -4966,6 +4976,8 @@
 				8AD3C6DCEC447BEBA9F3911D /* IssueAttachmentTests.swift */,
 				368A1EF043B97B531F2C275D /* IssuePromptBuilderTests.swift */,
 				0E2A10683D1B7D0258F28E5F /* IssueResolverTests.swift */,
+				1C0479721D1BC95DC664D4CB /* IssueWorktreeLaunchTests.swift */,
+				FDED017DE2DF29C817EF178C /* NewWorktreeIssueStateTests.swift */,
 				1BF0C3850E43BDA96ACA24F3 /* WebPageMetadataFetcherTests.swift */,
 			);
 			path = Issues;
@@ -6318,6 +6330,7 @@
 				AFC4DE3093E404E4D338E6EF /* AppState+RunScripts.swift in Sources */,
 				8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */,
 				3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */,
+				17EA736FA0386E75D8D42B2E /* AttachIssueDialog.swift in Sources */,
 				4DE075F8DA19958C4D55D671 /* AttachIssueDialogModel.swift in Sources */,
 				5015F89D084573BFC8A9E2C3 /* AttachedIssueDraft.swift in Sources */,
 				4200B95D724A2433F50C1B7C /* BaseBranchSelector.swift in Sources */,
@@ -6670,6 +6683,7 @@
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
 				92BDCA81E566BF56CFE87AFB /* NewRunScriptDialog.swift in Sources */,
 				11BA08BA4E2FE30CD6D4DA87 /* NewWorktreeDialog.swift in Sources */,
+				CFA6B63752FF405E2BABDB48 /* NewWorktreeIssueState.swift in Sources */,
 				F60AF5FD23412D018F263322 /* NotificationDelegate.swift in Sources */,
 				004A8BA5B9353F67AAA3AE83 /* NotificationService.swift in Sources */,
 				7B25B1405BFDE5570B267213 /* NumstatParser.swift in Sources */,
@@ -7364,6 +7378,7 @@
 				90F70E227F10C03224E2EF87 /* IssueAttachmentTests.swift in Sources */,
 				DFC027A85CE6CB2EC6F1BC4E /* IssuePromptBuilderTests.swift in Sources */,
 				143B0E5F6377013544CC24E3 /* IssueResolverTests.swift in Sources */,
+				24F8FC4320CB8B8EA19809F6 /* IssueWorktreeLaunchTests.swift in Sources */,
 				9C9EC609F3ED8EFF1151D611 /* JSONRPCFramerTests.swift in Sources */,
 				524B70F03B9A934CEEA5FA61 /* LSPClientTests.swift in Sources */,
 				FD797B47C5EE0F82796A3733 /* LSPInstallerTests.swift in Sources */,
@@ -7414,6 +7429,7 @@
 				E8F2D41CACB5211CEB1A9B45 /* MissionsFeatureFlagTests.swift in Sources */,
 				B0571620ECDFDC0CC84F6707 /* NewMissionDialogTests.swift in Sources */,
 				1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */,
+				1240D4046831ECB9ED93AD03 /* NewWorktreeIssueStateTests.swift in Sources */,
 				3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */,
 				D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */,
 				43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -140,6 +140,8 @@ final class AppState {
 
     @ObservationIgnored
     private var pendingACPDetachTasks: [String: [ACPSession.ID: PendingACPDetach]] = [:]
+    @ObservationIgnored
+    private var reconciledCreateFailureCompletionClaims: Set<String> = []
 #if DEBUG
     var pendingACPDetachCountForTesting: Int {
         pendingACPDetachTasks.values.reduce(0) { $0 + $1.count }
@@ -1310,6 +1312,22 @@ final class AppState {
         )
     }
 
+    func makeIssueResolver(selectedProjectID: String?) -> IssueResolver {
+        let issueProviders = CodeHostIssueProviderRegistry.live()
+        return IssueResolver(environment: .init(
+            projects: { [weak self] in self?.projects ?? [] },
+            selectedProjectID: { selectedProjectID },
+            remotes: { project in
+                try await GitService().remotes(worktreePath: URL(fileURLWithPath: project.path))
+            },
+            providers: IssueProviderRegistry([
+                CodeHostIssueSourceProvider(kind: .github, providers: issueProviders),
+                CodeHostIssueSourceProvider(kind: .gitlab, providers: issueProviders),
+                ManualIssueProvider(metadataFetcher: .live),
+            ])
+        ))
+    }
+
     private func refreshMissionSource(
         _ source: IssueSnapshot,
         projectID: String
@@ -2341,7 +2359,8 @@ final class AppState {
         destination: URL,
         runStartup: Bool,
         launchSurface: WorktreeLaunchSurface,
-        ggWorktreeMode: GGWorktreeMode = .inherit
+        ggWorktreeMode: GGWorktreeMode = .inherit,
+        issueAttachment: IssueAttachment? = nil
     ) async -> String {
         guard let project = projects.first(where: { $0.id == projectId }) else {
             // Should not happen if the dialog validated the project; fail silently.
@@ -2379,6 +2398,7 @@ final class AppState {
                 return ""
             }
         }
+        reconciledCreateFailureCompletionClaims.remove(optimisticId)
         rightPaneStore.invalidateSnapshot(worktreeId: optimisticId)
         let optimistic = Worktree(
             id: optimisticId,
@@ -2471,6 +2491,14 @@ final class AppState {
                     if wasHidden {
                         saveProjects()
                     }
+                    if let issueAttachment {
+                        projectsManager.setIssueAttachment(
+                            projectId: project.id,
+                            worktreeId: newWorktree.id,
+                            attachment: issueAttachment
+                        )
+                        saveProjects()
+                    }
 
                     if launchSurface != .delegated {
                         selectWorktree(id: newWorktree.id)
@@ -2490,8 +2518,16 @@ final class AppState {
                             for: newWorktree,
                             startupScriptSuffix: suffix
                         )
-                    case .acp(let agentId):
-                        openNewACPSession(agentID: agentId)
+                    case .acp(let agentId, let preparedPrompt):
+                        if let preparedPrompt {
+                            await openPreparedWorktreeACPSession(
+                                worktree: newWorktree,
+                                agentID: agentId,
+                                preparedPrompt: preparedPrompt
+                            )
+                        } else {
+                            openNewACPSession(agentID: agentId)
+                        }
                     case .delegated:
                         break
                     }
@@ -2507,7 +2543,9 @@ final class AppState {
                             projectId: projectId,
                             message: error.localizedDescription,
                             base: base,
-                            ggWorktreeMode: ggWorktreeMode
+                            ggWorktreeMode: ggWorktreeMode,
+                            launchSurface: launchSurface,
+                            issueAttachment: issueAttachment
                         )
                     )
                 }
@@ -2524,7 +2562,9 @@ final class AppState {
                         projectId: projectId,
                         message: msg,
                         base: base,
-                        ggWorktreeMode: ggWorktreeMode
+                        ggWorktreeMode: ggWorktreeMode,
+                        launchSurface: launchSurface,
+                        issueAttachment: issueAttachment
                     )
                 )
             }
@@ -3867,7 +3907,12 @@ final class AppState {
         let previousBranches = Dictionary(uniqueKeysWithValues: projectsManager
             .worktrees(projectId: projectId)
             .map { (Self.canonicalWorktreePath($0.path.path), (path: $0.path.path, branch: $0.branch)) })
+        let previousOperationStates = projectsManager.operationStatesSnapshot()
         let changed = try await projectsManager.refreshWorktrees(projectId: projectId)
+        let completedCreateFailure = await completeReconciledCreateFailures(
+            projectId: projectId,
+            previousOperationStates: previousOperationStates
+        )
         for worktree in projectsManager.worktrees(projectId: projectId) {
             let canonicalPath = Self.canonicalWorktreePath(worktree.path.path)
             guard let previous = previousBranches[canonicalPath], previous.branch != worktree.branch else {
@@ -3876,13 +3921,89 @@ final class AppState {
             GGStackSummaryStore.shared.summaries[previous.path] = nil
             GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
         }
-        if changed {
+        if changed || completedCreateFailure {
             saveProjects()
             rightPaneStore.reevaluateGGGates()
         }
         restartProjectGitWatchers(previousPaths: previousPaths)
+        return changed || completedCreateFailure
+    }
+
+    private func completeReconciledCreateFailures(
+        projectId: String,
+        previousOperationStates: [String: WorktreeOperationState]
+    ) async -> Bool {
+        guard let project = projects.first(where: { $0.id == projectId }) else { return false }
+        var changed = false
+        for (worktreeId, state) in previousOperationStates {
+            guard case .createFailed(
+                let failedProjectId,
+                _,
+                _,
+                _,
+                let launchSurface,
+                let issueAttachment
+            ) = state,
+                failedProjectId == projectId,
+                projectsManager.operationState(for: worktreeId) == nil,
+                let worktree = projectsManager.worktrees(projectId: projectId).first(where: { $0.id == worktreeId })
+            else { continue }
+            guard reconciledCreateFailureCompletionClaims.insert(worktreeId).inserted else { continue }
+
+            if let issueAttachment,
+               projectsManager.issueAttachment(projectId: projectId, worktreeId: worktreeId) != issueAttachment {
+                projectsManager.setIssueAttachment(
+                    projectId: projectId,
+                    worktreeId: worktreeId,
+                    attachment: issueAttachment
+                )
+                changed = true
+            }
+
+            if launchSurface != .delegated {
+                selectWorktree(id: worktree.id)
+            }
+
+            switch launchSurface {
+            case .none, .delegated:
+                break
+            case .terminal(let agentId):
+                let suffix: String? = {
+                    guard let id = agentId,
+                          let agent = self.agentRegistry.enabled().first(where: { $0.id == id })
+                    else { return nil }
+                    return self.agentStartupCommand(for: agent, project: project)
+                }()
+                _ = try? await openTerminalTabPreparingRemoteZmxIfNeeded(
+                    for: worktree,
+                    startupScriptSuffix: suffix
+                )
+            case .acp(let agentId, let preparedPrompt):
+                if let preparedPrompt {
+                    await openPreparedWorktreeACPSession(
+                        worktree: worktree,
+                        agentID: agentId,
+                        preparedPrompt: preparedPrompt
+                    )
+                } else {
+                    openNewACPSession(agentID: agentId)
+                }
+            }
+        }
         return changed
     }
+
+#if DEBUG
+    func completeReconciledCreateFailuresForTesting(
+        projectId: String,
+        previousOperationStates: [String: WorktreeOperationState]
+    ) async -> Bool {
+        await completeReconciledCreateFailures(
+            projectId: projectId,
+            previousOperationStates: previousOperationStates
+        )
+    }
+#endif
 
     func refreshProjectTopology(projectId: String) async {
         let beforeIds = allWorktreeIds()
@@ -3902,13 +4023,21 @@ final class AppState {
         isRefreshingProjectTopologies = true
         defer { isRefreshingProjectTopologies = false }
         let previousPaths = Dictionary(uniqueKeysWithValues: projectsManager.projects.map { ($0.id, $0.path) })
+        let previousOperationStates = projectsManager.operationStatesSnapshot()
         let changed = await projectsManager.refreshAll()
-        if changed {
+        var completedCreateFailure = false
+        for projectId in previousPaths.keys {
+            completedCreateFailure = await completeReconciledCreateFailures(
+                projectId: projectId,
+                previousOperationStates: previousOperationStates
+            ) || completedCreateFailure
+        }
+        if changed || completedCreateFailure {
             saveProjects()
             rightPaneStore.reevaluateGGGates()
         }
         restartProjectGitWatchers(previousPaths: previousPaths)
-        return changed
+        return changed || completedCreateFailure
     }
 
     private func restartProjectGitWatchers(previousPaths: [String: String]) {
@@ -7621,6 +7750,39 @@ final class AppState {
             promptID: promptID,
             prompt: prompt
         ))
+    }
+
+    private func openPreparedWorktreeACPSession(
+        worktree: Worktree,
+        agentID: String,
+        preparedPrompt: PreparedWorktreeACPPrompt
+    ) async {
+        guard let manager = acpManager(for: worktree) else { return }
+        let session = manager.createSession(
+            id: preparedPrompt.sessionID,
+            agentId: agentID,
+            autoRunDefault: config.harness.acpAutoRunByDefault
+        )
+        let tab = tabs.append(
+            acpSession: ACPSessionTabState(
+                sessionId: preparedPrompt.sessionID,
+                title: session.title
+            ),
+            to: worktree.id
+        )
+        activateWorktreeCenterTab(worktreeId: worktree.id, tabId: tab.id)
+        do {
+            _ = try await startACPSession(
+                worktree: worktree,
+                sessionID: preparedPrompt.sessionID,
+                agentID: agentID,
+                promptID: preparedPrompt.promptID,
+                prompt: preparedPrompt.text
+            )
+        } catch {
+            manager.liveSession(for: preparedPrompt.sessionID)?.lastError = error.localizedDescription
+        }
+        await manager.flushPersistence()
     }
 
     private static func acpBootstrapReadyState(for session: ACPSession?) -> ACPBootstrapReadyState {

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -45,7 +45,9 @@ enum WorktreeOperationState: Equatable {
         projectId: String,
         message: String,
         base: String,
-        ggWorktreeMode: GGWorktreeMode
+        ggWorktreeMode: GGWorktreeMode,
+        launchSurface: WorktreeLaunchSurface,
+        issueAttachment: IssueAttachment?
     )
     case deleteFailed(message: String)
 }
@@ -241,6 +243,10 @@ final class ProjectsManager {
         worktreeOperationStates[worktreeId]
     }
 
+    func operationStatesSnapshot() -> [String: WorktreeOperationState] {
+        worktreeOperationStates
+    }
+
     func setOperationState(id: String, state: WorktreeOperationState?) {
         if let state {
             worktreeOperationStates[id] = state
@@ -422,7 +428,7 @@ final class ProjectsManager {
                 if !liveIds.contains(id) {
                     clearOperationIds.append(id)
                 }
-            case .createFailed(let originProjectId, _, _, let ggWorktreeMode):
+            case .createFailed(let originProjectId, _, _, let ggWorktreeMode, _, _):
                 guard originProjectId == projectId else { continue }
                 if liveIds.contains(id) {
                     // Worktree exists in git — transient failure is resolved; clear state.

--- a/Alas/Sources/App/WorktreeCreationCompletion.swift
+++ b/Alas/Sources/App/WorktreeCreationCompletion.swift
@@ -21,7 +21,7 @@ enum WorktreeCreationCompletion {
             let reconciledWorktree = worktree()
 
             switch operationState() {
-            case .createFailed(_, let message, _, _):
+            case .createFailed(_, let message, _, _, _, _):
                 await reconcile()
                 if operationState() == nil, let reconciledWorktree = worktree() {
                     return .success(reconciledWorktree)

--- a/Alas/Sources/App/WorktreeLaunchSurface.swift
+++ b/Alas/Sources/App/WorktreeLaunchSurface.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+struct PreparedWorktreeACPPrompt: Equatable, Sendable {
+    let sessionID: ACPSession.ID
+    let promptID: UUID
+    let text: String
+}
+
 /// Describes what (if anything) the New Worktree dialog should open in the
 /// center pane after the worktree is created. Makes invalid combinations
 /// (ACP without an agent, "no tab" with an agent) unrepresentable.
@@ -11,7 +17,7 @@ enum WorktreeLaunchSurface: Equatable {
     case terminal(agentId: String?)
     /// An ACP chat session tab is opened for `agentId`. The agent must be
     /// ACP-capable (present in `ACPLaunchCatalog.specs`).
-    case acp(agentId: String)
+    case acp(agentId: String, preparedPrompt: PreparedWorktreeACPPrompt? = nil)
     /// An API-created worktree. It must not alter selection or open a tab.
     case delegated
 }

--- a/Alas/Sources/Dialogs/AttachIssueDialog.swift
+++ b/Alas/Sources/Dialogs/AttachIssueDialog.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+
+struct AttachIssuePresentation: Identifiable {
+    let id = UUID()
+    let draft: AttachedIssueDraft?
+}
+
+struct AttachIssueDialog: View {
+    let onCancel: () -> Void
+    let onAttach: (AttachedIssueDraft) -> Void
+
+    @State private var model: AttachIssueDialogModel
+    @Environment(\.theme) private var theme
+
+    init(
+        environment: AttachIssueDialogModel.Environment,
+        initialDraft: AttachedIssueDraft? = nil,
+        onCancel: @escaping () -> Void,
+        onAttach: @escaping (AttachedIssueDraft) -> Void
+    ) {
+        _model = State(initialValue: AttachIssueDialogModel(environment: environment, initialDraft: initialDraft))
+        self.onCancel = onCancel
+        self.onAttach = onAttach
+    }
+
+    var body: some View {
+        switch model.phase {
+        case .entry, .resolving:
+            entrySheet
+        case .confirmation:
+            confirmationSheet
+        }
+    }
+
+    private var entrySheet: some View {
+        DialogContainer(
+            title: "Attach issue",
+            subtitle: "Resolve an issue and prepare the first Chat prompt.",
+            content: {
+                DialogField(label: "Issue link") {
+                    AlasField(
+                        text: Bindable(model).reference,
+                        placeholder: "#42 or https://...",
+                        focusOnAppear: true,
+                        onSubmit: resolve
+                    )
+                    .disabled(model.phase == .resolving)
+                }
+                if model.phase == .resolving {
+                    HStack(spacing: 8) {
+                        Spinner(lineWidth: 1.5, duration: 0.7)
+                            .frame(width: 14, height: 14)
+                        Text("Resolving issue…")
+                            .font(.system(size: 11))
+                            .foregroundStyle(theme.color("fg-dim"))
+                    }
+                    .accessibilityElement(children: .combine)
+                }
+                if let errorMessage = model.errorMessage {
+                    Text(errorMessage)
+                        .font(.system(size: 11))
+                        .foregroundColor(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                if model.canContinueManually {
+                    AlasButton(title: "Continue manually", style: .normal) {
+                        Task { await model.continueManually() }
+                    }
+                    .disabled(model.phase != .entry)
+                }
+            },
+            cancelTitle: "Cancel",
+            confirmTitle: model.phase == .resolving ? "Resolving…" : "Resolve issue",
+            confirmStyle: .primary,
+            onCancel: onCancel,
+            onConfirm: resolve,
+            confirmEnabled: model.phase == .entry
+                && !model.reference.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        )
+        .interactiveDismissDisabled(model.phase == .resolving)
+    }
+
+    private var confirmationSheet: some View {
+        DialogContainer(
+            title: "Attach issue",
+            subtitle: "Resolve an issue and prepare the first Chat prompt.",
+            width: DialogContainerLayout.projectWidth,
+            content: {
+                if let source = model.resolved?.source {
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text([source.providerLabel, source.displayReference].compactMap { $0 }.joined(separator: " "))
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(theme.color("fg"))
+                        Text(source.canonicalURL.absoluteString)
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.color("fg-dim"))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    .padding(8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(theme.color("bg-0"))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(theme.color("line"), lineWidth: 0.5)
+                    )
+                }
+                DialogField(label: "Title") {
+                    AlasField(text: Bindable(model).title)
+                }
+                DialogField(label: "Issue context") {
+                    textEditor(text: Bindable(model).context, minHeight: 90, maxHeight: 150)
+                }
+                DialogField(label: "Initial prompt") {
+                    textEditor(text: promptBinding, minHeight: 130, maxHeight: 190)
+                }
+            },
+            cancelTitle: "Back",
+            confirmTitle: "Attach",
+            confirmStyle: .primary,
+            onCancel: model.cancelResolution,
+            onConfirm: attach,
+            confirmEnabled: model.makeDraft() != nil
+        )
+    }
+
+    private var promptBinding: Binding<String> {
+        Binding(
+            get: { model.prompt },
+            set: { model.setPrompt($0) }
+        )
+    }
+
+    private func textEditor(text: Binding<String>, minHeight: CGFloat, maxHeight: CGFloat) -> some View {
+        TextEditor(text: text)
+            .font(.system(size: 12))
+            .foregroundColor(theme.color("fg"))
+            .scrollContentBackground(.hidden)
+            .frame(minHeight: minHeight, maxHeight: maxHeight)
+            .padding(8)
+            .background(theme.color("bg-0"))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(theme.color("line"), lineWidth: 0.5)
+            )
+    }
+
+    private func resolve() {
+        Task { await model.resolve() }
+    }
+
+    private func attach() {
+        guard let draft = model.makeDraft() else { return }
+        onAttach(draft)
+    }
+}

--- a/Alas/Sources/Dialogs/AttachIssueDialogModel.swift
+++ b/Alas/Sources/Dialogs/AttachIssueDialogModel.swift
@@ -54,8 +54,23 @@ final class AttachIssueDialogModel {
 
     private let environment: Environment
 
-    init(environment: Environment) {
+    init(environment: Environment, initialDraft: AttachedIssueDraft? = nil) {
         self.environment = environment
+        if let initialDraft {
+            reference = initialDraft.source.canonicalURL.absoluteString
+            resolved = .init(
+                source: initialDraft.source,
+                repositoryLocator: initialDraft.source.repositoryLocator,
+                candidateProjectIDs: initialDraft.projectID.map { [$0] } ?? [],
+                selectedProjectID: initialDraft.projectID
+            )
+            projectID = initialDraft.projectID
+            title = initialDraft.source.title
+            context = initialDraft.source.body
+            prompt = initialDraft.prompt
+            promptIsUserOwned = initialDraft.prompt != IssuePromptBuilder.build(source: initialDraft.source)
+            phase = .confirmation
+        }
     }
 
     var branchSeed: String {

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -38,6 +38,9 @@ struct NewWorktreeDialog: View {
     @State private var isLoadingBranches = false
     @State private var branchLoadError: String?
     @State private var createErrorMessage: String?
+    @State private var issueState = NewWorktreeIssueState()
+    @State private var issueSheetPresentation: AttachIssuePresentation?
+    @State private var issueDrivenProjectChangeID: String?
 
     @Environment(\.theme) var theme
 
@@ -126,6 +129,7 @@ struct NewWorktreeDialog: View {
                 if let validationMessage = branchValidationMessage, activeName != state.config.worktrees.branchPrefix {
                     Text(validationMessage).font(.system(size: 11)).foregroundColor(.red)
                 }
+                issueAttachmentSection
                 DialogField(label: "Open after create") {
                     HStack(spacing: 8) {
                         launchSurfaceSegmented
@@ -172,9 +176,16 @@ struct NewWorktreeDialog: View {
             applyLaunchDefaults(for: projectId)
             loadBranchesForSelectedProject()
         }
-        .onChange(of: projectId) { _, _ in
+        .onChange(of: projectId) { _, newProjectId in
+            let shouldApplyLaunchDefaults = Self.appliesLaunchDefaultsAfterProjectChange(
+                projectID: newProjectId,
+                issueDrivenProjectID: issueDrivenProjectChangeID
+            )
+            issueDrivenProjectChangeID = nil
             applyGGModeDefault(for: projectId)
-            applyLaunchDefaults(for: projectId)
+            if shouldApplyLaunchDefaults {
+                applyLaunchDefaults(for: projectId)
+            }
             // Seed the base for the new project synchronously so the picker
             // never shows the previous project's value; the async branch load
             // refines it (guarded: it skips pinned bases and user edits).
@@ -200,6 +211,14 @@ struct NewWorktreeDialog: View {
                 branch: branch,
                 branchPrefix: state.config.worktrees.branchPrefix,
                 currentStackName: stackName
+            )
+        }
+        .sheet(item: $issueSheetPresentation) { presentation in
+            AttachIssueDialog(
+                environment: attachIssueEnvironment(),
+                initialDraft: presentation.draft,
+                onCancel: { issueSheetPresentation = nil },
+                onAttach: attachIssue
             )
         }
     }
@@ -323,6 +342,15 @@ struct NewWorktreeDialog: View {
         return resolved.flatMap { state.agent(id: $0.agentId) }
     }
 
+    private var currentLaunchPreference: NewWorktreeLaunchPreference {
+        .init(
+            openAfterCreate: openAfterCreate,
+            launchMode: launchMode,
+            persistableLaunchMode: persistableLaunchMode,
+            launchAgentID: launchAgentId
+        )
+    }
+
     private var renderedPath: String {
         guard let project = state.projects.first(where: { $0.id == projectId }) else { return "" }
         return WorktreePathTemplateRenderer.render(
@@ -390,6 +418,63 @@ struct NewWorktreeDialog: View {
         )
     }
 
+    private func attachIssueEnvironment() -> AttachIssueDialogModel.Environment {
+        .init(
+            resolve: { reference in
+                try await state.makeIssueResolver(selectedProjectID: projectId).resolve(reference)
+            },
+            projects: { state.projects },
+            configuredBranchPrefix: { _ in state.config.worktrees.branchPrefix }
+        )
+    }
+
+    private func attachIssue(_ draft: AttachedIssueDraft) {
+        let shouldApplyParentFields = Self.appliesParentFieldsAfterIssueAttach(existingDraft: issueState.draft)
+        let effects = issueState.attach(draft, currentLaunch: currentLaunchPreference)
+        guard shouldApplyParentFields else {
+            issueSheetPresentation = nil
+            createErrorMessage = nil
+            return
+        }
+        let resolvedProjectID = Self.projectIDAfterIssueAttach(
+            preferredProjectID: effects.preferredProjectID,
+            currentProjectID: projectId,
+            availableProjectIDs: state.projects.map(\.id)
+        )
+        if projectId != resolvedProjectID {
+            issueDrivenProjectChangeID = resolvedProjectID
+            projectId = resolvedProjectID
+            applyGGModeDefault(for: resolvedProjectID)
+            base = stackPinnedBase ?? state.config.worktrees.baseBranch
+            loadBranchesForSelectedProject()
+        }
+        let names = Self.namesAfterIssueAttach(
+            branchSeed: effects.branchSeed,
+            createsGGStack: createsGGStack,
+            branch: branch,
+            stackName: stackName
+        )
+        branch = names.branch
+        stackName = names.stackName
+        if effects.shouldSelectChat, acpSegmentEnabled {
+            openAfterCreate = true
+            launchMode = .acp
+            persistableLaunchMode = .acp
+            launchAgentId = Self.issueLaunchAgent(from: state.agentRegistry.enabled())
+        }
+        issueSheetPresentation = nil
+        createErrorMessage = nil
+    }
+
+    private func removeIssue() {
+        if let preference = issueState.remove() {
+            openAfterCreate = preference.openAfterCreate
+            launchMode = preference.launchMode
+            persistableLaunchMode = preference.persistableLaunchMode
+            launchAgentId = preference.launchAgentID
+        }
+    }
+
     private func applyGGModeDefault(for selectedProjectId: String) {
         guard let project = state.projects.first(where: { $0.id == selectedProjectId }) else {
             ggMode = .off
@@ -404,22 +489,25 @@ struct NewWorktreeDialog: View {
     private func create() {
         guard let project = state.projects.first(where: { $0.id == projectId }) else { return }
         let dest = URL(fileURLWithPath: renderedPath)
-        let surface: WorktreeLaunchSurface
-        if !openAfterCreate {
-            surface = .none
-        } else {
-            switch launchMode {
-            case .terminal:
-                surface = .terminal(agentId: launchAgentId == "none" ? nil : launchAgentId)
-            case .acp:
-                guard launchAgentId != "none" else {
-                    // Defensive: confirm button should already be disabled.
-                    createErrorMessage = "Pick an ACP-capable agent for the chat session."
-                    return
-                }
-                surface = .acp(agentId: launchAgentId)
-            }
+        let issueDraft = issueState.draft
+        guard launchMode != .acp || !openAfterCreate || launchAgentId != "none" else {
+            // Defensive: confirm button should already be disabled.
+            createErrorMessage = "Pick an ACP-capable agent for the chat session."
+            return
         }
+        let surface = Self.launchSurfaceForCreate(
+            openAfterCreate: openAfterCreate,
+            launchMode: launchMode,
+            launchAgentId: launchAgentId,
+            issueDraft: issueDraft,
+            makePreparedPrompt: { prompt in
+                PreparedWorktreeACPPrompt(
+                    sessionID: UUID().uuidString,
+                    promptID: UUID(),
+                    text: prompt
+                )
+            }
+        )
         Task { @MainActor in
             let id = await state.createWorktree(
                 projectId: project.id,
@@ -428,7 +516,8 @@ struct NewWorktreeDialog: View {
                 destination: dest,
                 runStartup: runStartup,
                 launchSurface: surface,
-                ggWorktreeMode: ggMode
+                ggWorktreeMode: ggMode,
+                issueAttachment: issueDraft?.attachment
             )
             guard !id.isEmpty else {
                 createErrorMessage = "A worktree already exists at this path."
@@ -595,6 +684,70 @@ struct NewWorktreeDialog: View {
         return availableBranches.first ?? configuredDefault
     }
 
+    nonisolated static func projectIDAfterIssueAttach(
+        preferredProjectID: String?,
+        currentProjectID: String,
+        availableProjectIDs: [String]
+    ) -> String {
+        guard let preferredProjectID,
+              availableProjectIDs.contains(preferredProjectID)
+        else { return currentProjectID }
+        return preferredProjectID
+    }
+
+    nonisolated static func namesAfterIssueAttach(
+        branchSeed: String,
+        createsGGStack: Bool,
+        branch: String,
+        stackName: String
+    ) -> (branch: String, stackName: String) {
+        if createsGGStack {
+            return (branch, branchSeed)
+        }
+        return (branchSeed, stackName)
+    }
+
+    nonisolated static func issueLaunchAgent(from agents: [AgentDefinition]) -> String {
+        acpCapableAgents(from: agents).first?.id ?? "none"
+    }
+
+    nonisolated static func issuePromptForLaunch(
+        draft: AttachedIssueDraft?,
+        openAfterCreate: Bool,
+        launchMode: AppConfig.LauncherMode
+    ) -> String? {
+        guard openAfterCreate, launchMode == .acp else { return nil }
+        return draft?.prompt
+    }
+
+    nonisolated static func launchSurfaceForCreate(
+        openAfterCreate: Bool,
+        launchMode: AppConfig.LauncherMode,
+        launchAgentId: String,
+        issueDraft: AttachedIssueDraft?,
+        makePreparedPrompt: (String) -> PreparedWorktreeACPPrompt
+    ) -> WorktreeLaunchSurface {
+        guard openAfterCreate else { return .none }
+        switch launchMode {
+        case .terminal:
+            return .terminal(agentId: launchAgentId == "none" ? nil : launchAgentId)
+        case .acp:
+            let preparedPrompt = issueDraft.map { makePreparedPrompt($0.prompt) }
+            return .acp(agentId: launchAgentId, preparedPrompt: preparedPrompt)
+        }
+    }
+
+    nonisolated static func appliesParentFieldsAfterIssueAttach(existingDraft: AttachedIssueDraft?) -> Bool {
+        existingDraft == nil
+    }
+
+    nonisolated static func appliesLaunchDefaultsAfterProjectChange(
+        projectID: String,
+        issueDrivenProjectID: String?
+    ) -> Bool {
+        issueDrivenProjectID != projectID
+    }
+
     nonisolated static let ggModeSegments: [NewWorktreeGGModeSegment] = [
         .init(mode: .on, label: "On", icon: .stack),
         .init(mode: .off, label: "Off", icon: .disabled),
@@ -617,6 +770,46 @@ struct NewWorktreeDialog: View {
         }
     }
 
+    private var issueAttachmentSection: some View {
+        Group {
+            if let draft = issueState.draft {
+                HStack(spacing: 8) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Issue")
+                            .font(.system(size: 11.5, weight: .medium))
+                            .foregroundColor(theme.color("fg-muted"))
+                        Text(draft.attachment.displayTitle)
+                            .font(.system(size: 12))
+                            .foregroundColor(theme.color("fg"))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    Spacer(minLength: 8)
+                    AlasButton(title: "Edit", style: .subtle) {
+                        issueSheetPresentation = AttachIssuePresentation(draft: draft)
+                    }
+                    AlasButton(title: "Remove", style: .subtle, action: removeIssue)
+                    AlasButton(title: "Open", style: .subtle) {
+                        NSWorkspace.shared.open(draft.attachment.canonicalURL)
+                    }
+                }
+                .padding(8)
+                .background(theme.color("bg-0"))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(theme.color("line"), lineWidth: 0.5)
+                )
+            } else {
+                HStack {
+                    AlasButton(title: "Attach issue...", style: .subtle) {
+                        issueSheetPresentation = AttachIssuePresentation(draft: nil)
+                    }
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+    }
+
     // MARK: - Launch surface UI
 
     private var pickerAgents: [AgentDefinition] {
@@ -632,7 +825,7 @@ struct NewWorktreeDialog: View {
     }
 
     private var launchAgentPicker: some View {
-        Picker("", selection: $launchAgentId) {
+        Picker("", selection: launchAgentSelection) {
             if launchMode == .terminal {
                 Text("None").tag("none")
             }
@@ -648,6 +841,16 @@ struct NewWorktreeDialog: View {
         .pickerStyle(.menu)
         .labelsHidden()
         .fixedSize()
+    }
+
+    private var launchAgentSelection: Binding<String> {
+        Binding(
+            get: { launchAgentId },
+            set: { newValue in
+                launchAgentId = newValue
+                issueState.recordLaunchPreferenceChangeAfterAttach()
+            }
+        )
     }
 
     private var launchSurfaceSegmented: some View {
@@ -700,6 +903,7 @@ struct NewWorktreeDialog: View {
                 enabledAgents: state.agentRegistry.enabled()
             )
         }
+        issueState.recordLaunchPreferenceChangeAfterAttach()
     }
 
     // MARK: - Launch surface helpers

--- a/Alas/Sources/Dialogs/NewWorktreeIssueState.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeIssueState.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+struct NewWorktreeLaunchPreference: Equatable {
+    let openAfterCreate: Bool
+    let launchMode: AppConfig.LauncherMode
+    let persistableLaunchMode: AppConfig.LauncherMode
+    let launchAgentID: String
+}
+
+struct NewWorktreeIssueAttachEffects: Equatable {
+    let preferredProjectID: String?
+    let branchSeed: String
+    let shouldSelectChat: Bool
+}
+
+struct NewWorktreeIssueState: Equatable {
+    private(set) var draft: AttachedIssueDraft?
+    private var capturedLaunchPreference: NewWorktreeLaunchPreference?
+
+    mutating func attach(
+        _ draft: AttachedIssueDraft,
+        currentLaunch: NewWorktreeLaunchPreference
+    ) -> NewWorktreeIssueAttachEffects {
+        if self.draft == nil {
+            capturedLaunchPreference = currentLaunch
+        }
+        self.draft = draft
+        return NewWorktreeIssueAttachEffects(
+            preferredProjectID: draft.projectID,
+            branchSeed: draft.branchSeed,
+            shouldSelectChat: true
+        )
+    }
+
+    mutating func remove() -> NewWorktreeLaunchPreference? {
+        guard draft != nil else { return nil }
+        draft = nil
+        let preference = capturedLaunchPreference
+        capturedLaunchPreference = nil
+        return preference
+    }
+
+    mutating func recordLaunchPreferenceChangeAfterAttach() {
+        guard draft != nil else { return }
+        capturedLaunchPreference = nil
+    }
+}

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -169,8 +169,9 @@ struct SidebarView: View {
                                             branch: wt.branch,
                                             destination: wt.path,
                                             runStartup: false,
-                                            launchSurface: .none,
-                                            ggWorktreeMode: retry.ggWorktreeMode
+                                            launchSurface: retry.launchSurface,
+                                            ggWorktreeMode: retry.ggWorktreeMode,
+                                            issueAttachment: retry.issueAttachment
                                         )
                                     }
                                 },
@@ -269,11 +270,16 @@ struct SidebarView: View {
     nonisolated static func retryCreateParameters(
         operationState: WorktreeOperationState?,
         defaultBase: String
-    ) -> (base: String, ggWorktreeMode: GGWorktreeMode) {
-        guard case .createFailed(_, _, let base, let ggWorktreeMode) = operationState else {
-            return (defaultBase, .inherit)
+    ) -> (
+        base: String,
+        ggWorktreeMode: GGWorktreeMode,
+        launchSurface: WorktreeLaunchSurface,
+        issueAttachment: IssueAttachment?
+    ) {
+        guard case .createFailed(_, _, let base, let ggWorktreeMode, let launchSurface, let issueAttachment) = operationState else {
+            return (defaultBase, .inherit, .none, nil)
         }
-        return (base, ggWorktreeMode)
+        return (base, ggWorktreeMode, launchSurface, issueAttachment)
     }
 
     nonisolated static func effectiveSelectedWorktreeId(

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -127,7 +127,7 @@ struct WorktreeRowView: View {
         case .creating: return "Creating…"
         case .preparingDelete: return "Preparing deletion…"
         case .deleting: return "Deleting…"
-        case .createFailed(_, let msg, _, _): return "Create failed: \(msg.trimmedForDisplay)"
+        case .createFailed(_, let msg, _, _, _, _): return "Create failed: \(msg.trimmedForDisplay)"
         case .deleteFailed(let msg): return "Delete failed: \(msg.trimmedForDisplay)"
         case .none: return ""
         }
@@ -146,7 +146,7 @@ struct WorktreeRowView: View {
 
     private var errorMessage: String? {
         switch operationState {
-        case .createFailed(_, let message, _, _), .deleteFailed(let message):
+        case .createFailed(_, let message, _, _, _, _), .deleteFailed(let message):
             return message
         case .creating, .preparingDelete, .deleting, .none:
             return nil

--- a/AlasTests/AgentTerminalLaunchTests.swift
+++ b/AlasTests/AgentTerminalLaunchTests.swift
@@ -231,8 +231,8 @@ struct AgentTerminalLaunchTests {
 
         #expect(capturedSuffix == [
             "A='two words' TOKEN='abc'\\''123' '/Applications/Auth CLI/bin/node' '/opt/claude agent/acp' --cli",
-            "status=$?",
-            "exit \"$status\"",
+            "exit_code=$?",
+            "exit \"$exit_code\"",
         ].joined(separator: "\n"))
         #expect(capturedIncludeUserStartupScript == false)
         #expect(capturedInheritParentEnv == true)

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -113,7 +113,9 @@ struct AppStateCleanupTests {
                 projectId: project.id,
                 message: "transient",
                 base: "main",
-                ggWorktreeMode: .off
+                ggWorktreeMode: .off,
+                launchSurface: .none,
+                issueAttachment: nil
             )
         )
 
@@ -527,7 +529,7 @@ struct AppStateCleanupTests {
         }
 
         #expect(state.projectsManager.worktrees(projectId: project.id).contains { $0.id == id })
-        if case .createFailed(_, let message, _, _) = state.projectsManager.operationState(for: id) {
+        if case .createFailed(_, let message, _, _, _, _) = state.projectsManager.operationState(for: id) {
             #expect(!message.isEmpty)
         } else {
             Issue.record("Expected createFailed state")
@@ -568,7 +570,7 @@ struct AppStateCleanupTests {
         )
         #expect(state.ggWorktreeMenuModel(project: project, worktree: failedWorktree).selectedMode == .inherit)
 
-        guard case .createFailed(_, _, let failedBase, let failedMode) =
+        guard case .createFailed(_, _, let failedBase, let failedMode, _, _) =
             state.projectsManager.operationState(for: failedId)
         else {
             Issue.record("Expected createFailed state")
@@ -602,6 +604,221 @@ struct AppStateCleanupTests {
         #expect(state.projectsManager.worktrees(projectId: project.id).contains { $0.id == retryId })
         #expect(state.projectsManager.ggWorktreeMode(projectId: project.id, worktreeId: retryId) == mode)
         #expect(state.projects.first(where: { $0.id == project.id })?.ggWorktreeModes[retryId] == mode)
+    }
+
+    @Test func createWorktreeRetryPreservesIssueLaunchMetadata() async throws {
+        let repo = try await makeRepo(name: "create-retry-issue")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let store = RecordingStore()
+        let state = AppState(store: store)
+        let project = try await state.projectsManager.addProject(
+            path: repo,
+            displayName: "create-retry-issue",
+            color: "#5fb7c4"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        let attachment = IssueAttachment(
+            canonicalURL: URL(string: "https://github.com/acme/alas/issues/42")!,
+            providerLabel: "GitHub",
+            displayReference: "#42",
+            title: "Fix retry"
+        )
+        let preparedPrompt = PreparedWorktreeACPPrompt(
+            sessionID: "retry-issue-session",
+            promptID: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+            text: "Fix issue #42."
+        )
+        let branch = "retry-issue"
+        let retryBase = "retry-issue-base"
+        let destination = repo.appendingPathComponent("wt-retry-issue")
+        let failedId = await state.createWorktree(
+            projectId: project.id,
+            base: retryBase,
+            branch: branch,
+            destination: destination,
+            runStartup: false,
+            launchSurface: .acp(agentId: "missing-acp-agent", preparedPrompt: preparedPrompt),
+            issueAttachment: attachment
+        )
+        try await waitForOperationStateMatching(state.projectsManager, id: failedId) { state in
+            if case .createFailed = state { return true }
+            return false
+        }
+
+        let retryParameters = SidebarView.retryCreateParameters(
+            operationState: state.projectsManager.operationState(for: failedId),
+            defaultBase: state.config.worktrees.baseBranch
+        )
+        #expect(retryParameters.launchSurface == .acp(agentId: "missing-acp-agent", preparedPrompt: preparedPrompt))
+        #expect(retryParameters.issueAttachment == attachment)
+
+        _ = try await Process.git(["branch", retryBase, "main"], cwd: repo)
+        let retryId = await state.createWorktree(
+            projectId: project.id,
+            base: retryParameters.base,
+            branch: branch,
+            destination: destination,
+            runStartup: false,
+            launchSurface: retryParameters.launchSurface,
+            ggWorktreeMode: retryParameters.ggWorktreeMode,
+            issueAttachment: retryParameters.issueAttachment
+        )
+
+        #expect(retryId == failedId)
+        try await waitForOperationState(state.projectsManager, id: retryId, equals: nil)
+        #expect(state.projectsManager.issueAttachment(projectId: project.id, worktreeId: retryId) == attachment)
+        let acpTabs = state.tabs.tabs(forWorktree: retryId).compactMap { tab -> ACPSessionTabState? in
+            if case .acpSession(let session) = tab { return session }
+            return nil
+        }
+        #expect(acpTabs.map(\.sessionId) == [preparedPrompt.sessionID])
+    }
+
+    @Test func reconciledCreateFailureCompletesIssueLaunchMetadata() async throws {
+        let repo = try await makeRepo(name: "create-reconcile-issue")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = AppState(store: RecordingStore())
+        let project = try await state.projectsManager.addProject(
+            path: repo,
+            displayName: "create-reconcile-issue",
+            color: "#5fb7c4"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        let destination = repo.appendingPathComponent("wt-reconciled-issue")
+        _ = try await Process.git(["worktree", "add", destination.path, "-b", "reconciled-issue", "main"], cwd: repo)
+        let worktreeID = Worktree.makeId(path: destination)
+        let attachment = IssueAttachment(
+            canonicalURL: URL(string: "https://github.com/acme/alas/issues/43")!,
+            providerLabel: "GitHub",
+            displayReference: "#43",
+            title: "Fix reconciled retry"
+        )
+        let preparedPrompt = PreparedWorktreeACPPrompt(
+            sessionID: "reconciled-issue-session",
+            promptID: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!,
+            text: "Fix issue #43."
+        )
+        state.projectsManager.setOperationState(
+            id: worktreeID,
+            state: .createFailed(
+                projectId: project.id,
+                message: "refresh failed",
+                base: "main",
+                ggWorktreeMode: .inherit,
+                launchSurface: .acp(agentId: "missing-acp-agent", preparedPrompt: preparedPrompt),
+                issueAttachment: attachment
+            )
+        )
+
+        await state.refreshProjectTopology(projectId: project.id)
+
+        #expect(state.projectsManager.operationState(for: worktreeID) == nil)
+        #expect(state.projectsManager.issueAttachment(projectId: project.id, worktreeId: worktreeID) == attachment)
+        let acpTabs = state.tabs.tabs(forWorktree: worktreeID).compactMap { tab -> ACPSessionTabState? in
+            if case .acpSession(let session) = tab { return session }
+            return nil
+        }
+        #expect(acpTabs.map(\.sessionId) == [preparedPrompt.sessionID])
+    }
+
+    @Test func refreshAllCompletesReconciledCreateFailureIssueLaunchMetadata() async throws {
+        let repo = try await makeRepo(name: "create-reconcile-all-issue")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = AppState(store: RecordingStore())
+        let project = try await state.projectsManager.addProject(
+            path: repo,
+            displayName: "create-reconcile-all-issue",
+            color: "#5fb7c4"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        let destination = repo.appendingPathComponent("wt-reconciled-all-issue")
+        _ = try await Process.git(["worktree", "add", destination.path, "-b", "reconciled-all-issue", "main"], cwd: repo)
+        let worktreeID = Worktree.makeId(path: destination)
+        let attachment = IssueAttachment(
+            canonicalURL: URL(string: "https://github.com/acme/alas/issues/44")!,
+            providerLabel: "GitHub",
+            displayReference: "#44",
+            title: "Fix refresh-all reconcile"
+        )
+        let preparedPrompt = PreparedWorktreeACPPrompt(
+            sessionID: "reconciled-all-issue-session",
+            promptID: UUID(uuidString: "44444444-4444-4444-4444-444444444444")!,
+            text: "Fix issue #44."
+        )
+        state.projectsManager.setOperationState(
+            id: worktreeID,
+            state: .createFailed(
+                projectId: project.id,
+                message: "refresh all failed",
+                base: "main",
+                ggWorktreeMode: .inherit,
+                launchSurface: .acp(agentId: "missing-acp-agent", preparedPrompt: preparedPrompt),
+                issueAttachment: attachment
+            )
+        )
+
+        await state.refreshAllProjectTopologies()
+
+        #expect(state.projectsManager.operationState(for: worktreeID) == nil)
+        #expect(state.projectsManager.issueAttachment(projectId: project.id, worktreeId: worktreeID) == attachment)
+        let acpTabs = state.tabs.tabs(forWorktree: worktreeID).compactMap { tab -> ACPSessionTabState? in
+            if case .acpSession(let session) = tab { return session }
+            return nil
+        }
+        #expect(acpTabs.map(\.sessionId) == [preparedPrompt.sessionID])
+    }
+
+    @Test func reconciledCreateFailureLaunchReplayIsIdempotentForSameSnapshot() async throws {
+        let repo = try await makeRepo(name: "create-reconcile-idempotent")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        var openedWorktreeIds: [String] = []
+        let state = AppState(
+            store: RecordingStore(),
+            terminalSessionOpener: { worktree, _, _, _, _, _, _, _, _ in
+                openedWorktreeIds.append(worktree.id)
+                return AppState.OpenedTerminalSession(
+                    id: "reconciled-terminal-\(openedWorktreeIds.count)",
+                    foregroundPid: { nil }
+                )
+            }
+        )
+        let project = try await state.projectsManager.addProject(
+            path: repo,
+            displayName: "create-reconcile-idempotent",
+            color: "#5fb7c4"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        let destination = repo.appendingPathComponent("wt-reconciled-idempotent")
+        _ = try await Process.git(["worktree", "add", destination.path, "-b", "reconciled-idempotent", "main"], cwd: repo)
+        let worktreeID = Worktree.makeId(path: destination)
+        state.projectsManager.setOperationState(
+            id: worktreeID,
+            state: .createFailed(
+                projectId: project.id,
+                message: "refresh failed",
+                base: "main",
+                ggWorktreeMode: .inherit,
+                launchSurface: .terminal(agentId: nil),
+                issueAttachment: nil
+            )
+        )
+        let previousOperationStates = state.projectsManager.operationStatesSnapshot()
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        _ = await state.completeReconciledCreateFailuresForTesting(
+            projectId: project.id,
+            previousOperationStates: previousOperationStates
+        )
+        _ = await state.completeReconciledCreateFailuresForTesting(
+            projectId: project.id,
+            previousOperationStates: previousOperationStates
+        )
+
+        #expect(openedWorktreeIds == [worktreeID])
     }
 
     @Test func successfulInheritCreationKeepsGGWorktreeModesSparse() async throws {

--- a/AlasTests/AppStateCreateWorktreeCompletionTests.swift
+++ b/AlasTests/AppStateCreateWorktreeCompletionTests.swift
@@ -37,7 +37,14 @@ struct AppStateCreateWorktreeCompletionTests {
             id: "pending",
             maxPolls: 1,
             operationState: {
-                .createFailed(projectId: "project", message: "branch exists", base: "main", ggWorktreeMode: .inherit)
+                .createFailed(
+                    projectId: "project",
+                    message: "branch exists",
+                    base: "main",
+                    ggWorktreeMode: .inherit,
+                    launchSurface: .none,
+                    issueAttachment: nil
+                )
             },
             worktree: { nil },
             sleep: {}
@@ -52,7 +59,9 @@ struct AppStateCreateWorktreeCompletionTests {
             projectId: "project",
             message: "connection lost",
             base: "main",
-            ggWorktreeMode: .inherit
+            ggWorktreeMode: .inherit,
+            launchSurface: .none,
+            issueAttachment: nil
         )
         var reconciled: Worktree?
 

--- a/AlasTests/CenterSelectionStateResolverTests.swift
+++ b/AlasTests/CenterSelectionStateResolverTests.swift
@@ -328,7 +328,9 @@ struct CenterSelectionStateResolverTests {
                 projectId: project.id,
                 message: "disk full",
                 base: "main",
-                ggWorktreeMode: .inherit
+                ggWorktreeMode: .inherit,
+                launchSurface: .none,
+                issueAttachment: nil
             )
         )
         let resolver = CenterSelectionStateResolver(

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -3600,6 +3600,17 @@ struct DiffReviewSurfaceTests {
     }
 
     @Test func surfacePassesFeedbackToMatchingFileOnly() {
+        let originalOverride = AppKitDiffScrollerFlag.readOverride(from: .standard)
+        defer {
+            if let originalOverride {
+                AppKitDiffScrollerFlag.setOverride(originalOverride)
+            } else {
+                UserDefaults.standard.removeObject(forKey: AppKitDiffScrollerFlag.defaultsKey)
+                NotificationCenter.default.post(name: AppKitDiffScrollerFlag.overrideDidChangeNotification, object: nil)
+            }
+        }
+        AppKitDiffScrollerFlag.setOverride(false)
+
         let first = summary(path: "Sources/App.swift")
         let second = summary(path: "Sources/Other.swift")
         let session = loadedSession(summaries: [first, second])

--- a/AlasTests/Issues/AttachIssueDialogModelTests.swift
+++ b/AlasTests/Issues/AttachIssueDialogModelTests.swift
@@ -144,6 +144,41 @@ struct AttachIssueDialogModelTests {
         #expect(!model.prompt.contains("Keep this only for the first issue."))
     }
 
+    @Test("reopened generated drafts keep generated prompt ownership")
+    func reopenedGeneratedDraftsKeepGeneratedPromptOwnership() {
+        let source = Fixture.resolvedIssue().source
+        let draft = AttachedIssueDraft(
+            source: source,
+            projectID: "alas",
+            branchSeed: "feature/42-fix-offline-sync-conflicts",
+            prompt: IssuePromptBuilder.build(source: source)
+        )
+        let model = AttachIssueDialogModel(environment: Fixture().environment, initialDraft: draft)
+
+        model.title = "Fix reopened issue"
+        model.context = "Use the updated reopened context."
+
+        #expect(model.prompt.contains("Fix reopened issue"))
+        #expect(model.prompt.contains("Use the updated reopened context."))
+    }
+
+    @Test("reopened custom drafts keep user prompt ownership")
+    func reopenedCustomDraftsKeepUserPromptOwnership() {
+        let source = Fixture.resolvedIssue().source
+        let draft = AttachedIssueDraft(
+            source: source,
+            projectID: "alas",
+            branchSeed: "feature/42-fix-offline-sync-conflicts",
+            prompt: "Keep this reopened custom prompt."
+        )
+        let model = AttachIssueDialogModel(environment: Fixture().environment, initialDraft: draft)
+
+        model.title = "Fix reopened issue"
+        model.context = "Use the updated reopened context."
+
+        #expect(model.prompt == "Keep this reopened custom prompt.")
+    }
+
     @Test("changing input rejects a stale generation")
     func rejectsStaleGenerationAfterInputChange() async {
         let fixture = Fixture(suspendResolution: true)

--- a/AlasTests/Issues/IssueWorktreeLaunchTests.swift
+++ b/AlasTests/Issues/IssueWorktreeLaunchTests.swift
@@ -1,0 +1,326 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct IssueWorktreeLaunchTests {
+    private static let promptID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+
+    @Test func chatLaunchCreatesAcpTabQueuesEditedPromptOnceAndPersistsAttachment() async throws {
+        let fixture = try await WorktreeLaunchFixture(name: "chat")
+        defer { fixture.cleanup() }
+        let prepared = Self.preparedPrompt()
+        let attachment = Self.attachment()
+
+        let id = try await fixture.create(
+            branch: "issue-chat",
+            launchSurface: .acp(agentId: "missing-acp-agent", preparedPrompt: prepared),
+            issueAttachment: attachment
+        )
+
+        #expect(fixture.state.projectsManager.issueAttachment(
+            projectId: fixture.project.id,
+            worktreeId: id
+        ) == attachment)
+        #expect(fixture.store.writtenProjectsFile?.projects.first?.issueAttachments[id] == attachment)
+        #expect(Self.acpTabs(in: fixture.state, worktreeId: id).map(\.sessionId) == [prepared.sessionID])
+
+        let manager = try #require(fixture.state.acpManager(forWorktreeId: id))
+        let session = try #require(manager.liveSession(for: prepared.sessionID))
+        #expect(session.queue.map(\.id) == [prepared.promptID])
+        #expect(session.queue.first.map { ACPSessionRunner.textPreview(of: $0.blocks) } == prepared.text)
+
+        let persisted = ACPSessionPersistence(path: Paths.acpSessionsDB(forWorktreeId: id).path)
+        #expect(try await persisted.loadSession(id: prepared.sessionID)?.agentId == "missing-acp-agent")
+        #expect(try await persisted.loadQueue(sessionId: prepared.sessionID).map(\.id) == [prepared.promptID])
+    }
+
+    @Test func retryWithSamePreparedPromptDoesNotDuplicateTheQueuedPrompt() async throws {
+        let fixture = try await WorktreeLaunchFixture(name: "retry")
+        defer { fixture.cleanup() }
+        let prepared = Self.preparedPrompt()
+        let id = try await fixture.create(
+            branch: "issue-retry",
+            launchSurface: .acp(agentId: "missing-acp-agent", preparedPrompt: prepared),
+            issueAttachment: Self.attachment()
+        )
+        let worktree = try #require(fixture.state.worktree(withId: id))
+
+        try? await fixture.state.startACPSession(
+            worktree: worktree,
+            sessionID: prepared.sessionID,
+            agentID: "missing-acp-agent",
+            promptID: prepared.promptID,
+            prompt: prepared.text
+        )
+
+        let manager = try #require(fixture.state.acpManager(forWorktreeId: id))
+        let session = try #require(manager.liveSession(for: prepared.sessionID))
+        #expect(session.queue.map(\.id) == [prepared.promptID])
+        let persisted = ACPSessionPersistence(path: Paths.acpSessionsDB(forWorktreeId: id).path)
+        #expect(try await persisted.loadQueue(sessionId: prepared.sessionID).map(\.id) == [prepared.promptID])
+    }
+
+    @Test func terminalLaunchPersistsAttachmentWithoutCreatingAcpPrompt() async throws {
+        let fixture = try await WorktreeLaunchFixture(name: "terminal")
+        defer { fixture.cleanup() }
+        let attachment = Self.attachment()
+
+        let id = try await fixture.create(
+            branch: "issue-terminal",
+            launchSurface: .terminal(agentId: nil),
+            issueAttachment: attachment
+        )
+
+        #expect(fixture.state.projectsManager.issueAttachment(
+            projectId: fixture.project.id,
+            worktreeId: id
+        ) == attachment)
+        #expect(Self.acpTabs(in: fixture.state, worktreeId: id).isEmpty)
+        #expect(fixture.state.acpManager(forWorktreeId: id) == nil)
+    }
+
+    @Test func noTabLaunchPersistsAttachmentWithoutCreatingAcpPrompt() async throws {
+        let fixture = try await WorktreeLaunchFixture(name: "none")
+        defer { fixture.cleanup() }
+        let attachment = Self.attachment()
+
+        let id = try await fixture.create(
+            branch: "issue-none",
+            launchSurface: .none,
+            issueAttachment: attachment
+        )
+
+        #expect(fixture.state.projectsManager.issueAttachment(
+            projectId: fixture.project.id,
+            worktreeId: id
+        ) == attachment)
+        #expect(fixture.state.tabs.tabs(forWorktree: id).isEmpty)
+        #expect(fixture.state.acpManager(forWorktreeId: id) == nil)
+    }
+
+    @Test func reloadRestoresAttachmentAndPreparedAcpState() async throws {
+        let fixture = try await WorktreeLaunchFixture(name: "reload")
+        defer { fixture.cleanup() }
+        let prepared = Self.preparedPrompt()
+        let attachment = Self.attachment()
+        let id = try await fixture.create(
+            branch: "issue-reload",
+            launchSurface: .acp(agentId: "missing-acp-agent", preparedPrompt: prepared),
+            issueAttachment: attachment
+        )
+        let persistedProjects = try #require(fixture.store.writtenProjectsFile)
+        let reloadedStore = WorktreeLaunchFixture.Store(initialProjectsFile: persistedProjects)
+        let tabsManager = TabsManager(
+            store: fixture.store,
+            tabsDirectory: fixture.tabsDirectory
+        )
+        let reloaded = AppState(store: reloadedStore, tabsManager: tabsManager)
+        try await reloaded.projectsManager.refreshWorktrees(projectId: fixture.project.id)
+        reloaded.tabs.loadAll(worktreeIds: [id])
+
+        #expect(reloaded.projectsManager.issueAttachment(
+            projectId: fixture.project.id,
+            worktreeId: id
+        ) == attachment)
+        #expect(Self.acpTabs(in: reloaded, worktreeId: id).map(\.sessionId) == [prepared.sessionID])
+
+        let worktree = try #require(reloaded.worktree(withId: id))
+        let manager = try #require(reloaded.acpManager(for: worktree))
+        #expect(await manager.persistedSessionRow(id: prepared.sessionID) != nil)
+        _ = manager.placeholderSession(id: prepared.sessionID)
+        await manager.hydrateIfNeeded(id: prepared.sessionID)
+        let session = try #require(manager.liveSession(for: prepared.sessionID))
+        #expect(session.queue.map(\.id) == [prepared.promptID])
+    }
+
+    @Test func dialogBuildsPreparedPromptOnlyForFinalChatSelection() {
+        var calls = 0
+        let draft = AttachedIssueDraft(
+            source: IssueSnapshot(
+                identity: .init(providerID: .manual, stableID: "issue-42"),
+                canonicalURL: URL(string: "https://example.com/issues/42")!,
+                providerLabel: "example.com",
+                displayReference: "#42",
+                repositoryLocator: nil,
+                title: "Fix sync",
+                body: "Issue context",
+                state: .unknown,
+                labels: [],
+                assignees: [],
+                providerUpdatedAt: nil,
+                capturedAt: .distantPast,
+                refreshError: nil,
+                contentOrigin: .manual,
+                isEditable: true,
+                isRefreshable: false
+            ),
+            projectID: nil,
+            branchSeed: "feature/42-fix-sync",
+            prompt: "Use the edited prompt."
+        )
+
+        let chat = NewWorktreeDialog.launchSurfaceForCreate(
+            openAfterCreate: true,
+            launchMode: .acp,
+            launchAgentId: "claude",
+            issueDraft: draft,
+            makePreparedPrompt: {
+                calls += 1
+                return PreparedWorktreeACPPrompt(
+                    sessionID: "issue-session",
+                    promptID: Self.promptID,
+                    text: $0
+                )
+            }
+        )
+        let terminal = NewWorktreeDialog.launchSurfaceForCreate(
+            openAfterCreate: true,
+            launchMode: .terminal,
+            launchAgentId: "claude",
+            issueDraft: draft,
+            makePreparedPrompt: {
+                calls += 1
+                return PreparedWorktreeACPPrompt(sessionID: "unused", promptID: UUID(), text: $0)
+            }
+        )
+        let none = NewWorktreeDialog.launchSurfaceForCreate(
+            openAfterCreate: false,
+            launchMode: .acp,
+            launchAgentId: "claude",
+            issueDraft: draft,
+            makePreparedPrompt: {
+                calls += 1
+                return PreparedWorktreeACPPrompt(sessionID: "unused", promptID: UUID(), text: $0)
+            }
+        )
+
+        #expect(chat == .acp(
+            agentId: "claude",
+            preparedPrompt: PreparedWorktreeACPPrompt(
+                sessionID: "issue-session",
+                promptID: Self.promptID,
+                text: "Use the edited prompt."
+            )
+        ))
+        #expect(terminal == .terminal(agentId: "claude"))
+        #expect(none == .none)
+        #expect(calls == 1)
+    }
+
+    private static func preparedPrompt() -> PreparedWorktreeACPPrompt {
+        PreparedWorktreeACPPrompt(
+            sessionID: "issue-session",
+            promptID: promptID,
+            text: "Fix the parser crash from GitHub issue #42."
+        )
+    }
+
+    private static func attachment() -> IssueAttachment {
+        IssueAttachment(
+            canonicalURL: URL(string: "https://github.com/acme/alas/issues/42")!,
+            providerLabel: "GitHub",
+            displayReference: "#42",
+            title: "Fix parser crash"
+        )
+    }
+
+    private static func acpTabs(in state: AppState, worktreeId: String) -> [ACPSessionTabState] {
+        state.tabs.tabs(forWorktree: worktreeId).compactMap {
+            if case .acpSession(let tab) = $0 { return tab }
+            return nil
+        }
+    }
+}
+
+@MainActor
+private final class WorktreeLaunchFixture {
+    final class Store: PersistenceStoreProtocol, @unchecked Sendable {
+        let initialProjectsFile: ProjectsFile
+        var writtenProjectsFile: ProjectsFile?
+        var writtenTabs: [String: TabsFile] = [:]
+
+        init(initialProjectsFile: ProjectsFile = ProjectsFile(projects: [])) {
+            self.initialProjectsFile = initialProjectsFile
+        }
+
+        func write<T: Encodable>(_ value: T, to url: URL) throws {
+            if let projectsFile = value as? ProjectsFile {
+                writtenProjectsFile = projectsFile
+            }
+            if let tabsFile = value as? TabsFile {
+                writtenTabs[url.lastPathComponent] = tabsFile
+            }
+        }
+
+        func readIfExists<T: Decodable>(_ type: T.Type, from url: URL) throws -> T? {
+            if type == ProjectsFile.self { return initialProjectsFile as? T }
+            if type == TabsFile.self { return writtenTabs[url.lastPathComponent] as? T }
+            return nil
+        }
+    }
+
+    let root: URL
+    let repo: URL
+    let tabsDirectory: URL
+    let store: Store
+    let state: AppState
+    let project: ProjectConfig
+
+    init(name: String) async throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-issue-worktree-launch-\(name)-\(UUID().uuidString)", isDirectory: true)
+        repo = root.appendingPathComponent("repo", isDirectory: true)
+        tabsDirectory = root.appendingPathComponent("tabs", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: tabsDirectory, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: repo)
+
+        store = Store()
+        state = AppState(
+            store: store,
+            tabsManager: TabsManager(store: store, tabsDirectory: tabsDirectory)
+        )
+        project = try await state.projectsManager.addProject(
+            path: repo,
+            displayName: "repo-\(name)",
+            color: "#5fb7c4"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+    }
+
+    func create(
+        branch: String,
+        launchSurface: WorktreeLaunchSurface,
+        issueAttachment: IssueAttachment
+    ) async throws -> String {
+        let destination = root.appendingPathComponent(branch, isDirectory: true)
+        let id = await state.createWorktree(
+            projectId: project.id,
+            base: "main",
+            branch: branch,
+            destination: destination,
+            runStartup: false,
+            launchSurface: launchSurface,
+            issueAttachment: issueAttachment
+        )
+        #expect(!id.isEmpty)
+        try await waitForOperationToClear(id: id)
+        return id
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    private func waitForOperationToClear(id: String, timeoutSeconds: Double = 10) async throws {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            if state.projectsManager.operationState(for: id) == nil { return }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        Issue.record("Timed out waiting for operationState to clear for id \(id)")
+    }
+}

--- a/AlasTests/Issues/NewWorktreeIssueStateTests.swift
+++ b/AlasTests/Issues/NewWorktreeIssueStateTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct NewWorktreeIssueStateTests {
+    @Test func matchingIssueSelectsItsRepositorySeedsBranchAndRequestsChat() {
+        var state = NewWorktreeIssueState()
+        let draft = Self.draft(projectID: "repo-b", branchSeed: "feature/42-fix-sync")
+
+        let effects = state.attach(draft, currentLaunch: Self.terminalLaunch)
+
+        #expect(state.draft == draft)
+        #expect(effects == NewWorktreeIssueAttachEffects(
+            preferredProjectID: "repo-b",
+            branchSeed: "feature/42-fix-sync",
+            shouldSelectChat: true
+        ))
+    }
+
+    @Test func unmatchedURLPreservesRepositoryWhileSeedingBranchAndRequestingChat() {
+        var state = NewWorktreeIssueState()
+
+        let effects = state.attach(
+            Self.draft(projectID: nil, branchSeed: "feature/external-issue"),
+            currentLaunch: Self.terminalLaunch
+        )
+
+        #expect(effects.preferredProjectID == nil)
+        #expect(effects.branchSeed == "feature/external-issue")
+        #expect(effects.shouldSelectChat)
+    }
+
+    @Test func editingReplacesDraftWithoutRecapturingLaunchPreference() {
+        var state = NewWorktreeIssueState()
+        let original = Self.draft(projectID: "repo-a", branchSeed: "feature/42-original", prompt: "Original")
+        let edited = Self.draft(projectID: "repo-b", branchSeed: "feature/42-edited", prompt: "Edited")
+
+        _ = state.attach(original, currentLaunch: Self.terminalLaunch)
+        _ = state.attach(edited, currentLaunch: Self.chatLaunch)
+
+        #expect(state.draft == edited)
+        #expect(state.remove() == Self.terminalLaunch)
+    }
+
+    @Test func removingAfterManualLaunchChangePreservesCurrentLaunchChoice() {
+        var state = NewWorktreeIssueState()
+        _ = state.attach(Self.draft(), currentLaunch: Self.terminalLaunch)
+
+        state.recordLaunchPreferenceChangeAfterAttach()
+
+        #expect(state.remove() == nil)
+    }
+
+    @Test func removingReturnsCapturedLaunchPreferenceAndClearsOnlyIssueState() {
+        var state = NewWorktreeIssueState()
+        _ = state.attach(Self.draft(), currentLaunch: Self.terminalLaunch)
+
+        let restoredLaunch = state.remove()
+
+        #expect(restoredLaunch == Self.terminalLaunch)
+        #expect(state.draft == nil)
+        #expect(state.remove() == nil)
+    }
+
+    private static let terminalLaunch = NewWorktreeLaunchPreference(
+        openAfterCreate: true,
+        launchMode: .terminal,
+        persistableLaunchMode: .terminal,
+        launchAgentID: "amp"
+    )
+
+    private static let chatLaunch = NewWorktreeLaunchPreference(
+        openAfterCreate: true,
+        launchMode: .acp,
+        persistableLaunchMode: .acp,
+        launchAgentID: "claude"
+    )
+
+    private static func draft(
+        projectID: String? = "repo-a",
+        branchSeed: String = "feature/42-fix-sync",
+        prompt: String = "Fix the issue."
+    ) -> AttachedIssueDraft {
+        AttachedIssueDraft(
+            source: IssueSnapshot(
+                identity: .init(providerID: .github, stableID: "github.com/acme/repo#42"),
+                canonicalURL: URL(string: "https://github.com/acme/repo/issues/42")!,
+                providerLabel: "GitHub",
+                displayReference: "#42",
+                repositoryLocator: .init(
+                    provider: .github,
+                    host: "github.com",
+                    repositorySlug: "acme/repo"
+                ),
+                title: "Fix sync",
+                body: "Issue context",
+                state: .open,
+                labels: [],
+                assignees: [],
+                providerUpdatedAt: nil,
+                capturedAt: .distantPast,
+                refreshError: nil,
+                contentOrigin: .provider,
+                isEditable: false,
+                isRefreshable: true
+            ),
+            projectID: projectID,
+            branchSeed: branchSeed,
+            prompt: prompt
+        )
+    }
+}

--- a/AlasTests/Missions/MissionCoordinatorTests.swift
+++ b/AlasTests/Missions/MissionCoordinatorTests.swift
@@ -673,7 +673,9 @@ struct MissionCoordinatorTests {
                 projectId: project.id,
                 message: "branch exists",
                 base: Self.draft.baseRef,
-                ggWorktreeMode: .off
+                ggWorktreeMode: .off,
+                launchSurface: .none,
+                issueAttachment: nil
             )
         )
 

--- a/AlasTests/Missions/MissionTabTests.swift
+++ b/AlasTests/Missions/MissionTabTests.swift
@@ -267,7 +267,9 @@ struct MissionTabTests {
                 projectId: fixture.worktree.projectId,
                 message: "branch exists",
                 base: "origin/main",
-                ggWorktreeMode: .off
+                ggWorktreeMode: .off,
+                launchSurface: .none,
+                issueAttachment: nil
             )
         )
         await fixture.state.missions.load()

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -269,6 +269,112 @@ struct NewWorktreeDialogTests {
         ))
     }
 
+    @Test func issueAttachmentUsesOnlyAnExactCurrentProjectMatch() {
+        #expect(NewWorktreeDialog.projectIDAfterIssueAttach(
+            preferredProjectID: "repo-b",
+            currentProjectID: "repo-a",
+            availableProjectIDs: ["repo-a", "repo-b"]
+        ) == "repo-b")
+        #expect(NewWorktreeDialog.projectIDAfterIssueAttach(
+            preferredProjectID: "stale",
+            currentProjectID: "repo-a",
+            availableProjectIDs: ["repo-a", "repo-b"]
+        ) == "repo-a")
+        #expect(NewWorktreeDialog.projectIDAfterIssueAttach(
+            preferredProjectID: nil,
+            currentProjectID: "repo-a",
+            availableProjectIDs: ["repo-a", "repo-b"]
+        ) == "repo-a")
+    }
+
+    @Test func issueAttachmentSeedsOnlyTheActiveBranchOrStackInput() {
+        #expect(NewWorktreeDialog.namesAfterIssueAttach(
+            branchSeed: "feature/42-fix-sync",
+            createsGGStack: false,
+            branch: "manual-branch",
+            stackName: "manual-stack"
+        ) == (branch: "feature/42-fix-sync", stackName: "manual-stack"))
+        #expect(NewWorktreeDialog.namesAfterIssueAttach(
+            branchSeed: "feature/42-fix-sync",
+            createsGGStack: true,
+            branch: "manual-branch",
+            stackName: "manual-stack"
+        ) == (branch: "manual-branch", stackName: "feature/42-fix-sync"))
+    }
+
+    @Test func issueAttachmentSelectsTheFirstEnabledACPCapableAgent() {
+        let agents = [
+            Self.agent(id: "amp", displayName: "Amp"),
+            Self.agent(id: "codex", displayName: "Codex"),
+            Self.agent(id: "claude", displayName: "Claude"),
+        ]
+
+        #expect(NewWorktreeDialog.issueLaunchAgent(from: agents) == "codex")
+    }
+
+    @Test func issuePromptIsAvailableOnlyForChatLaunchWhileAttachmentRemains() {
+        let draft = AttachedIssueDraft(
+            source: IssueSnapshot(
+                identity: .init(providerID: .manual, stableID: "issue-42"),
+                canonicalURL: URL(string: "https://example.com/issues/42")!,
+                providerLabel: "example.com",
+                displayReference: "#42",
+                repositoryLocator: nil,
+                title: "Fix sync",
+                body: "Issue context",
+                state: .unknown,
+                labels: [],
+                assignees: [],
+                providerUpdatedAt: nil,
+                capturedAt: .distantPast,
+                refreshError: nil,
+                contentOrigin: .manual,
+                isEditable: true,
+                isRefreshable: false
+            ),
+            projectID: nil,
+            branchSeed: "feature/42-fix-sync",
+            prompt: "Fix the issue."
+        )
+
+        #expect(NewWorktreeDialog.issuePromptForLaunch(
+            draft: draft,
+            openAfterCreate: true,
+            launchMode: .acp
+        ) == "Fix the issue.")
+        #expect(NewWorktreeDialog.issuePromptForLaunch(
+            draft: draft,
+            openAfterCreate: true,
+            launchMode: .terminal
+        ) == nil)
+        #expect(NewWorktreeDialog.issuePromptForLaunch(
+            draft: draft,
+            openAfterCreate: false,
+            launchMode: .acp
+        ) == nil)
+        #expect(draft.attachment.displayTitle == "#42 · Fix sync")
+    }
+
+    @Test func editingAttachedIssueDoesNotReapplyParentFieldEffects() {
+        #expect(NewWorktreeDialog.appliesParentFieldsAfterIssueAttach(existingDraft: nil))
+        #expect(!NewWorktreeDialog.appliesParentFieldsAfterIssueAttach(existingDraft: Self.issueDraft()))
+    }
+
+    @Test func issueDrivenProjectChangeDoesNotReapplyLaunchDefaults() {
+        #expect(!NewWorktreeDialog.appliesLaunchDefaultsAfterProjectChange(
+            projectID: "repo-b",
+            issueDrivenProjectID: "repo-b"
+        ))
+        #expect(NewWorktreeDialog.appliesLaunchDefaultsAfterProjectChange(
+            projectID: "repo-c",
+            issueDrivenProjectID: "repo-b"
+        ))
+        #expect(NewWorktreeDialog.appliesLaunchDefaultsAfterProjectChange(
+            projectID: "repo-b",
+            issueDrivenProjectID: nil
+        ))
+    }
+
     private static func project(
         id: String,
         ggMode: GGProjectMode = .auto
@@ -280,6 +386,32 @@ struct NewWorktreeDialogTests {
             color: "#5fb7c4",
             addedAt: Date(timeIntervalSince1970: 0),
             ggMode: ggMode
+        )
+    }
+
+    private static func issueDraft() -> AttachedIssueDraft {
+        AttachedIssueDraft(
+            source: IssueSnapshot(
+                identity: .init(providerID: .manual, stableID: "issue-42"),
+                canonicalURL: URL(string: "https://example.com/issues/42")!,
+                providerLabel: "example.com",
+                displayReference: "#42",
+                repositoryLocator: nil,
+                title: "Fix sync",
+                body: "Issue context",
+                state: .unknown,
+                labels: [],
+                assignees: [],
+                providerUpdatedAt: nil,
+                capturedAt: .distantPast,
+                refreshError: nil,
+                contentOrigin: .manual,
+                isEditable: true,
+                isRefreshable: false
+            ),
+            projectID: nil,
+            branchSeed: "feature/42-fix-sync",
+            prompt: "Fix the issue."
         )
     }
 

--- a/AlasTests/ProjectsManagerHeadUpdatesTests.swift
+++ b/AlasTests/ProjectsManagerHeadUpdatesTests.swift
@@ -108,7 +108,9 @@ struct ProjectsManagerHeadUpdatesTests {
                 projectId: project.id,
                 message: "x",
                 base: "main",
-                ggWorktreeMode: .inherit
+                ggWorktreeMode: .inherit,
+                launchSurface: .none,
+                issueAttachment: nil
             )
         )
 

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -574,7 +574,9 @@ extension ProjectsManagerTests {
                 projectId: project.id,
                 message: "disk full",
                 base: "main",
-                ggWorktreeMode: .inherit
+                ggWorktreeMode: .inherit,
+                launchSurface: .none,
+                issueAttachment: nil
             )
         )
 
@@ -585,7 +587,9 @@ extension ProjectsManagerTests {
             projectId: project.id,
             message: "disk full",
             base: "main",
-            ggWorktreeMode: .inherit
+            ggWorktreeMode: .inherit,
+            launchSurface: .none,
+            issueAttachment: nil
         ))
     }
 
@@ -622,7 +626,9 @@ extension ProjectsManagerTests {
                 projectId: project.id,
                 message: "transient",
                 base: "main",
-                ggWorktreeMode: mode
+                ggWorktreeMode: mode,
+                launchSurface: .none,
+                issueAttachment: nil
             )
         )
         let changed = try await mgr.refreshWorktrees(projectId: project.id)
@@ -664,7 +670,9 @@ extension ProjectsManagerTests {
                 projectId: origin.id,
                 message: "transient",
                 base: "main",
-                ggWorktreeMode: .on
+                ggWorktreeMode: .on,
+                launchSurface: .none,
+                issueAttachment: nil
             )
         )
 

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -463,7 +463,9 @@ struct RemoteAppStateAccessTests {
                 projectId: createFailed.projectId,
                 message: "failed",
                 base: "main",
-                ggWorktreeMode: .inherit
+                ggWorktreeMode: .inherit,
+                launchSurface: .none,
+                issueAttachment: nil
             )
         )
         state.projectsManager.setOperationState(id: deleteFailed.id, state: .deleteFailed(message: "failed"))

--- a/AlasTests/RightPaneSelectionStateResolverTests.swift
+++ b/AlasTests/RightPaneSelectionStateResolverTests.swift
@@ -100,7 +100,9 @@ struct RightPaneSelectionStateResolverTests {
                 projectId: project.id,
                 message: "disk full",
                 base: "main",
-                ggWorktreeMode: .inherit
+                ggWorktreeMode: .inherit,
+                launchSurface: .none,
+                issueAttachment: nil
             )
         )
         let resolver = RightPaneSelectionStateResolver(


### PR DESCRIPTION
## Summary

- Builds on #1012 by exposing issue attachment from the New Worktree dialog without adding Mission UX.
- Adds a compact parent-row plus nested Attach Issue sheet for resolving/editing issue URL, title, context, and initial prompt.
- Uses attached issues during worktree creation so Chat launches create the ACP tab/session and send the edited prompt once; Terminal/No tab still create the attached worktree without sending.

### What changed

- Adds `AttachIssueDialog`, `NewWorktreeIssueState`, and New Worktree integration.
- Persists the issue attachment during worktree creation and threads prepared ACP prompts through `WorktreeLaunchSurface`.
- Stabilizes two existing suite checks uncovered by the final full-suite gate.

### Reviewer notes

- Parent worktree fields remain editable; editing an existing attachment does not reapply first-attach defaults over user-edited repository/branch/launch choices.
- The sheet is deliberately separate from the main New Worktree dialog to keep the default flow compact.

### Verification

- `rtk xcodebuild ... -only-testing:AlasTests/Issues/IssueWorktreeLaunchTests -only-testing:AlasTests/Issues/NewWorktreeIssueStateTests -only-testing:AlasTests/NewWorktreeDialogTests`
- `rtk xcodebuild ... -only-testing:AlasTests/NewMissionDialogTests -only-testing:AlasTests/PairedAuthoredContentSurfaceTests`
- Final full-suite `.xcresult`: `Passed`, `7921` total, `7909` passed, `0` failed, `12` skipped.

<!-- gg:managed:start -->
Part of stack `missions`

Commit: 04fe12e
<!-- gg:managed:end -->
