### PR TITLE
fix(acp): chat scroll jumps after reading

### DIFF
--- a/Alas/Sources/ACP/UI/ACPScrollDirectionClassifier.swift
+++ b/Alas/Sources/ACP/UI/ACPScrollDirectionClassifier.swift
@@ -18,11 +18,6 @@ enum ACPScrollDirectionClassifier {
     /// considered to be "at the tail." Matches the prior `tailTolerance`.
     static let bottomTolerance: CGFloat = 36
 
-    /// Distance from the bottom before an upward scroll pauses tail following.
-    /// Roughly eight transcript text lines: enough to filter trackpad/layout
-    /// micro-hops while still respecting a deliberate scroll away.
-    static let pauseTolerance: CGFloat = 160
-
     static func decide(
         previousOffsetY: CGFloat?,
         newOffsetY: CGFloat,
@@ -39,11 +34,12 @@ enum ACPScrollDirectionClassifier {
         // Only a live scroll gesture pauses tail-following. Bounds changes
         // with no current input event are layout, not intent: a tool card
         // above the fold finishing async layout, streaming content reflow, or
-        // animated-restore lag can shift the viewport upward past
-        // `pauseTolerance` on their own. Treating those as "user scrolled up"
-        // is what made the transcript jump up a few lines and stop following
-        // while agents were still streaming.
-        guard isUserDriven, movedUp, distanceFromBottom > pauseTolerance else { return .noChange }
+        // animated-restore lag can shift the viewport upward on their own.
+        // Treating those as "user scrolled up" is what made the transcript
+        // stop following while agents were still streaming. Once verified
+        // user input has moved outside `bottomTolerance`, however, the reader
+        // has deliberately left the tail and must not be snapped back later.
+        guard isUserDriven, movedUp else { return .noChange }
         return .userScrolledUp
     }
 }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -304,24 +304,20 @@ final class ACPTranscriptScrollerReconciler {
     ///
     /// Those two are not the same thing, and treating `followsTail` alone as
     /// the answer is what made the transcript jump to the newest message
-    /// while the user was scrolling back. `ACPScrollDirectionClassifier
-    /// .pauseTolerance` deliberately withholds the tail-follow pause for the
-    /// first 160pt of upward travel (so trackpad micro-hops and layout reflow
-    /// can't stop the follow), so throughout that band the coordinator is
-    /// still reporting `followsTail: true` while the user is demonstrably
-    /// scrolling away. Any update landing in that window — a streamed chunk,
-    /// a queue change, any SwiftUI invalidation at all, since `updateNSView`
-    /// runs `apply()` unconditionally — slammed the viewport back to the
-    /// bottom mid-gesture.
+    /// while the user was scrolling back. Before the coordinator classifies
+    /// the first upward scroll tick, it can still report `followsTail: true`
+    /// while the user is already moving away. Any update landing in that
+    /// window — a streamed chunk, a queue change, any SwiftUI invalidation at
+    /// all, since `updateNSView` runs `apply()` unconditionally — must not slam
+    /// the viewport back to the bottom mid-gesture.
     ///
     /// Position alone is NOT enough to decide this, and gating on it alone
-    /// was wrong: between `bottomTolerance` and `pauseTolerance` (37–160pt
-    /// off the bottom) the session still reports that it follows the tail, so
-    /// suppressing the pin there indefinitely leaves a state with neither
-    /// behavior — streaming content accumulates below the viewport while the
-    /// "go to newest" affordance stays hidden, because it keys off
-    /// `session.followsTranscriptTail` which nothing has paused. The
-    /// suppression is therefore scoped to an ACTIVE GESTURE. This includes
+    /// was wrong: while the viewport remains within `bottomTolerance` the
+    /// session still reports that it follows the tail. Suppressing the pin
+    /// there indefinitely leaves a state with neither behavior — streaming
+    /// content accumulates below the viewport while the "go to newest"
+    /// affordance stays hidden. The suppression is therefore scoped to an
+    /// ACTIVE GESTURE. This includes
     /// elastic overrun at the bottom: `distanceFromBottom` is clamped to zero
     /// there, but re-pinning would fight AppKit's rebound. Once the gesture
     /// ends, an update re-pins exactly as it always did.
@@ -334,9 +330,9 @@ final class ACPTranscriptScrollerReconciler {
     ///
     /// The state machine still converges from here: scrolling back within
     /// `bottomTolerance` re-arms the glue through the coordinator's
-    /// `.userAtBottom` → `resumeTailFollow`, and travelling past
-    /// `pauseTolerance` pauses the follow outright. What it no longer does is
-    /// fight a gesture that is still in progress.
+    /// `.userAtBottom` → `resumeTailFollow`, and travelling past that tolerance
+    /// pauses the follow outright. What it no longer does is fight a gesture
+    /// that is still in progress.
     ///
     /// The "at the tail" test is skipped on the RISING EDGE of tail-follow —
     /// `followsTail` true where `wasFollowingTail` is false. That transition
@@ -704,11 +700,9 @@ final class ACPTranscriptScrollerReconciler {
     /// The re-pin additionally requires the viewport to have BEEN at the tail
     /// when the invalidation arrived, not merely `lastFollowsTail`. Those two
     /// are not the same thing, and conflating them made scrolling back
-    /// impossible: `ACPScrollDirectionClassifier.pauseTolerance` deliberately
-    /// withholds the tail-follow pause for the first 160pt of upward travel
-    /// (so trackpad micro-hops and layout reflow don't stop the follow), so
-    /// every scroll tick inside that band still reports `lastFollowsTail ==
-    /// true`. Each such tick mounts the rows the scroll exposed, and
+    /// impossible: before the coordinator pauses tail-follow for a verified
+    /// upward gesture, a scroll tick can still report `lastFollowsTail ==
+    /// true`. That tick mounts the rows the scroll exposed, and
     /// `performLayoutPass`'s mount-time `measuredHeight(forWidth:)` reassigns
     /// `rootView`, which SwiftUI answers by invalidating the hosting view's
     /// intrinsic size — landing right here. Re-pinning then yanked the user
@@ -724,9 +718,9 @@ final class ACPTranscriptScrollerReconciler {
     /// the viewport to BE at the tail — keeps the behavior this method exists for —
     /// content growing under a viewport that IS sitting at the tail keeps the
     /// tail glued — while leaving a viewport the user has already moved off
-    /// the tail alone. `bottomTolerance` (not `pauseTolerance`) is the right
-    /// threshold: the question here is "is the viewport at the tail right
-    /// now", which is exactly what that constant answers for the classifier.
+    /// the tail alone. `bottomTolerance` is the right threshold: the question
+    /// here is "is the viewport at the tail right now", which is exactly what
+    /// that constant answers for the classifier.
     /// While genuinely pinned, `scrollToBottom()` remains idempotent — its
     /// `setScrollY` clamp reports no `onScroll` change (`reportScroll` skips
     /// when the offset is unchanged) — so calling it on every tail-following

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerLiveScrollTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerLiveScrollTests.swift
@@ -66,7 +66,7 @@ struct ACPTranscriptScrollerLiveScrollTests {
         )
     }
 
-    @Test("an upward live scroll past the pause tolerance pauses tail-follow, with no current NSEvent")
+    @Test("an upward live scroll pauses tail-follow, with no current NSEvent")
     func liveScrollUpPausesTailFollow() {
         // The coordinator must stay in scope: its `onScroll` closure captures
         // it weakly, so binding it to `_` would silently disable every scroll
@@ -75,13 +75,29 @@ struct ACPTranscriptScrollerLiveScrollTests {
         #expect(host.session.followsTranscriptTail, "fixture should start following the tail")
         #expect(scroller.distanceFromBottom < 1, "fixture should start pinned to the bottom")
 
-        // 470pt from the bottom: the furthest the real captured gesture got,
-        // and comfortably past `pauseTolerance` (160).
+        // 470pt from the bottom: the furthest the real captured gesture got.
         liveScroll(scroller, to: max(0, scroller.contentHeight - scroller.viewportHeight - 470))
 
         #expect(
             host.session.followsTranscriptTail == false,
             "a deliberate upward scroll must pause tail-follow even though NSApp.currentEvent is not a scrollWheel"
+        )
+        withExtendedLifetime(coordinator) {}
+    }
+
+    @Test("a small upward live scroll remains where the reader stopped after settling")
+    func smallLiveScrollDoesNotSnapBackAfterSettling() async throws {
+        let (host, scroller, coordinator) = tailFollowingHost()
+        let target = max(0, scroller.contentHeight - scroller.viewportHeight - 80)
+
+        liveScroll(scroller, to: target)
+        let distanceFromBottom = scroller.distanceFromBottom
+        try await Task.sleep(for: .milliseconds(700))
+
+        #expect(!host.session.followsTranscriptTail)
+        #expect(
+            abs(scroller.distanceFromBottom - distanceFromBottom) < 1,
+            "the settled transcript changed its tail distance from \(distanceFromBottom) to \(scroller.distanceFromBottom)"
         )
         withExtendedLifetime(coordinator) {}
     }

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerScrollBackTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerScrollBackTests.swift
@@ -8,10 +8,9 @@ import Testing
 /// SwiftUI content is measured as they mount.
 ///
 /// This is the shape of the bug that made the AppKit scroller unusable: a
-/// user scrolling up out of the tail is inside
-/// `ACPScrollDirectionClassifier.pauseTolerance` for the first 160pt, so
-/// tail-follow is deliberately still on. Every tick mounts the rows the
-/// scroll just exposed, mount-time measurement invalidates the hosting view's
+/// user scrolling up out of the tail can arrive before the coordinator has
+/// paused tail-follow. That tick mounts the rows the scroll just exposed,
+/// mount-time measurement invalidates the hosting view's
 /// intrinsic size, and `remeasureRow` re-pinned to the bottom — putting the
 /// user back where they started, forever.
 @MainActor
@@ -183,9 +182,8 @@ struct ACPTranscriptScrollerScrollBackTests {
         )
     }
 
-    /// The mirror of the `remeasureRow` trap, one level up: inside
-    /// `ACPScrollDirectionClassifier.pauseTolerance` the coordinator has not
-    /// paused tail-follow yet, so any SwiftUI update landing mid-gesture
+    /// The mirror of the `remeasureRow` trap, one level up: before the
+    /// coordinator has paused tail-follow, any SwiftUI update landing mid-gesture
     /// reaches `apply(followsTail: true)` and used to slam the viewport back
     /// to the bottom — the user scrolls up, and the transcript jumps to the
     /// newest message "for no reason".
@@ -197,8 +195,8 @@ struct ACPTranscriptScrollerScrollBackTests {
         nsWindow.layoutIfNeeded()
         #expect(scroller.distanceFromBottom < 1)
 
-        // The user scrolls up less than `pauseTolerance`, so tail-follow is
-        // deliberately still on — exactly as the coordinator leaves it.
+        // Model the instant before the coordinator's pause reaches the
+        // reconciler: the viewport moved, but tail-follow is still on.
         let target = scroller.scrollY - 90
         scroller.contentView.setBoundsOrigin(NSPoint(x: 0, y: target))
         scroller.reflectScrolledClipView(scroller.contentView)
@@ -220,12 +218,10 @@ struct ACPTranscriptScrollerScrollBackTests {
         #expect(abs(scroller.scrollY - target) < 0.5, "viewport was re-pinned to \(scroller.scrollY)")
     }
 
-    /// The suppression must not outlive the gesture. Between
-    /// `bottomTolerance` and `pauseTolerance` the session still reports that
-    /// it follows the tail, so a viewport left permanently unpinned there
-    /// would get neither behavior: streaming content piling up below the
-    /// fold while the "go to newest" affordance stays hidden, because it keys
-    /// off `session.followsTranscriptTail` and nothing paused it.
+    /// The suppression must not outlive the gesture when the reconciler still
+    /// has tail-follow armed. A viewport left permanently unpinned in that
+    /// state would get neither behavior: streaming content piling up below the
+    /// fold while the "go to newest" affordance stays hidden.
     @Test("once the gesture ends, an update re-pins to the tail again")
     func rePinResumesAfterTheGestureEnds() async throws {
         let (reconciler, scroller, _, nsWindow) = makeStackInWindow()
@@ -233,8 +229,7 @@ struct ACPTranscriptScrollerScrollBackTests {
         reconciler.apply(specs: specs, contentWidth: 800, followsTail: true)
         nsWindow.layoutIfNeeded()
 
-        // Parked in the band where tail-follow is deliberately still on:
-        // past `bottomTolerance`, short of `pauseTolerance`.
+        // Model stale tail-follow state during a gesture.
         let target = scroller.scrollY - 90
         scroller.contentView.setBoundsOrigin(NSPoint(x: 0, y: target))
         scroller.reflectScrolledClipView(scroller.contentView)

--- a/AlasTests/ACPScrollDirectionClassifierTests.swift
+++ b/AlasTests/ACPScrollDirectionClassifierTests.swift
@@ -144,7 +144,7 @@ struct ACPScrollDirectionClassifierTests {
         #expect(decision == .userAtBottom)
     }
 
-    @Test func upwardMoveNearTailDoesNotPause() {
+    @Test func layoutInducedUpwardMoveNearTailDoesNotPause() {
         // A small upward hop near the tail should not latch auto-scroll off.
         let viewportH: CGFloat = 600
         let contentH: CGFloat = 5000
@@ -177,7 +177,7 @@ struct ACPScrollDirectionClassifierTests {
     @Test func layoutInducedUpwardMoveAwayFromTailDoesNotPause() {
         // The classic "jumps up a few lines on its own" failure: a tool card
         // above the fold finishing async layout (or restore lag) shifts the
-        // viewport past pauseTolerance with NO live scroll gesture. Without a
+        // viewport far from the tail with NO live scroll gesture. Without a
         // user event this must not latch auto-scroll off.
         let viewportH: CGFloat = 600
         let contentH: CGFloat = 5000
@@ -193,7 +193,7 @@ struct ACPScrollDirectionClassifierTests {
         #expect(decision == .noChange)
     }
 
-    @Test func restoringUserInputNearTailDoesNotPause() {
+    @Test func restoringUserInputOutsideBottomTolerancePauses() {
         let viewportH: CGFloat = 600
         let contentH: CGFloat = 5000
         let newY = contentH - viewportH - 80
@@ -205,7 +205,7 @@ struct ACPScrollDirectionClassifierTests {
             isRestoring: true,
             isUserDriven: true
         )
-        #expect(decision == .noChange)
+        #expect(decision == .userScrolledUp)
     }
 
     @Test func contentShorterThanViewportIsAtBottom() {
@@ -232,7 +232,7 @@ struct ACPScrollDirectionClassifierTests {
         #expect(decision == .noChange)
     }
 
-    // MARK: - Boundary tests pinning upwardEpsilon, bottomTolerance, and pauseTolerance
+    // MARK: - Boundary tests pinning upwardEpsilon and bottomTolerance
     //
     // Derive values from the classifier's constants so the tests track
     // any retune of the thresholds instead of silently passing.
@@ -292,26 +292,10 @@ struct ACPScrollDirectionClassifierTests {
         #expect(decision == .noChange)
     }
 
-    @Test func atExactPauseToleranceBoundaryDoesNotPause() {
-        // distanceFromBottom == pauseTolerance → strict `>` means noChange.
+    @Test func justOutsideBottomTolerancePausesOnUserDrivenUpwardMove() {
         let viewportH: CGFloat = 600
         let contentH: CGFloat = 5000
-        let newY = contentH - viewportH - ACPScrollDirectionClassifier.pauseTolerance
-        let decision = ACPScrollDirectionClassifier.decide(
-            previousOffsetY: newY + 10,
-            newOffsetY: newY,
-            viewportHeight: viewportH,
-            contentHeight: contentH,
-            isRestoring: false
-        )
-        #expect(decision == .noChange)
-    }
-
-    @Test func justOutsidePauseTolerancePausesOnUpwardMove() {
-        // distanceFromBottom == pauseTolerance + 1 and moving up → userScrolledUp.
-        let viewportH: CGFloat = 600
-        let contentH: CGFloat = 5000
-        let newY = contentH - viewportH - ACPScrollDirectionClassifier.pauseTolerance - 1
+        let newY = contentH - viewportH - ACPScrollDirectionClassifier.bottomTolerance - 1
         let decision = ACPScrollDirectionClassifier.decide(
             previousOffsetY: newY + 10,
             newOffsetY: newY,


### PR DESCRIPTION
## Summary

- pause transcript tail-follow as soon as a verified upward user scroll leaves the bottom tolerance
- keep layout-driven bounds changes from disabling tail-follow
- add a delayed-settle regression test for small upward scrolls

## Verification

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- focused ACP scroll classifier, live-scroll, and scroll-back test suites (35 tests)
- `swiftformat --lint` on the five changed files
- `git diff --check`

## Manual testing

- launched the local Debug build and confirmed the non-streaming ACP chat stays where the reader stops after a small upward scroll