### PR TITLE
ci: speed up CI release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,9 @@ jobs:
           cat .ghostty-pin
 
       - name: Restore Ghostty cache
-        # Split restore + save (Option B): the combined `actions/cache@v4` only
+        # Restore the shared arm64 cache. `build-ghostty.sh` validates the
+        # restored entry and populates `.build/ghostty`. Split restore + save
+        # (Option B): the combined `actions/cache@v4` only
         # saves at end-of-job on success. When build/test fails or is canceled,
         # we lose the freshly-built xcframework and the next CI run pays the
         # full 20–30 min cold zig build again. With explicit restore + save,
@@ -105,9 +107,10 @@ jobs:
         id: ghostty-cache
         uses: actions/cache/restore@v6
         with:
-          path: |
-            .build/ghostty
-          key: ghostty-${{ runner.os }}-${{ hashFiles('.ghostty-pin') }}
+          path: ~/Library/Caches/Alas/GhosttyKit/arm64
+          key: ghostty-${{ runner.os }}-arm64-${{ hashFiles('.ghostty-pin') }}
+          restore-keys: |
+            ghostty-${{ runner.os }}-arm64-
 
       - name: Build Ghostty xcframework
         # xcodebuild validates the GhosttyKit.xcframework dependency at the
@@ -125,8 +128,7 @@ jobs:
         if: success() && steps.ghostty-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
-          path: |
-            .build/ghostty
+          path: ~/Library/Caches/Alas/GhosttyKit/arm64
           key: ${{ steps.ghostty-cache.outputs.cache-primary-key }}
 
       - name: Compute prebuilt tools cache key inputs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,13 +86,10 @@ jobs:
         run: bash scripts/tests/build-alas-cli/run.sh
 
       - name: Compute Ghostty cache key inputs
-        # Submodules track their HEAD via .git/modules/... in the parent repo, so
-        # `ThirdParty/ghostty/.git` is a *file* (not a dir) and hashFiles can't
-        # follow it. Dump the submodule SHA + script hash into a small file we
-        # can feed to hashFiles. Re-runs whenever the pinned commit moves.
+        # Use the script's authoritative fingerprint so the Actions key tracks
+        # every input that can change the produced artifact.
         run: |
-          git -C ThirdParty/ghostty rev-parse HEAD > .ghostty-pin
-          shasum scripts/build-ghostty.sh >> .ghostty-pin
+          ALAS_GHOSTTY_TARGET_ARCH=arm64 ./scripts/build-ghostty.sh --print-fingerprint > .ghostty-pin
           cat .ghostty-pin
 
       - name: Restore Ghostty cache
@@ -118,6 +115,9 @@ jobs:
         # If the xcframework doesn't already exist on disk, the build fails
         # before our pre-build script ever gets a chance to produce it. So
         # we run the script as its own CI step, ahead of xcodebuild.
+        env:
+          ALAS_GHOSTTY_TARGET_ARCH: arm64
+          ALAS_GHOSTTY_CACHE_KEEP: 1
         run: ./scripts/build-ghostty.sh
 
       - name: Save Ghostty cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,25 +244,6 @@ jobs:
           path: .build/xcode/SourcePackages
           key: ${{ steps.swiftpm-cache.outputs.cache-primary-key }}
 
-      - name: Restore Swift compilation cache
-        # Xcode 26 compilation caching: the build system fingerprints each
-        # compile action and stores artifacts in a content-addressable store
-        # (CAS) under DerivedData. Restoring a recent CAS turns most of the
-        # app-module compile in Build for testing into cache hits. Content
-        # addressing makes stale restores safe: misses just compile as
-        # usual, hits are byte-exact — a wrong binary can't come out of it.
-        # The primary key embeds the commit SHA so it never hits; the
-        # restore-keys prefix pulls the most recent CAS for this toolchain
-        # (hash of .xcode-cache-toolchain, computed above), so an Xcode
-        # bump starts a fresh lineage instead of downloading useless bytes.
-        id: swiftcas-cache
-        uses: actions/cache/restore@v6
-        with:
-          path: .build/xcode/DerivedData/CompilationCache.noindex
-          key: swiftcas-${{ runner.os }}-${{ hashFiles('.xcode-cache-toolchain') }}-${{ github.sha }}
-          restore-keys: |
-            swiftcas-${{ runner.os }}-${{ hashFiles('.xcode-cache-toolchain') }}-
-
       - name: Build for testing
         # Splitting build/test into `build-for-testing` + `test-without-building`
         # avoids the lsregister/CoreServices hang we observed locally and on CI
