### PR TITLE
feat(agents): lock the launcher surface from the empty state

### DIFF
--- a/Alas/Sources/Agents/AgentLauncherDialog.swift
+++ b/Alas/Sources/Agents/AgentLauncherDialog.swift
@@ -51,11 +51,16 @@ struct AgentLauncherDialog: View {
             }
         }
         .onChange(of: appState.isAgentLauncherOpen) { _, isOpen in
-            if isOpen {
-                requestInputFocus()
-            } else {
-                resetSessionBrowser()
-            }
+            if !isOpen { resetSessionBrowser() }
+        }
+        // Fires on every open request, including one that arrives while the
+        // launcher is already visible (⌘⌥⇧T while browsing an agent's
+        // sessions). That case never flips `isAgentLauncherOpen`, so without
+        // this the session browser would outlive the surface it belongs to
+        // and ↵ would still start a chat under a Terminal lock.
+        .onChange(of: appState.agentLauncher.openTick) { _, _ in
+            resetSessionBrowser()
+            requestInputFocus()
         }
     }
 
@@ -92,10 +97,12 @@ struct AgentLauncherDialog: View {
                 // Intercept tab BEFORE the TextField hands it to the
                 // system focus traversal. Without this the key would
                 // bounce out of the search field instead of toggling
-                // mode. Still swallowed while the mode is locked — the
-                // alternative is focus escaping the field on ⇥.
+                // mode. Still swallowed when the picker is hidden (locked,
+                // or browsing sessions) — the alternative is focus escaping
+                // the field, and swapping mode under a visible session list
+                // would leave ↵ launching a chat on the Terminal surface.
                 .onKeyPress(.tab) {
-                    appState.agentLauncher.toggleMode()
+                    if showsModePicker { appState.agentLauncher.toggleMode() }
                     return .handled
                 }
         }

