### PR TITLE
perf(diff): cache pinned diff rows in appkit mode

### DIFF
--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
@@ -11,6 +11,7 @@ final class AppKitDiffScrollerReconciler {
 
     private var specsByID: [String: AppKitDiffRowSpec] = [:]
     private var orderedIDs: [String] = []
+    private var pinnedRowIDs: Set<String> = []
     private var measuredHeights: [String: CGFloat] = [:]
     private var contentWidth: CGFloat = 0
     private var contentInsets: AppKitDiffContentInsets = .zero
@@ -22,6 +23,8 @@ final class AppKitDiffScrollerReconciler {
     #if DEBUG
     private(set) var fullPlanApplyCountForTests = 0
     private(set) var layoutPassCountForTests = 0
+    private(set) var retentionInspectionCountForTests = 0
+    var pinnedRowIDsForTests: Set<String> { pinnedRowIDs }
     #endif
 
     init(
@@ -65,9 +68,16 @@ final class AppKitDiffScrollerReconciler {
         let previousSpecs = specsByID
         let previousMeasuredHeights = measuredHeights
         var nextSpecs: [String: AppKitDiffRowSpec] = [:]
+        var nextPinnedRowIDs: Set<String> = []
         var nextMeasuredHeights: [String: CGFloat] = [:]
         for spec in plan.rows {
+            #if DEBUG
+            retentionInspectionCountForTests += 1
+            #endif
             nextSpecs[spec.id] = spec
+            if spec.retention == .pinned {
+                nextPinnedRowIDs.insert(spec.id)
+            }
             if !widthChanged,
                previousSpecs[spec.id]?.equalityToken.isEqual(to: spec.equalityToken) == true,
                let height = previousMeasuredHeights[spec.id] {
@@ -97,6 +107,7 @@ final class AppKitDiffScrollerReconciler {
         let previousScrollY = scrollView.scrollY
         specsByID = nextSpecs
         orderedIDs = ids
+        pinnedRowIDs = nextPinnedRowIDs
         measuredHeights = nextMeasuredHeights
         contentWidth = rowContentWidth
         contentInsets = plan.contentInsets
@@ -244,8 +255,7 @@ final class AppKitDiffScrollerReconciler {
             let bandIDs = Set(band.compactMap { index in
                 orderedIDs.indices.contains(index) ? orderedIDs[index] : nil
             })
-            let pinnedIDs = Set(specsByID.values.lazy.filter { $0.retention == .pinned }.map(\.id))
-            let keep = bandIDs.union(pinnedIDs)
+            let keep = bandIDs.union(pinnedRowIDs)
             pool.releaseAll(except: keep)
 
             var geometryChanged = false

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerStressTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerStressTests.swift
@@ -43,6 +43,34 @@ struct AppKitDiffScrollerStressTests {
         #expect(applyCount == 2)
     }
 
+    @Test("viewport movement does not rescan plan-wide row retention")
+    func viewportMovementDoesNotRescanRowRetention() {
+        let stack = makeStack()
+        var rows = (0..<20_000).map { row(index: $0) }
+        rows[0] = accessibleRow(retention: .pinned)
+        stack.reconciler.apply(plan: AppKitDiffRowPlan(rows: rows), contentWidth: stack.scrollView.contentWidth)
+
+        let inspectionsAfterApply = stack.reconciler.retentionInspectionCountForTests
+        #expect(inspectionsAfterApply == 20_000)
+        #expect(stack.reconciler.pinnedRowIDsForTests == ["focus-row"])
+
+        for (generation, index) in [5_000, 10_000, 15_000, 19_999].enumerated() {
+            stack.reconciler.scroll(to: AppKitDiffScrollRequest(
+                targetID: "row-\(index)", fallbackID: nil, alignment: .top,
+                animated: false, generation: generation
+            ))
+        }
+
+        #expect(stack.reconciler.retentionInspectionCountForTests == inspectionsAfterApply)
+        #expect(stack.pool.mountedIDs.contains("focus-row"))
+
+        rows[0] = accessibleRow(retention: .recyclable)
+        stack.reconciler.apply(plan: AppKitDiffRowPlan(rows: rows), contentWidth: stack.scrollView.contentWidth)
+        #expect(stack.reconciler.retentionInspectionCountForTests == inspectionsAfterApply + 20_000)
+        #expect(stack.reconciler.pinnedRowIDsForTests.isEmpty)
+        #expect(!stack.pool.mountedIDs.contains("focus-row"))
+    }
+
     @Test("hosted accessibility survives recycling and focus retention can be released")
     func accessibilityAndFocusRetention() throws {
         let stack = makeStack()


### PR DESCRIPTION
## Summary

Cache pinned diff-row IDs when the render plan changes, so viewport updates do not rescan every row.

Adds a 20,000-row regression test that verifies scrolling does not repeat retention inspection.

## Validation

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet -only-testing:AlasTests/AppKitDiffScrollerStressTests test`\n\nThe full suite was attempted but hangs in existing ACP test lifecycle infrastructure; the ACP classes pass individually.