### PR TITLE
fix(gg): recover stacks while detached

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7492,7 +7492,10 @@ final class AppState {
                     context: integration.context,
                     snapshot: self.rightPaneStore.ggStackSnapshotForWorktreePath(
                         integration.worktree.path.path,
-                        effectiveContext: integration.context
+                        effectiveContext: integration.context,
+                        liveBranch: self.rightPaneStore.currentBranchForWorktreePath(
+                            integration.worktree.path.path
+                        ) ?? integration.worktree.branch
                     )
                 )
             },
@@ -8348,7 +8351,8 @@ final class AppState {
                 worktree,
                 rightPaneStore.effectiveGGContextForWorktreePath(
                     worktree.path.path,
-                    branchContext: branchContext
+                    branchContext: branchContext,
+                    liveBranch: branch
                 )
             )
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3361,6 +3361,7 @@ final class AppState {
             GGStackSummaryStore.shared.summaries[path] = nil
         }
         invalidateGGStackCacheAndRebumpGeneration(projectId: projectId)
+        rightPaneStore.refreshActiveGGPresentationForProjectRevision(projectId: projectId)
     }
 
     private func handleProjectRevisionChange(projectId: String) {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3361,7 +3361,10 @@ final class AppState {
             GGStackSummaryStore.shared.summaries[path] = nil
         }
         invalidateGGStackCacheAndRebumpGeneration(projectId: projectId)
-        rightPaneStore.refreshActiveGGPresentationForProjectRevision(projectId: projectId)
+        rightPaneStore.refreshActiveGGPresentationForHeadUpdates(
+            projectId: projectId,
+            worktreePaths: Array(branchByWorktreePath.keys)
+        )
     }
 
     private func handleProjectRevisionChange(projectId: String) {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -3353,12 +3353,17 @@ final class AppState {
 
     func handleProjectHeadUpdates(projectId: String, branchByWorktreePath: [URL: String]) {
         bumpRevisionGenerationForProject(projectId: projectId)
-        let changedPaths = projectsManager.applyHeadUpdates(
+        let reportedPaths = Set(branchByWorktreePath.keys.map {
+            Self.canonicalWorktreePath($0.path)
+        })
+        projectsManager.applyHeadUpdates(
             projectId: projectId,
             branchByWorktreePath: branchByWorktreePath
         )
-        for path in changedPaths {
-            GGStackSummaryStore.shared.summaries[path] = nil
+        for worktree in projectsManager.worktrees(projectId: projectId)
+            where reportedPaths.contains(Self.canonicalWorktreePath(worktree.path.path))
+        {
+            GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
         }
         invalidateGGStackCacheAndRebumpGeneration(projectId: projectId)
         rightPaneStore.refreshActiveGGPresentationForHeadUpdates(

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -8337,14 +8337,18 @@ final class AppState {
             }) else { continue }
             let branch = rightPaneStore.currentBranchForWorktreePath(worktree.path.path)
                 ?? worktree.branch
+            let branchContext = ggWorktreeContext(
+                project: project,
+                worktree: worktree,
+                branch: branch,
+                ggInstalled: ggInstalled
+            )
             return (
                 project,
                 worktree,
-                ggWorktreeContext(
-                    project: project,
-                    worktree: worktree,
-                    branch: branch,
-                    ggInstalled: ggInstalled
+                rightPaneStore.effectiveGGContextForWorktreePath(
+                    worktree.path.path,
+                    branchContext: branchContext
                 )
             )
         }

--- a/Alas/Sources/Integrations/GG/GGWorktreeContext.swift
+++ b/Alas/Sources/Integrations/GG/GGWorktreeContext.swift
@@ -26,17 +26,17 @@ enum GGWorktreeContext: Equatable {
 
     /// Branch naming determines the immediate stack identity, but a detached
     /// HEAD can still belong to a GG stack. Policy failures must stay closed;
-    /// branch-derived failures may ask `gg ls --json` for the authoritative
-    /// current stack instead.
+    /// a branch-prefix mismatch may ask `gg ls --json` for the authoritative
+    /// current stack instead. Missing GG naming configuration remains closed.
     var permitsCurrentStackQuery: Bool {
         switch self {
         case .active:
             return true
         case .inactive(let reason):
             switch reason {
-            case .branchUsernameMissing, .branchPrefixMismatch:
+            case .branchPrefixMismatch:
                 return true
-            case .masterDisabled, .cliMissing, .remoteProject, .policyOff:
+            case .masterDisabled, .cliMissing, .remoteProject, .policyOff, .branchUsernameMissing:
                 return false
             }
         }

--- a/Alas/Sources/Integrations/GG/GGWorktreeContext.swift
+++ b/Alas/Sources/Integrations/GG/GGWorktreeContext.swift
@@ -23,6 +23,24 @@ enum GGWorktreeContext: Equatable {
         if case .active = self { return true }
         return false
     }
+
+    /// Branch naming determines the immediate stack identity, but a detached
+    /// HEAD can still belong to a GG stack. Policy failures must stay closed;
+    /// branch-derived failures may ask `gg ls --json` for the authoritative
+    /// current stack instead.
+    var permitsCurrentStackQuery: Bool {
+        switch self {
+        case .active:
+            return true
+        case .inactive(let reason):
+            switch reason {
+            case .branchUsernameMissing, .branchPrefixMismatch:
+                return true
+            case .masterDisabled, .cliMissing, .remoteProject, .policyOff:
+                return false
+            }
+        }
+    }
 }
 
 enum GGWorktreeContextResolver {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1138,6 +1138,37 @@ final class RightPaneState: GGSplitCommitServicing {
         await coordinator.restoreUndoCandidate(currentStackName: ggStack?.name)
     }
 
+    /// Supersedes every prior stack refresh and clears its published
+    /// presentation. Active callers may atomically install a replacement
+    /// refresh; quiescent callers leave the state invalidated for activation.
+    @MainActor
+    @discardableResult
+    func invalidateGGPresentation(
+        startingRefresh shouldRefresh: Bool
+    ) -> Task<Void, Never>? {
+        // Advance ownership before cancellation: a direct/untracked caller may
+        // ignore cancellation, but its generation guard must still reject the
+        // response after this presentation is invalidated.
+        ggStackRefreshGeneration &+= 1
+        ggStackRefreshTask?.cancel()
+        ggStackRefreshTask = nil
+        invalidateOlderHistoryForDisplaySourceChange()
+        ggStackCommitsKey = nil
+        if ggStack != nil { ggStack = nil }
+        if !ggStackDisplayCommits.isEmpty { ggStackDisplayCommits = [] }
+        ggStackLoadState = ggContext.isActive ? .loading : .inactive
+        if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
+            GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
+        }
+        guard shouldRefresh else { return nil }
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.refreshGGStack()
+        }
+        ggStackRefreshTask = task
+        return task
+    }
+
     /// Re-run the gg gate immediately (e.g. after a Settings toggle) rather
     /// than waiting for the next watcher-driven refresh. Resets the
     /// commits-key so the gate is fully re-evaluated even when commits are
@@ -1147,8 +1178,7 @@ final class RightPaneState: GGSplitCommitServicing {
     @MainActor
     @discardableResult
     func reevaluateGGGate() -> Task<Void, Never> {
-        ggStackCommitsKey = nil
-        ggStackRefreshTask?.cancel()
+        invalidateGGPresentation(startingRefresh: false)
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
             await self.refreshGGStack()
@@ -1684,20 +1714,12 @@ final class RightPaneState: GGSplitCommitServicing {
         indexFingerprint = ""
         fileTree = []
         commits = []
-        invalidateOlderHistoryForDisplaySourceChange()
         // gg stack state is derived from commits above — reset it here too,
         // and cancel any in-flight load, so a delayed or failed refresh
         // after this invalidation can't leave a stale "Stack · …"
         // header/sidebar badge rendered against the now-empty commit list.
-        ggStackRefreshTask?.cancel()
         ggStackSourceCommits = []
-        ggStackCommitsKey = nil
-        if ggStack != nil { ggStack = nil }
-        if !ggStackDisplayCommits.isEmpty { ggStackDisplayCommits = [] }
-        ggStackLoadState = ggContext.isActive ? .loading : .inactive
-        if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
-            GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
-        }
+        invalidateGGPresentation(startingRefresh: false)
         comparisonRef = nil
         commitRemote = nil
         primaryCommitRemote = nil

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -953,12 +953,14 @@ final class RightPaneState: GGSplitCommitServicing {
             currentBranch = branch
             ggStackCommitsKey = nil
         }
-        let context = ggContextProvider?(branch) ?? .inactive(reason: .policyOff)
-        if ggContext != context { ggContext = context }
+        let branchContext = ggContextProvider?(branch) ?? .inactive(reason: .policyOff)
+        if branchContext.isActive || !branchContext.permitsCurrentStackQuery || !ggContext.isActive {
+            if ggContext != branchContext { ggContext = branchContext }
+        }
         if ggStackLoadState == .loaded {
             invalidateOlderHistoryForDisplaySourceChange()
         }
-        ggStackLoadState = context.isActive ? .loading : .inactive
+        ggStackLoadState = branchContext.permitsCurrentStackQuery ? .loading : .inactive
     }
 
     @MainActor
@@ -966,10 +968,12 @@ final class RightPaneState: GGSplitCommitServicing {
         let snapshotGeneration = snapshotInvalidationGeneration
         ggStackRefreshGeneration &+= 1
         let refreshGeneration = ggStackRefreshGeneration
-        let context = ggContextProvider?(currentBranch) ?? .inactive(reason: .policyOff)
-        if ggContext != context { ggContext = context }
+        let branchContext = ggContextProvider?(currentBranch) ?? .inactive(reason: .policyOff)
+        if branchContext.isActive || !branchContext.permitsCurrentStackQuery || !ggContext.isActive {
+            if ggContext != branchContext { ggContext = branchContext }
+        }
         reconcilePausedOperation()
-        guard context.isActive else {
+        guard branchContext.permitsCurrentStackQuery else {
             if ggStackLoadState == .loaded {
                 invalidateOlderHistoryForDisplaySourceChange()
             }
@@ -1058,7 +1062,16 @@ final class RightPaneState: GGSplitCommitServicing {
             guard snapshotGeneration == snapshotInvalidationGeneration,
                   refreshGeneration == ggStackRefreshGeneration
             else { return }
-            ggStackCommitsKey = key
+            let resolvedContext: GGWorktreeContext
+            if branchContext.isActive {
+                resolvedContext = branchContext
+            } else if let stack {
+                resolvedContext = .active(stackName: stack.name)
+            } else {
+                resolvedContext = branchContext
+            }
+            if ggContext != resolvedContext { ggContext = resolvedContext }
+            ggStackCommitsKey = currentGGStackCommitsKey
             if ggStack != stack { ggStack = stack }
             ggStackDisplayCommits = displayCommits
             let stackIsEmpty = stack.map { $0.totalCommits == 0 || $0.entries.isEmpty } ?? true
@@ -1092,6 +1105,7 @@ final class RightPaneState: GGSplitCommitServicing {
             guard snapshotGeneration == snapshotInvalidationGeneration,
                   refreshGeneration == ggStackRefreshGeneration
             else { return }
+            if ggContext != branchContext { ggContext = branchContext }
             ggStackCommitsKey = nil
             if ggStack != nil { ggStack = nil }
             if !ggStackDisplayCommits.isEmpty { ggStackDisplayCommits = [] }

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -428,11 +428,13 @@ final class RightPaneStore {
         guard let state = states.values.first(where: { $0.worktree.path.path == path }) else {
             return nil
         }
+        let liveBranchIdentity = Self.normalizedGGBranchIdentity(liveBranch)
+        let cachedBranchIdentity = Self.normalizedGGBranchIdentity(state.currentBranch)
         let loadState: GGStackLoadState
         let recoveredDetachedContext = !effectiveContext.isActive
             && effectiveContext.permitsCurrentStackQuery
-            && liveBranch.isEmpty
-            && state.currentBranch == liveBranch
+            && liveBranchIdentity.isEmpty
+            && cachedBranchIdentity == liveBranchIdentity
             && state.ggContext.isActive
             && state.ggStackLoadState == .loaded
         if state.ggStackLoadState == .loaded,
@@ -457,16 +459,21 @@ final class RightPaneStore {
         branchContext: GGWorktreeContext,
         liveBranch: String
     ) -> GGWorktreeContext {
+        let liveBranchIdentity = Self.normalizedGGBranchIdentity(liveBranch)
         guard !branchContext.isActive,
               branchContext.permitsCurrentStackQuery,
               let state = states.values.first(where: { $0.worktree.path.path == path }),
-              liveBranch.isEmpty,
-              state.currentBranch == liveBranch,
+              liveBranchIdentity.isEmpty,
+              Self.normalizedGGBranchIdentity(state.currentBranch) == liveBranchIdentity,
               state.ggContext.isActive,
               state.ggStackLoadState == .loaded,
               state.ggStackCommitsKey == state.currentGGStackCommitsKey
         else { return branchContext }
         return state.ggContext
+    }
+
+    private static func normalizedGGBranchIdentity(_ branch: String) -> String {
+        branch == "(detached)" ? "" : branch
     }
 
     /// Latest branch observed by the active pane state. Quiescent cached panes

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -342,17 +342,43 @@ final class RightPaneStore {
         projectId: String
     ) -> Task<Void, Never>? {
         let projectStates = states.values.filter { $0.worktree.projectId == projectId }
-        for state in projectStates {
+        return refreshActiveGGPresentation(invalidating: projectStates)
+    }
+
+    /// HEAD notifications identify the concrete worktrees whose checked-out
+    /// commits changed. Invalidate those panes even when the detached branch
+    /// label stayed the same, while preserving cached panes for other
+    /// worktrees in the project.
+    @discardableResult
+    func refreshActiveGGPresentationForHeadUpdates(
+        projectId: String,
+        worktreePaths: [URL]
+    ) -> Task<Void, Never>? {
+        let affectedPaths = Set(worktreePaths.map(Self.canonicalWorktreePath))
+        let affectedStates = states.values.filter {
+            $0.worktree.projectId == projectId
+                && affectedPaths.contains(Self.canonicalWorktreePath($0.worktree.path))
+        }
+        return refreshActiveGGPresentation(invalidating: affectedStates)
+    }
+
+    private func refreshActiveGGPresentation(
+        invalidating affectedStates: [RightPaneState]
+    ) -> Task<Void, Never>? {
+        for state in affectedStates {
             state.ggStackCommitsKey = nil
         }
         guard let activeId,
-              let state = states[activeId],
-              state.worktree.projectId == projectId,
+              let state = affectedStates.first(where: { $0.worktree.id == activeId }),
               state.ggContext.isActive
         else { return nil }
         return Task { @MainActor in
             await state.refreshGGStack()
         }
+    }
+
+    private static func canonicalWorktreePath(_ url: URL) -> String {
+        url.standardizedFileURL.resolvingSymlinksInPath().path
     }
 
     /// Re-evaluate the gg gate for one cached worktree after its override

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -428,9 +428,13 @@ final class RightPaneStore {
             return nil
         }
         let loadState: GGStackLoadState
+        let recoveredDetachedContext = !effectiveContext.isActive
+            && effectiveContext.permitsCurrentStackQuery
+            && state.ggContext.isActive
+            && state.ggStackLoadState == .loaded
         if state.ggStackLoadState == .loaded,
            (state.ggStackCommitsKey != state.currentGGStackCommitsKey
-            || state.ggContext != effectiveContext)
+            || (state.ggContext != effectiveContext && !recoveredDetachedContext))
         {
             loadState = effectiveContext.isActive ? .loading : .inactive
         } else {
@@ -440,6 +444,23 @@ final class RightPaneStore {
             stack: state.ggStack,
             loadState: loadState
         )
+    }
+
+    /// A detached branch cannot name its stack, but a loaded GG snapshot can.
+    /// Keep policy-denied contexts closed; only branch-derived uncertainty is
+    /// eligible to inherit the recovered context.
+    func effectiveGGContextForWorktreePath(
+        _ path: String,
+        branchContext: GGWorktreeContext
+    ) -> GGWorktreeContext {
+        guard !branchContext.isActive,
+              branchContext.permitsCurrentStackQuery,
+              let state = states.values.first(where: { $0.worktree.path.path == path }),
+              state.ggContext.isActive,
+              state.ggStackLoadState == .loaded,
+              state.ggStackCommitsKey == state.currentGGStackCommitsKey
+        else { return branchContext }
+        return state.ggContext
     }
 
     /// Latest branch observed by the active pane state. Quiescent cached panes

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -367,7 +367,7 @@ final class RightPaneStore {
     ) -> Task<Void, Never>? {
         var activeRefresh: Task<Void, Never>?
         for state in affectedStates {
-            let shouldRefresh = state.worktree.id == activeId && state.ggContext.isActive
+            let shouldRefresh = state.worktree.id == activeId
             if let task = state.invalidateGGPresentation(startingRefresh: shouldRefresh) {
                 activeRefresh = task
             }

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -365,16 +365,14 @@ final class RightPaneStore {
     private func refreshActiveGGPresentation(
         invalidating affectedStates: [RightPaneState]
     ) -> Task<Void, Never>? {
+        var activeRefresh: Task<Void, Never>?
         for state in affectedStates {
-            state.ggStackCommitsKey = nil
+            let shouldRefresh = state.worktree.id == activeId && state.ggContext.isActive
+            if let task = state.invalidateGGPresentation(startingRefresh: shouldRefresh) {
+                activeRefresh = task
+            }
         }
-        guard let activeId,
-              let state = affectedStates.first(where: { $0.worktree.id == activeId }),
-              state.ggContext.isActive
-        else { return nil }
-        return Task { @MainActor in
-            await state.refreshGGStack()
-        }
+        return activeRefresh
     }
 
     private static func canonicalWorktreePath(_ url: URL) -> String {
@@ -454,16 +452,15 @@ final class RightPaneStore {
         guard let state = states.values.first(where: { $0.worktree.path.path == path }) else {
             return nil
         }
-        let liveBranchIdentity = Self.normalizedGGBranchIdentity(liveBranch)
-        let cachedBranchIdentity = Self.normalizedGGBranchIdentity(state.currentBranch)
         let loadState: GGStackLoadState
-        let recoveredDetachedContext = !effectiveContext.isActive
-            && effectiveContext.permitsCurrentStackQuery
-            && liveBranchIdentity.isEmpty
-            && cachedBranchIdentity == liveBranchIdentity
-            && state.ggContext.isActive
-            && state.ggStackLoadState == .loaded
-        if state.ggStackLoadState == .loaded,
+        let recoveredDetachedContext = Self.canUseRecoveredDetachedContext(
+            state: state,
+            branchContext: effectiveContext,
+            liveBranch: liveBranch
+        )
+        if !effectiveContext.isActive && !recoveredDetachedContext {
+            loadState = .inactive
+        } else if state.ggStackLoadState == .loaded,
            (state.ggStackCommitsKey != state.currentGGStackCommitsKey
             || (state.ggContext != effectiveContext && !recoveredDetachedContext))
         {
@@ -485,17 +482,29 @@ final class RightPaneStore {
         branchContext: GGWorktreeContext,
         liveBranch: String
     ) -> GGWorktreeContext {
-        let liveBranchIdentity = Self.normalizedGGBranchIdentity(liveBranch)
-        guard !branchContext.isActive,
-              branchContext.permitsCurrentStackQuery,
-              let state = states.values.first(where: { $0.worktree.path.path == path }),
-              liveBranchIdentity.isEmpty,
-              Self.normalizedGGBranchIdentity(state.currentBranch) == liveBranchIdentity,
-              state.ggContext.isActive,
-              state.ggStackLoadState == .loaded,
+        guard let state = states.values.first(where: { $0.worktree.path.path == path }),
+              Self.canUseRecoveredDetachedContext(
+                  state: state,
+                  branchContext: branchContext,
+                  liveBranch: liveBranch
+              ),
               state.ggStackCommitsKey == state.currentGGStackCommitsKey
         else { return branchContext }
         return state.ggContext
+    }
+
+    private static func canUseRecoveredDetachedContext(
+        state: RightPaneState,
+        branchContext: GGWorktreeContext,
+        liveBranch: String
+    ) -> Bool {
+        let liveBranchIdentity = normalizedGGBranchIdentity(liveBranch)
+        return !branchContext.isActive
+            && branchContext.permitsCurrentStackQuery
+            && liveBranchIdentity.isEmpty
+            && normalizedGGBranchIdentity(state.currentBranch) == liveBranchIdentity
+            && state.ggContext.isActive
+            && state.ggStackLoadState == .loaded
     }
 
     private static func normalizedGGBranchIdentity(_ branch: String) -> String {

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -422,7 +422,8 @@ final class RightPaneStore {
     /// exposed as loading so non-UI consumers cannot treat it as current.
     func ggStackSnapshotForWorktreePath(
         _ path: String,
-        effectiveContext: GGWorktreeContext
+        effectiveContext: GGWorktreeContext,
+        liveBranch: String
     ) -> RightPaneGGStackSnapshot? {
         guard let state = states.values.first(where: { $0.worktree.path.path == path }) else {
             return nil
@@ -430,6 +431,8 @@ final class RightPaneStore {
         let loadState: GGStackLoadState
         let recoveredDetachedContext = !effectiveContext.isActive
             && effectiveContext.permitsCurrentStackQuery
+            && liveBranch.isEmpty
+            && state.currentBranch == liveBranch
             && state.ggContext.isActive
             && state.ggStackLoadState == .loaded
         if state.ggStackLoadState == .loaded,
@@ -451,11 +454,14 @@ final class RightPaneStore {
     /// eligible to inherit the recovered context.
     func effectiveGGContextForWorktreePath(
         _ path: String,
-        branchContext: GGWorktreeContext
+        branchContext: GGWorktreeContext,
+        liveBranch: String
     ) -> GGWorktreeContext {
         guard !branchContext.isActive,
               branchContext.permitsCurrentStackQuery,
               let state = states.values.first(where: { $0.worktree.path.path == path }),
+              liveBranch.isEmpty,
+              state.currentBranch == liveBranch,
               state.ggContext.isActive,
               state.ggStackLoadState == .loaded,
               state.ggStackCommitsKey == state.currentGGStackCommitsKey

--- a/AlasTests/Integrations/GGWorktreeContextTests.swift
+++ b/AlasTests/Integrations/GGWorktreeContextTests.swift
@@ -2,6 +2,23 @@ import Foundation
 import Testing
 @testable import Alas
 
+private actor HeadUpdateCountingGGRunner: GGCommandRunning {
+    private var callCount = 0
+
+    func run(args _: [String], cwd _: URL?) async throws -> ProcessResult {
+        callCount += 1
+        return ProcessResult(
+            exitCode: 0,
+            stdout: #"{"version":1,"stack":null}"#,
+            stderr: ""
+        )
+    }
+
+    func calls() -> Int {
+        callCount
+    }
+}
+
 struct GGWorktreeContextTests {
     @Test func policyResolverPreservesWorktreeSemantics() {
         #expect(GGWorktreeContextResolver.isPolicyEnabled(
@@ -488,7 +505,7 @@ struct AppStateGGACPWorktreeContextTests {
         #expect(snapshot.loadState == .loaded)
     }
 
-    @Test func quiescentDetachedHeadRevisionInvalidatesRecoveredStackForACP() throws {
+    @Test func detachedHeadUpdateScopesRecoveredStackInvalidationToReportedWorktree() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-gg-acp-detached-revision-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: root) }
@@ -509,43 +526,72 @@ struct AppStateGGACPWorktreeContextTests {
             ggMode: .off
         )
         let state = AppState(store: MemoryStore(projectsFile: ProjectsFile(projects: [project])))
-        let path = root.appendingPathComponent("linked")
-        let worktree = Worktree(
-            id: Worktree.makeId(path: path),
+        let changedPath = root.appendingPathComponent("changed")
+        let unchangedPath = root.appendingPathComponent("unchanged")
+        let changedWorktree = Worktree(
+            id: Worktree.makeId(path: changedPath),
             projectId: project.id,
             name: "(detached)",
             branch: "(detached)",
-            path: path,
+            path: changedPath,
             status: .clean,
             lastActivity: .now
         )
-        state.projectsManager.insertOptimisticWorktree(worktree)
-        state.projectsManager.setGGWorktreeMode(
+        let unchangedWorktree = Worktree(
+            id: Worktree.makeId(path: unchangedPath),
             projectId: project.id,
-            worktreeId: worktree.id,
-            mode: .on
+            name: "(detached)",
+            branch: "(detached)",
+            path: unchangedPath,
+            status: .clean,
+            lastActivity: .now
         )
-        let pane = state.rightPaneStore.state(
-            for: worktree,
+        for worktree in [changedWorktree, unchangedWorktree] {
+            state.projectsManager.insertOptimisticWorktree(worktree)
+            state.projectsManager.setGGWorktreeMode(
+                projectId: project.id,
+                worktreeId: worktree.id,
+                mode: .on
+            )
+        }
+        let changedPane = state.rightPaneStore.state(
+            for: changedWorktree,
             baseBranch: "main",
             comparisonMode: .manual
         )
-        state.rightPaneStore.deactivate()
-        pane.currentBranch = ""
-        pane.ggContext = .active(stackName: "detached-a")
-        pane.ggStack = try GGStackSnapshot.decode(
+        let unchangedPane = state.rightPaneStore.state(
+            for: unchangedWorktree,
+            baseBranch: "main",
+            comparisonMode: .manual
+        )
+        changedPane.stop()
+        unchangedPane.stop()
+        defer { state.rightPaneStore.deactivate() }
+
+        let stack = try GGStackSnapshot.decode(
             fromJSON: Data(GGStackModelsTests.fixture.utf8)
         ).stack
-        pane.ggStackLoadState = .loaded
-        pane.ggStackCommitsKey = pane.currentGGStackCommitsKey
+        changedPane.currentBranch = ""
+        changedPane.ggContext = .active(stackName: "detached-a")
+        changedPane.ggStack = stack
+        changedPane.ggStackLoadState = .loaded
+        changedPane.ggStackCommitsKey = changedPane.currentGGStackCommitsKey
+        unchangedPane.currentBranch = ""
+        unchangedPane.ggContext = .active(stackName: "detached-b")
+        unchangedPane.ggStack = stack
+        unchangedPane.ggStackLoadState = .loaded
+        unchangedPane.ggStackCommitsKey = unchangedPane.currentGGStackCommitsKey
+        let unchangedKey = try #require(unchangedPane.ggStackCommitsKey)
+        let unchangedRunner = HeadUpdateCountingGGRunner()
+        unchangedPane.ggService = GGService(runner: unchangedRunner)
 
         let beforeRevision = try #require(state.ggACPWorktreeIntegration(
-            worktreePath: path.path,
+            worktreePath: changedPath.path,
             ggInstalled: true
         ))
         #expect(beforeRevision.context == .active(stackName: "detached-a"))
         let beforeSnapshot = try #require(state.rightPaneStore.ggStackSnapshotForWorktreePath(
-            path.path,
+            changedPath.path,
             effectiveContext: beforeRevision.context,
             liveBranch: "(detached)"
         ))
@@ -555,20 +601,35 @@ struct AppStateGGACPWorktreeContextTests {
         // watcher reports the same label for every detached HEAD.
         state.handleProjectHeadUpdates(
             projectId: project.id,
-            branchByWorktreePath: [path: "(detached)"]
+            branchByWorktreePath: [changedPath: "(detached)"]
         )
-        #expect(state.revisionChangeGeneration(worktreeID: worktree.id) == 1)
+        #expect(state.revisionChangeGeneration(worktreeID: changedWorktree.id) == 1)
 
         let afterRevision = try #require(state.ggACPWorktreeIntegration(
-            worktreePath: path.path,
+            worktreePath: changedPath.path,
             ggInstalled: true
         ))
         #expect(afterRevision.context == .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/")))
         let afterSnapshot = try #require(state.rightPaneStore.ggStackSnapshotForWorktreePath(
-            path.path,
+            changedPath.path,
             effectiveContext: afterRevision.context,
             liveBranch: "(detached)"
         ))
         #expect(afterSnapshot.loadState == .inactive)
+
+        let unchangedIntegration = try #require(state.ggACPWorktreeIntegration(
+            worktreePath: unchangedPath.path,
+            ggInstalled: true
+        ))
+        #expect(unchangedIntegration.context == .active(stackName: "detached-b"))
+        let unchangedSnapshot = try #require(state.rightPaneStore.ggStackSnapshotForWorktreePath(
+            unchangedPath.path,
+            effectiveContext: unchangedIntegration.context,
+            liveBranch: "(detached)"
+        ))
+        #expect(unchangedSnapshot.loadState == .loaded)
+        #expect(unchangedPane.ggStackCommitsKey == unchangedKey)
+        await Task.yield()
+        #expect(await unchangedRunner.calls() == 0)
     }
 }

--- a/AlasTests/Integrations/GGWorktreeContextTests.swift
+++ b/AlasTests/Integrations/GGWorktreeContextTests.swift
@@ -487,4 +487,88 @@ struct AppStateGGACPWorktreeContextTests {
         ))
         #expect(snapshot.loadState == .loaded)
     }
+
+    @Test func quiescentDetachedHeadRevisionInvalidatesRecoveredStackForACP() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-gg-acp-detached-revision-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent(".git/gg"),
+            withIntermediateDirectories: true
+        )
+        try Data(#"{"defaults":{"branch_username":"nacho"}}"#.utf8).write(
+            to: root.appendingPathComponent(".git/gg/config.json")
+        )
+
+        let project = ProjectConfig(
+            id: "project",
+            name: "Alas",
+            path: root.path,
+            color: "teal",
+            addedAt: .now,
+            ggMode: .off
+        )
+        let state = AppState(store: MemoryStore(projectsFile: ProjectsFile(projects: [project])))
+        let path = root.appendingPathComponent("linked")
+        let worktree = Worktree(
+            id: Worktree.makeId(path: path),
+            projectId: project.id,
+            name: "(detached)",
+            branch: "(detached)",
+            path: path,
+            status: .clean,
+            lastActivity: .now
+        )
+        state.projectsManager.insertOptimisticWorktree(worktree)
+        state.projectsManager.setGGWorktreeMode(
+            projectId: project.id,
+            worktreeId: worktree.id,
+            mode: .on
+        )
+        let pane = state.rightPaneStore.state(
+            for: worktree,
+            baseBranch: "main",
+            comparisonMode: .manual
+        )
+        state.rightPaneStore.deactivate()
+        pane.currentBranch = ""
+        pane.ggContext = .active(stackName: "detached-a")
+        pane.ggStack = try GGStackSnapshot.decode(
+            fromJSON: Data(GGStackModelsTests.fixture.utf8)
+        ).stack
+        pane.ggStackLoadState = .loaded
+        pane.ggStackCommitsKey = pane.currentGGStackCommitsKey
+
+        let beforeRevision = try #require(state.ggACPWorktreeIntegration(
+            worktreePath: path.path,
+            ggInstalled: true
+        ))
+        #expect(beforeRevision.context == .active(stackName: "detached-a"))
+        let beforeSnapshot = try #require(state.rightPaneStore.ggStackSnapshotForWorktreePath(
+            path.path,
+            effectiveContext: beforeRevision.context,
+            liveBranch: "(detached)"
+        ))
+        #expect(beforeSnapshot.loadState == .loaded)
+
+        // A second detached SHA is indistinguishable in topology because the
+        // watcher reports the same label for every detached HEAD.
+        state.handleProjectHeadUpdates(
+            projectId: project.id,
+            branchByWorktreePath: [path: "(detached)"]
+        )
+        #expect(state.revisionChangeGeneration(worktreeID: worktree.id) == 1)
+
+        let afterRevision = try #require(state.ggACPWorktreeIntegration(
+            worktreePath: path.path,
+            ggInstalled: true
+        ))
+        #expect(afterRevision.context == .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/")))
+        let afterSnapshot = try #require(state.rightPaneStore.ggStackSnapshotForWorktreePath(
+            path.path,
+            effectiveContext: afterRevision.context,
+            liveBranch: "(detached)"
+        ))
+        #expect(afterSnapshot.loadState == .inactive)
+    }
 }

--- a/AlasTests/Integrations/GGWorktreeContextTests.swift
+++ b/AlasTests/Integrations/GGWorktreeContextTests.swift
@@ -418,4 +418,73 @@ struct AppStateGGACPWorktreeContextTests {
         #expect(AppState.ggPreambleSignal(context: reactivated.context, snapshot: nil) == .generic)
         #expect(reactivated.context == .active(stackName: "reactivated-stack"))
     }
+
+    @Test func quiescentDetachedTopologyLabelRetainsRecoveredStackForACP() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-gg-acp-detached-topology-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent(".git/gg"),
+            withIntermediateDirectories: true
+        )
+        try Data(#"{"defaults":{"branch_username":"nacho"}}"#.utf8).write(
+            to: root.appendingPathComponent(".git/gg/config.json")
+        )
+
+        let project = ProjectConfig(
+            id: "project",
+            name: "Alas",
+            path: root.path,
+            color: "teal",
+            addedAt: .now,
+            ggMode: .off
+        )
+        let state = AppState(store: MemoryStore(projectsFile: ProjectsFile(projects: [project])))
+        let path = root.appendingPathComponent("linked")
+        let worktree = Worktree(
+            id: Worktree.makeId(path: path),
+            projectId: project.id,
+            name: "nacho/old-stack",
+            branch: "nacho/old-stack",
+            path: path,
+            status: .clean,
+            lastActivity: .now
+        )
+        state.projectsManager.insertOptimisticWorktree(worktree)
+        state.projectsManager.setGGWorktreeMode(
+            projectId: project.id,
+            worktreeId: worktree.id,
+            mode: .on
+        )
+        let pane = state.rightPaneStore.state(
+            for: worktree,
+            baseBranch: "main",
+            comparisonMode: .manual
+        )
+        state.rightPaneStore.deactivate()
+        pane.currentBranch = ""
+        pane.ggContext = .active(stackName: "agent-inbox")
+        pane.ggStack = try GGStackSnapshot.decode(
+            fromJSON: Data(GGStackModelsTests.fixture.utf8)
+        ).stack
+        pane.ggStackLoadState = .loaded
+        pane.ggStackCommitsKey = pane.currentGGStackCommitsKey
+        state.projectsManager.applyHeadUpdates(
+            projectId: project.id,
+            branchByWorktreePath: [path: "(detached)"]
+        )
+        #expect(state.projectsManager.worktrees(projectId: project.id).first?.branch == "(detached)")
+
+        let integration = try #require(state.ggACPWorktreeIntegration(
+            worktreePath: path.path,
+            ggInstalled: true
+        ))
+        #expect(integration.context == .active(stackName: "agent-inbox"))
+        let snapshot = try #require(state.rightPaneStore.ggStackSnapshotForWorktreePath(
+            path.path,
+            effectiveContext: integration.context,
+            liveBranch: "(detached)"
+        ))
+        #expect(snapshot.loadState == .loaded)
+    }
 }