@@ -283,33 +264,8 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
-            COMPILATION_CACHE_ENABLE_CACHING=YES \
+            -showBuildTimingSummary \
             build-for-testing
-
-      - name: Report Swift compilation cache size
-        # Round-2 experiment diagnostic: confirms the CAS actually lives
-        # where the cache steps expect (the default location under our
-        # -derivedDataPath) and how big it grows — that number decides
-        # whether every-run saves are sustainable inside the repo's 10 GB
-        # Actions cache quota. `|| true` keeps a missing dir (feature
-        # wrote nowhere / somewhere else) from failing the job; the save
-        # below surfaces the real error in that case.
-        run: |
-          du -sh .build/xcode/DerivedData/CompilationCache.noindex || true
-          ls .build/xcode/DerivedData/ || true
-
-      - name: Save Swift compilation cache
-        # Rolling snapshot: the primary key embeds the SHA and never hits,
-        # so every successful build saves a fresh CAS (no cache-hit gate
-        # needed). Saved BEFORE the test steps so an unrelated test failure
-        # doesn't throw away the compile work. Scoping does the sharing:
-        # main-push saves land in the repo-wide scope every PR restores
-        # from; PR-run saves warm that PR's own subsequent pushes.
-        if: success()
-        uses: actions/cache/save@v6
-        with:
-          path: .build/xcode/DerivedData/CompilationCache.noindex
-          key: ${{ steps.swiftcas-cache.outputs.cache-primary-key }}
 
       # Each xcodebuild test invocation gets its own LaunchServices /
       # CoreServices teardown cycle. Combining 4+ subprocess-heavy suites

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -89,7 +89,9 @@ jobs:
           shasum scripts/build-ghostty.sh >> .ghostty-pin
 
       - name: Restore Ghostty cache
-        # Split restore + save — and gate save on main-built refs only — so a
+        # Restore the shared arm64 cache. `build-ghostty.sh` validates the
+        # restored entry and populates `.build/ghostty`. Split restore + save —
+        # and gate save on main-built refs only — so a
         # non-main dispatch building an arbitrary tree can never write into the
         # repo-wide cache scope. Without this gate, a feature ref leaving
         # .ghostty-pin unchanged could seed the main-scope key with a poisoned
@@ -98,9 +100,10 @@ jobs:
         id: ghostty-cache
         uses: actions/cache/restore@v6
         with:
-          path: |
-            .build/ghostty
-          key: ghostty-${{ runner.os }}-${{ hashFiles('.ghostty-pin') }}
+          path: ~/Library/Caches/Alas/GhosttyKit/arm64
+          key: ghostty-${{ runner.os }}-arm64-${{ hashFiles('.ghostty-pin') }}
+          restore-keys: |
+            ghostty-${{ runner.os }}-arm64-
 
       - name: Build Ghostty xcframework
         if: steps.skip-check.outputs.skip != 'true'
@@ -113,8 +116,7 @@ jobs:
           && (inputs.ref == '' || inputs.ref == 'main')
         uses: actions/cache/save@v6
         with:
-          path: |
-            .build/ghostty
+          path: ~/Library/Caches/Alas/GhosttyKit/arm64
           key: ${{ steps.ghostty-cache.outputs.cache-primary-key }}
 
       - name: Compute prebuilt tools cache key inputs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,9 @@ concurrency:
 jobs:
   warm-release-x86:
     name: Warm x86_64 Release Dependencies