--- a/Alas/Sources/Agents/AgentLauncherDialog.swift
+++ b/Alas/Sources/Agents/AgentLauncherDialog.swift
@@ -20,7 +20,7 @@ struct AgentLauncherDialog: View {
 
                     VStack(spacing: 0) {
                         inputRow
-                        if chatAgent == nil {
+                        if showsModePicker {
                             modePicker
                         }
                         Divider().background(theme.color("line"))
@@ -63,6 +63,12 @@ struct AgentLauncherDialog: View {
         appState.agentLauncher.rows(enabledAgents: appState.agentRegistry.enabled())
     }
 
+    /// Hidden while browsing an agent's sessions, and while the launcher is
+    /// pinned to one surface (opened from "New Agent in Chat"/"in Terminal").
+    private var showsModePicker: Bool {
+        chatAgent == nil && !appState.agentLauncher.isModeLocked
+    }
+
     private var inputRow: some View {
         HStack(spacing: 8) {
             if let chatAgent {
@@ -86,26 +92,15 @@ struct AgentLauncherDialog: View {
                 // Intercept tab BEFORE the TextField hands it to the
                 // system focus traversal. Without this the key would
                 // bounce out of the search field instead of toggling
-                // mode.
+                // mode. Still swallowed while the mode is locked — the
+                // alternative is focus escaping the field on ⇥.
                 .onKeyPress(.tab) {
-                    toggleMode(reverse: false)
+                    appState.agentLauncher.toggleMode()
                     return .handled
                 }
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
-    }
-
-    /// Cycle between terminal and ACP modes. `reverse` walks the other
-    /// way (for shift-tab) — currently we only have two modes so it's
-    /// the same flip either way, but the flag keeps the call site honest
-    /// if more modes get added.
-    private func toggleMode(reverse: Bool) {
-        let cycle = AppConfig.LauncherMode.allCases
-        let i = cycle.firstIndex(of: appState.agentLauncher.mode) ?? 0
-        let step = reverse ? -1 : 1
-        let next = (i + step + cycle.count) % cycle.count
-        appState.agentLauncher.mode = cycle[next]
     }
 
     private var placeholder: String {
@@ -144,7 +139,7 @@ struct AgentLauncherDialog: View {
                          label: String) -> some View {
         let isOn = appState.agentLauncher.mode == mode
         return Button {
-            appState.agentLauncher.mode = mode
+            appState.agentLauncher.selectMode(mode)
         } label: {
             HStack(spacing: 5) {
                 Icon(name: icon, size: 11,
@@ -359,7 +354,7 @@ struct AgentLauncherDialog: View {
         HStack(spacing: 12) {
             label("↑↓ navigate")
             label(chatAgent == nil ? "↵ select" : "↵ open")
-            if chatAgent == nil { label("⇥ swap mode") }
+            if showsModePicker { label("⇥ swap mode") }
             label(chatAgent == nil ? "esc close" : "esc back")
             Spacer()
         }

--- a/Alas/Sources/Agents/AgentLauncherModel.swift
+++ b/Alas/Sources/Agents/AgentLauncherModel.swift
@@ -31,6 +31,11 @@ final class AgentLauncherModel {
     /// in Chat" and friends): the segmented picker is hidden and ⇥ no longer
     /// swaps modes.
     private(set) var isModeLocked: Bool = false
+    /// Bumped by every `prepareForOpen`. Re-opening an already-visible
+    /// launcher never flips `AppState.isAgentLauncherOpen`, so the dialog
+    /// watches this instead to tear down view-local state (the ACP session
+    /// browser) that belongs to the previous open.
+    private(set) var openTick: Int = 0
     var query: String = "" {
         didSet { selectedIndex = 0 }
     }
@@ -97,6 +102,7 @@ final class AgentLauncherModel {
         mode = defaultMode
         scrollToSelectionTick = 0
         isModeLocked = locked
+        openTick &+= 1
     }
 
     /// Cycle between terminal and ACP modes. `reverse` walks the other way

--- a/Alas/Sources/Agents/AgentLauncherModel.swift
+++ b/Alas/Sources/Agents/AgentLauncherModel.swift
@@ -1,6 +1,22 @@
 import Foundation
 import Observation
 
+/// Payload for `.alasOpenAgentLauncher`. A nil `mode` means "start on the
+/// user's configured default"; `isLocked` hides the surface picker so the
+/// dialog can only launch on `mode`.
+struct AgentLauncherRequest: Sendable {
+    var mode: AppConfig.LauncherMode?
+    var isLocked: Bool = false
+
+    /// Open on the configured default surface, picker visible.
+    static let picker = AgentLauncherRequest(mode: nil, isLocked: false)
+
+    /// Open on `mode` with the picker hidden.
+    static func locked(_ mode: AppConfig.LauncherMode) -> AgentLauncherRequest {
+        AgentLauncherRequest(mode: mode, isLocked: true)
+    }
+}
+
 @Observable
 @MainActor
 final class AgentLauncherModel {
@@ -11,6 +27,10 @@ final class AgentLauncherModel {
         didSet { selectedIndex = 0
         scrollToSelectionTick &+= 1 }
     }
+    /// When true the dialog was opened for one specific surface ("New Agent
+    /// in Chat" and friends): the segmented picker is hidden and ⇥ no longer
+    /// swaps modes.
+    private(set) var isModeLocked: Bool = false
     var query: String = "" {
         didSet { selectedIndex = 0 }
     }
@@ -60,20 +80,41 @@ final class AgentLauncherModel {
     }
 
     /// Reset query + selection. Mode is preserved across opens via
-    /// `prepareForOpen(defaultMode:)`.
+    /// `prepareForOpen(defaultMode:locked:)`.
     func reset() {
         query = ""
         selectedIndex = 0
         scrollToSelectionTick = 0
+        isModeLocked = false
     }
 
     /// Called when the launcher opens. Resets the search and clamps the
-    /// mode to the user's configured default.
-    func prepareForOpen(defaultMode: AppConfig.LauncherMode) {
+    /// mode to the requested surface (or the user's configured default).
+    /// `locked` pins the dialog to that surface for this open.
+    func prepareForOpen(defaultMode: AppConfig.LauncherMode, locked: Bool = false) {
         query = ""
         selectedIndex = 0
         mode = defaultMode
         scrollToSelectionTick = 0
+        isModeLocked = locked
+    }
+
+    /// Cycle between terminal and ACP modes. `reverse` walks the other way
+    /// (for shift-tab) — currently we only have two modes so it's the same
+    /// flip either way, but the flag keeps the call site honest if more
+    /// modes get added. No-op while the mode is locked.
+    func toggleMode(reverse: Bool = false) {
+        guard !isModeLocked else { return }
+        let cycle = AppConfig.LauncherMode.allCases
+        let i = cycle.firstIndex(of: mode) ?? 0
+        let step = reverse ? -1 : 1
+        mode = cycle[(i + step + cycle.count) % cycle.count]
+    }
+
+    /// Direct segment selection from the picker. Ignored while locked.
+    func selectMode(_ newMode: AppConfig.LauncherMode) {
+        guard !isModeLocked else { return }
+        mode = newMode
     }
 
     private func clampedIndex(rowCount: Int) -> Int {

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -262,14 +262,22 @@ struct AlasApp: App {
             }
             .keyboardShortcut(state.shortcut(for: .newTerminalTab))
             Button("Launch Agent…") {
-                NotificationCenter.default.post(name: .alasOpenAgentLauncher, object: nil)
+                NotificationCenter.default.post(name: .alasOpenAgentLauncher,
+                                                object: AgentLauncherRequest.picker)
             }
-            .keyboardShortcut(state.shortcut(for: .launchAgentTerminal))
+            .keyboardShortcut(state.shortcut(for: .launchAgent))
             .disabled(state.projects.isEmpty)
-            Button("Launch Agent Chat…") {
-                NotificationCenter.default.post(name: .alasOpenAgentLauncher, object: AppConfig.LauncherMode.acp)
+            Button("Launch Agent in Chat…") {
+                NotificationCenter.default.post(name: .alasOpenAgentLauncher,
+                                                object: AgentLauncherRequest.locked(.acp))
             }
-            .keyboardShortcut(state.shortcut(for: .launchAgentChat))
+            .keyboardShortcut(state.shortcut(for: .launchAgentInChat))
+            .disabled(state.projects.isEmpty)
+            Button("Launch Agent in Terminal…") {
+                NotificationCenter.default.post(name: .alasOpenAgentLauncher,
+                                                object: AgentLauncherRequest.locked(.terminal))
+            }
+            .keyboardShortcut(state.shortcut(for: .launchAgentInTerminal))
             .disabled(state.projects.isEmpty)
             Button("Close Tab") {
                 NotificationCenter.default.post(name: .alasCloseTab, object: nil)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -365,7 +365,11 @@ final class AppState {
         }
     }
 
-    func openAgentLauncherOverlay(mode: AppConfig.LauncherMode? = nil) {
+    func openAgentLauncherOverlay(_ request: AgentLauncherRequest) {
+        openAgentLauncherOverlay(mode: request.mode, locked: request.isLocked)
+    }
+
+    func openAgentLauncherOverlay(mode: AppConfig.LauncherMode? = nil, locked: Bool = false) {
         reviewPalette.close()
         isReviewPaletteOpen = false
         search.close()
@@ -375,19 +379,10 @@ final class AppState {
         runScriptPalette.reset()
         isRunScriptPaletteOpen = false
         agentLauncher.prepareForOpen(
-            defaultMode: mode ?? config.agents.defaultLauncherMode
+            defaultMode: mode ?? config.agents.defaultLauncherMode,
+            locked: locked
         )
         isAgentLauncherOpen = true
-    }
-
-    func toggleAgentLauncherOverlay(canOpen: Bool) {
-        guard canOpen else { return }
-        if isAgentLauncherOpen {
-            agentLauncher.reset()
-            isAgentLauncherOpen = false
-        } else {
-            openAgentLauncherOverlay(mode: nil)
-        }
     }
 
     func openRunScriptPaletteOverlay(mode: RunScriptPaletteModel.Mode = .run) {

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -295,11 +295,11 @@ struct RootView: View {
             } else {
                 EmptyTabView(
                     onNewTerminal: {},
-                    onNewAgentTerminal: {},
-                    onNewAgentChat: {},
+                    onNewAgentInChat: {},
+                    onNewAgentInTerminal: {},
                     newTerminalShortcut: nil,
-                    newAgentTerminalShortcut: nil,
-                    newAgentChatShortcut: nil
+                    newAgentInChatShortcut: nil,
+                    newAgentInTerminalShortcut: nil
                 )
             }
         }
@@ -1019,8 +1019,8 @@ private struct RootBaseHandlers: ViewModifier {
         let r = q
             .onReceive(NotificationCenter.default.publisher(for: .alasOpenAgentLauncher)) { notification in
                 guard selectedWorktree() != nil else { return }
-                let mode = notification.object as? AppConfig.LauncherMode
-                state.openAgentLauncherOverlay(mode: mode)
+                let request = notification.object as? AgentLauncherRequest ?? .picker
+                state.openAgentLauncherOverlay(request)
             }
         let r2 = r
             .onReceive(NotificationCenter.default.publisher(for: .alasOpenRunScriptPalette)) { _ in

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -332,11 +332,11 @@ struct CenterPaneView: View {
                 } else if tabs.isEmpty {
                     EmptyTabView(
                         onNewTerminal: openTerminal,
-                        onNewAgentTerminal: { state.openAgentLauncherOverlay(mode: nil) },
-                        onNewAgentChat: { state.openAgentLauncherOverlay(mode: .acp) },
+                        onNewAgentInChat: { state.openAgentLauncherOverlay(.locked(.acp)) },
+                        onNewAgentInTerminal: { state.openAgentLauncherOverlay(.locked(.terminal)) },
                         newTerminalShortcut: state.binding(for: .newTerminalTab)?.displayString,
-                        newAgentTerminalShortcut: state.binding(for: .launchAgentTerminal)?.displayString,
-                        newAgentChatShortcut: state.binding(for: .launchAgentChat)?.displayString
+                        newAgentInChatShortcut: state.binding(for: .launchAgentInChat)?.displayString,
+                        newAgentInTerminalShortcut: state.binding(for: .launchAgentInTerminal)?.displayString
                     )
                 } else if let activeId = composition.activeId,
                           let tab = tabs.first(where: { $0.id == activeId }) {

--- a/Alas/Sources/Center/EmptyTabView.swift
+++ b/Alas/Sources/Center/EmptyTabView.swift
@@ -4,11 +4,11 @@ struct EmptyTabView: View {
     static let emptyIcon = "🥺"
 
     let onNewTerminal: () -> Void
-    let onNewAgentTerminal: () -> Void
-    let onNewAgentChat: () -> Void
+    let onNewAgentInChat: () -> Void
+    let onNewAgentInTerminal: () -> Void
     let newTerminalShortcut: String?
-    let newAgentTerminalShortcut: String?
-    let newAgentChatShortcut: String?
+    let newAgentInChatShortcut: String?
+    let newAgentInTerminalShortcut: String?
     @Environment(\.theme) var theme
 
     var body: some View {
@@ -42,17 +42,17 @@ struct EmptyTabView: View {
                 )
                 EmptyTabActionRow(
                     icon: "sparkle",
-                    title: "New Agent",
-                    subtitle: "Pick an agent to launch on the default surface",
-                    shortcut: newAgentTerminalShortcut,
-                    action: onNewAgentTerminal
+                    title: "New Agent in Chat",
+                    subtitle: "Pick an ACP-capable agent for chat",
+                    shortcut: newAgentInChatShortcut,
+                    action: onNewAgentInChat
                 )
                 EmptyTabActionRow(
                     icon: "sparkle",
-                    title: "New Agent Chat",
-                    subtitle: "Pick an ACP-capable agent for chat",
-                    shortcut: newAgentChatShortcut,
-                    action: onNewAgentChat
+                    title: "New Agent in Terminal",
+                    subtitle: "Pick an agent to run in a terminal",
+                    shortcut: newAgentInTerminalShortcut,
+                    action: onNewAgentInTerminal
                 )
             }
             .frame(maxWidth: 420)

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -793,6 +793,8 @@ extension AppConfig {
         migrateLegacyFindAndReplaceShortcutOverride()
         migrateLegacyAgentLauncherShortcutOverrides()
         removeShortcutOverridesCollidingWithReservedBindings()
+        // Last: it must see the final override set.
+        unbindNewAgentLauncherDefaultsClaimedByOverrides()
     }
 }
 
@@ -830,6 +832,25 @@ private extension AppConfig {
             guard legacyOverride != legacyDefault,
                   !shortcutOverrides.keys.contains(action.rawValue) else { continue }
             shortcutOverrides.updateValue(legacyOverride, forKey: action.rawValue)
+        }
+    }
+
+    /// The split actions introduce defaults (⌘⌥⇧C, and ⌘⌥⇧T for the terminal
+    /// half) that an older config may already have assigned to something else
+    /// — legal at the time, since `conflict(for:excluding:)` only guards
+    /// interactive assignment in Settings, never decode. Without an override
+    /// of their own the new actions would silently claim the same chord and
+    /// both menu items would register it. Leave the user's binding alone and
+    /// start the new action explicitly unbound; Settings can restore its
+    /// default once the chord is free.
+    mutating func unbindNewAgentLauncherDefaultsClaimedByOverrides() {
+        for action in [ShortcutAction.launchAgentInTerminal, .launchAgentInChat] {
+            guard !shortcutOverrides.keys.contains(action.rawValue) else { continue }
+            let isClaimed = shortcutOverrides.contains { key, override in
+                key != action.rawValue && override == action.defaultBinding
+            }
+            guard isClaimed else { continue }
+            shortcutOverrides.updateValue(nil, forKey: action.rawValue)
         }
     }
 

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -791,6 +791,7 @@ extension AppConfig {
         shortcutOverrides =
             (try? c.decode([String: ShortcutBinding?].self, forKey: .shortcutOverrides)) ?? [:]
         migrateLegacyFindAndReplaceShortcutOverride()
+        migrateLegacyAgentLauncherShortcutOverrides()
         removeShortcutOverridesCollidingWithReservedBindings()
     }
 }
@@ -807,6 +808,29 @@ private extension AppConfig {
         }
         shortcutOverrides.updateValue(legacyOverride, forKey: replaceKey)
         shortcutOverrides.removeValue(forKey: legacyKey)
+    }
+
+    /// `launchAgentTerminal`/`launchAgentChat` were split into three actions:
+    /// `launchAgent` (surface picker), `launchAgentInTerminal` and
+    /// `launchAgentInChat`. Carry any custom binding over to the action that
+    /// kept its meaning; an override that merely restated the old default is
+    /// dropped so the new defaults apply.
+    mutating func migrateLegacyAgentLauncherShortcutOverrides() {
+        let renames: [(legacyKey: String, legacyDefault: ShortcutBinding, action: ShortcutAction)] = [
+            ("launchAgentTerminal",
+             .init(key: "t", modifiers: [.command, .option]),
+             .launchAgent),
+            ("launchAgentChat",
+             .init(key: "t", modifiers: [.command, .option, .shift]),
+             .launchAgentInChat),
+        ]
+        for (legacyKey, legacyDefault, action) in renames {
+            guard let legacyOverride = shortcutOverrides[legacyKey] else { continue }
+            shortcutOverrides.removeValue(forKey: legacyKey)
+            guard legacyOverride != legacyDefault,
+                  !shortcutOverrides.keys.contains(action.rawValue) else { continue }
+            shortcutOverrides.updateValue(legacyOverride, forKey: action.rawValue)
+        }
     }
 
     mutating func removeShortcutOverridesCollidingWithReservedBindings() {

--- a/Alas/Sources/Shortcuts/ShortcutAction.swift
+++ b/Alas/Sources/Shortcuts/ShortcutAction.swift
@@ -15,7 +15,8 @@ enum ShortcutGroup: String, CaseIterable, Sendable {
 enum ShortcutAction: String, CaseIterable, Codable, Sendable {
     // Global
     case searchFiles, switchRepository, findAndReplace, replaceInEditor, toggleSidebar, toggleRightPane,
-         createProject, newWorktree, focusMainWorktree, newTerminalTab, launchAgentTerminal, launchAgentChat,
+         createProject, newWorktree, focusMainWorktree, newTerminalTab,
+         launchAgent, launchAgentInTerminal, launchAgentInChat,
          openReviewPalette, runScript, selectPreviousTab, selectNextTab,
          increaseFontSize, decreaseFontSize, resetFontSize
     // Code editor
@@ -28,7 +29,8 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
     var group: ShortcutGroup {
         switch self {
         case .searchFiles, .switchRepository, .findAndReplace, .replaceInEditor, .toggleSidebar, .toggleRightPane,
-             .createProject, .newWorktree, .focusMainWorktree, .newTerminalTab, .launchAgentTerminal, .launchAgentChat,
+             .createProject, .newWorktree, .focusMainWorktree, .newTerminalTab,
+             .launchAgent, .launchAgentInTerminal, .launchAgentInChat,
              .openReviewPalette, .runScript, .selectPreviousTab, .selectNextTab,
              .increaseFontSize, .decreaseFontSize, .resetFontSize:
             return .global
@@ -55,8 +57,9 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         case .newWorktree:              return "New Worktree"
         case .focusMainWorktree:        return "Focus Main Worktree"
         case .newTerminalTab:           return "New Terminal Tab"
-        case .launchAgentTerminal:      return "Launch Agent"
-        case .launchAgentChat:          return "Launch Agent Chat"
+        case .launchAgent:              return "Launch Agent"
+        case .launchAgentInTerminal:    return "Launch Agent in Terminal"
+        case .launchAgentInChat:        return "Launch Agent in Chat"
         case .openReviewPalette:        return "Review Worktree"
         case .runScript:                return "Run Script"
         case .selectPreviousTab:        return "Select Previous Tab"
@@ -84,8 +87,9 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         switch self {
         case .searchFiles:        return "Open the file search"
         case .switchRepository:   return "Open the repository picker"
-        case .launchAgentTerminal: return "Open the agent launcher on the default surface"
-        case .launchAgentChat:     return "Open the agent launcher in Chat mode"
+        case .launchAgent:            return "Open the agent launcher with the surface picker"
+        case .launchAgentInTerminal:  return "Open the agent launcher locked to Terminal"
+        case .launchAgentInChat:      return "Open the agent launcher locked to Chat"
         case .openReviewPalette:   return "Open the review target palette"
         case .runScript:           return "Open the run script palette"
         case .commitInComposer:   return "In the draft commit tab"
@@ -120,8 +124,9 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         // Cmd+Shift+M is Toggle Markdown Preview; Cmd+Option+M is macOS Minimize All.
         case .focusMainWorktree:        return .init(key: "m",          modifiers: [.command, .control])
         case .newTerminalTab:           return .init(key: "t",          modifiers: [.command])
-        case .launchAgentTerminal:      return .init(key: "t",          modifiers: [.command, .option])
-        case .launchAgentChat:          return .init(key: "t",          modifiers: [.command, .option, .shift])
+        case .launchAgent:              return .init(key: "t",          modifiers: [.command, .option])
+        case .launchAgentInTerminal:    return .init(key: "t",          modifiers: [.command, .option, .shift])
+        case .launchAgentInChat:        return .init(key: "c",          modifiers: [.command, .option, .shift])
         case .openReviewPalette:        return .init(key: "r",          modifiers: [.command, .shift])
         case .runScript:                return .init(key: "r",          modifiers: [.command])
         case .selectPreviousTab:        return .init(key: "tab",        modifiers: [.control, .shift])

--- a/AlasTests/AgentLauncherModelTests.swift
+++ b/AlasTests/AgentLauncherModelTests.swift
@@ -132,6 +132,20 @@ struct AgentLauncherModelTests {
         #expect(model.mode == .acp)
     }
 
+    @Test func everyPrepareForOpenBumpsTheOpenTick() {
+        let model = AgentLauncherModel()
+        let initial = model.openTick
+
+        model.prepareForOpen(defaultMode: .acp)
+        let afterFirst = model.openTick
+        #expect(afterFirst != initial)
+
+        // Re-opening on another surface while already open must still signal
+        // the dialog, so it can tear down the ACP session browser.
+        model.prepareForOpen(defaultMode: .terminal, locked: true)
+        #expect(model.openTick != afterFirst)
+    }
+
     @Test func resetClearsModeLock() {
         let model = AgentLauncherModel()
         model.prepareForOpen(defaultMode: .terminal, locked: true)

--- a/AlasTests/AgentLauncherModelTests.swift
+++ b/AlasTests/AgentLauncherModelTests.swift
@@ -105,5 +105,49 @@ struct AgentLauncherModelTests {
         #expect(model.mode == .acp)
         #expect(model.query == "")
         #expect(model.selectedIndex == 0)
+        #expect(!model.isModeLocked)
+    }
+
+    @Test func toggleModeSwapsSurfaceWhenUnlocked() {
+        let model = AgentLauncherModel()
+        model.prepareForOpen(defaultMode: .terminal)
+
+        model.toggleMode()
+        #expect(model.mode == .acp)
+
+        model.toggleMode(reverse: true)
+        #expect(model.mode == .terminal)
+    }
+
+    @Test func lockedLauncherIgnoresModeChanges() {
+        let model = AgentLauncherModel()
+        model.prepareForOpen(defaultMode: .acp, locked: true)
+
+        #expect(model.isModeLocked)
+
+        model.toggleMode()
+        #expect(model.mode == .acp)
+
+        model.selectMode(.terminal)
+        #expect(model.mode == .acp)
+    }
+
+    @Test func resetClearsModeLock() {
+        let model = AgentLauncherModel()
+        model.prepareForOpen(defaultMode: .terminal, locked: true)
+
+        model.reset()
+
+        #expect(!model.isModeLocked)
+    }
+
+    @Test func reopeningUnlockedClearsPriorLock() {
+        let model = AgentLauncherModel()
+        model.prepareForOpen(defaultMode: .acp, locked: true)
+
+        model.prepareForOpen(defaultMode: .terminal)
+
+        #expect(!model.isModeLocked)
+        #expect(model.mode == .terminal)
     }
 }

--- a/AlasTests/AppConfigShortcutsCodingTests.swift
+++ b/AlasTests/AppConfigShortcutsCodingTests.swift
@@ -95,6 +95,40 @@ struct AppConfigShortcutsCodingTests {
         #expect(decoded.shortcutOverrides[ShortcutAction.findAndReplace.rawValue] == nil)
     }
 
+    @Test func migratesLegacyAgentLauncherOverridesToSplitActions() throws {
+        var cfg = AppConfig.defaults
+        let legacyLauncher = ShortcutBinding(key: "j", modifiers: [.command, .option])
+        let legacyChat = ShortcutBinding(key: "k", modifiers: [.command, .option, .shift])
+        cfg.shortcutOverrides = [
+            "launchAgentTerminal": legacyLauncher,
+            "launchAgentChat": legacyChat,
+        ]
+
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.shortcutOverrides[ShortcutAction.launchAgent.rawValue] == .some(legacyLauncher))
+        #expect(decoded.shortcutOverrides[ShortcutAction.launchAgentInChat.rawValue] == .some(legacyChat))
+        #expect(decoded.shortcutOverrides[ShortcutAction.launchAgentInTerminal.rawValue] == nil)
+        #expect(decoded.shortcutOverrides["launchAgentTerminal"] == nil)
+        #expect(decoded.shortcutOverrides["launchAgentChat"] == nil)
+    }
+
+    @Test func dropsLegacyAgentLauncherOverridesThatRestateOldDefaults() throws {
+        var cfg = AppConfig.defaults
+        cfg.shortcutOverrides = [
+            "launchAgentTerminal": ShortcutBinding(key: "t", modifiers: [.command, .option]),
+            "launchAgentChat": ShortcutBinding(key: "t", modifiers: [.command, .option, .shift]),
+        ]
+
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.shortcutOverrides.isEmpty)
+        #expect(ShortcutAction.launchAgentInChat.defaultBinding ==
+                ShortcutBinding(key: "c", modifiers: [.command, .option, .shift]))
+    }
+
     @Test func dropsOverridesThatCollideWithReservedBindingsOnDecode() throws {
         var cfg = AppConfig.defaults
         let preserved = ShortcutBinding(key: "j", modifiers: [.command, .option])

--- a/AlasTests/AppConfigShortcutsCodingTests.swift
+++ b/AlasTests/AppConfigShortcutsCodingTests.swift
@@ -129,6 +129,61 @@ struct AppConfigShortcutsCodingTests {
                 ShortcutBinding(key: "c", modifiers: [.command, .option, .shift]))
     }
 
+    @Test func unbindsNewChatActionWhenItsDefaultIsAlreadyTaken() throws {
+        var cfg = AppConfig.defaults
+        let chatDefault = ShortcutBinding(key: "c", modifiers: [.command, .option, .shift])
+        cfg.shortcutOverrides = [ShortcutAction.toggleRightPane.rawValue: chatDefault]
+
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        // The user keeps their chord; the new action starts unbound rather
+        // than registering the same one.
+        #expect(decoded.shortcutOverrides[ShortcutAction.toggleRightPane.rawValue] == .some(chatDefault))
+        #expect(decoded.shortcutOverrides[ShortcutAction.launchAgentInChat.rawValue] == .some(nil))
+    }
+
+    @Test func unbindsNewTerminalActionWhenItsDefaultIsAlreadyTaken() throws {
+        var cfg = AppConfig.defaults
+        let terminalDefault = ShortcutBinding(key: "t", modifiers: [.command, .option, .shift])
+        cfg.shortcutOverrides = [
+            "launchAgentChat": nil,
+            ShortcutAction.openReviewPalette.rawValue: terminalDefault,
+        ]
+
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.shortcutOverrides[ShortcutAction.openReviewPalette.rawValue] == .some(terminalDefault))
+        #expect(decoded.shortcutOverrides[ShortcutAction.launchAgentInTerminal.rawValue] == .some(nil))
+    }
+
+    @Test func leavesNewAgentDefaultsAloneWhenNothingClaimsThem() throws {
+        var cfg = AppConfig.defaults
+        cfg.shortcutOverrides = [
+            ShortcutAction.toggleRightPane.rawValue: ShortcutBinding(key: "j", modifiers: [.command, .option])
+        ]
+
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.shortcutOverrides[ShortcutAction.launchAgentInChat.rawValue] == nil)
+        #expect(decoded.shortcutOverrides[ShortcutAction.launchAgentInTerminal.rawValue] == nil)
+    }
+
+    @Test func doesNotUnbindNewActionThatCarriedAMigratedOverride() throws {
+        var cfg = AppConfig.defaults
+        let custom = ShortcutBinding(key: "c", modifiers: [.command, .option, .shift])
+        // Legacy chat override lands on launchAgentInChat, which then holds
+        // ⌘⌥⇧C itself — that is not a collision with another action.
+        cfg.shortcutOverrides = ["launchAgentChat": custom]
+
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.shortcutOverrides[ShortcutAction.launchAgentInChat.rawValue] == .some(custom))
+    }
+
     @Test func dropsOverridesThatCollideWithReservedBindingsOnDecode() throws {
         var cfg = AppConfig.defaults
         let preserved = ShortcutBinding(key: "j", modifiers: [.command, .option])

--- a/AlasTests/AppStateOverlayFocusTests.swift
+++ b/AlasTests/AppStateOverlayFocusTests.swift
@@ -31,14 +31,16 @@ struct AppStateOverlayFocusTests {
         let state = AppState()
 
         state.openSearchOverlay()
-        state.toggleAgentLauncherOverlay(canOpen: true)
+        state.openAgentLauncherOverlay(.picker)
 
         #expect(!state.isSearchOpen)
         #expect(!state.isRepoSelectorOpen)
         #expect(state.isAgentLauncherOpen)
         #expect(state.isKeyboardOverlayOpen)
 
-        state.toggleAgentLauncherOverlay(canOpen: true)
+        // How AgentLauncherDialog.close() dismisses itself.
+        state.agentLauncher.reset()
+        state.isAgentLauncherOpen = false
 
         #expect(!state.isSearchOpen)
         #expect(!state.isRepoSelectorOpen)

--- a/AlasTests/AppStateOverlayTests.swift
+++ b/AlasTests/AppStateOverlayTests.swift
@@ -92,28 +92,45 @@ struct AppStateOverlayTests {
         #expect(state.agentLauncher.mode == .acp)
     }
 
-    @Test func toggleAgentLauncherClosedOpensUsingConfiguredDefault() {
+    @Test func lockedChatRequestPinsModeRegardlessOfDefault() {
         let state = AppState(store: MemoryStore())
-        state.config.agents.defaultLauncherMode = .acp
+        state.config.agents.defaultLauncherMode = .terminal
 
-        state.toggleAgentLauncherOverlay(canOpen: true)
+        state.openAgentLauncherOverlay(.locked(.acp))
 
         #expect(state.isAgentLauncherOpen)
         #expect(state.agentLauncher.mode == .acp)
+        #expect(state.agentLauncher.isModeLocked)
     }
 
-    @Test func toggleAgentLauncherOpenClosesAndResets() {
+    @Test func lockedTerminalRequestPinsModeRegardlessOfDefault() {
         let state = AppState(store: MemoryStore())
-        state.isAgentLauncherOpen = true
-        state.agentLauncher.mode = .acp
-        state.agentLauncher.query = "claude"
-        state.agentLauncher.selectedIndex = 3
+        state.config.agents.defaultLauncherMode = .acp
 
-        state.toggleAgentLauncherOverlay(canOpen: true)
+        state.openAgentLauncherOverlay(.locked(.terminal))
+
+        #expect(state.agentLauncher.mode == .terminal)
+        #expect(state.agentLauncher.isModeLocked)
+    }
+
+    @Test func pickerRequestUsesConfiguredDefaultUnlocked() {
+        let state = AppState(store: MemoryStore())
+        state.config.agents.defaultLauncherMode = .acp
+
+        state.openAgentLauncherOverlay(.picker)
+
+        #expect(state.agentLauncher.mode == .acp)
+        #expect(!state.agentLauncher.isModeLocked)
+    }
+
+    @Test func closingLockedLauncherClearsTheLock() {
+        let state = AppState(store: MemoryStore())
+        state.openAgentLauncherOverlay(.locked(.acp))
+
+        state.openSearchOverlay()
 
         #expect(!state.isAgentLauncherOpen)
-        #expect(state.agentLauncher.query == "")
-        #expect(state.agentLauncher.selectedIndex == 0)
+        #expect(!state.agentLauncher.isModeLocked)
     }
 
     @Test func openingRunScriptPaletteWhileOpenKeepsLoadedScripts() {

--- a/AlasTests/EmptyTabViewTests.swift
+++ b/AlasTests/EmptyTabViewTests.swift
@@ -19,11 +19,11 @@ struct EmptyTabViewTests {
     func emptyStateRenders() {
         let view = EmptyTabView(
             onNewTerminal: {},
-            onNewAgentTerminal: {},
-            onNewAgentChat: {},
+            onNewAgentInChat: {},
+            onNewAgentInTerminal: {},
             newTerminalShortcut: "⌘ T",
-            newAgentTerminalShortcut: nil,
-            newAgentChatShortcut: nil
+            newAgentInChatShortcut: nil,
+            newAgentInTerminalShortcut: nil
         )
         .environment(\.theme, currentTheme())
 

--- a/AlasTests/ShortcutActionTests.swift
+++ b/AlasTests/ShortcutActionTests.swift
@@ -30,8 +30,9 @@ struct ShortcutActionTests {
             (.newWorktree,          "n",          [.command, .option]),
             (.focusMainWorktree,    "m",          [.command, .control]),
             (.newTerminalTab,       "t",          [.command]),
-            (.launchAgentTerminal,  "t",          [.command, .option]),
-            (.launchAgentChat,      "t",          [.command, .option, .shift]),
+            (.launchAgent,          "t",          [.command, .option]),
+            (.launchAgentInTerminal, "t",         [.command, .option, .shift]),
+            (.launchAgentInChat,    "c",          [.command, .option, .shift]),
             (.openReviewPalette,    "r",          [.command, .shift]),
             (.runScript,            "r",          [.command]),
             (.selectPreviousTab,    "tab",        [.control, .shift]),
@@ -63,7 +64,8 @@ struct ShortcutActionTests {
     @Test func groupAssignmentsMatchSpec() {
         let global: Set<ShortcutAction> = [
             .searchFiles, .switchRepository, .findAndReplace, .replaceInEditor, .toggleSidebar, .toggleRightPane,
-            .createProject, .newWorktree, .newTerminalTab, .launchAgentTerminal, .launchAgentChat,
+            .createProject, .newWorktree, .newTerminalTab,
+            .launchAgent, .launchAgentInTerminal, .launchAgentInChat,
             .openReviewPalette, .runScript, .selectPreviousTab, .selectNextTab, .focusMainWorktree,
             .increaseFontSize, .decreaseFontSize, .resetFontSize,
         ]

--- a/AlasTests/ShortcutResolverTests.swift
+++ b/AlasTests/ShortcutResolverTests.swift
@@ -65,11 +65,18 @@ struct ShortcutResolverTests {
         #expect(conflict == nil)
     }
 
-    @Test func conflictDetectsAgentChatDefaultBinding() async {
+    @Test func conflictDetectsAgentInTerminalDefaultBinding() async {
         let state = makeState()
         let binding = ShortcutBinding(key: "t", modifiers: [.command, .option, .shift])
         let conflict = state.conflict(for: binding, excluding: .searchFiles)
-        #expect(conflict == .launchAgentChat)
+        #expect(conflict == .launchAgentInTerminal)
+    }
+
+    @Test func conflictDetectsAgentInChatDefaultBinding() async {
+        let state = makeState()
+        let binding = ShortcutBinding(key: "c", modifiers: [.command, .option, .shift])
+        let conflict = state.conflict(for: binding, excluding: .searchFiles)
+        #expect(conflict == .launchAgentInChat)
     }
 
     @Test func conflictDetectsReplaceInEditorDefaultBinding() async {


### PR DESCRIPTION
## Problem

Both agent rows in the no-tabs empty state opened the *same* launcher, with the segmented Terminal/Chat control visible — and "New Agent" passed no mode, so it followed `defaultLauncherMode` and could land in Chat no matter which row you clicked.

## Change

**Three launcher actions instead of two:**

| Action | Binding | Behavior |
|---|---|---|
| `launchAgent` | ⌘⌥T | Dialog **with** the segmented control, starting on `defaultLauncherMode` |
| `launchAgentInTerminal` | ⌘⌥⇧T | Locked to Terminal |
| `launchAgentInChat` | ⌘⌥⇧C | Locked to Chat |

The empty-state rows call the locked variants, so they can't land on the wrong surface.

**Locking lives in the model.** `AgentLauncherModel` gains `isModeLocked` plus `toggleMode`/`selectMode`; the dialog calls those instead of assigning `mode` directly, so ⇥ and the segment buttons are both covered by one guard. While locked the dialog hides the segmented control and the "⇥ swap mode" footer hint — ⇥ still returns `.handled` so focus can't escape the search field.

**Rows renamed and reordered:** New Terminal (⌘T) → New Agent in Chat (⌘⌥⇧C) → New Agent in Terminal (⌘⌥⇧T).

**Migration:** `shortcutOverrides` is keyed by action rawValue, so a saved custom binding carries to whichever new action kept its meaning (`launchAgentTerminal` → `launchAgent`, `launchAgentChat` → `launchAgentInChat`). An override that merely restated the old default is dropped so the new ⌘⌥⇧C default applies.

Also drops `AppState.toggleAgentLauncherOverlay(canOpen:)`, which had no production callers left.

## Notes

- The `.alasOpenAgentLauncher` notification now carries an `AgentLauncherRequest { mode, isLocked }` instead of a bare `LauncherMode?`.
- Opening "in Chat" with no ACP-capable agent enabled shows the existing "No ACP-capable agents enabled" empty state with no control to swap to Terminal; esc closes. Intended for an explicit "in Chat" action.

## Testing

`xcodebuild ... test` on the 8 affected suites: 70 tests passed. New coverage for the mode lock (model + AppState), the three default bindings and their conflict detection, and both override-migration paths.