--- a/AlasTests/Integrations/GGWorktreeContextTests.swift
+++ b/AlasTests/Integrations/GGWorktreeContextTests.swift
@@ -303,6 +303,46 @@ struct AppStateGGACPWorktreeContextTests {
         #expect(GGStackSummaryStore.shared.summaries[path.path] == nil)
     }
 
+    @Test func sameLabelDetachedHeadUpdateClearsOnlyReportedSidebarSummary() {
+        let project = ProjectConfig(
+            id: "project",
+            name: "Alas",
+            path: "/tmp/alas-detached-summary-project",
+            color: "teal",
+            addedAt: .now
+        )
+        let state = AppState(store: MemoryStore(projectsFile: ProjectsFile(projects: [project])))
+        let changedPath = URL(fileURLWithPath: "/tmp/alas-detached-summary-changed")
+        let unchangedPath = URL(fileURLWithPath: "/tmp/alas-detached-summary-unchanged")
+        for path in [changedPath, unchangedPath] {
+            state.projectsManager.insertOptimisticWorktree(Worktree(
+                id: Worktree.makeId(path: path),
+                projectId: project.id,
+                name: "(detached)",
+                branch: "(detached)",
+                path: path,
+                status: .clean,
+                lastActivity: .now
+            ))
+        }
+        let changedSummary = GGStackSummary(merged: 1, total: 2)
+        let unchangedSummary = GGStackSummary(merged: 2, total: 3)
+        GGStackSummaryStore.shared.summaries[changedPath.path] = changedSummary
+        GGStackSummaryStore.shared.summaries[unchangedPath.path] = unchangedSummary
+        defer {
+            GGStackSummaryStore.shared.summaries[changedPath.path] = nil
+            GGStackSummaryStore.shared.summaries[unchangedPath.path] = nil
+        }
+
+        state.handleProjectHeadUpdates(
+            projectId: project.id,
+            branchByWorktreePath: [changedPath: "(detached)"]
+        )
+
+        #expect(GGStackSummaryStore.shared.summaries[changedPath.path] == nil)
+        #expect(GGStackSummaryStore.shared.summaries[unchangedPath.path] == unchangedSummary)
+    }
+
     @Test func fullTopologyRefreshClearsCachedSidebarSummaryWhenBranchChanges() async throws {
         let repo = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-gg-summary-topology-\(UUID().uuidString)")

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -1178,10 +1178,40 @@ struct RightPaneGGStackTests {
 
         let snapshot = try #require(store.ggStackSnapshotForWorktreePath(
             worktree.path.path,
-            effectiveContext: .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/"))
+            effectiveContext: .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/")),
+            liveBranch: ""
         ))
         #expect(snapshot.stack?.name == "agent-inbox")
         #expect(snapshot.loadState == .loaded)