-    if: github.event_name == 'schedule' || inputs.ref == '' || inputs.ref == 'main'
+    # `inputs.ref` selects the checkout; `github.ref` keeps manual cache
+    # producers in the default-branch cache scope.
+    if: github.event_name == 'schedule' || (github.ref == 'refs/heads/main' && (inputs.ref == '' || inputs.ref == 'main'))
     runs-on: macos-26
     timeout-minutes: 45
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,110 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  warm-release-x86:
+    name: Warm x86_64 Release Dependencies
+    if: github.event_name == 'schedule' || inputs.ref == '' || inputs.ref == 'main'
+    runs-on: macos-26
+    timeout-minutes: 45
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ inputs.ref || 'main' }}
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Install zig@0.15
+        run: brew install zig@0.15
+
+      - name: Test build-ghostty.sh harness
+        run: bash scripts/tests/build-ghostty/run.sh
+
+      - name: Compute Ghostty cache key inputs
+        run: |
+          git -C ThirdParty/ghostty rev-parse HEAD > .ghostty-pin
+          shasum scripts/build-ghostty.sh >> .ghostty-pin
+
+      - name: Restore Ghostty cache
+        id: ghostty-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/Library/Caches/Alas/GhosttyKit/x86_64
+          key: ghostty-${{ runner.os }}-x86_64-${{ hashFiles('.ghostty-pin') }}
+          restore-keys: |
+            ghostty-${{ runner.os }}-x86_64-
+
+      - name: Build Ghostty xcframework (x86_64)
+        env:
+          ALAS_GHOSTTY_TARGET_ARCH: x86_64
+        run: ./scripts/build-ghostty.sh
+
+      - name: Save Ghostty cache
+        if: success() && steps.ghostty-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/Library/Caches/Alas/GhosttyKit/x86_64
+          key: ${{ steps.ghostty-cache.outputs.cache-primary-key }}
+
+      - name: Compute prebuilt tools cache key inputs
+        run: |
+          git -C ThirdParty/zmx rev-parse HEAD > .tools-pin
+          {
+            git -C ThirdParty/fff rev-parse HEAD
+            git rev-parse HEAD:AlasHelper
+            git rev-parse HEAD:AlasCLI
+            shasum scripts/build-zmx.sh scripts/build-fff.sh scripts/build-alas-helper.sh scripts/build-alas-cli.sh
+            shasum -a 256 "$(brew --prefix zig@0.15)/bin/zig"
+          } >> .tools-pin
+          cat .tools-pin
+
+      - name: Restore prebuilt tools cache
+        id: tools-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            ~/Library/Caches/Alas/zmx
+            .build/zmx/linux-*/install
+            .build/zmx/linux-*/fingerprint
+            .build/fff/*/install
+            .build/fff/*/fingerprint
+            .build/fff/include
+            .build/alas-helper/*/release/alas-helper
+            .build/alas-helper/fingerprint
+            .build/alas-cli/*/release/alas
+            .build/alas-cli/fingerprint
+          key: tools-${{ runner.os }}-x86_64-${{ hashFiles('.tools-pin') }}
+          restore-keys: |
+            tools-${{ runner.os }}-x86_64-
+            tools-${{ runner.os }}-arm64-
+
+      - name: Prebuild zmx + fff + Alas Helper + Alas CLI (x86_64)
+        env:
+          ALAS_ZMX_TARGET_ARCH: x86_64
+          ALAS_FFF_TARGET_ARCH: x86_64
+        run: |
+          ./scripts/build-zmx.sh
+          ./scripts/build-fff.sh
+          ./scripts/build-alas-helper.sh
+          ./scripts/build-alas-cli.sh
+
+      - name: Save prebuilt tools cache
+        if: success() && steps.tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            ~/Library/Caches/Alas/zmx
+            .build/zmx/linux-*/install
+            .build/zmx/linux-*/fingerprint
+            .build/fff/*/install
+            .build/fff/*/fingerprint
+            .build/fff/include
+            .build/alas-helper/*/release/alas-helper
+            .build/alas-helper/fingerprint
+            .build/alas-cli/*/release/alas
+            .build/alas-cli/fingerprint
+          key: ${{ steps.tools-cache.outputs.cache-primary-key }}
+
   nightly:
     runs-on: macos-26
     # Two notarytool --wait --timeout 30m calls in this job (one for the

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,8 +42,8 @@ jobs:
 
       - name: Compute Ghostty cache key inputs
         run: |
-          git -C ThirdParty/ghostty rev-parse HEAD > .ghostty-pin
-          shasum scripts/build-ghostty.sh >> .ghostty-pin
+          ALAS_GHOSTTY_TARGET_ARCH=x86_64 ./scripts/build-ghostty.sh --print-fingerprint > .ghostty-pin
+          cat .ghostty-pin
 
       - name: Restore Ghostty cache
         id: ghostty-cache
