### PR TITLE
fix(remote): group sessions by repository with stable ordering

### DIFF
--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -13,6 +13,7 @@ let queueItems = [];             // [{id, text, imageCount, resourceCount, statu
 let steerUndoAvailable = false;
 let lastStreamingState = "idle"; // so composer state can be recomputed on text input
 let sessionTitles = new Map();
+let listedSessions = new Map();
 let canDrive = false, canDriveKnown = false;
 let reconnectDelay = 1500;
 let reconnectTimer = null;
@@ -275,6 +276,8 @@ function handle(msg) {
 
 function renderSessions(sessions) {
   const list = $("session-list"); list.innerHTML = "";
+  listedSessions.clear();
+  sessions.forEach(s => listedSessions.set(s.id, s));
   sessionTitles = new Map(sessions.map(s => [s.id, s.title]));
   RemoteSessionOrdering.groupSessions(sessions).forEach(section => {
     const element = el("section", "session-section");
@@ -645,16 +648,8 @@ function applyCreatedSession(session) {
 
   const previousSession = currentSession;
   hideCreateSheet(true);
-  sessionTitles.set(session.id, session.title);
-  const list = $("session-list");
-  const row = renderSessionRow(session);
-  const existing = Array.from(document.querySelectorAll("[data-session-id]"))
-    .find(candidate => candidate.dataset.sessionId === session.id);
-  if (existing) {
-    existing.replaceWith(row);
-  } else {
-    list.prepend(row);
-  }
+  listedSessions.set(session.id, session);
+  renderSessions([...listedSessions.values()]);
   if (previousSession && previousSession !== session.id) send({ type: "unsubscribe", sessionId: previousSession });
   openSession(session.id);
 }

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -276,23 +276,22 @@ function handle(msg) {
 function renderSessions(sessions) {
   const list = $("session-list"); list.innerHTML = "";
   sessionTitles = new Map(sessions.map(s => [s.id, s.title]));
-  sortedSessions(sessions).forEach(s => list.appendChild(renderSessionRow(s)));
+  RemoteSessionOrdering.groupSessions(sessions).forEach(section => {
+    const element = el("section", "session-section");
+    element.append(el("h2", "session-section-title", section.title));
+    const rows = el("div", "session-section-list");
+    section.sessions.forEach(s => rows.appendChild(renderSessionRow(s)));
+    element.append(rows);
+    list.appendChild(element);
+  });
   if (currentSession) setDetailTitle(currentSession);
-}
-
-function sortedSessions(sessions) {
-  return [...sessions].sort((a, b) => Number(sessionIsActive(b)) - Number(sessionIsActive(a)));
-}
-
-function sessionIsActive(session) {
-  return session.isActive !== false;
 }
 
 function renderSessionRow(s) {
   const row = document.createElement("div");
   row.dataset.sessionId = s.id;
   row.className = "session-row";
-  const active = sessionIsActive(s);
+  const active = RemoteSessionOrdering.sessionIsActive(s);
   row.classList.add(active ? "session-row-active" : "session-row-inactive");
 
   const open = document.createElement("button");
@@ -314,7 +313,7 @@ function renderSessionRow(s) {
 
   if (s.worktree) {
     row.classList.add("session-row-card");
-    open.append(el("div", "session-worktree", `${s.worktree.projectName} / ${s.worktree.worktreeName}`));
+    open.append(el("div", "session-worktree", s.worktree.worktreeName));
     const meta = el("div", "session-meta");
     const parts = sessionMetaParts(s.worktree);
     parts.forEach(part => meta.append(part));

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/icon.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/icon-180.png" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=39" />
+  <link rel="stylesheet" href="/style.css?v=40" />
 </head>
 <body>
   <header id="bar">
@@ -151,7 +151,8 @@
   </div>
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
-  <script src="/app.js?v=61"></script>
+  <script src="/session-ordering.js?v=1"></script>
+  <script src="/app.js?v=62"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/session-ordering.js
+++ b/Alas/Resources/RemoteWeb/session-ordering.js
@@ -1,0 +1,52 @@
+function sessionIsActive(session) {
+  return session.isActive !== false;
+}
+
+function sessionRecency(session) {
+  const updatedAt = Number(session.updatedAt);
+  return Number.isFinite(updatedAt) ? updatedAt : 0;
+}
+
+function compareSessions(a, b) {
+  const active = Number(sessionIsActive(b)) - Number(sessionIsActive(a));
+  if (active) return active;
+
+  const recency = sessionRecency(b) - sessionRecency(a);
+  if (recency) return recency;
+
+  const title = String(a.title || "").localeCompare(String(b.title || ""), undefined, { sensitivity: "accent" });
+  return title || String(a.id || "").localeCompare(String(b.id || ""), undefined, { sensitivity: "accent" });
+}
+
+function groupSessions(sessions) {
+  const groups = new Map();
+  const other = [];
+
+  sessions.forEach((session) => {
+    if (!session.projectId || !session.worktree) {
+      other.push(session);
+      return;
+    }
+
+    const group = groups.get(session.projectId) || {
+      id: session.projectId,
+      title: session.worktree.projectName,
+      sessions: [],
+      isOther: false,
+    };
+    group.sessions.push(session);
+    groups.set(session.projectId, group);
+  });
+
+  const sections = [...groups.values()];
+  if (other.length) sections.push({ id: "other", title: "Other", sessions: other, isOther: true });
+
+  sections.forEach((section) => section.sessions.sort(compareSessions));
+  return sections.sort((a, b) => {
+    if (a.isOther) return 1;
+    if (b.isOther) return -1;
+    return Math.max(...b.sessions.map(sessionRecency)) - Math.max(...a.sessions.map(sessionRecency));
+  });
+}
+
+globalThis.RemoteSessionOrdering = { groupSessions, sessionIsActive };

--- a/Alas/Resources/RemoteWeb/session-ordering.js
+++ b/Alas/Resources/RemoteWeb/session-ordering.js
@@ -49,7 +49,12 @@ function groupSessions(sessions) {
   return sections.sort((a, b) => {
     if (a.isOther) return 1;
     if (b.isOther) return -1;
-    return Math.max(...b.sessions.map(sessionRecency)) - Math.max(...a.sessions.map(sessionRecency));
+    const recency = Math.max(...b.sessions.map(sessionRecency)) - Math.max(...a.sessions.map(sessionRecency));
+    if (recency) return recency;
+
+    const title = a.title.localeCompare(b.title, undefined, { sensitivity: "accent" });
+    if (title) return title;
+    return a.id === b.id ? 0 : a.id < b.id ? -1 : 1;
   });
 }
 

--- a/Alas/Resources/RemoteWeb/session-ordering.js
+++ b/Alas/Resources/RemoteWeb/session-ordering.js
@@ -15,7 +15,11 @@ function compareSessions(a, b) {
   if (recency) return recency;
 
   const title = String(a.title || "").localeCompare(String(b.title || ""), undefined, { sensitivity: "accent" });
-  return title || String(a.id || "").localeCompare(String(b.id || ""), undefined, { sensitivity: "accent" });
+  if (title) return title;
+
+  const aID = String(a.id || "");
+  const bID = String(b.id || "");
+  return aID === bID ? 0 : aID < bID ? -1 : 1;
 }
 
 function groupSessions(sessions) {

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -55,7 +55,10 @@ main { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
 
 /* Sessions list */
 h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
-#session-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px; }
+#session-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 18px; }
+.session-section { min-width: 0; }
+.session-section-title { margin: 4px 4px 8px; color: var(--fg-muted); font-size: 13px; font-weight: 700; }
+.session-section-list { display: flex; flex-direction: column; gap: 10px; }
 .session-row { width: 100%; color: var(--fg); font: inherit; text-align: left; display: flex; align-items: flex-start; gap: 8px; -webkit-tap-highlight-color: transparent; }
 .session-open { flex: 1; min-width: 0; border: none; background: none; color: inherit; font: inherit; text-align: left; padding: 0; cursor: pointer; -webkit-tap-highlight-color: transparent; }
 .session-open:focus-visible { outline: 1.5px solid var(--accent); outline-offset: 2px; }

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,9 +1,10 @@
-const CACHE_NAME = "alas-remote-shell-v39";
+const CACHE_NAME = "alas-remote-shell-v40";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
-  "/style.css?v=39",
-  "/app.js?v=61",
+  "/style.css?v=40",
+  "/session-ordering.js?v=1",
+  "/app.js?v=62",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -8479,6 +8479,8 @@ extension AppState: RemoteSessionsProvider {
     private func remoteSessionSummary(
         session: ACPSession,
         manager: ACPSessionManager,
+        projectId: String,
+        updatedAt: Int64,
         worktreeSummary: RemoteWorktreeSummary?
     ) -> RemoteSessionSummary {
         let streamingState = manager.runners[session.id]?.session.transcript.streamingState
@@ -8489,6 +8491,8 @@ extension AppState: RemoteSessionsProvider {
             agentId: session.agentId,
             status: RemoteSessionGateway.stateString(streamingState),
             canDrive: manager.isWriter(for: session.id),
+            projectId: projectId,
+            updatedAt: updatedAt,
             worktree: worktreeSummary
         )
     }
@@ -8708,7 +8712,14 @@ extension AppState: RemoteSessionsProvider {
         }
 
         let worktreeSummary = remoteWorktreeSummaryWithoutMetrics(project: resolved.project, worktree: resolved.worktree)
-        return .success(remoteSessionSummary(session: session, manager: manager, worktreeSummary: worktreeSummary))
+        let updatedAt = manager.sessionRows.first(where: { $0.id == session.id })?.updatedAt ?? 0
+        return .success(remoteSessionSummary(
+            session: session,
+            manager: manager,
+            projectId: resolved.project.id,
+            updatedAt: updatedAt,
+            worktreeSummary: worktreeSummary
+        ))
     }
 
     func session(for id: String) -> ACPSession? {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -8499,10 +8499,13 @@ extension AppState: RemoteSessionsProvider {
 
         for mgr in acpManagers.values {
             let worktreeSummary: RemoteWorktreeSummary?
+            let projectId: String?
             if let resolved = projectAndWorktree(withWorktreeId: mgr.worktreeId) {
                 worktreeSummary = await remoteWorktreeSummary(project: resolved.project, worktree: resolved.worktree)
+                projectId = resolved.project.id
             } else {
                 worktreeSummary = nil
+                projectId = nil
             }
 
             for row in mgr.sessionRows where !row.archived {
@@ -8519,6 +8522,8 @@ extension AppState: RemoteSessionsProvider {
                     hasRunner: state != nil,
                     isActive: hasOpenACPSessionTab(worktreeId: mgr.worktreeId, sessionId: row.id),
                     canDrive: mgr.isWriter(for: row.id),
+                    projectId: projectId,
+                    updatedAt: row.updatedAt,
                     worktree: worktreeSummary
                 )
                 let identity = remoteSessionListIdentity(worktreeId: mgr.worktreeId, row: effectiveRow)
@@ -8557,6 +8562,8 @@ extension AppState: RemoteSessionsProvider {
         var hasRunner: Bool
         var isActive: Bool
         var canDrive: Bool
+        var projectId: String?
+        var updatedAt: Int64
         let worktree: RemoteWorktreeSummary?
 
         init(
@@ -8565,6 +8572,8 @@ extension AppState: RemoteSessionsProvider {
             hasRunner: Bool,
             isActive: Bool,
             canDrive: Bool,
+            projectId: String?,
+            updatedAt: Int64,
             worktree: RemoteWorktreeSummary?
         ) {
             self.operationalRow = row
@@ -8573,6 +8582,8 @@ extension AppState: RemoteSessionsProvider {
             self.hasRunner = hasRunner
             self.isActive = isActive
             self.canDrive = canDrive
+            self.projectId = projectId
+            self.updatedAt = updatedAt
             self.worktree = worktree
         }
 
@@ -8584,12 +8595,16 @@ extension AppState: RemoteSessionsProvider {
                 status: status,
                 canDrive: canDrive,
                 isActive: isActive,
+                projectId: projectId,
+                updatedAt: updatedAt,
                 worktree: worktree
             )
         }
 
         func merging(_ other: RemoteSessionSummaryCandidate) -> RemoteSessionSummaryCandidate {
             var merged = self
+            merged.updatedAt = max(merged.updatedAt, other.updatedAt)
+            merged.projectId = merged.projectId ?? other.projectId
             if other.isBetterOperationalRow(than: merged) {
                 merged.operationalRow = other.operationalRow
                 merged.status = other.status

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -73,6 +73,8 @@ struct RemoteSessionSummary: Equatable, Sendable {
     let status: String       // "idle" | "streaming" | "awaitingPermission" | "awaitingInput"
     let canDrive: Bool       // this remote-host instance currently holds the writer lease
     let isActive: Bool       // still backed by an open Alas tab
+    let projectId: String?
+    let updatedAt: Int64
     let worktree: RemoteWorktreeSummary?
 
     init(
@@ -82,6 +84,8 @@ struct RemoteSessionSummary: Equatable, Sendable {
         status: String,
         canDrive: Bool,
         isActive: Bool = true,
+        projectId: String? = nil,
+        updatedAt: Int64 = 0,
         worktree: RemoteWorktreeSummary? = nil
     ) {
         self.id = id
@@ -90,13 +94,15 @@ struct RemoteSessionSummary: Equatable, Sendable {
         self.status = status
         self.canDrive = canDrive
         self.isActive = isActive
+        self.projectId = projectId
+        self.updatedAt = updatedAt
         self.worktree = worktree
     }
 }
 
 extension RemoteSessionSummary: Codable {
     private enum CodingKeys: String, CodingKey {
-        case id, title, agentId, status, canDrive, isActive, worktree
+        case id, title, agentId, status, canDrive, isActive, projectId, updatedAt, worktree
     }
 
     init(from decoder: Decoder) throws {
@@ -108,6 +114,8 @@ extension RemoteSessionSummary: Codable {
             status: try c.decode(String.self, forKey: .status),
             canDrive: try c.decode(Bool.self, forKey: .canDrive),
             isActive: try c.decodeIfPresent(Bool.self, forKey: .isActive) ?? true,
+            projectId: try c.decodeIfPresent(String.self, forKey: .projectId),
+            updatedAt: try c.decodeIfPresent(Int64.self, forKey: .updatedAt) ?? 0,
             worktree: try c.decodeIfPresent(RemoteWorktreeSummary.self, forKey: .worktree)
         )
     }
@@ -120,6 +128,8 @@ extension RemoteSessionSummary: Codable {
         try c.encode(status, forKey: .status)
         try c.encode(canDrive, forKey: .canDrive)
         try c.encode(isActive, forKey: .isActive)
+        try c.encodeIfPresent(projectId, forKey: .projectId)
+        try c.encode(updatedAt, forKey: .updatedAt)
         try c.encodeIfPresent(worktree, forKey: .worktree)
     }
 }

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -124,6 +124,7 @@ struct RemoteAppStateAccessTests {
             id: tab.sessionId,
             title: "New session",
             titleSource: .placeholder,
+            updatedAt: 1,
             in: manager
         )
         try await seedStoredSession(
@@ -131,6 +132,7 @@ struct RemoteAppStateAccessTests {
             title: "Actual Remote Title",
             titleSource: .manual,
             remoteSessionId: "remote-shared",
+            updatedAt: 2,
             in: manager
         )
 
@@ -140,6 +142,7 @@ struct RemoteAppStateAccessTests {
         #expect(summaries.first?.id == tab.sessionId)
         #expect(summaries.first?.title == "Actual Remote Title")
         #expect(summaries.first?.isActive == true)
+        #expect(summaries.first?.updatedAt == 2)
     }
 
     @Test func remoteSessionSummariesMarkStoredRowsWithoutTabsInactive() async throws {
@@ -159,6 +162,7 @@ struct RemoteAppStateAccessTests {
             id: "historical-\(UUID().uuidString)",
             title: "Historical",
             titleSource: .manual,
+            updatedAt: 42,
             in: manager
         )
 
@@ -166,6 +170,8 @@ struct RemoteAppStateAccessTests {
         let historical = try #require(summaries.first { $0.title == "Historical" })
 
         #expect(!historical.isActive)
+        #expect(historical.projectId == state.projects.first?.id)
+        #expect(historical.updatedAt == 42)
     }
 
     @Test func openingUncachedStoredSessionUsesPersistedTitleForTab() async throws {

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -568,6 +568,9 @@ struct RemoteAppStateAccessTests {
         #expect(state.tabs.activeTabId(forWorktree: worktreeId) == tab.id)
         let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
         #expect(manager.liveSession(for: summary.id) != nil)
+        let row = try #require(manager.sessionRows.first { $0.id == summary.id })
+        #expect(summary.projectId == state.projects.first?.id)
+        #expect(summary.updatedAt == row.updatedAt)
         #expect(scheduledAttach?.managerWorktreeId == worktreeId)
         #expect(scheduledAttach?.sessionId == summary.id)
     }

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -80,6 +80,8 @@ struct RemoteProtocolTests {
             agentId: "claude",
             status: "streaming",
             canDrive: false,
+            projectId: "project-1",
+            updatedAt: 123,
             worktree: RemoteWorktreeSummary(
                 projectName: "alas",
                 worktreeName: "nacho-improve-remote-sessions",
@@ -95,6 +97,16 @@ struct RemoteProtocolTests {
             )
         )
         #expect(try roundTrip(summary) == summary)
+    }
+
+    @Test func sessionSummaryDecodesLegacyPayloadWithoutProjectOrActivity() throws {
+        let summary = try JSONDecoder().decode(
+            RemoteSessionSummary.self,
+            from: Data(#"{"id":"s1","title":"Legacy","agentId":"claude","status":"idle","canDrive":true}"#.utf8)
+        )
+
+        #expect(summary.projectId == nil)
+        #expect(summary.updatedAt == 0)
     }
 
     @Test func worktreeOptionRoundTrips() throws {

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -44,15 +44,18 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".tool-toggle"))
     }
 
-    @Test func toolCardMobileFixBustsServiceWorkerAssetCache() throws {
+    @Test func remoteSessionOrderingAssetsAreLoadedAndCached() throws {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=61"#))
-        #expect(html.contains(#"/style.css?v=39"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v39";"#))
-        #expect(sw.contains(#""/app.js?v=61""#))
-        #expect(sw.contains(#""/style.css?v=39""#))
+        #expect(html.contains(#"/session-ordering.js?v=1"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=62"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=62"#))
+        #expect(html.contains(#"/style.css?v=40"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v40";"#))
+        #expect(sw.contains(#""/session-ordering.js?v=1""#))
+        #expect(sw.contains(#""/app.js?v=62""#))
+        #expect(sw.contains(#""/style.css?v=40""#))
     }
 
     @Test func remoteWebToolRowsAvoidNativeButtonRenderingOnMobileSafari() throws {
@@ -65,11 +68,11 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=61"#))
-        #expect(html.contains(#"/style.css?v=39"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v39";"#))
-        #expect(sw.contains(#""/app.js?v=61""#))
-        #expect(sw.contains(#""/style.css?v=39""#))
+        #expect(html.contains(#"/app.js?v=62"#))
+        #expect(html.contains(#"/style.css?v=40"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v40";"#))
+        #expect(sw.contains(#""/app.js?v=62""#))
+        #expect(sw.contains(#""/style.css?v=40""#))
     }
 
     @Test func remoteBareURLLinkifierPreservesIndentedCodeBlocks() throws {
@@ -96,8 +99,9 @@ struct RemoteWebAssetTests {
 
         #expect(app.contains("function sessionMetaParts"))
         #expect(app.contains("function renderSessionRow"))
-        #expect(app.contains("function sortedSessions"))
-        #expect(app.contains("function sessionIsActive"))
+        #expect(app.contains("RemoteSessionOrdering.groupSessions(sessions)"))
+        #expect(app.contains("session-section-title"))
+        #expect(app.contains("s.worktree.worktreeName"))
         #expect(app.contains(#""session-row-active""#))
         #expect(app.contains(#""session-row-inactive""#))
         #expect(app.contains(#""Active""#))
@@ -110,8 +114,11 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-state-active"))
         #expect(css.contains(".session-state-inactive"))
         #expect(css.contains(".session-meta"))
-        #expect(html.contains("/app.js?v=61"))
-        #expect(html.contains("/style.css?v=39"))
+        #expect(css.contains(".session-section"))
+        #expect(css.contains(".session-section-title"))
+        #expect(css.contains(".session-section-list"))
+        #expect(html.contains("/app.js?v=62"))
+        #expect(html.contains("/style.css?v=40"))
     }
 
     @Test func remoteWebExposesSessionRenameControls() throws {
@@ -136,8 +143,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=61""#))
-        #expect(sw.contains(#""/style.css?v=39""#))
+        #expect(sw.contains(#""/app.js?v=62""#))
+        #expect(sw.contains(#""/style.css?v=40""#))
     }
 
     @Test func configSheetScrollsWhenModelListOverflows() throws {

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -100,6 +100,8 @@ struct RemoteWebAssetTests {
         #expect(app.contains("function sessionMetaParts"))
         #expect(app.contains("function renderSessionRow"))
         #expect(app.contains("RemoteSessionOrdering.groupSessions(sessions)"))
+        #expect(app.contains("listedSessions.set(session.id, session);"))
+        #expect(app.contains("renderSessions([...listedSessions.values()]);"))
         #expect(app.contains("session-section-title"))
         #expect(app.contains("s.worktree.worktreeName"))
         #expect(app.contains(#""session-row-active""#))

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -294,9 +294,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v39"))
-        #expect(sw.contains("/app.js?v=61"))
-        #expect(html.contains("app.js?v=61"))
+        #expect(sw.contains("alas-remote-shell-v40"))
+        #expect(sw.contains("/app.js?v=62"))
+        #expect(html.contains("app.js?v=62"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the

--- a/docs/superpowers/specs/2026-08-14-remote-web-session-repository-ordering-design.md
+++ b/docs/superpowers/specs/2026-08-14-remote-web-session-repository-ordering-design.md
@@ -1,0 +1,72 @@
+# Remote Web Session Repository Ordering Design
+
+## Context
+
+The remote web UI renders one flat session list. It puts sessions backed by an open Alas tab before closed sessions, but otherwise preserves backend arrival order. Each resolved worktree summary already includes the repository display name, while the persisted ACP session row already tracks `updatedAt`. Neither a stable repository identity nor `updatedAt` is currently sent to the browser.
+
+## Goals
+
+- Separate sessions into repository sections.
+- Order repository sections by their most recently updated session.
+- Within each repository, show active sessions first and inactive sessions last, with each group ordered by most recent update.
+- Keep unresolved sessions visible in an `Other` section at the bottom.
+
+## Non-Goals
+
+- No collapsing or filtering of repository sections.
+- No visible relative activity timestamp.
+- No backend-specific grouped response type.
+- No change to the meaning of active: a session remains active when backed by an open Alas tab.
+
+## Protocol
+
+Extend `RemoteSessionSummary` with:
+
+- `projectId: String?`, the stable `ProjectConfig.id` used for grouping.
+- `updatedAt: Int64`, the persisted session update time in Unix seconds.
+
+Decode missing values as `nil` and `0` respectively. This preserves compatibility with older payloads and lightweight test fixtures. The existing `worktree.projectName` remains the section's display label.
+
+When AppState deduplicates multiple stored rows for the same remote session identity, the resulting summary uses the greatest `updatedAt` across every candidate. Repository identity comes from the resolved project associated with the session's worktree.
+
+## Web Rendering and Ordering
+
+`renderSessions` groups summaries before creating DOM nodes:
+
+1. Sessions with a `projectId` and resolved worktree are grouped by `projectId`.
+2. The group heading uses `worktree.projectName`.
+3. Sessions without resolved repository data are grouped under `Other`.
+4. Repository groups are sorted descending by their greatest session `updatedAt`.
+5. `Other` is always last.
+
+Within each group, sessions are sorted by:
+
+1. Active before inactive.
+2. `updatedAt` descending.
+3. Title using a stable case-insensitive comparison.
+4. Session ID as the final deterministic tie-breaker.
+
+Each group renders as a section with a heading and its session rows. Because the heading already names the repository, a resolved row's identity line shows only the worktree name instead of repeating `projectName / worktreeName`. Existing status, active/closed treatment, metrics, rename, and open actions remain unchanged.
+
+## Error Handling and Compatibility
+
+Missing repository data is ordinary fallback behavior, not an error: the session appears under `Other`. A missing or legacy `updatedAt` becomes `0`, placing the session behind summaries with known activity while retaining deterministic tie-breaking.
+
+The browser continues to accept `isActive` being absent as active, matching current behavior. No session is omitted because grouping metadata is unavailable.
+
+## Tests
+
+- Extend `RemoteProtocolTests` to cover encoding and decoding `projectId` and `updatedAt`, including absent-field defaults.
+- Extend `RemoteAppStateAccessTests` to verify repository identity projection and that deduplicated summaries use the greatest candidate `updatedAt`.
+- Extend `RemoteWebAssetTests` to require the repository grouping, section ordering, session ordering, `Other` fallback, and section styles.
+- Bump the remote web asset URLs and service-worker cache version so installed PWAs receive the JavaScript and CSS changes.
+
+Manual verification should cover two repositories with mixed active and inactive sessions, equal timestamps, and one unresolved session.
+
+Final verification uses the project commands:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```

--- a/scripts/tests/remote-web-session-ordering/run.sh
+++ b/scripts/tests/remote-web-session-ordering/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+node "$(dirname "$0")/test-session-ordering.js"

--- a/scripts/tests/remote-web-session-ordering/test-session-ordering.js
+++ b/scripts/tests/remote-web-session-ordering/test-session-ordering.js
@@ -1,0 +1,34 @@
+const assert = require("node:assert/strict");
+
+require("../../../Alas/Resources/RemoteWeb/session-ordering.js");
+
+const ordering = globalThis.RemoteSessionOrdering;
+
+function session(id, projectId, projectName, updatedAt, isActive, title = id) {
+  return {
+    id, title, projectId, updatedAt, isActive,
+    worktree: projectName ? { projectName, worktreeName: `${id}-worktree` } : null,
+  };
+}
+
+const sections = ordering.groupSessions([
+  session("a-closed", "repo-a", "Alpha", 100, false),
+  session("a-active-old", "repo-a", "Alpha", 90, true),
+  session("a-active-new", "repo-a", "Alpha", 110, true),
+  session("b-active", "repo-b", "Beta", 105, true),
+  session("orphan", null, null, 999, true),
+]);
+
+assert.deepStrictEqual(sections.map(({ id }) => id), ["repo-a", "repo-b", "other"]);
+assert.deepStrictEqual(sections[0].sessions.map(({ id }) => id), ["a-active-new", "a-active-old", "a-closed"]);
+assert.equal(sections[2].title, "Other");
+
+const equalTimestamps = ordering.groupSessions([
+  session("z-id", "repo-ties", "Ties", 50, true, "alpha"),
+  session("a-id", "repo-ties", "Ties", 50, true, "Alpha"),
+  session("b-id", "repo-ties", "Ties", 50, true, "beta"),
+]);
+
+assert.deepStrictEqual(equalTimestamps[0].sessions.map(({ id }) => id), ["a-id", "z-id", "b-id"]);
+
+console.log("session ordering tests passed");

--- a/scripts/tests/remote-web-session-ordering/test-session-ordering.js
+++ b/scripts/tests/remote-web-session-ordering/test-session-ordering.js
@@ -38,4 +38,11 @@ const caseSensitiveIds = ordering.groupSessions([
 
 assert.deepStrictEqual(caseSensitiveIds[0].sessions.map(({ id }) => id), ["A-id", "a-id"]);
 
+const equalRecencySections = ordering.groupSessions([
+  session("z-session", "repo-z", "Zulu", 50, true),
+  session("a-session", "repo-a", "Alpha", 50, true),
+]);
+
+assert.deepStrictEqual(equalRecencySections.map(({ id }) => id), ["repo-a", "repo-z"]);
+
 console.log("session ordering tests passed");

--- a/scripts/tests/remote-web-session-ordering/test-session-ordering.js
+++ b/scripts/tests/remote-web-session-ordering/test-session-ordering.js
@@ -31,4 +31,11 @@ const equalTimestamps = ordering.groupSessions([
 
 assert.deepStrictEqual(equalTimestamps[0].sessions.map(({ id }) => id), ["a-id", "z-id", "b-id"]);
 
+const caseSensitiveIds = ordering.groupSessions([
+  session("a-id", "repo-case", "Case", 50, true, "same"),
+  session("A-id", "repo-case", "Case", 50, true, "Same"),
+]);
+
+assert.deepStrictEqual(caseSensitiveIds[0].sessions.map(({ id }) => id), ["A-id", "a-id"]);
+
 console.log("session ordering tests passed");


### PR DESCRIPTION
Group remote sessions by repository with stable ordering

## Summary
- Remote web session list now groups sessions into per-repository sections (sorted by most recent activity), with active sessions before inactive within each group and an `Other` section for unresolved sessions.
- Extends `RemoteSessionSummary` with `projectId` and `updatedAt` so the web client can group and order sessions; deduplication in `AppState` now keeps the greatest `updatedAt` and resolved `projectId` across merged candidates.
- Newly created sessions are inserted into the grouped list via a tracked `listedSessions` map instead of being prepended ungrouped; worktree session rows now show only the worktree name since the section heading already carries the repository name.

## Testing
- Extended `RemoteProtocolTests`, `RemoteAppStateAccessTests`, and `RemoteWebAssetTests` covering encode/decode of the new fields (including legacy payloads without them), summary projection/dedup of `projectId`/`updatedAt`, and the updated web assets/versions.
- Added a standalone Node test (`scripts/tests/remote-web-session-ordering/test-session-ordering.js`) exercising `session-ordering.js` grouping/sorting logic directly, including tie-breaking by title and session ID.