+    }
+
+    @Test func quiescentActiveStackDoesNotPublishAsDetachedRecovery() throws {
+        let store = RightPaneStore()
+        let worktree = makeWorktree()
+        let state = store.state(for: worktree, baseBranch: "main", comparisonMode: .manual)
+        store.deactivate()
+        state.currentBranch = "nacho/old-stack"
+        state.ggContext = .active(stackName: "old-stack")
+        state.ggStack = try GGStackSnapshot.decode(
+            fromJSON: Data(GGStackModelsTests.fixture.utf8)
+        ).stack
+        state.ggStackLoadState = .loaded
+        state.ggStackCommitsKey = state.currentGGStackCommitsKey
+
+        let detachedContext = GGWorktreeContext.inactive(
+            reason: .branchPrefixMismatch(expectedPrefix: "nacho/")
+        )
+        #expect(store.effectiveGGContextForWorktreePath(
+            worktree.path.path,
+            branchContext: detachedContext,
+            liveBranch: ""
+        ) == detachedContext)
+        let snapshot = try #require(store.ggStackSnapshotForWorktreePath(
+            worktree.path.path,
+            effectiveContext: detachedContext,
+            liveBranch: ""
+        ))
+        #expect(snapshot.loadState == .inactive)
     }
 
     @Test func detachedRefreshWithNoCurrentStackClearsPriorPresentation() async {
@@ -1562,7 +1592,8 @@ struct RightPaneGGStackTests {
         #expect(inactive.ggStackCommitsKey == nil)
         #expect(store.ggStackSnapshotForWorktreePath(
             inactiveWorktree.path.path,
-            effectiveContext: .active(stackName: "agent-inbox")
+            effectiveContext: .active(stackName: "agent-inbox"),
+            liveBranch: inactive.currentBranch
         )?.loadState == .loading)
         #expect(active.ggStackLoadState == .loaded)
     }
