### PR TITLE
fix(gg): load stacks before PR status

### DIFF
--- a/Alas/Sources/Integrations/GG/GGMutationModels.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationModels.swift
@@ -13,6 +13,7 @@ struct GGCapabilities: Equatable, Sendable {
     var clientOperationID: Bool = false
     var stagedOnlyAmend: Bool = false
     var syncJSONL: Bool = false
+    var localStackSnapshot: Bool = false
 }
 
 struct GGLocalChangeStatistics: Equatable, Sendable {

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -318,6 +318,7 @@ struct GGService {
         let unstack = try? await runner.run(args: ["unstack", "--help"], cwd: nil)
         let sc = try? await runner.run(args: ["sc", "--help"], cwd: nil)
         let sync = try? await runner.run(args: ["sync", "--help"], cwd: nil)
+        let ls = try? await runner.run(args: ["ls", "--help"], cwd: nil)
         return GGCapabilities(
             structuredSplit: split?.exitCode == 0
                 && split?.stdout.contains("--describe") == true
@@ -328,21 +329,31 @@ struct GGService {
                 && root?.stdout.contains("--client-operation-id") == true,
             stagedOnlyAmend: sc?.exitCode == 0
                 && sc?.stdout.contains("--staged-only") == true,
-            syncJSONL: sync?.exitCode == 0 && sync?.stdout.contains("--jsonl") == true
+            syncJSONL: sync?.exitCode == 0 && sync?.stdout.contains("--jsonl") == true,
+            localStackSnapshot: ls?.exitCode == 0
+                && ls?.stdout.contains("--no-refresh") == true
         )
     }
 
     /// Loads the current branch's stack via `gg ls --json`. Returns nil
     /// when the branch is not a gg stack (gg emits the all-stacks shape).
-    func currentStack(worktreePath: String) async throws -> GGStack? {
-        try await currentStackSnapshot(worktreePath: worktreePath).stack
+    func currentStack(worktreePath: String, refreshRemote: Bool = true) async throws -> GGStack? {
+        try await currentStackSnapshot(
+            worktreePath: worktreePath,
+            refreshRemote: refreshRemote
+        ).stack
     }
 
-    func currentStackSnapshot(worktreePath: String) async throws -> GGStackSnapshot {
+    func currentStackSnapshot(
+        worktreePath: String,
+        refreshRemote: Bool = true
+    ) async throws -> GGStackSnapshot {
         let result: ProcessResult
         do {
             result = try await runner.run(
-                args: ["ls", "--json"],
+                args: refreshRemote
+                    ? ["ls", "--json"]
+                    : ["ls", "--json", "--no-refresh"],
                 cwd: URL(fileURLWithPath: worktreePath)
             )
         } catch let error as GGServiceError {

--- a/Alas/Sources/Integrations/GG/GGStackDrawer.swift
+++ b/Alas/Sources/Integrations/GG/GGStackDrawer.swift
@@ -122,7 +122,7 @@ struct GGStackDrawer: View {
         expandableCollapsedRow(
             title: model.title,
             summaryChip: model.summaryChip,
-            isPaused: model.isPaused,
+            isPaused: model.isPaused || rps.ggStackRemoteError != nil,
             showsLoading: false
         )
     }
@@ -266,6 +266,16 @@ struct GGStackDrawer: View {
     @ViewBuilder
     private func expandedBody(_ model: GGStackReadinessModel) -> some View {
         VStack(alignment: .leading, spacing: 8) {
+            if let error = rps.ggStackRemoteError {
+                Text("PR status unavailable: \(error)")
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.color("warn"))
+                    .fixedSize(horizontal: false, vertical: true)
+                Button("Retry PR status", action: refresh)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(isRefreshing)
+            }
             if model.isPaused {
                 if let progress = model.syncProgress { syncProgressView(progress) }
                 Text("A gg operation is paused on conflicts. Resolve them in the Conflicts section, then Continue — or Abort to roll back.")

--- a/Alas/Sources/Integrations/GG/GGStackModels.swift
+++ b/Alas/Sources/Integrations/GG/GGStackModels.swift
@@ -124,6 +124,36 @@ struct GGStack: Decodable, Equatable {
         entries.first { sha.hasPrefix($0.sha) || $0.sha.hasPrefix(sha) }
     }
 
+    func mergingRemoteMetadata(from remote: GGStack?) -> GGStack {
+        guard let remote, name == remote.name else { return self }
+        return GGStack(
+            name: name,
+            base: base,
+            totalCommits: totalCommits,
+            syncedCommits: syncedCommits,
+            currentPosition: currentPosition,
+            behindBase: behindBase,
+            entries: entries.map { entry in
+                guard let match = remote.entries.first(where: {
+                    entry.ggId != nil ? $0.ggId == entry.ggId : $0.prNumber == entry.prNumber
+                }), entry.ggId != nil || entry.prNumber != nil
+                else { return entry }
+                return GGStackEntry(
+                    position: entry.position,
+                    sha: entry.sha,
+                    title: entry.title,
+                    ggId: entry.ggId,
+                    ggParent: entry.ggParent,
+                    prNumber: entry.prNumber,
+                    prState: match.prState,
+                    approved: match.approved,
+                    ciStatus: match.ciStatus,
+                    isCurrent: entry.isCurrent
+                )
+            }
+        )
+    }
+
     func projectCommits(_ infosBySHA: [String: CommitInfo]) throws -> [CommitInfo] {
         guard hasValidEntryShape,
               infosBySHA.allSatisfy({ !$0.key.isEmpty && $0.key == $0.value.sha })

--- a/Alas/Sources/Integrations/GG/GGStackModels.swift
+++ b/Alas/Sources/Integrations/GG/GGStackModels.swift
@@ -135,8 +135,10 @@ struct GGStack: Decodable, Equatable {
             behindBase: behindBase,
             entries: entries.map { entry in
                 guard let match = remote.entries.first(where: {
-                    entry.ggId != nil ? $0.ggId == entry.ggId : $0.prNumber == entry.prNumber
-                }), entry.ggId != nil || entry.prNumber != nil
+                    if let ggId = entry.ggId { return $0.ggId == ggId }
+                    if let prNumber = entry.prNumber { return $0.prNumber == prNumber }
+                    return entry.sha.hasPrefix($0.sha) || $0.sha.hasPrefix(entry.sha)
+                })
                 else { return entry }
                 return GGStackEntry(
                     position: entry.position,
@@ -144,7 +146,7 @@ struct GGStack: Decodable, Equatable {
                     title: entry.title,
                     ggId: entry.ggId,
                     ggParent: entry.ggParent,
-                    prNumber: entry.prNumber,
+                    prNumber: entry.prNumber ?? match.prNumber,
                     prState: match.prState,
                     approved: match.approved,
                     ciStatus: match.ciStatus,

--- a/Alas/Sources/Integrations/GG/GGStackModels.swift
+++ b/Alas/Sources/Integrations/GG/GGStackModels.swift
@@ -135,7 +135,9 @@ struct GGStack: Decodable, Equatable {
             behindBase: behindBase,
             entries: entries.map { entry in
                 guard let match = remote.entries.first(where: {
-                    if let ggId = entry.ggId { return $0.ggId == ggId }
+                    if let ggId = entry.ggId {
+                        return $0.ggId == ggId && (entry.prNumber == nil || $0.prNumber == nil || entry.prNumber == $0.prNumber)
+                    }
                     if let prNumber = entry.prNumber { return $0.prNumber == prNumber }
                     return entry.sha.hasPrefix($0.sha) || $0.sha.hasPrefix(entry.sha)
                 })

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -138,6 +138,7 @@ final class RightPaneState: GGSplitCommitServicing {
     var ggContext: GGWorktreeContext = .inactive(reason: .policyOff)
     var ggStackLoadState: GGStackLoadState = .inactive
     var ggStackRemoteError: String? = nil
+    var ggStackRemoteEnrichmentPending = false
     @ObservationIgnored
     var ggCapabilities: @MainActor () -> GGCapabilities = {
         GGAvailability.shared.capabilities
@@ -985,6 +986,7 @@ final class RightPaneState: GGSplitCommitServicing {
             ggStackCommitsKey = nil
             ggStackLoadState = .inactive
             ggStackRemoteError = nil
+            ggStackRemoteEnrichmentPending = false
             if ggStack != nil { ggStack = nil }
             if !ggStackDisplayCommits.isEmpty { ggStackDisplayCommits = [] }
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
@@ -1005,6 +1007,12 @@ final class RightPaneState: GGSplitCommitServicing {
         // to share the same commits (e.g. right after `git checkout -b`)
         // must not reuse the old branch's cached stack.
         let key = currentGGStackCommitsKey
+        if !forceRemote, key == ggStackCommitsKey, ggStackRemoteEnrichmentPending {
+            await enrichGGStackRemote(
+                snapshotGeneration: snapshotGeneration,
+                refreshGeneration: refreshGeneration
+            )
+        }
         guard forceRemote || key != ggStackCommitsKey else {
             await reconcileGGUndoCandidateIfNeeded()
             return
@@ -1043,6 +1051,7 @@ final class RightPaneState: GGSplitCommitServicing {
         invalidateOlderHistoryForDisplaySourceChange()
         ggStackLoadState = .loading
         ggStackRemoteError = nil
+        ggStackRemoteEnrichmentPending = false
         ggStackCommitsKey = nil
         if ggStack != nil { ggStack = nil }
         if !ggStackDisplayCommits.isEmpty { ggStackDisplayCommits = [] }
@@ -1100,27 +1109,10 @@ final class RightPaneState: GGSplitCommitServicing {
             await reconcileGGUndoCandidateIfNeeded()
             guard usesLocalSnapshot else { return }
 
-            do {
-                let remote = try await ggService.currentStack(worktreePath: worktree.path.path)
-                if Task.isCancelled { return }
-                guard snapshotGeneration == snapshotInvalidationGeneration,
-                      refreshGeneration == ggStackRefreshGeneration,
-                      ggStackCommitsKey == currentGGStackCommitsKey
-                else { return }
-                if let enriched = ggStack?.mergingRemoteMetadata(from: remote), ggStack != enriched {
-                    ggStack = enriched
-                    GGStackSummaryStore.shared.summaries[worktree.path.path] = enriched.summary
-                }
-                ggStackRemoteError = nil
-            } catch {
-                if Task.isCancelled { return }
-                guard snapshotGeneration == snapshotInvalidationGeneration,
-                      refreshGeneration == ggStackRefreshGeneration,
-                      ggStackCommitsKey == currentGGStackCommitsKey
-                else { return }
-                ggStackRemoteError = (error as? GGServiceError)?.userMessage
-                    ?? error.localizedDescription
-            }
+            await enrichGGStackRemote(
+                snapshotGeneration: snapshotGeneration,
+                refreshGeneration: refreshGeneration
+            )
         } catch {
             // A transient gg/provider failure (gh/glab auth hiccup, network
             // blip, etc.) must not cache the *failed* key `key` — it stays
@@ -1159,6 +1151,33 @@ final class RightPaneState: GGSplitCommitServicing {
             // does not offer an Undo scoped to the previous stack; it is
             // rebuilt once a later reconcile validates against the new stack.
             ggMutationCoordinator.suspendUndoCandidate()
+        }
+    }
+
+    private func enrichGGStackRemote(snapshotGeneration: Int, refreshGeneration: UInt) async {
+        ggStackRemoteEnrichmentPending = true
+        do {
+            let remote = try await ggService.currentStack(worktreePath: worktree.path.path)
+            if Task.isCancelled { return }
+            guard snapshotGeneration == snapshotInvalidationGeneration,
+                  refreshGeneration == ggStackRefreshGeneration,
+                  ggStackCommitsKey == currentGGStackCommitsKey
+            else { return }
+            if let enriched = ggStack?.mergingRemoteMetadata(from: remote), ggStack != enriched {
+                ggStack = enriched
+                GGStackSummaryStore.shared.summaries[worktree.path.path] = enriched.summary
+            }
+            ggStackRemoteError = nil
+            ggStackRemoteEnrichmentPending = false
+        } catch {
+            if Task.isCancelled { return }
+            guard snapshotGeneration == snapshotInvalidationGeneration,
+                  refreshGeneration == ggStackRefreshGeneration,
+                  ggStackCommitsKey == currentGGStackCommitsKey
+            else { return }
+            ggStackRemoteError = (error as? GGServiceError)?.userMessage
+                ?? error.localizedDescription
+            ggStackRemoteEnrichmentPending = false
         }
     }
 

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -137,6 +137,11 @@ final class RightPaneState: GGSplitCommitServicing {
     var ggEffectiveConfig: GGEffectiveConfig = .defaults
     var ggContext: GGWorktreeContext = .inactive(reason: .policyOff)
     var ggStackLoadState: GGStackLoadState = .inactive
+    var ggStackRemoteError: String? = nil
+    @ObservationIgnored
+    var ggCapabilities: @MainActor () -> GGCapabilities = {
+        GGAvailability.shared.capabilities
+    }
     /// Injected by RightPaneStore to resolve the current live branch against
     /// app-, project-, and worktree-level GG policy.
     var ggContextProvider: (@MainActor (_ branch: String) -> GGWorktreeContext)? = nil
@@ -979,6 +984,7 @@ final class RightPaneState: GGSplitCommitServicing {
             }
             ggStackCommitsKey = nil
             ggStackLoadState = .inactive
+            ggStackRemoteError = nil
             if ggStack != nil { ggStack = nil }
             if !ggStackDisplayCommits.isEmpty { ggStackDisplayCommits = [] }
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
@@ -1036,6 +1042,7 @@ final class RightPaneState: GGSplitCommitServicing {
         }
         invalidateOlderHistoryForDisplaySourceChange()
         ggStackLoadState = .loading
+        ggStackRemoteError = nil
         ggStackCommitsKey = nil
         if ggStack != nil { ggStack = nil }
         if !ggStackDisplayCommits.isEmpty { ggStackDisplayCommits = [] }
@@ -1044,7 +1051,14 @@ final class RightPaneState: GGSplitCommitServicing {
         }
         ggMutationCoordinator.suspendUndoCandidate()
         do {
-            let stack = try await ggService.currentStack(worktreePath: worktree.path.path)
+            let usesLocalSnapshot = ggCapabilities().localStackSnapshot
+            var stack = try await ggService.currentStack(
+                worktreePath: worktree.path.path,
+                refreshRemote: !usesLocalSnapshot
+            )
+            if usesLocalSnapshot {
+                stack = stack?.mergingRemoteMetadata(from: previousStack)
+            }
             let displayCommits: [CommitInfo]
             if let stack {
                 let infos = stack.entries.isEmpty
@@ -1084,6 +1098,29 @@ final class RightPaneState: GGSplitCommitServicing {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = summary
             }
             await reconcileGGUndoCandidateIfNeeded()
+            guard usesLocalSnapshot else { return }
+
+            do {
+                let remote = try await ggService.currentStack(worktreePath: worktree.path.path)
+                if Task.isCancelled { return }
+                guard snapshotGeneration == snapshotInvalidationGeneration,
+                      refreshGeneration == ggStackRefreshGeneration,
+                      ggStackCommitsKey == currentGGStackCommitsKey
+                else { return }
+                if let enriched = ggStack?.mergingRemoteMetadata(from: remote), ggStack != enriched {
+                    ggStack = enriched
+                    GGStackSummaryStore.shared.summaries[worktree.path.path] = enriched.summary
+                }
+                ggStackRemoteError = nil
+            } catch {
+                if Task.isCancelled { return }
+                guard snapshotGeneration == snapshotInvalidationGeneration,
+                      refreshGeneration == ggStackRefreshGeneration,
+                      ggStackCommitsKey == currentGGStackCommitsKey
+                else { return }
+                ggStackRemoteError = (error as? GGServiceError)?.userMessage
+                    ?? error.localizedDescription
+            }
         } catch {
             // A transient gg/provider failure (gh/glab auth hiccup, network
             // blip, etc.) must not cache the *failed* key `key` — it stays
@@ -1115,6 +1152,7 @@ final class RightPaneState: GGSplitCommitServicing {
             ggStackLoadState = .failed(
                 (error as? GGServiceError)?.userMessage ?? error.localizedDescription
             )
+            ggStackRemoteError = nil
             // The cached stack we just dropped belonged to a different key, so
             // the current stack identity is unknown until a refresh succeeds.
             // Hide any recovery candidate (keeping its marker) so the drawer
@@ -1157,6 +1195,7 @@ final class RightPaneState: GGSplitCommitServicing {
         if ggStack != nil { ggStack = nil }
         if !ggStackDisplayCommits.isEmpty { ggStackDisplayCommits = [] }
         ggStackLoadState = ggContext.isActive ? .loading : .inactive
+        ggStackRemoteError = nil
         if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
             GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
         }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -139,6 +139,7 @@ final class RightPaneState: GGSplitCommitServicing {
     var ggStackLoadState: GGStackLoadState = .inactive
     var ggStackRemoteError: String? = nil
     var ggStackRemoteEnrichmentPending = false
+    private var ggStackRemoteMetadataCache: GGStack?
     @ObservationIgnored
     var ggCapabilities: @MainActor () -> GGCapabilities = {
         GGAvailability.shared.capabilities
@@ -987,6 +988,7 @@ final class RightPaneState: GGSplitCommitServicing {
             ggStackLoadState = .inactive
             ggStackRemoteError = nil
             ggStackRemoteEnrichmentPending = false
+            ggStackRemoteMetadataCache = nil
             if ggStack != nil { ggStack = nil }
             if !ggStackDisplayCommits.isEmpty { ggStackDisplayCommits = [] }
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
@@ -1066,7 +1068,7 @@ final class RightPaneState: GGSplitCommitServicing {
                 refreshRemote: !usesLocalSnapshot
             )
             if usesLocalSnapshot {
-                stack = stack?.mergingRemoteMetadata(from: previousStack)
+                stack = stack?.mergingRemoteMetadata(from: previousStack ?? ggStackRemoteMetadataCache)
             }
             let displayCommits: [CommitInfo]
             if let stack {
@@ -1106,6 +1108,7 @@ final class RightPaneState: GGSplitCommitServicing {
             if GGStackSummaryStore.shared.summaries[worktree.path.path] != summary {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = summary
             }
+            ggStackRemoteMetadataCache = nil
             await reconcileGGUndoCandidateIfNeeded()
             guard usesLocalSnapshot else { return }
 
@@ -1215,6 +1218,7 @@ final class RightPaneState: GGSplitCommitServicing {
         if !ggStackDisplayCommits.isEmpty { ggStackDisplayCommits = [] }
         ggStackLoadState = ggContext.isActive ? .loading : .inactive
         ggStackRemoteError = nil
+        ggStackRemoteMetadataCache = nil
         if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
             GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
         }
@@ -1236,7 +1240,9 @@ final class RightPaneState: GGSplitCommitServicing {
     @MainActor
     @discardableResult
     func reevaluateGGGate() -> Task<Void, Never> {
+        let remoteMetadata = ggStack
         invalidateGGPresentation(startingRefresh: false)
+        ggStackRemoteMetadataCache = remoteMetadata
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
             await self.refreshGGStack()

--- a/AlasTests/Integrations/GGAvailabilityTests.swift
+++ b/AlasTests/Integrations/GGAvailabilityTests.swift
@@ -20,6 +20,7 @@ private struct HelpGGRunner: GGCommandRunning {
     let unstack: String?
     let sc: String?
     let sync: String?
+    let ls: String?
 
     init(
         version: String? = "1.0.0",
@@ -27,7 +28,8 @@ private struct HelpGGRunner: GGCommandRunning {
         split: String?,
         unstack: String?,
         sc: String? = nil,
-        sync: String? = nil
+        sync: String? = nil,
+        ls: String? = nil
     ) {
         self.version = version
         self.root = root
@@ -35,6 +37,7 @@ private struct HelpGGRunner: GGCommandRunning {
         self.unstack = unstack
         self.sc = sc
         self.sync = sync
+        self.ls = ls
     }
 
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
@@ -57,6 +60,9 @@ private struct HelpGGRunner: GGCommandRunning {
         case ["sync", "--help"]:
             guard let sync else { break }
             return ProcessResult(exitCode: 0, stdout: sync, stderr: "")
+        case ["ls", "--help"]:
+            guard let ls else { break }
+            return ProcessResult(exitCode: 0, stdout: ls, stderr: "")
         default:
             break
         }
@@ -138,6 +144,16 @@ struct GGAvailabilityTests {
             split: "", unstack: "", sync: "--json"
         ))
         #expect(!(await old.probeCapabilities()).syncJSONL)
+    }
+
+    @Test func localStackSnapshotCapabilityUsesListHelpAndDefaultsOff() async {
+        let current = GGService(runner: HelpGGRunner(
+            split: "", unstack: "", ls: "--json --no-refresh"
+        ))
+        #expect((await current.probeCapabilities()).localStackSnapshot)
+
+        let old = GGService(runner: HelpGGRunner(split: "", unstack: "", ls: "--json"))
+        #expect(!(await old.probeCapabilities()).localStackSnapshot)
     }
 
     @Test func probePopulatesVersionAndMCPPath() async {

--- a/AlasTests/Integrations/GGServiceTests.swift
+++ b/AlasTests/Integrations/GGServiceTests.swift
@@ -86,6 +86,17 @@ struct GGServiceTests {
         #expect(runner.lastCwd == URL(fileURLWithPath: "/tmp/wt"))
     }
 
+    @Test func currentStackCanSkipRemoteRefresh() async throws {
+        let runner = FakeGGRunner(
+            result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        )
+        let service = GGService(runner: runner)
+
+        _ = try await service.currentStack(worktreePath: "/tmp/wt", refreshRemote: false)
+
+        #expect(runner.lastArgs == ["ls", "--json", "--no-refresh"])
+    }
+
     @Test func currentStackReturnsNilOffStack() async throws {
         let runner = FakeGGRunner(
             result: ProcessResult(

--- a/AlasTests/Integrations/GGStackModelsTests.swift
+++ b/AlasTests/Integrations/GGStackModelsTests.swift
@@ -106,6 +106,25 @@ struct GGStackModelsTests {
         #expect(merged.entries[1].ciStatus == .running)
     }
 
+    @Test func localStackMatchesLegacyRemoteMetadataBySHA() {
+        let local = GGStack(
+            name: "stack", base: "main", totalCommits: 1, syncedCommits: 1,
+            currentPosition: 1, behindBase: nil,
+            entries: [GGStackEntry(position: 1, sha: "abcdef0", title: "one", isCurrent: true)]
+        )
+        let remote = GGStack(
+            name: "stack", base: "main", totalCommits: 1, syncedCommits: 1,
+            currentPosition: 1, behindBase: nil,
+            entries: [GGStackEntry(position: 1, sha: "abcdef012345", title: "one", prNumber: 42, prState: .open, ciStatus: .success, isCurrent: true)]
+        )
+
+        let merged = local.mergingRemoteMetadata(from: remote)
+
+        #expect(merged.entries[0].prNumber == 42)
+        #expect(merged.entries[0].prState == .open)
+        #expect(merged.entries[0].ciStatus == .success)
+    }
+
     @Test func entryMatchesFullCommitSHAByPrefix() throws {
         let snapshot = try GGStackSnapshot.decode(fromJSON: Data(Self.fixture.utf8))
         let stack = try #require(snapshot.stack)

--- a/AlasTests/Integrations/GGStackModelsTests.swift
+++ b/AlasTests/Integrations/GGStackModelsTests.swift
@@ -125,6 +125,26 @@ struct GGStackModelsTests {
         #expect(merged.entries[0].ciStatus == .success)
     }
 
+    @Test func localStackDoesNotReuseMetadataWhenPRNumberChanges() {
+        let local = GGStack(
+            name: "stack", base: "main", totalCommits: 1, syncedCommits: 1,
+            currentPosition: 1, behindBase: nil,
+            entries: [GGStackEntry(position: 1, sha: "newaaaa", title: "one", ggId: "id-1", prNumber: 11, isCurrent: true)]
+        )
+        let remote = GGStack(
+            name: "stack", base: "main", totalCommits: 1, syncedCommits: 1,
+            currentPosition: 1, behindBase: nil,
+            entries: [GGStackEntry(position: 1, sha: "oldaaaa", title: "one", ggId: "id-1", prNumber: 10, prState: .merged, approved: true, ciStatus: .success, isCurrent: true)]
+        )
+
+        let merged = local.mergingRemoteMetadata(from: remote)
+
+        #expect(merged.entries[0].prNumber == 11)
+        #expect(merged.entries[0].prState == nil)
+        #expect(!merged.entries[0].approved)
+        #expect(merged.entries[0].ciStatus == nil)
+    }
+
     @Test func entryMatchesFullCommitSHAByPrefix() throws {
         let snapshot = try GGStackSnapshot.decode(fromJSON: Data(Self.fixture.utf8))
         let stack = try #require(snapshot.stack)

--- a/AlasTests/Integrations/GGStackModelsTests.swift
+++ b/AlasTests/Integrations/GGStackModelsTests.swift
@@ -80,6 +80,32 @@ struct GGStackModelsTests {
         #expect(summary.total == 3)
     }
 
+    @Test func localStackRetainsRemoteMetadataByStableIdentity() {
+        let local = GGStack(
+            name: "stack", base: "main", totalCommits: 2, syncedCommits: 2,
+            currentPosition: 2, behindBase: nil,
+            entries: [
+                GGStackEntry(position: 1, sha: "newaaaa", title: "one", ggId: "id-1", prNumber: 10),
+                GGStackEntry(position: 2, sha: "newbbbb", title: "two", prNumber: 20, isCurrent: true),
+            ]
+        )
+        let remote = GGStack(
+            name: "stack", base: "main", totalCommits: 2, syncedCommits: 2,
+            currentPosition: 2, behindBase: nil,
+            entries: [
+                GGStackEntry(position: 1, sha: "oldaaaa", title: "old", ggId: "id-1", prNumber: 10, prState: .merged, approved: true, ciStatus: .success),
+                GGStackEntry(position: 2, sha: "oldbbbb", title: "old", prNumber: 20, prState: .open, ciStatus: .running, isCurrent: true),
+            ]
+        )
+
+        let merged = local.mergingRemoteMetadata(from: remote)
+
+        #expect(merged.entries.map(\.sha) == ["newaaaa", "newbbbb"])
+        #expect(merged.entries.map(\.prState) == [.merged, .open])
+        #expect(merged.entries[0].approved)
+        #expect(merged.entries[1].ciStatus == .running)
+    }
+
     @Test func entryMatchesFullCommitSHAByPrefix() throws {
         let snapshot = try GGStackSnapshot.decode(fromJSON: Data(Self.fixture.utf8))
         let stack = try #require(snapshot.stack)

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -80,15 +80,18 @@ private final class SequencedFakeGGRunner: GGCommandRunning, @unchecked Sendable
 private final class LocalFirstGGRunner: GGCommandRunning, @unchecked Sendable {
     private(set) var calls: [[String]] = []
     var delaysRemote = false
+    var localJSON = GGStackModelsTests.fixture
+    var remoteResults: [ProcessResult] = []
 
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
         calls.append(args)
         if args == ["ls", "--json", "--no-refresh"] {
-            return ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+            return ProcessResult(exitCode: 0, stdout: localJSON, stderr: "")
         }
         if delaysRemote {
             try await Task.sleep(nanoseconds: 1_000_000_000)
         }
+        if !remoteResults.isEmpty { return remoteResults.removeFirst() }
         throw GGServiceError.commandFailed(stderr: "remote unavailable")
     }
 }
@@ -785,6 +788,37 @@ struct RightPaneGGStackTests {
         #expect(state.ggStackDisplayCommits.count == 3)
         #expect(state.ggStackRemoteError == "remote unavailable")
         #expect(!state.ggStackRemoteEnrichmentPending)
+    }
+
+    @Test func manualRetryPreservesCachedMetadataWhenRemoteFailsAgain() async {
+        let runner = LocalFirstGGRunner()
+        runner.localJSON = GGStackModelsTests.fixture
+            .replacingOccurrences(of: #""pr_state": "merged""#, with: #""pr_state": null"#)
+            .replacingOccurrences(of: #""pr_state": "open""#, with: #""pr_state": null"#)
+            .replacingOccurrences(of: #""ci_status": "success""#, with: #""ci_status": null"#)
+            .replacingOccurrences(of: #""ci_status": "running""#, with: #""ci_status": null"#)
+        runner.remoteResults = [
+            ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: ""),
+        ]
+        let state = makeState()
+        state.ggService = GGService(runner: runner)
+        state.ggCapabilities = {
+            GGCapabilities(
+                structuredSplit: false,
+                keepCurrentUnstack: false,
+                localStackSnapshot: true
+            )
+        }
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+
+        await state.refreshGGStack()
+        #expect(state.ggStack?.entries[0].prState == .merged)
+
+        await state.reevaluateGGGate().value
+
+        #expect(state.ggStack?.entries[0].prState == .merged)
+        #expect(state.ggStack?.entries[0].ciStatus == .success)
+        #expect(state.ggStackRemoteError == "remote unavailable")
     }
 
     @Test func failedHydrationClearsStackAndKeepsPlainCommitRows() async {

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -77,6 +77,22 @@ private final class SequencedFakeGGRunner: GGCommandRunning, @unchecked Sendable
     }
 }
 
+private final class LocalFirstGGRunner: GGCommandRunning, @unchecked Sendable {
+    private(set) var calls: [[String]] = []
+    var delaysRemote = false
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        calls.append(args)
+        if args == ["ls", "--json", "--no-refresh"] {
+            return ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        }
+        if delaysRemote {
+            try await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+        throw GGServiceError.commandFailed(stderr: "remote unavailable")
+    }
+}
+
 enum GGStackClassificationFixture: CaseIterable, Sendable {
     case nilStack
     case zeroTotalWithEntry
@@ -685,6 +701,56 @@ struct RightPaneGGStackTests {
         #expect(state.ggStackDisplayCommits.map(\.shortSha) == ["ccccccc", "bbbbbbb", "aaaaaaa"])
         #expect(state.commitsForDisplay == state.ggStackDisplayCommits)
         #expect(state.commits == [reachable])
+    }
+
+    @Test func localFirstRefreshKeepsRowsWhenRemoteEnrichmentFails() async {
+        let runner = LocalFirstGGRunner()
+        let state = makeState()
+        state.ggService = GGService(runner: runner)
+        state.ggCapabilities = {
+            GGCapabilities(
+                structuredSplit: false,
+                keepCurrentUnstack: false,
+                localStackSnapshot: true
+            )
+        }
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+
+        #expect(runner.calls == [
+            ["ls", "--json", "--no-refresh"],
+            ["ls", "--json"],
+        ])
+        #expect(state.ggStackLoadState == .loaded)
+        #expect(state.ggStackDisplayCommits.count == 3)
+        #expect(state.ggStackRemoteError == "remote unavailable")
+    }
+
+    @Test func localFirstRefreshPublishesRowsBeforeRemoteEnrichmentCompletes() async throws {
+        let runner = LocalFirstGGRunner()
+        runner.delaysRemote = true
+        let state = makeState()
+        state.ggService = GGService(runner: runner)
+        state.ggCapabilities = {
+            GGCapabilities(
+                structuredSplit: false,
+                keepCurrentUnstack: false,
+                localStackSnapshot: true
+            )
+        }
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+
+        let refresh = Task { @MainActor in await state.refreshGGStack() }
+        for _ in 0..<500 where runner.calls.count < 2 {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+
+        #expect(state.ggStackLoadState == .loaded)
+        #expect(state.ggStackDisplayCommits.count == 3)
+        refresh.cancel()
+        await refresh.value
     }
 
     @Test func failedHydrationClearsStackAndKeepsPlainCommitRows() async {

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -753,6 +753,40 @@ struct RightPaneGGStackTests {
         await refresh.value
     }
 
+    @Test func cancelledRemoteEnrichmentIsRetriedForTheSameStack() async throws {
+        let runner = LocalFirstGGRunner()
+        runner.delaysRemote = true
+        let state = makeState()
+        state.ggService = GGService(runner: runner)
+        state.ggCapabilities = {
+            GGCapabilities(
+                structuredSplit: false,
+                keepCurrentUnstack: false,
+                localStackSnapshot: true
+            )
+        }
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+
+        let first = Task { @MainActor in await state.refreshGGStack() }
+        for _ in 0..<500 where runner.calls.count < 2 {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        first.cancel()
+        await first.value
+
+        await state.refreshGGStack()
+
+        #expect(runner.calls == [
+            ["ls", "--json", "--no-refresh"],
+            ["ls", "--json"],
+            ["ls", "--json"],
+        ])
+        #expect(state.ggStackLoadState == .loaded)
+        #expect(state.ggStackDisplayCommits.count == 3)
+        #expect(state.ggStackRemoteError == "remote unavailable")
+        #expect(!state.ggStackRemoteEnrichmentPending)
+    }
+
     @Test func failedHydrationClearsStackAndKeepsPlainCommitRows() async {
         let state = makeState()
         let reachable = commit(sha: String(repeating: "f", count: 40), stackShaped: true)


### PR DESCRIPTION
## Summary
- detect and use git-gud local-only stack snapshots
- publish the full stack immediately, then enrich it with PR and CI status
- preserve cached remote metadata and keep rows visible when provider refresh fails
- fall back to the existing refresh path with older git-gud versions

Depends on mrmans0n/git-gud#428 for local-first snapshots.

## Verification
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RightPaneGGStackTests` (passes)
- full local suite: two unrelated `AppStateCLIRoutingTests` failures reproduced; CI will verify the clean runner