### PR TITLE
fix(launcher): drop dead space in the mode-locked agent launcher

### DIFF
--- a/Alas/Sources/Agents/AgentLauncherDialog.swift
+++ b/Alas/Sources/Agents/AgentLauncherDialog.swift
@@ -28,7 +28,11 @@ struct AgentLauncherDialog: View {
                         footer
                     }
                     .frame(width: 460)
-                    .frame(maxHeight: 420)
+                    // No outer height cap: a max-only frame grows to the
+                    // proposed height, so the panel would stay 420pt tall and
+                    // center shorter content — leaving dead background above
+                    // the field and below the footer whenever the mode picker
+                    // is hidden (⌘⌥⇧T / ⌘⌥⇧C). The row list carries the cap.
                     .background(theme.color("bg-1").opacity(0.92))
                     .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                     .overlay(


### PR DESCRIPTION
## Problem

The ⌘⌥⇧T (new terminal agent) and ⌘⌥⇧C (new ACP chat) launchers render with extra empty background above the search field and below the footer. The ⌘⌥T launcher — same view, different state — does not.

## Cause

`AgentLauncherDialog` wrapped the panel in an outer `.frame(maxHeight: 420)`. A flexible frame with only a maximum grows to the *proposed* height, so the panel was always exactly 420pt tall and centered shorter content.

- ⌘⌥T: input row + mode picker + divider + list (320) + footer ≈ 428pt → squeezed to 420, fills the panel.
- ⌘⌥⇧T / ⌘⌥⇧C: `showsModePicker` is false, content ≈ 392pt → centered in the 420pt panel → ~14pt of dead background top and bottom.

## Fix

Remove the outer cap so the panel hugs its content. This matches the sibling palettes — `RepoSelectorDialog` and `ReviewTargetDialog` have no outer height frame and cap only their row list. Here the existing `rowList.frame(minHeight: 180, maxHeight: 320)` already bounds growth.

Side effect: ⌘⌥T now renders at its natural ~428pt instead of being compressed to 420, so its row list gets the full 320pt rather than ~312. Same look, 8pt taller.

## Verification

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' build` — succeeds.
- Ran a debug build and opened both launchers; the dead space is gone and the two dialogs now share the same chrome.