### PR TITLE
feat(worktrees): move attach issue to dialog header

### DIFF
--- a/Alas/Sources/Dialogs/DialogChrome.swift
+++ b/Alas/Sources/Dialogs/DialogChrome.swift
@@ -5,10 +5,11 @@ enum DialogContainerLayout {
     static let projectWidth: CGFloat = 640
 }
 
-struct DialogContainer<Content: View>: View {
+struct DialogContainer<Content: View, HeaderAccessory: View>: View {
     let title: String
     let subtitle: String?
     let width: CGFloat
+    @ViewBuilder let headerAccessory: () -> HeaderAccessory
     @ViewBuilder let content: () -> Content
     let cancelTitle: String
     let confirmTitle: String
@@ -23,6 +24,7 @@ struct DialogContainer<Content: View>: View {
         title: String,
         subtitle: String?,
         width: CGFloat = DialogContainerLayout.defaultWidth,
+        @ViewBuilder headerAccessory: @escaping () -> HeaderAccessory,
         @ViewBuilder content: @escaping () -> Content,
         cancelTitle: String,
         confirmTitle: String,
@@ -34,6 +36,7 @@ struct DialogContainer<Content: View>: View {
         self.title = title
         self.subtitle = subtitle
         self.width = width
+        self.headerAccessory = headerAccessory
         self.content = content
         self.cancelTitle = cancelTitle
         self.confirmTitle = confirmTitle
@@ -45,15 +48,18 @@ struct DialogContainer<Content: View>: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title).font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(theme.color("fg"))
-                if let subtitle {
-                    Text(subtitle).font(.system(size: 12))
-                        .foregroundColor(theme.color("fg-dim"))
+            HStack(alignment: .top, spacing: 10) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title).font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(theme.color("fg"))
+                    if let subtitle {
+                        Text(subtitle).font(.system(size: 12))
+                            .foregroundColor(theme.color("fg-dim"))
+                    }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                headerAccessory()
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 22).padding(.top, 18).padding(.bottom, 6)
 
             VStack(alignment: .leading, spacing: 14) { content() }
@@ -74,6 +80,65 @@ struct DialogContainer<Content: View>: View {
         .background(theme.color("bg-1"))
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .shadow(color: .black.opacity(0.6), radius: 80, y: 30)
+    }
+}
+
+extension DialogContainer where HeaderAccessory == EmptyView {
+    init(
+        title: String,
+        subtitle: String?,
+        width: CGFloat = DialogContainerLayout.defaultWidth,
+        @ViewBuilder content: @escaping () -> Content,
+        cancelTitle: String,
+        confirmTitle: String,
+        confirmStyle: AlasButtonStyle,
+        onCancel: @escaping () -> Void,
+        onConfirm: @escaping () -> Void,
+        confirmEnabled: Bool
+    ) {
+        self.init(
+            title: title,
+            subtitle: subtitle,
+            width: width,
+            headerAccessory: { EmptyView() },
+            content: content,
+            cancelTitle: cancelTitle,
+            confirmTitle: confirmTitle,
+            confirmStyle: confirmStyle,
+            onCancel: onCancel,
+            onConfirm: onConfirm,
+            confirmEnabled: confirmEnabled
+        )
+    }
+}
+
+/// Icon-only affordance rendered in a dialog header's top-right corner.
+struct DialogHeaderIconButton: View {
+    let icon: String
+    let tooltip: String
+    let action: () -> Void
+    @Environment(\.theme) private var theme
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Icon(name: icon, size: 13, color: hovering ? theme.color("fg") : theme.color("fg-muted"))
+                .frame(width: 26, height: 26)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(hovering ? theme.color("bg-3") : Color.clear)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(hovering ? theme.color("line") : Color.clear, lineWidth: 0.5)
+                )
+                .contentShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        // Pull the 26pt hit target up so the glyph optically centers on the title line.
+        .padding(.top, -4)
+        .onHover { hovering = $0 }
+        .help(tooltip)
     }
 }
 

