### PR TITLE
fix(commit): keep draft editor focused while typing

### DIFF
--- a/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
+++ b/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
@@ -17,7 +17,7 @@ struct CommitMessageEditorView: View {
     var accessory: AnyView? = nil
 
     @Environment(\.theme) private var theme
-    @FocusState private var focused: Field?
+    @State private var focused: Field?
     private enum Field: Hashable { case subject, body }
 
     private var canRunPrimary: Bool {

--- a/AlasTests/CommitMessageEditorViewTests.swift
+++ b/AlasTests/CommitMessageEditorViewTests.swift
@@ -106,6 +106,29 @@ struct CommitMessageEditorViewTests {
         window.orderOut(nil)
     }
 
+    @Test func subjectKeepsFocusAcrossRepeatedTextUpdates() async throws {
+        let model = CommitComposerModel(subject: "", body: "")
+        let controller = NSHostingController(rootView: CommitComposerHarness(model: model, theme: currentTheme()))
+        let window = attach(controller)
+        await drain(controller.view)
+
+        let subject = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
+        #expect(window.makeFirstResponder(subject))
+        let editor = try #require(subject.currentEditor() as? PairedDelimiterTextView)
+
+        for character in ["a", "b", "c"] {
+            editor.performKeyboardTextInsertion {
+                editor.insertText(character, replacementRange: NSRange(location: NSNotFound, length: 0))
+            }
+            try await Task.sleep(for: .milliseconds(50))
+            await drain(controller.view)
+            #expect(window.firstResponder === editor)
+        }
+        #expect(model.subject == "abc")
+
+        window.orderOut(nil)
+    }
+
     private func attach<Content: View>(_ controller: NSHostingController<Content>) -> NSWindow {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 480, height: 240),


### PR DESCRIPTION
## Summary

- keep the draft commit subject and description focused while their text bindings update
- cover repeated subject keystrokes with a regression test

## Root cause

The AppKit-backed composer controls were bridged through a manually managed `@FocusState`. Text updates caused that focus state to be reconciled as SwiftUI focus, which could resign the native field editor after one or two keystrokes. Ordinary `@State` keeps the visual focus selection stable while AppKit remains the source of truth for first-responder ownership.

## Validation

- manually verified in a freshly built Alas instance
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- focused repeated-keystroke regression test

The full test suite was also attempted, but Xcode's test runner stalled while finalizing the test session and was interrupted after 699 seconds without reporting a test failure.