@@ -57,6 +57,7 @@ jobs:
       - name: Build Ghostty xcframework (x86_64)
         env:
           ALAS_GHOSTTY_TARGET_ARCH: x86_64
+          ALAS_GHOSTTY_CACHE_KEEP: 1
         run: ./scripts/build-ghostty.sh
 
       - name: Save Ghostty cache
@@ -191,8 +192,8 @@ jobs:
       - name: Compute Ghostty cache key inputs
         if: steps.skip-check.outputs.skip != 'true'
         run: |
-          git -C ThirdParty/ghostty rev-parse HEAD > .ghostty-pin
-          shasum scripts/build-ghostty.sh >> .ghostty-pin
+          ALAS_GHOSTTY_TARGET_ARCH=arm64 ./scripts/build-ghostty.sh --print-fingerprint > .ghostty-pin
+          cat .ghostty-pin
 
       - name: Restore Ghostty cache
         # Restore the shared arm64 cache. `build-ghostty.sh` validates the
@@ -213,6 +214,9 @@ jobs:
 
       - name: Build Ghostty xcframework
         if: steps.skip-check.outputs.skip != 'true'
+        env:
+          ALAS_GHOSTTY_TARGET_ARCH: arm64
+          ALAS_GHOSTTY_CACHE_KEEP: 1
         run: ./scripts/build-ghostty.sh
 
       - name: Save Ghostty cache (main builds only)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,7 @@ jobs:
           key: tools-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('.tools-pin') }}
           restore-keys: |
             tools-${{ runner.os }}-${{ matrix.arch }}-
+            tools-${{ runner.os }}-arm64-
 
       - name: Prebuild zmx + fff + Alas Helper + Alas CLI (${{ matrix.arch }})
         # These normally run as pre-build script phases *inside* xcodebuild,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