--- a/Alas/Sources/Dialogs/DialogChrome.swift
+++ b/Alas/Sources/Dialogs/DialogChrome.swift
@@ -139,6 +139,7 @@ struct DialogHeaderIconButton: View {
         .padding(.top, -4)
         .onHover { hovering = $0 }
         .help(tooltip)
+        .accessibilityLabel(tooltip)
     }
 }
 

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -67,6 +67,13 @@ struct NewWorktreeDialog: View {
         DialogContainer(
             title: "New worktree",
             subtitle: subtitleText,
+            headerAccessory: {
+                if issueState.draft == nil {
+                    DialogHeaderIconButton(icon: "paperclip", tooltip: "Attach issue…") {
+                        issueSheetPresentation = AttachIssuePresentation(draft: nil)
+                    }
+                }
+            },
             content: {
                 if state.projects.isEmpty {
                     DialogField(label: "Repository") {
@@ -770,43 +777,35 @@ struct NewWorktreeDialog: View {
         }
     }
 
+    @ViewBuilder
     private var issueAttachmentSection: some View {
-        Group {
-            if let draft = issueState.draft {
-                HStack(spacing: 8) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Issue")
-                            .font(.system(size: 11.5, weight: .medium))
-                            .foregroundColor(theme.color("fg-muted"))
-                        Text(draft.attachment.displayTitle)
-                            .font(.system(size: 12))
-                            .foregroundColor(theme.color("fg"))
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                    }
-                    Spacer(minLength: 8)
-                    AlasButton(title: "Edit", style: .subtle) {
-                        issueSheetPresentation = AttachIssuePresentation(draft: draft)
-                    }
-                    AlasButton(title: "Remove", style: .subtle, action: removeIssue)
-                    AlasButton(title: "Open", style: .subtle) {
-                        NSWorkspace.shared.open(draft.attachment.canonicalURL)
-                    }
+        if let draft = issueState.draft {
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Issue")
+                        .font(.system(size: 11.5, weight: .medium))
+                        .foregroundColor(theme.color("fg-muted"))
+                    Text(draft.attachment.displayTitle)
+                        .font(.system(size: 12))
+                        .foregroundColor(theme.color("fg"))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
                 }
-                .padding(8)
-                .background(theme.color("bg-0"))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .strokeBorder(theme.color("line"), lineWidth: 0.5)
-                )
-            } else {
-                HStack {
-                    AlasButton(title: "Attach issue...", style: .subtle) {
-                        issueSheetPresentation = AttachIssuePresentation(draft: nil)
-                    }
-                    Spacer(minLength: 0)
+                Spacer(minLength: 8)
+                AlasButton(title: "Edit", style: .subtle) {
+                    issueSheetPresentation = AttachIssuePresentation(draft: draft)
+                }
+                AlasButton(title: "Remove", style: .subtle, action: removeIssue)
+                AlasButton(title: "Open", style: .subtle) {
+                    NSWorkspace.shared.open(draft.attachment.canonicalURL)
                 }
             }
+            .padding(8)
+            .background(theme.color("bg-0"))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(theme.color("line"), lineWidth: 0.5)
+            )
         }
     }
 


### PR DESCRIPTION
## What

The `Attach issue...` button in the New worktree dialog sat between the Stacked Diffs Mode description and the "Open after create" field, where it read as part of neither section and was easy to miss.

It's now an icon-only paperclip button in the dialog header's top-right corner, with a tooltip and hover feedback.

## How

- `DialogContainer` gains an optional `headerAccessory` view builder, rendered top-right opposite the title/subtitle. Existing call sites are untouched via a `where HeaderAccessory == EmptyView` convenience init.
- New `DialogHeaderIconButton`: 26×26 icon-only button, glyph goes `fg-muted` → `fg` on hover with a `bg-3` fill and `line` border appearing, `.help()` tooltip, full-rect hit target.
- `NewWorktreeDialog` renders the button only while no issue is attached. Once an issue is attached, the existing issue card in the body keeps the Edit / Remove / Open actions.

## Testing

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -configuration Debug build` — succeeds.
- No test references the changed views beyond `DialogContainerLayout` constants, which are unchanged.