@@ -2074,7 +2105,8 @@ struct RightPaneGGStackTests {
         state.ggStackSourceCommits = [commit(sha: String(repeating: "p", count: 40), stackShaped: true)]
         let snapshot = try #require(store.ggStackSnapshotForWorktreePath(
             worktree.path.path,
-            effectiveContext: .active(stackName: "stack")
+            effectiveContext: .active(stackName: "stack"),
+            liveBranch: state.currentBranch
         ))
 
         #expect(snapshot.stack != nil)
@@ -2095,7 +2127,8 @@ struct RightPaneGGStackTests {
 
         let snapshot = try #require(store.ggStackSnapshotForWorktreePath(
             worktree.path.path,
-            effectiveContext: .active(stackName: "new-stack")
+            effectiveContext: .active(stackName: "new-stack"),
+            liveBranch: state.currentBranch
         ))
 
         #expect(snapshot.stack != nil)

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -60,6 +60,23 @@ private final class CountingFakeGGRunner: GGCommandRunning, @unchecked Sendable 
     }
 }
 
+private final class SequencedFakeGGRunner: GGCommandRunning, @unchecked Sendable {
+    private(set) var callCount = 0
+    private var results: [ProcessResult]
+
+    init(results: [ProcessResult]) {
+        self.results = results
+    }
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        callCount += 1
+        guard args == ["ls", "--json"], !results.isEmpty else {
+            return ProcessResult(exitCode: 1, stdout: "", stderr: "unexpected args: \(args)")
+        }
+        return results.removeFirst()
+    }
+}
+
 enum GGStackClassificationFixture: CaseIterable, Sendable {
     case nilStack
     case zeroTotalWithEntry
@@ -1114,6 +1131,100 @@ struct RightPaneGGStackTests {
         #expect(state.ggStackLoadState == .loaded)
     }
 
+    @Test func detachedRefreshRecoversCurrentStackAndDedupesThePromotedContext() async {
+        let runner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        let state = makeState()
+        var branchContext = GGWorktreeContext.active(stackName: "agent-inbox")
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in branchContext }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "d", count: 40), stackShaped: true)]
+
+        state.seedGGContext(branch: "nacho/agent-inbox")
+        await state.refreshGGStack()
+
+        branchContext = .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/"))
+        state.seedGGContext(branch: "")
+        await state.refreshGGStack()
+
+        #expect(runner.callCount == 2)
+        #expect(state.ggContext == .active(stackName: "agent-inbox"))
+        #expect(state.ggStackLoadState == .loaded)
+        #expect(state.ggStackDisplayCommits.map(\.shortSha) == ["ccccccc", "bbbbbbb", "aaaaaaa"])
+
+        await state.refreshGGStack()
+
+        #expect(runner.callCount == 2)
+    }
+
+    @Test func coldDetachedRefreshPublishesStackToStoreSnapshotConsumers() async throws {
+        let store = RightPaneStore()
+        let worktree = makeWorktree()
+        let state = store.state(for: worktree, baseBranch: "main", comparisonMode: .manual)
+        store.deactivate()
+        state.ggService = GGService(runner: CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        ))
+        state.ggContextProvider = { _ in .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/")) }
+        state.ggStackCommitLoader = { _, entries in
+            Dictionary(uniqueKeysWithValues: entries.map { sha in
+                (sha, commit(sha: sha, stackShaped: true))
+            })
+        }
+        state.seedGGContext(branch: "")
+
+        await state.refreshGGStack()
+
+        let snapshot = try #require(store.ggStackSnapshotForWorktreePath(
+            worktree.path.path,
+            effectiveContext: .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/"))
+        ))
+        #expect(snapshot.stack?.name == "agent-inbox")
+        #expect(snapshot.loadState == .loaded)
+    }
+
+    @Test func detachedRefreshWithNoCurrentStackClearsPriorPresentation() async {
+        let runner = SequencedFakeGGRunner(results: [
+            ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: #"{"version":1,"stack":null}"#, stderr: ""),
+        ])
+        let state = makeState()
+        var branchContext = GGWorktreeContext.active(stackName: "agent-inbox")
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in branchContext }
+        state.commits = [commit(sha: String(repeating: "p", count: 40), stackShaped: true)]
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "d", count: 40), stackShaped: true)]
+
+        state.seedGGContext(branch: "nacho/agent-inbox")
+        await state.refreshGGStack()
+        branchContext = .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/"))
+        state.seedGGContext(branch: "")
+        await state.refreshGGStack()
+
+        #expect(runner.callCount == 2)
+        #expect(state.ggContext == .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/")))
+        #expect(state.ggStack == nil)
+        #expect(state.ggStackDisplayCommits.isEmpty)
+        #expect(state.commitsForDisplay == state.commits)
+    }
+
+    @Test func policyDeniedDetachedRefreshDoesNotQueryGG() async {
+        let runner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        let state = makeState()
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .inactive(reason: .policyOff) }
+        state.seedGGContext(branch: "")
+
+        await state.refreshGGStack()
+
+        #expect(runner.callCount == 0)
+        #expect(state.ggContext == .inactive(reason: .policyOff))
+        #expect(state.ggStackLoadState == .inactive)
+    }
+
     @Test(arguments: GGStackClassificationFixture.allCases)
     func stackClassificationKeepsEmptyUIConsistent(_ fixture: GGStackClassificationFixture) async {
         let worktree = makeWorktree()
@@ -2110,7 +2221,8 @@ struct RightPaneGGStackTests {
 
         await state.refreshGGStack()
 
-        #expect(state.ggStackLoadState == .inactive)
+        #expect(state.ggContext == .active(stackName: "agent-inbox"))
+        #expect(state.ggStackLoadState == .loaded)
         #expect(state.ggActionState.pausedOperation == GGPausedOperation(pausedBy: .sync))
 
         state.onGGStackAction(.continueOp, appState: AppState(store: MemoryStore()))

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -1916,6 +1916,57 @@ struct RightPaneGGStackTests {
         #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] == nil)
     }
 
+    @Test func activeHeadInvalidationReplacesInFlightColdDetachedRecovery() async throws {
+        let worktree = makeWorktree()
+        defer { GGStackSummaryStore.shared.summaries[worktree.path.path] = nil }
+        let staleSnapshot = GGStackModelsTests.fixture.replacingOccurrences(
+            of: "agent-inbox",
+            with: "stale-stack"
+        )
+        let runner = ControlledStackGGRunner(
+            stackResults: [
+                ("stale-stack", ProcessResult(exitCode: 0, stdout: staleSnapshot, stderr: "")),
+                ("agent-inbox", ProcessResult(
+                    exitCode: 0,
+                    stdout: GGStackModelsTests.fixture,
+                    stderr: ""
+                )),
+            ],
+            suspendedCalls: [1]
+        )
+        let store = RightPaneStore()
+        let state = store.state(for: worktree, baseBranch: "main", comparisonMode: .manual)
+        state.stop()
+        installFakeGGStackLoader(on: state)
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in
+            .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/"))
+        }
+        state.seedGGContext(branch: "")
+
+        let initialRefresh = state.reevaluateGGGate()
+        await runner.waitUntilCall(1)
+        #expect(state.ggStackLoadState == .loading)
+
+        let replacementRefresh = store.refreshActiveGGPresentationForHeadUpdates(
+            projectId: worktree.projectId,
+            worktreePaths: [worktree.path]
+        )
+        await runner.complete(call: 1)
+        await initialRefresh.value
+        for _ in 0..<500 where await runner.lsCallCount < 2 {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        await replacementRefresh?.value
+
+        #expect(await runner.lsCallCount == 2)
+        #expect(state.ggContext == .active(stackName: "agent-inbox"))
+        #expect(state.ggStack?.name == "agent-inbox")
+        #expect(state.ggStackLoadState == .loaded)
+        #expect(state.ggStackDisplayCommits.map(\.shortSha) == ["ccccccc", "bbbbbbb", "aaaaaaa"])
+        #expect(state.ggStackCommitsKey != nil)
+    }
+
     @Test func cancelledSameKeyReloadRestoresPreviousStableStack() async throws {
         let worktree = makeWorktree()
         defer { GGStackSummaryStore.shared.summaries[worktree.path.path] = nil }

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -1163,9 +1163,10 @@ struct RightPaneGGStackTests {
         let worktree = makeWorktree()
         let state = store.state(for: worktree, baseBranch: "main", comparisonMode: .manual)
         store.deactivate()
-        state.ggService = GGService(runner: CountingFakeGGRunner(
+        let runner = CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
-        ))
+        )
+        state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/")) }
         state.ggStackCommitLoader = { _, entries in
             Dictionary(uniqueKeysWithValues: entries.map { sha in
@@ -1183,6 +1184,11 @@ struct RightPaneGGStackTests {
         ))
         #expect(snapshot.stack?.name == "agent-inbox")
         #expect(snapshot.loadState == .loaded)
+        #expect(state.ggStackDisplayCommits.map(\.shortSha) == ["ccccccc", "bbbbbbb", "aaaaaaa"])
+
+        await state.refreshGGStack()
+
+        #expect(runner.callCount == 1)
     }
 
     @Test func quiescentActiveStackDoesNotPublishAsDetachedRecovery() throws {
@@ -1252,6 +1258,22 @@ struct RightPaneGGStackTests {
 
         #expect(runner.callCount == 0)
         #expect(state.ggContext == .inactive(reason: .policyOff))
+        #expect(state.ggStackLoadState == .inactive)
+    }
+
+    @Test func missingBranchUsernameDetachedRefreshDoesNotQueryGG() async {
+        let runner = CountingFakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        let state = makeState()
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .inactive(reason: .branchUsernameMissing) }
+        state.seedGGContext(branch: "")
+
+        await state.refreshGGStack()
+
+        #expect(runner.callCount == 0)
+        #expect(state.ggContext == .inactive(reason: .branchUsernameMissing))
         #expect(state.ggStackLoadState == .inactive)
     }
 
@@ -1848,6 +1870,50 @@ struct RightPaneGGStackTests {
 
         #expect(state.ggContext == .active(stackName: "stack-b"))
         #expect(runner.callCount == 2)
+    }
+
+    @Test func headInvalidationPreventsInFlightRefreshFromRepublishingQuiescentStack() async {
+        let worktree = makeWorktree()
+        defer { GGStackSummaryStore.shared.summaries[worktree.path.path] = nil }
+        let runner = ControlledStackGGRunner(
+            stackResults: [
+                ("agent-inbox", ProcessResult(
+                    exitCode: 0,
+                    stdout: GGStackModelsTests.fixture,
+                    stderr: ""
+                )),
+            ],
+            suspendedCalls: [1]
+        )
+        let store = RightPaneStore()
+        let state = store.state(for: worktree, baseBranch: "main", comparisonMode: .manual)
+        state.stop()
+        installFakeGGStackLoader(on: state)
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in
+            .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/"))
+        }
+        state.seedGGContext(branch: "")
+
+        let inFlightRefresh = Task { @MainActor in
+            await state.refreshGGStack()
+        }
+        await runner.waitUntilCall(1)
+        #expect(state.ggStackLoadState == .loading)
+
+        store.deactivate()
+        store.refreshActiveGGPresentationForHeadUpdates(
+            projectId: worktree.projectId,
+            worktreePaths: [worktree.path]
+        )
+        await runner.complete(call: 1)
+        await inFlightRefresh.value
+
+        #expect(state.ggStack == nil)
+        #expect(state.ggStackDisplayCommits.isEmpty)
+        #expect(state.ggStackCommitsKey == nil)
+        #expect(state.ggStackLoadState != .loaded)
+        #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] == nil)
     }
 
     @Test func cancelledSameKeyReloadRestoresPreviousStableStack() async throws {


### PR DESCRIPTION
## Summary
- recover GG stack presentation after `gg mv` or `gg first` detaches HEAD
- invalidate stale detached stack state per affected worktree while preserving GG policy gates
- replace interrupted cold detached recovery for the active pane

## Testing
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination platform=macOS -quiet build`
- focused `RightPaneGGStackTests`, `GGWorktreeContextTests`, and `AppStateGGACPWorktreeContextTests`

The full local suite was also exercised; it has existing order-dependent ACP/DiffReview failures outside this GG change, so CI is the final integration gate.