+            -showBuildTimingSummary \
             build
 
       - name: Sign + notarize + staple .app (${{ matrix.arch }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,22 +58,12 @@ jobs:
 
       - name: Compute Ghostty cache key inputs
         run: |
-          git -C ThirdParty/ghostty rev-parse HEAD > .ghostty-pin
-          shasum scripts/build-ghostty.sh >> .ghostty-pin
+          ALAS_GHOSTTY_TARGET_ARCH="${{ matrix.arch }}" ./scripts/build-ghostty.sh --print-fingerprint > .ghostty-pin
+          cat .ghostty-pin
 
       - name: Restore Ghostty cache
-        # Split restore + save: the combined `actions/cache@v5` only saves at
-        # end-of-job on success. With explicit restore + save, the cache is
-        # persisted immediately after the Ghostty build completes, before
-        # notary work starts.
-        #
-        # Each matrix leg gets its own arch-qualified cache key so two runners
-        # don't race on saving the same immutable key.
-        #
-        # restore-keys gives us a warm cache when .ghostty-pin changes (new
-        # submodule SHA or build-ghostty.sh edit): we fall back to the most
-        # recent prior cache, and build-ghostty.sh's in-script fingerprint
-        # table can fast-path the build if any prior fingerprint matches.
+        # Release restores trusted cache entries only; the build script
+        # validates them before populating this checkout.
         id: ghostty-cache
         uses: actions/cache/restore@v6
         with:
@@ -133,18 +123,6 @@ jobs:
         env:
           ALAS_GHOSTTY_TARGET_ARCH: ${{ matrix.arch }}
         run: ./scripts/build-ghostty.sh
-
-      - name: Save Ghostty cache
-        # Save immediately after the Ghostty build completes, BEFORE the rest
-        # of the job (xcodebuild + notarytool) has a chance to fail. If we
-        # waited until end-of-job, a notary timeout would throw away ~12 min
-        # of cold zig work. `cache-hit != 'true'` skips a no-op save when
-        # restore already hit the exact primary key.
-        if: success() && steps.ghostty-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v6
-        with:
-          path: ~/Library/Caches/Alas/GhosttyKit/${{ matrix.arch }}
-          key: ${{ steps.ghostty-cache.outputs.cache-primary-key }}
 
       - name: Compute prebuilt tools cache key inputs
         # Same pin-file pattern as .ghostty-pin: the fingerprint inputs the
@@ -214,39 +192,12 @@ jobs:
           ./scripts/build-alas-helper.sh
           ./scripts/build-alas-cli.sh
 
-      - name: Save prebuilt tools cache
-        # Save immediately after the prebuild step succeeds, BEFORE
-        # xcodebuild/tests get a chance to fail — same split restore/save
-        # rationale as the Ghostty cache above.
-        if: success() && steps.tools-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v6
-        with:
-          path: |
-            ~/Library/Caches/Alas/zmx
-            .build/zmx/linux-*/install
-            .build/zmx/linux-*/fingerprint
-            .build/fff/*/install
-            .build/fff/*/fingerprint
-            .build/fff/include
-            .build/alas-helper/*/release/alas-helper
-            .build/alas-helper/fingerprint
-            .build/alas-cli/*/release/alas
-            .build/alas-cli/fingerprint
-          key: ${{ steps.tools-cache.outputs.cache-primary-key }}
-
       - name: Resolve SwiftPM packages
         run: |
           xcodebuild -resolvePackageDependencies \
             -project Alas.xcodeproj \
             -scheme Alas \
             -clonedSourcePackagesDirPath .build/xcode/SourcePackages
-
-      - name: Save SwiftPM package cache
-        if: success() && steps.swiftpm-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v6
-        with:
-          path: .build/xcode/SourcePackages
-          key: ${{ steps.swiftpm-cache.outputs.cache-primary-key }}
 
       - name: Build release app (${{ matrix.arch }})
         run: |

--- a/docs/superpowers/specs/2026-08-14-ci-release-cache-design.md
+++ b/docs/superpowers/specs/2026-08-14-ci-release-cache-design.md
@@ -1,0 +1,144 @@
+# CI Release Cache Design
+
+## Problem
+
+Release builds repeatedly compile dependencies that already succeeded on
+trusted `main` builds. Release `v0.14.11` spent 11–14 minutes per architecture
+building Ghostty, while the x86_64 leg spent another 13 minutes building zmx,
+fff, Alas Helper, and Alas CLI. The two Xcode Release builds then took 30 and
+38 minutes. Signing, packaging, notarization, and upload took about three
+minutes per architecture.
+
+The caches do not currently preserve the expensive work effectively:
+
+- PR and nightly builds cache `.build/ghostty` under a non-architecture key,
+  while releases cache the smaller shared Ghostty directory under an
+  architecture-qualified key. GitHub therefore cannot match the default-branch
+  cache for release jobs.
+- Trusted `main` workflows produce only arm64 tool caches, so tag-triggered
+  x86_64 release jobs have no default-branch cache to restore.
+- CI saves an immutable Swift compilation-cache snapshot for every commit. One
+  active PR occupied roughly 7.3 GB of the repository cache quota, evicting the
+  shared `main` snapshot. Recent runs did not show a reliable wall-time benefit:
+  a build with 84% cache hits took 18 minutes 45 seconds, while a cold `main`
+  build took 15 minutes 10 seconds.
+
+## Goals
+
+- Keep version tags and exact tag checkout as the release source of truth.
+- Remove repeated release dependency builds without skipping validation,
+  signing, notarization, packaging, or Homebrew verification.
+- Keep every restored binary subject to the build scripts' existing
+  fingerprint validation.
+- Bound cache usage so useful shared caches are not evicted by per-commit
+  snapshots.
+
+## Design
+
+### Shared Ghostty Cache
+
+`build.yml`, `nightly.yml`, and `release.yml` will use the same cache path and
+key shape:
+
+```text
+~/Library/Caches/Alas/GhosttyKit/<arch>
+ghostty-<runner-os>-<arch>-<pin-hash>
+```
+
+The arm64 PR/main build will restore this shared directory before running
+`build-ghostty.sh`. The script will populate `.build/ghostty` from the restored
+entry, preserving the existing local output expected by Xcode. On a miss it
+will build, validate, and publish the fingerprinted entry before the workflow
+saves it.
+
+This replaces the current approximately 871 MB `.build/ghostty` archive with
+the approximately 128 MB shared-cache archive. A tag-triggered release can
+restore the matching entry from the default `main` branch scope.
+
+### Nightly x86_64 Dependency Warmer
+
+`nightly.yml` will add an independent job that runs only for scheduled builds
+and manual builds of `main`. It will:
+
+1. Check out `main` with recursive submodules.
+2. Install the existing pinned build tools.
+3. Restore x86_64 Ghostty and prebuilt-tool caches.
+4. Run the existing Ghostty, zmx, fff, Alas Helper, and Alas CLI build scripts
+   with the same architecture overrides used by `release.yml`.
+5. Save successful cache misses immediately.
+
+The warmer will not build the app, receive signing or notarization secrets,
+publish artifacts, or delay the existing arm64 nightly job. Manual nightly
+runs for non-main refs will skip it, so feature-branch scripts cannot seed
+trusted default-branch caches.
+
+The combined tools cache remains unchanged. Alas Helper and Alas CLI already
+build all required targets and validate a source-and-script fingerprint; zmx
+and fff additionally validate their requested architecture.
+
+### Release Restore Behavior
+
+`release.yml` will retain its tag, published-release, and manual triggers and
+will continue checking out the exact release tag. Its Ghostty cache path and
+key will match the shared format above. Its existing arch-qualified tools key
+will consume the x86_64 cache produced by nightly.
+
+The x86_64 tools restore will also fall back to the trusted arm64 tools cache.
+This allows architecture-independent Alas Helper and Alas CLI outputs to
+fast-path if the x86_64 cache is absent; zmx and fff will reject mismatched
+fingerprints and rebuild their x86_64 outputs.
+
+### Swift Compilation Cache
+
+`build.yml` will remove cross-run Swift compilation-cache restore, reporting,
+and save steps, along with the build-only cache enablement flag. This removes
+the per-commit immutable snapshots responsible for cache-quota churn. Existing
+entries can expire through GitHub's normal cache eviction; the workflow will
+not add deletion permissions or cache-maintenance scripting.
+
+Both PR and release Xcode invocations will enable Xcode's build timing summary
+so subsequent optimization decisions use measured task timings. This changes
+logging only.
+
+## Failure and Security Behavior
+
+- A cache miss remains a supported cold build, not a workflow failure.
+- Cache saves occur only after the corresponding build scripts succeed.
+- Existing script fingerprints continue covering source revisions, local
+  changes, scripts, architecture, and relevant toolchain identity.
+- Tag releases may read trusted default-branch caches but cannot overwrite
+  them; nightly writes x86_64 caches only while building `main`.
+- Signing, notarization, package verification, and Homebrew verification remain
+  unchanged.
+
+## Validation
+
+- Run the existing build-script harnesses, especially the Ghostty, zmx, fff,
+  Alas Helper, and Alas CLI cache and fingerprint tests.
+- Regenerate the Xcode project and run the required macOS build and test
+  commands.
+- Validate workflow syntax locally if an installed checker is available.
+- Dispatch nightly against the feature ref to verify the ordinary nightly path
+  while confirming the main-only x86_64 warmer is skipped.
+- After merge, confirm one scheduled nightly creates arm64 and x86_64 caches in
+  the `refs/heads/main` scope. The next tag release should report exact cache
+  hits and dependency prebuild steps should complete in seconds.
+- Compare the Xcode timing summaries across several PR and release runs before
+  considering Release compilation caching or larger runners.
+
+## Expected Result
+
+In steady state, dependency preparation in both release matrix legs should
+complete in seconds. Release wall time should fall from roughly 70 minutes to
+approximately 40–45 minutes and become dominated by the unchanged Xcode
+Release compile. PR behavior remains fully validated while avoiding compiler
+cache restore/save overhead and quota churn.
+
+## Out of Scope
+
+- Skipping or reducing tests, signing, notarization, packaging, or publication
+  verification.
+- Replacing tag-triggered releases with a manual release process.
+- Adding self-hosted or paid larger runners.
+- Caching Release-mode Xcode compilation outputs before timing data shows a
+  reliable benefit and a bounded storage strategy is defined.

--- a/scripts/build-fff.sh
+++ b/scripts/build-fff.sh
@@ -12,7 +12,7 @@ script_path="${script_dir}/$(basename "${BASH_SOURCE[0]}")"
 srcroot="${SRCROOT:-$(cd "${script_dir}/.." && pwd)}"
 fff_src="${srcroot}/ThirdParty/fff"
 rustup_bin="${ALAS_RUSTUP_BIN:-rustup}"
-rust_toolchain="${ALAS_RUST_TOOLCHAIN:-stable}"
+rust_toolchain="${ALAS_RUST_TOOLCHAIN:-1.97.1}"
 
 if [ -z "${ALAS_FFF_TARGET_ARCH:-}" ] && [ "${CURRENT_ARCH:-}" = "undefined_arch" ]; then
     target_arch="universal"
@@ -33,8 +33,8 @@ die() {
 }
 
 # Fingerprint over the fff submodule (HEAD + working-tree dirt), target
-# arch, and this script's content hash. A stale `.build/fff` from a
-# previous submodule checkout is invalidated by the SHA change.
+# arch, Rust toolchain, and this script's content hash. A stale `.build/fff`
+# from a previous submodule checkout or toolchain is invalidated.
 fff_sha="$(git -C "${fff_src}" rev-parse HEAD 2>/dev/null || echo "")"
 fff_dirt="$(
     {
@@ -47,7 +47,7 @@ fff_dirt="$(
     } | shasum -a 256 | awk '{print $1}'
 )"
 script_id="$(shasum -a 256 "${script_path}" 2>/dev/null | awk '{print $1}')"
-fingerprint="$(printf '%s\n%s\n%s\n%s\n' "${fff_sha}" "${fff_dirt}" "${target_arch}" "${script_id}" | shasum -a 256 | awk '{print $1}')"
+fingerprint="$(printf '%s\n%s\n%s\n%s\n%s\n' "${fff_sha}" "${fff_dirt}" "${target_arch}" "${rust_toolchain}" "${script_id}" | shasum -a 256 | awk '{print $1}')"
 
 # Fast path: if the expected dylib for this arch already exists AND the
 # fingerprint matches, skip the cargo build. The Xcode build phase runs

--- a/scripts/tests/build-fff/run.sh
+++ b/scripts/tests/build-fff/run.sh
@@ -73,12 +73,23 @@ SRCROOT="${srcroot}" \
     PATH="${sandbox}/bin:${PATH}" \
     bash "${srcroot}/scripts/build-fff.sh"
 
-grep -qx 'rustup toolchain install stable --profile minimal' "${invocations}"
-grep -qx 'rustup target list --installed --toolchain stable' "${invocations}"
-grep -qx 'rustup target add --toolchain stable x86_64-apple-darwin' "${invocations}"
-grep -qx 'rustup which --toolchain stable rustc' "${invocations}"
-grep -qx 'rustup which --toolchain stable cargo' "${invocations}"
+grep -qx 'rustup toolchain install 1.97.1 --profile minimal' "${invocations}"
+grep -qx 'rustup target list --installed --toolchain 1.97.1' "${invocations}"
+grep -qx 'rustup target add --toolchain 1.97.1 x86_64-apple-darwin' "${invocations}"
+grep -qx 'rustup which --toolchain 1.97.1 rustc' "${invocations}"
+grep -qx 'rustup which --toolchain 1.97.1 cargo' "${invocations}"
 grep -q "^cargo RUSTC=${toolchain_bin}/rustc build " "${invocations}"
 test -f "${srcroot}/.build/fff/x86_64/install/lib/libfff_c.dylib"
+
+: > "${invocations}"
+SRCROOT="${srcroot}" \
+    ALAS_FFF_TARGET_ARCH="x86_64" \
+    ALAS_RUST_TOOLCHAIN="1.98.0" \
+    ALAS_RUSTUP_BIN="${sandbox}/rustup" \
+    PATH="${sandbox}/bin:${PATH}" \
+    bash "${srcroot}/scripts/build-fff.sh"
+
+grep -qx 'rustup toolchain install 1.98.0 --profile minimal' "${invocations}"
+grep -q "^cargo RUSTC=${toolchain_bin}/rustc build " "${invocations}"
 
 echo "build-fff tests passed"

--- a/scripts/tests/build-zmx/test_02_cache_hit_skips_build.sh
+++ b/scripts/tests/build-zmx/test_02_cache_hit_skips_build.sh
@@ -43,8 +43,8 @@ env_vars=(
 )
 env "${env_vars[@]}" bash "${repo_root}/scripts/build-zmx.sh"
 first=$(cat "${counter}")
-[ "${first}" = "1" ] || { echo "expected 1 build on cold cache, got ${first}" >&2; exit 1; }
+[ "${first}" = "3" ] || { echo "expected 3 total Zig invocations on cold cache, got ${first}" >&2; exit 1; }
 
 env "${env_vars[@]}" bash "${repo_root}/scripts/build-zmx.sh"
 second=$(cat "${counter}")
-[ "${second}" = "1" ] || { echo "expected cache hit (still 1 build), got ${second}" >&2; exit 1; }
+[ "${second}" = "3" ] || { echo "expected cache hit (still 3 total Zig invocations), got ${second}" >&2; exit 1; }

--- a/scripts/tests/build-zmx/test_04_retries_transient_build_failure.sh
+++ b/scripts/tests/build-zmx/test_04_retries_transient_build_failure.sh
@@ -46,7 +46,7 @@ ALAS_ZMX_CACHE_DIR="${tmp}/cache" \
 ALAS_ZMX_RETRY_DELAYS="0 0" \
     bash "${repo_root}/scripts/build-zmx.sh" >"${tmp}/out" 2>"${tmp}/err"
 
-[ "$(cat "${counter}")" = "3" ] || { echo "expected 3 build attempts" >&2; exit 1; }
+[ "$(cat "${counter}")" = "5" ] || { echo "expected 5 total Zig invocations" >&2; exit 1; }
 grep -q "retrying in 0s (attempt 2/3)" "${tmp}/err" || { echo "missing first retry warning" >&2; exit 1; }
 grep -q "retrying in 0s (attempt 3/3)" "${tmp}/err" || { echo "missing second retry warning" >&2; exit 1; }
 [ -x "${srcroot}/.build/zmx/arm64/install/bin/zmx" ] || { echo "missing zmx output after retry" >&2; exit 1; }

--- a/scripts/tests/build-zmx/test_05_retries_missing_output_after_success_exit.sh
+++ b/scripts/tests/build-zmx/test_05_retries_missing_output_after_success_exit.sh
@@ -46,7 +46,7 @@ ALAS_ZMX_CACHE_DIR="${tmp}/cache" \
 ALAS_ZMX_RETRY_DELAYS="0 0" \
     bash "${repo_root}/scripts/build-zmx.sh" >"${tmp}/out" 2>"${tmp}/err"
 
-[ "$(cat "${counter}")" = "3" ] || { echo "expected 3 build attempts" >&2; exit 1; }
+[ "$(cat "${counter}")" = "5" ] || { echo "expected 5 total Zig invocations" >&2; exit 1; }
 grep -q "retrying in 0s (attempt 2/3)" "${tmp}/err" || { echo "missing first retry warning" >&2; exit 1; }
 grep -q "retrying in 0s (attempt 3/3)" "${tmp}/err" || { echo "missing second retry warning" >&2; exit 1; }
 [ -x "${srcroot}/.build/zmx/arm64/install/bin/zmx" ] || { echo "missing zmx output after retry" >&2; exit 1; }


### PR DESCRIPTION
## What changed

- align PR, nightly, and release Ghostty caches on architecture-qualified authoritative fingerprints
- prewarm x86_64 Ghostty and release-tool artifacts nightly from trusted `main`
- make release cache usage restore-only so tag/manual builds cannot publish into trusted caches
- remove the ineffective per-commit Swift compiler cache and add Xcode build timing summaries
- pin the fff Rust toolchain and repair stale zmx harness expectations

## Why

Release builds were repeatedly rebuilding expensive Ghostty, zmx, fff, helper, and CLI dependencies. Per-commit Swift compiler caches also consumed cache quota without producing useful cross-commit hits, evicting reusable dependency caches.

This keeps tag-triggered release semantics and all signing/notarization steps unchanged. Cache entries are optimization hints only; build scripts still validate restored artifacts against their own fingerprints.

## Validation

- `bash scripts/tests/build-ghostty/run.sh` — 21/21 pass
- `bash scripts/tests/build-zmx/run.sh` — 5/5 pass
- `bash scripts/tests/build-fff/run.sh`
- `bash scripts/tests/build-alas-helper/run.sh`
- `bash scripts/tests/build-alas-cli/run.sh`
- workflow YAML parsing and `git diff --check`
- `xcodegen`
- full macOS app build

The repository-wide local Swift suite still reproduces two failures in untouched `AppStateCLIRoutingTests`; CI is the authoritative check for this PR.