### PR TITLE
fix(gg): stack query timeout

### DIFF
--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -63,24 +63,17 @@ struct ProcessGGCommandRunner: GGCommandRunning {
     }
 
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
-        let timeout = Self.isStackQuery(args) ? Process.defaultTimeout : Self.commandTimeout
         return try await processLaunch(
             "/usr/bin/env",
             ["gg"] + args,
             cwd,
             Process.gitEnv(),
-            timeout
+            Self.commandTimeout
         )
     }
 
     func runStreaming(args: [String], cwd: URL?) -> AsyncThrowingStream<String, Error> {
         Self.streamProcess(executable: "/usr/bin/env", args: ["gg"] + args, cwd: cwd, env: Process.gitEnv(), timeout: Self.commandTimeout)
-    }
-
-    private static func isStackQuery(_ args: [String]) -> Bool {
-        let commandIndex = args.first == "--client-operation-id" ? 2 : 0
-        guard args.indices.contains(commandIndex), args[commandIndex] == "ls" else { return false }
-        return args[args.index(after: commandIndex)...].contains("--json")
     }
 
     /// Pipe-lifecycle core of `runStreaming`, parameterized on the

--- a/AlasTests/Integrations/GGServiceTests.swift
+++ b/AlasTests/Integrations/GGServiceTests.swift
@@ -27,11 +27,11 @@ private struct FakeGGRunner: GGCommandRunning {
 }
 
 struct GGServiceTests {
-    @Test func processRunnerUsesShortTimeoutOnlyForStackQueries() async throws {
+    @Test func processRunnerUsesGGTimeoutForEveryCommand() async throws {
         let cases: [([String], TimeInterval)] = [
-            (["ls", "--json"], Process.defaultTimeout),
-            (["--client-operation-id", "alas:1", "ls", "--json"], Process.defaultTimeout),
-            (["ls", "--json", "--client-operation-id", "alas:1"], Process.defaultTimeout),
+            (["ls", "--json"], 600),
+            (["--client-operation-id", "alas:1", "ls", "--json"], 600),
+            (["ls", "--json", "--client-operation-id", "alas:1"], 600),
             (["sync", "--json"], 600),
             (["sync", "--help"], 600),
             (["ls"], 600),

--- a/docs/superpowers/specs/2026-08-13-gg-stack-query-timeout-design.md
+++ b/docs/superpowers/specs/2026-08-13-gg-stack-query-timeout-design.md
@@ -1,0 +1,21 @@
+# GG Stack Query Timeout
+
+## Goal
+
+Allow `gg ls --json` to finish in repositories where forge metadata lookup takes longer than Git's 30-second read timeout, so detached stack navigation can publish the complete stack.
+
+## Design
+
+`ProcessGGCommandRunner` will use its existing 600-second GG command timeout for stack queries instead of `Process.defaultTimeout`. No new setting, retry policy, cache behavior, or presentation state will be introduced.
+
+The existing timeout-routing test will assert that `gg ls --json`, including the client-operation-ID form, receives 600 seconds. Other GG commands continue using the same 600-second timeout they use today.
+
+## Failure Behavior
+
+Commands that exceed 600 seconds continue through the existing timeout error and stack fallback path. Cancellation behavior is unchanged.
+
+## Out of Scope
+
+- Making `gg ls --json` local-only or reducing its forge API work.
+- Retaining stale stack rows after a failed refresh.
+- Adding configurable timeouts, retries, or new UI.


### PR DESCRIPTION
## What changed

Use the GG runner's existing 600-second command timeout for `gg ls --json`, rather than the generic 30-second process timeout.

## Why

On larger stacks, `gg ls --json` can take longer than 30 seconds. The timeout cleared the GG stack state and made Alas fall back to the ordinary commit list, hiding stack commits above the checked-out position.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet test -only-testing:AlasTests/GGServiceTests`

The complete local suite was interrupted after two unrelated, reproducible `AppStateCLIRoutingTests` failures (`cliWorktreeNewUsesDialogPreferredBaseWhenBaseIsOmitted` and `cliWorktreeDeleteMarksMatchedWorktreeDeleting`).