### PR TITLE
feat(treesitter): add 24 more language grammars

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		1B16FCB3621BB868C34334D7 /* ACPStreamingTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16F771D1DD9CAC618459D41 /* ACPStreamingTextTests.swift */; };
 		1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */; };
 		1B1A33B610D29116A1D08A74 /* PointingHandCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */; };
+		1B2909B6FF2CF876FA6B937B /* LanguageRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322B5870F5D4DCBE6F07121B /* LanguageRegistryTests.swift */; };
 		1B387AAB575A42ED1AFB5D46 /* RepoSelectorRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */; };
 		1B68197F3766CF78E8FED978 /* MissionLegPromptBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EF117AF22C11E37BB5B1F0 /* MissionLegPromptBuilder.swift */; };
 		1B7A283F7F585BA8D67C1959 /* ACPSteerUndoToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741E646CFDECE0AF9520265 /* ACPSteerUndoToast.swift */; };
@@ -1888,6 +1889,7 @@
 		31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowController.swift; sourceTree = "<group>"; };
 		321866B3EB8CCE337B1D3A58 /* ACPMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessage.swift; sourceTree = "<group>"; };
 		321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcherTests.swift; sourceTree = "<group>"; };
+		322B5870F5D4DCBE6F07121B /* LanguageRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageRegistryTests.swift; sourceTree = "<group>"; };
 		3253B229B757C725B7747249 /* initialize-request.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "initialize-request.json"; sourceTree = "<group>"; };
 		327D6F0E386398E6A512ADDF /* ProviderReviewActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewActionsTests.swift; sourceTree = "<group>"; };
 		328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageRegistry.swift; sourceTree = "<group>"; };
@@ -4879,6 +4881,7 @@
 		99296E46F8BEA6DE0DFBBBD2 /* Highlight */ = {
 			isa = PBXGroup;
 			children = (
+				322B5870F5D4DCBE6F07121B /* LanguageRegistryTests.swift */,
 				20556618656218B845371F37 /* TreeSitterHighlighterTests.swift */,
 			);
 			path = Highlight;
@@ -7309,6 +7312,7 @@
 				FD797B47C5EE0F82796A3733 /* LSPInstallerTests.swift in Sources */,
 				79575F0DA597D2C2DFCDC9E2 /* LSPMessagesTests.swift in Sources */,
 				C2CE2E3DE88344FDDE67D66A /* LSPTransportTests.swift in Sources */,
+				1B2909B6FF2CF876FA6B937B /* LanguageRegistryTests.swift in Sources */,
 				4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */,
 				9422B6F8F6C1E3E64B259712 /* LanguageServerRegistryTests.swift in Sources */,
 				599A6D9A3A1CCF1F618146C8 /* LegacyHookSweepTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift
+++ b/Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift
@@ -73,7 +73,28 @@ enum ACPCodeLanguage {
         case "tfvars": return "tfvars"
         case "dockerfile": return "dockerfile"
         case "sql": return "sql"
-        case "pl", "perl", "ex", "exs", "elixir", "ini":
+        case "cs", "csharp", "c#": return "cs"
+        case "scala": return "scala"
+        case "r": return "r"
+        case "dart": return "dart"
+        case "ex", "exs", "elixir": return "ex"
+        case "erl", "erlang": return "erl"
+        case "hs", "haskell": return "hs"
+        case "clj", "cljs", "cljc", "edn", "clojure": return "clj"
+        case "jl", "julia": return "jl"
+        case "zig": return "zig"
+        case "ps1", "pwsh", "powershell": return "ps1"
+        case "groovy", "gradle": return "groovy"
+        case "objc", "objective-c", "objectivec", "m", "mm": return "m"
+        case "graphql", "gql": return "graphql"
+        case "proto", "protobuf": return "proto"
+        case "svelte": return "svelte"
+        case "ini", "dosini", "properties", "cfg": return "ini"
+        case "make", "makefile", "mk": return "mk"
+        case "cmake": return "cmake"
+        // No tree-sitter-perl grammar exists (see ThirdParty/treesitter-pack's
+        // Cargo.toml for why), so Perl fences stay plain.
+        case "pl", "perl":
             return nil
         default:
             return nil
@@ -85,8 +106,14 @@ enum ACPCodeLanguage {
         if LanguageRegistry.language(forFileExtension: normalized) != nil {
             return normalized
         }
+        // `xml`, `scss`, and `sql` used to need a case here too, back when
+        // they had no tree-sitter grammar and only `RegexFallbackHighlighter`
+        // could render them; now they resolve through the branch above like
+        // any other grammar-backed extension. `diff`/`patch` and `sass` (no
+        // grammar of its own — `scss` covers only the SCSS dialect) still
+        // rely purely on that fallback, so they stay listed here.
         switch normalized {
-        case "diff", "patch", "xml", "scss", "sass", "sql":
+        case "diff", "patch", "sass":
             return normalized
         default:
             return nil

--- a/Alas/Sources/ACP/UI/InlineDiffView.swift
+++ b/Alas/Sources/ACP/UI/InlineDiffView.swift
@@ -85,6 +85,6 @@ struct InlineDiffView: View {
     }
 
     private var fileExtension: String {
-        (relativePath as NSString).pathExtension
+        LanguageRegistry.highlighterExtension(forPath: relativePath)
     }
 }

--- a/Alas/Sources/Center/StashDiffTabView.swift
+++ b/Alas/Sources/Center/StashDiffTabView.swift
@@ -97,7 +97,7 @@ struct StashDiffTabView: View {
             } else if let displayModel {
                 DiffPaneView(
                     model: displayModel,
-                    fileExtension: (state.file.path as NSString).pathExtension,
+                    fileExtension: LanguageRegistry.highlighterExtension(forPath: state.file.path),
                     layoutMode: $layoutMode,
                     wrapLines: $wrapLines,
                     showWhitespace: $showWhitespace,

--- a/Alas/Sources/Code/Highlight/LanguageRegistry.swift
+++ b/Alas/Sources/Code/Highlight/LanguageRegistry.swift
@@ -51,7 +51,7 @@ enum LanguageRegistry {
         "hcl": "hcl", "tf": "hcl", "tfvars": "hcl",
         "dockerfile": "dockerfile",
         "cs": "csharp",
-        "scala": "scala", "sc": "scala",
+        "scala": "scala", "sc": "scala", "sbt": "scala",
         "r": "r",
         "dart": "dart",
         "ex": "elixir", "exs": "elixir",

--- a/Alas/Sources/Code/Highlight/LanguageRegistry.swift
+++ b/Alas/Sources/Code/Highlight/LanguageRegistry.swift
@@ -92,7 +92,8 @@ enum LanguageRegistry {
         "makefile": "mk",
         "gnumakefile": "mk",
         "cmakelists.txt": "cmake",
-        ".editorconfig": "ini"
+        ".editorconfig": "ini",
+        "jenkinsfile": "groovy"
     ]
 
     /// Grammar ids whose highlight query is more than just their own, listed

--- a/Alas/Sources/Code/Highlight/LanguageRegistry.swift
+++ b/Alas/Sources/Code/Highlight/LanguageRegistry.swift
@@ -49,7 +49,50 @@ enum LanguageRegistry {
         "md": "markdown", "markdown": "markdown",
         "markdown-inline": "markdown_inline",
         "hcl": "hcl", "tf": "hcl", "tfvars": "hcl",
-        "dockerfile": "dockerfile"
+        "dockerfile": "dockerfile",
+        "cs": "csharp",
+        "scala": "scala", "sc": "scala",
+        "r": "r",
+        "dart": "dart",
+        "ex": "elixir", "exs": "elixir",
+        "erl": "erlang", "hrl": "erlang",
+        "hs": "haskell",
+        "clj": "clojure", "cljs": "clojure", "cljc": "clojure", "edn": "clojure",
+        "jl": "julia",
+        "zig": "zig",
+        "ps1": "powershell", "psm1": "powershell", "psd1": "powershell",
+        // Gradle build scripts are Groovy; `.gradle.kts` lands on Kotlin via
+        // its own `kts` entry above.
+        "groovy": "groovy", "gradle": "groovy", "gvy": "groovy",
+        // `.m` is Objective-C here rather than MATLAB — this is a macOS
+        // workspace, and `.mm` next to it is unambiguous.
+        "m": "objc", "mm": "objc",
+        "sql": "sql",
+        "graphql": "graphql", "gql": "graphql",
+        "proto": "proto",
+        "scss": "scss",
+        "svelte": "svelte",
+        "xml": "xml", "xsd": "xml", "xsl": "xml", "xslt": "xml", "svg": "xml",
+        "plist": "xml", "storyboard": "xml", "xib": "xml",
+        "csproj": "xml", "resx": "xml",
+        "ini": "ini", "cfg": "ini", "properties": "ini",
+        "mk": "make",
+        "cmake": "cmake",
+        // TypeScript's ESM/CJS variants, which the base `ts` entry misses.
+        "mts": "typescript", "cts": "typescript"
+    ]
+
+    /// Files whose language is carried by the whole filename rather than an
+    /// extension. Values are keys into `languageIDsByExtension`, not grammar
+    /// ids. `CMakeLists.txt` is why this is matched before the extension: its
+    /// `.txt` would otherwise win and resolve to nothing.
+    private static let extensionsByFilename: [String: String] = [
+        "dockerfile": "dockerfile",
+        "containerfile": "dockerfile",
+        "makefile": "mk",
+        "gnumakefile": "mk",
+        "cmakelists.txt": "cmake",
+        ".editorconfig": "ini"
     ]
 
     /// Grammar ids whose highlight query is more than just their own, listed
@@ -62,16 +105,23 @@ enum LanguageRegistry {
     /// in pure-JS files its patterns simply never match. TSX gets it too, but
     /// plain TypeScript must not: that grammar has no `jsx_*` nodes, so
     /// including the overlay would fail `Query` compilation outright.
+    /// Objective-C and SCSS both extend another grammar the same way C++ does.
+    /// SCSS is the starkest case: its own query covers only SCSS-specific
+    /// constructs (mixins, `@use`, variables) and names no selector, property,
+    /// colour or comment node at all, so without CSS merged in front of it a
+    /// stylesheet would highlight almost nothing.
     private static let queryIDsByLanguageID: [String: [String]] = [
         "javascript": ["javascript", "javascript_jsx"],
         "typescript": ["javascript", "typescript"],
         "tsx": ["javascript", "javascript_jsx", "tsx"],
-        "cpp": ["c", "cpp"]
+        "cpp": ["c", "cpp"],
+        "objc": ["c", "objc"],
+        "scss": ["css", "scss"]
     ]
 
     static func highlighterExtension(forPath path: String) -> String {
         let filename = (path as NSString).lastPathComponent.lowercased()
-        if filename == "dockerfile" { return "dockerfile" }
+        if let byFilename = extensionsByFilename[filename] { return byFilename }
         return (path as NSString).pathExtension.lowercased()
     }
 

--- a/Alas/Sources/Code/Highlight/LanguageRegistry.swift
+++ b/Alas/Sources/Code/Highlight/LanguageRegistry.swift
@@ -50,7 +50,7 @@ enum LanguageRegistry {
         "markdown-inline": "markdown_inline",
         "hcl": "hcl", "tf": "hcl", "tfvars": "hcl",
         "dockerfile": "dockerfile",
-        "cs": "csharp",
+        "cs": "csharp", "csx": "csharp",
         "scala": "scala", "sc": "scala", "sbt": "scala",
         "r": "r",
         "dart": "dart",

--- a/Alas/Sources/Code/Highlight/LanguageRegistry.swift
+++ b/Alas/Sources/Code/Highlight/LanguageRegistry.swift
@@ -56,7 +56,7 @@ enum LanguageRegistry {
         "dart": "dart",
         "ex": "elixir", "exs": "elixir",
         "erl": "erlang", "hrl": "erlang",
-        "hs": "haskell",
+        "hs": "haskell", "lhs": "haskell",
         "clj": "clojure", "cljs": "clojure", "cljc": "clojure", "edn": "clojure",
         "jl": "julia",
         "zig": "zig",

--- a/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
+++ b/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
@@ -271,7 +271,10 @@ struct TreeSitterHighlighter {
     }
 }
 
-private enum RegexFallbackHighlighter {
+/// Not `private`: tests exercise this directly, bypassing `LanguageRegistry`
+/// routing, so its markup/CSS-specific heuristics stay covered even for
+/// extensions (`xml`, `scss`, ...) that a real tree-sitter grammar now claims.
+enum RegexFallbackHighlighter {
     static func highlight(source: String, fileExtension ext: String) -> [HighlightSpan] {
         let language = language(forFileExtension: ext)
         guard language != "plain" else { return [] }

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -67,7 +67,32 @@ final class MarkdownRenderer {
         "typescript": "ts", "ts": "ts",
         "javascript": "js", "js": "js",
         "tsx": "tsx", "jsx": "jsx",
-        "kotlin": "kt", "kt": "kt"
+        "kotlin": "kt", "kt": "kt",
+        // The languages ThirdParty/treesitter-pack registered alongside this
+        // list's original entries. No perl: no tree-sitter-perl grammar
+        // exists (see the pack's Cargo.toml for why).
+        "cs": "cs", "csharp": "cs", "c#": "cs",
+        "scala": "scala",
+        "r": "r",
+        "dart": "dart",
+        "ex": "ex", "exs": "ex", "elixir": "ex",
+        "erl": "erl", "erlang": "erl",
+        "hs": "hs", "haskell": "hs",
+        "clj": "clj", "cljs": "clj", "cljc": "clj", "edn": "clj", "clojure": "clj",
+        "jl": "jl", "julia": "jl",
+        "zig": "zig",
+        "ps1": "ps1", "pwsh": "ps1", "powershell": "ps1",
+        "groovy": "groovy", "gradle": "groovy",
+        "objc": "m", "objective-c": "m", "objectivec": "m", "m": "m", "mm": "m",
+        "sql": "sql",
+        "xml": "xml",
+        "graphql": "graphql", "gql": "graphql",
+        "make": "mk", "makefile": "mk", "mk": "mk",
+        "cmake": "cmake",
+        "proto": "proto", "protobuf": "proto",
+        "scss": "scss",
+        "svelte": "svelte",
+        "ini": "ini", "dosini": "ini", "properties": "ini", "cfg": "ini"
     ]
 
     private func extensionFor(fenceLanguage info: String?) -> String? {

--- a/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+++ b/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
@@ -149,6 +149,7 @@ struct ACPCodeBlockHighlighterTests {
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "Program.cs") == "cs")
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "main.zig") == "zig")
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "build.sbt") == "sbt")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "build.csx") == "csx")
     }
 
     @Test("tool output syntax prefers diff shape over paths")

--- a/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+++ b/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
@@ -148,6 +148,7 @@ struct ACPCodeBlockHighlighterTests {
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "Jenkinsfile") == "groovy")
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "Program.cs") == "cs")
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "main.zig") == "zig")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "build.sbt") == "sbt")
     }
 
     @Test("tool output syntax prefers diff shape over paths")

--- a/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+++ b/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
@@ -77,14 +77,49 @@ struct ACPCodeBlockHighlighterTests {
         #expect(ACPCodeLanguage.highlighterExtension(for: "sql") == "sql")
     }
 
-    @Test("future-known unsupported ACP fence labels remain plain")
-    func futureKnownUnsupportedFenceLabelsRemainPlain() {
+    @Test("maps fence labels for the 2026-08 grammar additions")
+    func mapsNewGrammarFenceLabels() {
+        #expect(ACPCodeLanguage.highlighterExtension(for: "cs") == "cs")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "csharp") == "cs")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "c#") == "cs")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "scala") == "scala")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "r") == "r")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "dart") == "dart")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "ex") == "ex")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "exs") == "ex")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "elixir") == "ex")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "erl") == "erl")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "erlang") == "erl")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "hs") == "hs")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "haskell") == "hs")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "clj") == "clj")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "clojure") == "clj")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "jl") == "jl")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "julia") == "jl")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "zig") == "zig")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "ps1") == "ps1")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "powershell") == "ps1")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "groovy") == "groovy")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "gradle") == "groovy")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "objc") == "m")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "objective-c") == "m")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "graphql") == "graphql")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "gql") == "graphql")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "proto") == "proto")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "protobuf") == "proto")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "svelte") == "svelte")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "ini") == "ini")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "make") == "mk")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "makefile") == "mk")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "cmake") == "cmake")
+    }
+
+    @Test("labels with no grammar remain plain")
+    func labelsWithNoGrammarRemainPlain() {
+        // No tree-sitter-perl grammar exists at all (see the pack's
+        // Cargo.toml for why the only published version is unusable).
         #expect(ACPCodeLanguage.highlighterExtension(for: "pl") == nil)
         #expect(ACPCodeLanguage.highlighterExtension(for: "perl") == nil)
-        #expect(ACPCodeLanguage.highlighterExtension(for: "ex") == nil)
-        #expect(ACPCodeLanguage.highlighterExtension(for: "exs") == nil)
-        #expect(ACPCodeLanguage.highlighterExtension(for: "elixir") == nil)
-        #expect(ACPCodeLanguage.highlighterExtension(for: "ini") == nil)
     }
 
     @Test("path resolution maps only supported editor highlighter paths")
@@ -98,6 +133,20 @@ struct ACPCodeBlockHighlighterTests {
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "changes.patch") == "patch")
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "query.sql") == "sql")
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "README") == nil)
+    }
+
+    @Test("path resolution routes filename-based grammars through LanguageRegistry")
+    func pathResolutionRoutesFilenameBasedGrammars() {
+        // Regression coverage: this previously went through a bare
+        // `pathExtension` in some call sites, which resolves `Makefile` to
+        // "" and `CMakeLists.txt` to "txt" — losing the grammar entirely.
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "Makefile") == "mk")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "GNUmakefile") == "mk")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "CMakeLists.txt") == "cmake")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "Containerfile") == "dockerfile")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: ".editorconfig") == "ini")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "Program.cs") == "cs")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "main.zig") == "zig")
     }
 
     @Test("tool output syntax prefers diff shape over paths")
@@ -188,9 +237,11 @@ struct ACPCodeBlockHighlighterTests {
             content: "let value = 1",
             locations: ["Sources/App.swift", "Sources/Other.swift"]
         ) == nil)
+        // `.ini` gained a grammar alongside this test's other additions, so a
+        // plain `.txt` is the still-genuinely-unsupported case here now.
         #expect(ACPToolOutputSyntax.highlighterExtension(
             content: "theme = cool-slate",
-            locations: ["config.ini"]
+            locations: ["notes.txt"]
         ) == nil)
     }
 
@@ -403,7 +454,7 @@ struct ACPCodeBlockHighlighterTests {
         let theme = try Theme.loadBundled(id: "cool-slate")
         let editorTheme = EditorTheme(theme: theme)
         let content = "theme = cool-slate"
-        let ext = ACPToolOutputSyntax.highlighterExtension(content: content, locations: ["config.ini"])
+        let ext = ACPToolOutputSyntax.highlighterExtension(content: content, locations: ["notes.txt"])
         let attributed = ACPCodeBlockHighlighter.attributedString(
             code: content,
             language: ext,

--- a/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+++ b/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
@@ -150,6 +150,7 @@ struct ACPCodeBlockHighlighterTests {
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "main.zig") == "zig")
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "build.sbt") == "sbt")
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "build.csx") == "csx")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "Main.lhs") == "lhs")
     }
 
     @Test("tool output syntax prefers diff shape over paths")

--- a/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+++ b/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
@@ -145,6 +145,7 @@ struct ACPCodeBlockHighlighterTests {
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "CMakeLists.txt") == "cmake")
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "Containerfile") == "dockerfile")
         #expect(ACPCodeLanguage.highlighterExtension(forPath: ".editorconfig") == "ini")
+        #expect(ACPCodeLanguage.highlighterExtension(forPath: "Jenkinsfile") == "groovy")
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "Program.cs") == "cs")
         #expect(ACPCodeLanguage.highlighterExtension(forPath: "main.zig") == "zig")
     }

--- a/AlasTests/Code/Highlight/LanguageRegistryTests.swift
+++ b/AlasTests/Code/Highlight/LanguageRegistryTests.swift
@@ -20,7 +20,7 @@ struct LanguageRegistryTests {
         "tf": "hcl", "lua": "lua", "sh": "bash",
         // Added alongside the new grammars.
         "cs": "csharp",
-        "scala": "scala", "sc": "scala",
+        "scala": "scala", "sc": "scala", "sbt": "scala",
         "r": "r",
         "dart": "dart",
         "ex": "elixir", "exs": "elixir",
@@ -90,6 +90,16 @@ struct LanguageRegistryTests {
                 "\(path) resolved to no grammar"
             )
         }
+    }
+
+    @Test("build.sbt resolves to the Scala grammar")
+    func sbtFilesResolveToScala() throws {
+        // `.sbt` is a real (if unusual) extension, not a filename special
+        // case, but sbt projects' conventional `build.sbt` is exactly the
+        // path this needs to resolve for in practice.
+        let resolved = LanguageRegistry.highlighterExtension(forPath: "/repo/build.sbt")
+        #expect(resolved == "sbt")
+        #expect(LanguageRegistry.language(forFileExtension: resolved) != nil)
     }
 
     @Test("A plain .txt file still resolves to nothing")

--- a/AlasTests/Code/Highlight/LanguageRegistryTests.swift
+++ b/AlasTests/Code/Highlight/LanguageRegistryTests.swift
@@ -79,7 +79,8 @@ struct LanguageRegistryTests {
             "/repo/GNUmakefile": "mk",
             // `.txt` would otherwise win and resolve to nothing.
             "/repo/CMakeLists.txt": "cmake",
-            "/repo/.editorconfig": "ini"
+            "/repo/.editorconfig": "ini",
+            "/repo/Jenkinsfile": "groovy"
         ]
         for (path, expected) in cases {
             let resolved = LanguageRegistry.highlighterExtension(forPath: path)

--- a/AlasTests/Code/Highlight/LanguageRegistryTests.swift
+++ b/AlasTests/Code/Highlight/LanguageRegistryTests.swift
@@ -19,7 +19,7 @@ struct LanguageRegistryTests {
         "json": "json", "yaml": "yaml", "toml": "toml", "md": "markdown",
         "tf": "hcl", "lua": "lua", "sh": "bash",
         // Added alongside the new grammars.
-        "cs": "csharp",
+        "cs": "csharp", "csx": "csharp",
         "scala": "scala", "sc": "scala", "sbt": "scala",
         "r": "r",
         "dart": "dart",
@@ -99,6 +99,13 @@ struct LanguageRegistryTests {
         // path this needs to resolve for in practice.
         let resolved = LanguageRegistry.highlighterExtension(forPath: "/repo/build.sbt")
         #expect(resolved == "sbt")
+        #expect(LanguageRegistry.language(forFileExtension: resolved) != nil)
+    }
+
+    @Test(".csx C# scripts resolve to the C# grammar")
+    func csxFilesResolveToCSharp() throws {
+        let resolved = LanguageRegistry.highlighterExtension(forPath: "/repo/build.csx")
+        #expect(resolved == "csx")
         #expect(LanguageRegistry.language(forFileExtension: resolved) != nil)
     }
 

--- a/AlasTests/Code/Highlight/LanguageRegistryTests.swift
+++ b/AlasTests/Code/Highlight/LanguageRegistryTests.swift
@@ -25,7 +25,7 @@ struct LanguageRegistryTests {
         "dart": "dart",
         "ex": "elixir", "exs": "elixir",
         "erl": "erlang", "hrl": "erlang",
-        "hs": "haskell",
+        "hs": "haskell", "lhs": "haskell",
         "clj": "clojure", "cljs": "clojure", "cljc": "clojure", "edn": "clojure",
         "jl": "julia",
         "zig": "zig",
@@ -106,6 +106,13 @@ struct LanguageRegistryTests {
     func csxFilesResolveToCSharp() throws {
         let resolved = LanguageRegistry.highlighterExtension(forPath: "/repo/build.csx")
         #expect(resolved == "csx")
+        #expect(LanguageRegistry.language(forFileExtension: resolved) != nil)
+    }
+
+    @Test(".lhs literate Haskell resolves to the Haskell grammar")
+    func lhsFilesResolveToHaskell() throws {
+        let resolved = LanguageRegistry.highlighterExtension(forPath: "/repo/Main.lhs")
+        #expect(resolved == "lhs")
         #expect(LanguageRegistry.language(forFileExtension: resolved) != nil)
     }
 

--- a/AlasTests/Code/Highlight/LanguageRegistryTests.swift
+++ b/AlasTests/Code/Highlight/LanguageRegistryTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import Testing
+@testable import Alas
+
+/// Guards the extension → grammar mapping. The pack's own Rust suite proves
+/// every grammar resolves and every query compiles; what it cannot see is
+/// whether Alas ever *reaches* a grammar, which is what this file covers.
+@Suite("LanguageRegistry")
+struct LanguageRegistryTests {
+    /// Deliberately spelled out rather than derived from
+    /// `languageIDsByExtension`: a test that reads the same table it checks
+    /// would keep passing if an entry were dropped.
+    private static let expectedExtensions: [String: String] = [
+        // Pre-existing, so a regression in the new filename handling shows up.
+        "swift": "swift", "py": "python", "rs": "rust", "go": "go",
+        "ts": "typescript", "tsx": "tsx", "js": "javascript",
+        "java": "java", "kt": "kotlin", "rb": "ruby", "php": "php",
+        "c": "c", "cpp": "cpp", "html": "html", "css": "css",
+        "json": "json", "yaml": "yaml", "toml": "toml", "md": "markdown",
+        "tf": "hcl", "lua": "lua", "sh": "bash",
+        // Added alongside the new grammars.
+        "cs": "csharp",
+        "scala": "scala", "sc": "scala",
+        "r": "r",
+        "dart": "dart",
+        "ex": "elixir", "exs": "elixir",
+        "erl": "erlang", "hrl": "erlang",
+        "hs": "haskell",
+        "clj": "clojure", "cljs": "clojure", "cljc": "clojure", "edn": "clojure",
+        "jl": "julia",
+        "zig": "zig",
+        "ps1": "powershell", "psm1": "powershell", "psd1": "powershell",
+        "groovy": "groovy", "gradle": "groovy", "gvy": "groovy",
+        "m": "objc", "mm": "objc",
+        "sql": "sql",
+        "graphql": "graphql", "gql": "graphql",
+        "proto": "proto",
+        "scss": "scss",
+        "svelte": "svelte",
+        "xml": "xml", "xsd": "xml", "xsl": "xml", "xslt": "xml", "svg": "xml",
+        "plist": "xml", "storyboard": "xml", "xib": "xml",
+        "csproj": "xml", "resx": "xml",
+        "ini": "ini", "cfg": "ini", "properties": "ini",
+        "mk": "make",
+        "cmake": "cmake",
+        "mts": "typescript", "cts": "typescript"
+    ]
+
+    @Test("Every mapped extension resolves to a grammar and a compiling query")
+    func everyMappedExtensionResolves() throws {
+        for ext in Self.expectedExtensions.keys.sorted() {
+            #expect(
+                LanguageRegistry.language(forFileExtension: ext) != nil,
+                "\(ext) resolved to no grammar"
+            )
+            // A nil query here means the text would silently render as plain
+            // text even though the grammar loaded.
+            #expect(
+                LanguageRegistry.highlightQuery(forExtension: ext) != nil,
+                "\(ext) resolved to no highlight query"
+            )
+        }
+    }
+
+    @Test("Extensions are matched case-insensitively")
+    func extensionsAreCaseInsensitive() throws {
+        // `.R` is the conventional spelling for R sources, so this is the
+        // common path rather than an edge case.
+        #expect(LanguageRegistry.language(forFileExtension: "R") != nil)
+        #expect(LanguageRegistry.highlightQuery(forExtension: "SQL") != nil)
+    }
+
+    @Test("Extensionless and misleading filenames resolve by filename")
+    func filenamesResolve() throws {
+        let cases: [String: String] = [
+            "/repo/Dockerfile": "dockerfile",
+            "/repo/Containerfile": "dockerfile",
+            "/repo/Makefile": "mk",
+            "/repo/GNUmakefile": "mk",
+            // `.txt` would otherwise win and resolve to nothing.
+            "/repo/CMakeLists.txt": "cmake",
+            "/repo/.editorconfig": "ini"
+        ]
+        for (path, expected) in cases {
+            let resolved = LanguageRegistry.highlighterExtension(forPath: path)
+            #expect(resolved == expected, "\(path) resolved to \(resolved)")
+            #expect(
+                LanguageRegistry.language(forFileExtension: resolved) != nil,
+                "\(path) resolved to no grammar"
+            )
+        }
+    }
+
+    @Test("A plain .txt file still resolves to nothing")
+    func unknownExtensionsStayUnmapped() throws {
+        // The filename table must not accidentally swallow every `.txt`.
+        #expect(LanguageRegistry.highlighterExtension(forPath: "/repo/notes.txt") == "txt")
+        #expect(LanguageRegistry.language(forFileExtension: "txt") == nil)
+    }
+
+    @Test("SCSS merges the CSS query, not just its own")
+    func scssInheritsCSSPatterns() throws {
+        let src = """
+        $primary: #333;
+        .card { color: $primary; font-weight: bold; }
+        """
+        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "scss")
+        let captures = Set(spans.map { $0.capture })
+        // `property` comes from `(property_name) @property`, which exists only
+        // in the CSS query — the SCSS query names no `property_name` at all.
+        // Without the merge a stylesheet would highlight almost nothing.
+        #expect(captures.contains(.property), "SCSS did not inherit CSS patterns: \(captures)")
+    }
+
+    @Test("Objective-C merges the C query, not just its own")
+    func objcInheritsCPatterns() throws {
+        let src = """
+        // greeter
+        #import <Foundation/Foundation.h>
+        @interface Greeter : NSObject
+        - (NSString *)greet:(NSString *)name;
+        @end
+        """
+        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "m")
+        let captures = Set(spans.map { $0.capture })
+        // The Objective-C query declares `; inherits: c` and names no comment
+        // pattern itself, so a captured comment can only have come from C's.
+        #expect(captures.contains(.comment), "Obj-C did not inherit C patterns: \(captures)")
+    }
+
+    @Test("Newly added grammars highlight real source")
+    func newGrammarsHighlightRealSource() throws {
+        // One representative source per new grammar. Asserting on `.keyword`
+        // (or the nearest structural capture) proves the query actually fired,
+        // which compiling it cannot: the regex fallback never emits these for
+        // extensions it does not know.
+        let cases: [(ext: String, source: String, expected: HighlightCapture)] = [
+            ("cs", "public class Greeter { public string Greet() => \"hi\"; }", .keyword),
+            ("scala", "object Main { def greet(name: String): String = name }", .keyword),
+            ("r", "greet <- function(name) { paste(\"hi\", name) }", .function),
+            ("dart", "class Greeter { String greet(String name) => name; }", .keyword),
+            ("ex", "defmodule Greeter do\n  def greet(name), do: name\nend", .function),
+            ("erl", "-module(greeter).\ngreet(Name) -> Name.", .function),
+            ("hs", "greet :: String -> String\ngreet name = name", .function),
+            // tree-sitter-clojure-orchard's query is deliberately minimal —
+            // literals, comments, and quasiquote operators only, no
+            // function/keyword captures — so `"hi "` (a `str_lit`) is the
+            // capture this grammar can actually produce.
+            ("clj", "(defn greet [name] (str \"hi \" name))", .string),
+            ("jl", "function greet(name)\n    return name\nend", .keyword),
+            ("zig", "pub fn greet(name: []const u8) []const u8 { return name; }", .keyword),
+            ("ps1", "function Get-Greeting { param($Name) return $Name }", .keyword),
+            ("gradle", "apply plugin: 'java'\ndependencies { implementation 'a:b:1.0' }", .string),
+            ("sql", "SELECT name FROM users WHERE id = 1;", .keyword),
+            ("graphql", "query GetUser { user(id: 1) { name } }", .keyword),
+            ("proto", "syntax = \"proto3\";\nmessage User { string name = 1; }", .keyword),
+            ("svelte", "<script>let name = 'x';</script>\n<h1>{name}</h1>", .keyword),
+            // XML tag names capture as `@tag`, which folds into `.keyword`.
+            ("xml", "<?xml version=\"1.0\"?>\n<root><child id=\"a\">t</child></root>", .keyword),
+            ("ini", "[server]\nhost = localhost\nport = 8080", .property),
+            // `all` matches the query's well-known-target regex
+            // (`@constant.macro`); Make's query has no `@function` capture
+            // for recipe commands at all.
+            ("mk", "all: build\n\tgcc -o out main.c", .constant),
+            ("cmake", "project(Alas)\nadd_executable(alas main.c)", .function)
+        ]
+
+        for testCase in cases {
+            let spans = TreeSitterHighlighter.highlight(
+                source: testCase.source,
+                fileExtension: testCase.ext
+            )
+            let captures = Set(spans.map { $0.capture })
+            #expect(
+                captures.contains(testCase.expected),
+                "\(testCase.ext): expected \(testCase.expected), got \(captures.sorted { $0.rawValue < $1.rawValue })"
+            )
+        }
+    }
+}

--- a/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
+++ b/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
@@ -368,9 +368,16 @@ struct TreeSitterHighlighterTests {
 
     @Test("markup, CSS, and SQL fallback emit useful spans")
     func chatFallbackBasics() throws {
-        let html = TreeSitterHighlighter.highlight(source: #"<button class="primary">Save</button>"#, fileExtension: "xml")
-        let css = TreeSitterHighlighter.highlight(source: #".primary { display: flex; color: #fff; }"#, fileExtension: "scss")
-        let sql = TreeSitterHighlighter.highlight(source: #"SELECT id FROM users WHERE active = true;"#, fileExtension: "sql")
+        // Calls `RegexFallbackHighlighter` directly: `xml` and `scss` now
+        // have real tree-sitter grammars, so routing through
+        // `TreeSitterHighlighter.highlight` would no longer reach the
+        // fallback this test targets. `<button class="...">` also isn't
+        // well-formed XML (bare markup, no declaration), which the real
+        // XML grammar can't parse meaningfully anyway — the fallback's
+        // markup heuristic is the only thing that makes sense of it.
+        let html = RegexFallbackHighlighter.highlight(source: #"<button class="primary">Save</button>"#, fileExtension: "xml")
+        let css = RegexFallbackHighlighter.highlight(source: #".primary { display: flex; color: #fff; }"#, fileExtension: "scss")
+        let sql = RegexFallbackHighlighter.highlight(source: #"SELECT id FROM users WHERE active = true;"#, fileExtension: "sql")
 
         #expect(html.contains(where: { $0.capture == .keyword }))
         #expect(html.contains(where: { $0.capture == .attribute }))
@@ -510,7 +517,13 @@ struct TreeSitterHighlighterTests {
     @Test("CSS fallback does not treat hashes as line comments")
     func cssFallbackDoesNotTreatHashesAsLineComments() throws {
         let src = #".primary { color: #fff; background: red; } #app { display: grid; }"#
-        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "scss")
+        // `scss` now has a real tree-sitter grammar (merged with CSS), so this
+        // targets the fallback directly. `sass` (the indented-syntax dialect,
+        // no grammar of its own) would also still route through
+        // `TreeSitterHighlighter.highlight`, but calling the fallback
+        // directly matches the other tests in this group and doesn't depend
+        // on `sass` staying ungrammared.
+        let spans = RegexFallbackHighlighter.highlight(source: src, fileExtension: "scss")
         let swallowedRange = NSRange(src.range(of: "#fff; background")!, in: src)
 
         #expect(capture(for: "background", in: src, spans: spans) == .keyword)
@@ -521,7 +534,10 @@ struct TreeSitterHighlighterTests {
     @Test("markup fallback captures spaced and boolean attributes exactly")
     func markupFallbackExactAttributes() throws {
         let src = #"<button class = "primary" disabled>Save</button>"#
-        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "xml")
+        // `xml` now has a real tree-sitter grammar, and this markup (a bare
+        // tag with a boolean attribute) isn't well-formed XML anyway — call
+        // the fallback directly rather than route through it.
+        let spans = RegexFallbackHighlighter.highlight(source: src, fileExtension: "xml")
 
         #expect(capture(for: "class", in: src, spans: spans) == .attribute)
         #expect(capture(for: "disabled", in: src, spans: spans) == .attribute)
@@ -531,7 +547,7 @@ struct TreeSitterHighlighterTests {
     @Test("markup fallback does not classify assigned text outside tags as attributes")
     func markupFallbackDoesNotClassifyAssignedTextOutsideTagsAsAttributes() throws {
         let src = #"x = 1 <button class="primary">Save</button>"#
-        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "xml")
+        let spans = RegexFallbackHighlighter.highlight(source: src, fileExtension: "xml")
 
         #expect(capture(for: "x", in: src, spans: spans) != .attribute)
         #expect(capture(for: "class", in: src, spans: spans) == .attribute)
@@ -541,7 +557,7 @@ struct TreeSitterHighlighterTests {
     @Test("markup fallback does not recover boolean attributes inside comments or strings")
     func markupFallbackSkipsBooleanAttributesInsideCommentsAndStrings() throws {
         let src = #"<!-- <button disabled> --> <input disabled value="<tag disabled>">"#
-        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "xml")
+        let spans = RegexFallbackHighlighter.highlight(source: src, fileExtension: "xml")
 
         #expect(capture(for: "disabled", occurrence: 0, in: src, spans: spans) != .attribute)
         #expect(capture(for: "disabled", occurrence: 1, in: src, spans: spans) == .attribute)

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -199,6 +199,29 @@ struct MarkdownRendererTests {
         #expect(color != defaultFG)
     }
 
+    @Test func highlightsNewGrammarCodeBlocks() throws {
+        // Regression coverage for the 2026-08 grammar additions: each of
+        // these fence labels must resolve through fenceLanguageToExtension
+        // and actually highlight, not just render monospaced plain text.
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let defaultFG = NSColor(theme.color("fg"))
+        let cases: [(label: String, source: String, needle: String)] = [
+            ("csharp", "public class Greeter {}", "class"),
+            ("elixir", "defmodule Greeter do\nend", "defmodule"),
+            ("graphql", "query GetUser { user { name } }", "query"),
+            ("zig", "pub fn greet() void {}", "pub"),
+            ("ini", "[server]\nhost = localhost", "server")
+        ]
+        for testCase in cases {
+            let r = try MarkdownRendererTests.render("```\(testCase.label)\n\(testCase.source)\n```")
+            let s = r.attributedString
+            let range = (s.string as NSString).range(of: testCase.needle)
+            try #require(range.location != NSNotFound, "\(testCase.label): needle not found in rendered output")
+            let color = s.attribute(.foregroundColor, at: range.location, effectiveRange: nil) as? NSColor
+            #expect(color != defaultFG, "\(testCase.label) did not highlight")
+        }
+    }
+
     @Test func unknownLanguageRemainsPlainMonospaced() throws {
         let r = try MarkdownRendererTests.render("```neverheardofit\nfoo\n```")
         let s = r.attributedString

--- a/ThirdParty/treesitter-pack/Cargo.lock
+++ b/ThirdParty/treesitter-pack/Cargo.lock
@@ -15,36 +15,59 @@ dependencies = [
 name = "alas-treesitter-pack"
 version = "0.1.0"
 dependencies = [
- "tree-sitter 0.25.10",
+ "tree-sitter 0.26.12",
  "tree-sitter-bash",
  "tree-sitter-c",
+ "tree-sitter-c-sharp",
+ "tree-sitter-clojure-orchard",
+ "tree-sitter-cmake",
  "tree-sitter-cpp",
  "tree-sitter-css",
+ "tree-sitter-dart",
  "tree-sitter-dockerfile",
+ "tree-sitter-elixir",
+ "tree-sitter-erlang",
  "tree-sitter-go",
+ "tree-sitter-graphql",
+ "tree-sitter-groovy",
+ "tree-sitter-haskell",
  "tree-sitter-hcl",
  "tree-sitter-html",
+ "tree-sitter-ini",
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-json",
+ "tree-sitter-julia",
  "tree-sitter-kotlin-ng",
+ "tree-sitter-language",
  "tree-sitter-lua",
+ "tree-sitter-make",
  "tree-sitter-md",
+ "tree-sitter-objc",
  "tree-sitter-php",
+ "tree-sitter-powershell",
+ "tree-sitter-proto",
  "tree-sitter-python",
+ "tree-sitter-r",
  "tree-sitter-ruby",
  "tree-sitter-rust",
+ "tree-sitter-scala",
+ "tree-sitter-scss",
+ "tree-sitter-sequel",
+ "tree-sitter-svelte",
  "tree-sitter-swift",
  "tree-sitter-toml-ng",
  "tree-sitter-typescript",
+ "tree-sitter-xml",
  "tree-sitter-yaml",
+ "tree-sitter-zig",
 ]
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -215,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.25.10"
+version = "0.26.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
 dependencies = [
  "cc",
  "regex",
@@ -248,6 +271,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-clojure-orchard"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b854ba5935d62a713280b867c09cae08c6ad2286895734b5550ed02122d8fd"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-cmake"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164e0c4f4236ec5ceff14824a5528615cf462e100467e49826442ff57d327061"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-cpp"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +321,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-dart"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325dd1e24ee9ee21111e9c43680ae7d6010aaa9f282b048a99b9c7163c1cf553"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-dockerfile"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,10 +341,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-elixir"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66dd064a762ed95bfc29857fa3cb7403bb1e5cb88112de0f6341b7e47284ba40"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-erlang"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3107efc581d335488dc38d2f51ca8b7a6a98e36f07f95a8e963f031edda6f568"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-go"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-graphql"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfea063b7fa0e07529c2ca9cecf59d490fbc0259987493728596c16932ab2027"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-groovy"
+version = "0.0.1"
+source = "git+https://github.com/murtaza64/tree-sitter-groovy?rev=deb0dcf8c4544f07564060f6e9b9f6e4b0bfc27d#deb0dcf8c4544f07564060f6e9b9f6e4b0bfc27d"
+dependencies = [
+ "cc",
+ "tree-sitter 0.26.12",
+]
+
+[[package]]
+name = "tree-sitter-haskell"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977c51e504548cba13fc27cb5a2edab2124cf6716a1934915d07ab99523b05a4"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -301,6 +413,16 @@ name = "tree-sitter-html"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "261b708e5d92061ede329babaaa427b819329a9d427a1d710abb0f67bbef63ee"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-ini"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387f79682cd53b7c0a5777c96e601a02b9965a787984ef86dbb8952bdab2d62f"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -337,6 +459,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-julia"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4144731a178812ee867619b1e98b3b91e54c1652304b26e5ebe3175b701de323"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-kotlin-ng"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,10 +495,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-make"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5998dc7cbcbdab19fae8aefef982bf2d6544513d8d2e69cc44aec4c63810104"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-md"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2efd398be546456c814598ee56c0f51769a77241511b4a58077815d120afa882"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-objc"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca8bb556423fc176f0535e79d525f783a6684d3c9da81bf9d905303c129e1d2"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -383,10 +535,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-powershell"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3faf304d44b9ddd4a7d97804bb8de7daf564336dd5a526dc6de5b39238243022"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-proto"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e410ccb5fa3cbd6bf7b8e512ecf7ad9d5254395b822bfe9f751b50fa978f31c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-python"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-r"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc9954ec870dcad6cffdd302b405306c68cf031ed79a78cd9746f6740d9fe20"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -410,6 +592,46 @@ checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
 dependencies = [
  "cc",
  "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-scala"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e0ab4505990bfe30051761d40a7bf4033ce5a81c9eda9e20e987a5cdc84826"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-scss"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33909a9ca86390ebbf3461e9949c4bbe2767d2d024b486306d27616641d4ba24"
+dependencies = [
+ "cc",
+ "tree-sitter 0.26.12",
+]
+
+[[package]]
+name = "tree-sitter-sequel"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d198ad3c319c02e43c21efa1ec796b837afcb96ffaef1a40c1978fbdcec7d17"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-svelte"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "800f8ed6f5bdfee1f5444b653aefb6749bebed0ce58ac261dde64275c303e782"
+dependencies = [
+ "cc",
+ "tree-sitter 0.20.10",
 ]
 
 [[package]]
@@ -443,10 +665,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-xml"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e670041f591d994f54d597ddcd8f4ebc930e282c4c76a42268743b71f0c8b6b3"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-yaml"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-zig"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab11fc124851b0db4dd5e55983bbd9631192e93238389dcd44521715e5d53e28"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/ThirdParty/treesitter-pack/Cargo.toml
+++ b/ThirdParty/treesitter-pack/Cargo.toml
@@ -15,38 +15,87 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 tree-sitter-bash = "0.25.1"
 tree-sitter-c = "0.24.2"
+tree-sitter-c-sharp = "0.23.5"
+# Preferred over `tree-sitter-clojure` (0.1.0, and stale): this one is current
+# and keeps `tree-sitter` to a dev-dependency, reaching the grammar through
+# `tree-sitter-language`. That matters because the `tree-sitter` crate sets
+# `links = "tree-sitter"`, so every requirement in the graph must resolve to a
+# single version — a grammar that pins one hard can veto every other grammar.
+# Its C entry point is `tree_sitter_clojure_orchard`, not `tree_sitter_clojure`.
+tree-sitter-clojure-orchard = "0.2.8"
+tree-sitter-cmake = "0.7.4"
 tree-sitter-cpp = "0.23.4"
 tree-sitter-css = "0.25.0"
+tree-sitter-dart = "0.2.0"
 tree-sitter-dockerfile = "0.2.0"
+tree-sitter-elixir = "0.3.5"
+tree-sitter-erlang = "0.20.0"
 tree-sitter-go = "0.25.0"
+tree-sitter-graphql = "0.2.0"
+tree-sitter-haskell = "0.23.1"
 tree-sitter-html = "0.23.2"
+tree-sitter-ini = "1.4.0"
 tree-sitter-java = "0.23.5"
 tree-sitter-javascript = "0.25.0"
 tree-sitter-json = "0.24.8"
+tree-sitter-julia = "0.23.1"
 # fwcd/tree-sitter-kotlin is stale (last release Aug 2024); this is the
 # tree-sitter-grammars org's maintained successor. It ships no queries, so
 # queries/kotlin/highlights.scm below is vendored from the fwcd grammar
 # Alas shipped previously and verified to still compile (see kotlin_query_compiles_against_kotlin_ng_grammar).
 tree-sitter-kotlin-ng = "1.1.0"
 tree-sitter-lua = "0.5.0"
+tree-sitter-make = "1.1.1"
 tree-sitter-md = "0.5.3"
+tree-sitter-objc = "3.0.2"
+# No Perl grammar here on purpose: tree-sitter-perl 1.1.2 (the only version
+# ever published) is a broken publish — its bindings `include_str!` a
+# `queries/` directory the package does not ship, so the crate cannot compile.
 tree-sitter-php = "0.24.2"
+tree-sitter-powershell = "0.26.4"
+tree-sitter-proto = "0.4.0"
 tree-sitter-python = "0.25.0"
+tree-sitter-r = "1.3.0"
 tree-sitter-ruby = "0.23.1"
 tree-sitter-rust = "0.24.2"
+tree-sitter-scala = "0.26.2"
+tree-sitter-scss = "1.0.0"
+# The maintained SQL grammar. `tree-sitter-sql` on crates.io is an
+# unrelated 0.0.2 stub — do not swap it in.
+tree-sitter-sequel = "0.3.11"
+tree-sitter-svelte = "0.10.2"
 tree-sitter-swift = "0.7.3"
 tree-sitter-toml-ng = "0.7.0"
 tree-sitter-typescript = "0.23.2"
+tree-sitter-xml = "0.7.0"
 tree-sitter-yaml = "0.7.2"
+tree-sitter-zig = "1.1.2"
 
 # crates.io only has 1.1.0; Alas ships the v1.2.0 grammar.
 tree-sitter-hcl = { git = "https://github.com/tree-sitter-grammars/tree-sitter-hcl", tag = "v1.2.0" }
+
+# Not the crates.io `tree-sitter-groovy` (amaanq's, 0.1.2): that grammar has no
+# highlight query published anywhere, and the only maintained Groovy query —
+# nvim-treesitter's — is written against *this* grammar instead. The two
+# disagree on 22 of 33 named nodes, so the query is not portable between them.
+# Pinned to the revision nvim-treesitter itself pins, so the vendored
+# queries/groovy/highlights.scm and this grammar stay a matched pair.
+tree-sitter-groovy = { git = "https://github.com/murtaza64/tree-sitter-groovy", rev = "deb0dcf8c4544f07564060f6e9b9f6e4b0bfc27d" }
 
 [dev-dependencies]
 # Only used by tests that compile a `Query` against a `tree_sitter::Language`
 # to validate a vendored query text actually parses — real Query compilation,
 # not just presence, catches a grammar/query mismatch before it ships.
-tree-sitter = "0.25"
+#
+# The `tree-sitter` crate sets `links = "tree-sitter"`, so only one version may
+# ever exist in the graph. This must stay compatible with every grammar that
+# depends on it non-optionally — currently tree-sitter-groovy (`~0.26.8`) — or
+# resolution fails outright. Bump it only alongside those.
+tree-sitter = "0.26"
+# Lets the tests turn a raw `tree_sitter_*` entry point back into a
+# `tree_sitter::Language`, so every registered grammar can be exercised
+# generically rather than one hand-written test per language.
+tree-sitter-language = "0.1"
 
 [profile.release]
 opt-level = 2

--- a/ThirdParty/treesitter-pack/queries/graphql/highlights.scm
+++ b/ThirdParty/treesitter-pack/queries/graphql/highlights.scm
@@ -1,0 +1,163 @@
+; Types
+;------
+(scalar_type_definition
+  (name) @type)
+
+(object_type_definition
+  (name) @type)
+
+(interface_type_definition
+  (name) @type)
+
+(union_type_definition
+  (name) @type)
+
+(enum_type_definition
+  (name) @type)
+
+(input_object_type_definition
+  (name) @type)
+
+(scalar_type_extension
+  (name) @type)
+
+(object_type_extension
+  (name) @type)
+
+(interface_type_extension
+  (name) @type)
+
+(union_type_extension
+  (name) @type)
+
+(enum_type_extension
+  (name) @type)
+
+(input_object_type_extension
+  (name) @type)
+
+(named_type
+  (name) @type)
+
+; Directives
+;-----------
+(directive_definition
+  "@" @attribute
+  (name) @attribute)
+
+(directive) @attribute
+
+; Properties
+;-----------
+(field
+  (name) @property)
+
+(field
+  (alias
+    (name) @property))
+
+(field_definition
+  (name) @property)
+
+(object_value
+  (object_field
+    (name) @property))
+
+(enum_value
+  (name) @property)
+
+; Variable Definitions and Arguments
+;-----------------------------------
+(operation_definition
+  (name) @variable)
+
+(fragment_name
+  (name) @variable)
+
+(input_fields_definition
+  (input_value_definition
+    (name) @variable.parameter))
+
+(argument
+  (name) @variable.parameter)
+
+(arguments_definition
+  (input_value_definition
+    (name) @variable.parameter))
+
+(variable_definition
+  (variable) @variable.parameter)
+
+(argument
+  (value
+    (variable) @variable))
+
+; Constants
+;----------
+(string_value) @string
+
+(int_value) @number
+
+(float_value) @number.float
+
+(boolean_value) @boolean
+
+; Literals
+;---------
+(description
+  (string_value) @string.documentation @spell)
+
+(comment) @comment @spell
+
+(directive_location
+  (executable_directive_location) @type.builtin)
+
+(directive_location
+  (type_system_directive_location) @type.builtin)
+
+; Keywords
+;----------
+[
+  "query"
+  "mutation"
+  "subscription"
+  "fragment"
+  "scalar"
+  "input"
+  "extend"
+  "directive"
+  "schema"
+  "on"
+  "repeatable"
+  "implements"
+] @keyword
+
+[
+  "enum"
+  "union"
+  "type"
+  "interface"
+] @keyword.type
+
+; Punctuation
+;------------
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+"=" @operator
+
+"|" @punctuation.delimiter
+
+"&" @punctuation.delimiter
+
+":" @punctuation.delimiter
+
+"..." @punctuation.special
+
+"!" @punctuation.special

--- a/ThirdParty/treesitter-pack/queries/groovy/highlights.scm
+++ b/ThirdParty/treesitter-pack/queries/groovy/highlights.scm
@@ -1,0 +1,266 @@
+[
+  "!instanceof"
+  "assert"
+  "extends"
+  "instanceof"
+  "package"
+] @keyword
+
+"class" @keyword.type
+
+[
+  "!in"
+  "as"
+  "in"
+] @keyword.operator
+
+[
+  "case"
+  "default"
+  "else"
+  "if"
+  "switch"
+] @keyword.conditional
+
+[
+  "catch"
+  "finally"
+  "try"
+] @keyword.exception
+
+"def" @keyword.function
+
+"import" @keyword.import
+
+[
+  "for"
+  "while"
+  (break)
+  (continue)
+] @keyword.repeat
+
+"return" @keyword.return
+
+[
+  "true"
+  "false"
+] @boolean
+
+(null) @constant.builtin
+
+"this" @variable.builtin
+
+[
+  "int"
+  "char"
+  "short"
+  "long"
+  "boolean"
+  "float"
+  "double"
+  "void"
+] @type.builtin
+
+[
+  "final"
+  "private"
+  "protected"
+  "public"
+  "static"
+  "synchronized"
+] @keyword.modifier
+
+(comment) @comment @spell
+
+(shebang) @keyword.directive
+
+(string) @string
+
+(string
+  (escape_sequence) @string.escape)
+
+(string
+  (interpolation
+    "$" @punctuation.special))
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  ":"
+  ","
+  "."
+] @punctuation.delimiter
+
+(number_literal) @number
+
+(identifier) @variable
+
+((identifier) @constant
+  (#match? @constant "^[A-Z][A-Z_]+"))
+
+[
+  "%"
+  "*"
+  "/"
+  "+"
+  "-"
+  "<<"
+  ">>"
+  ">>>"
+  ".."
+  "..<"
+  "<..<"
+  "<.."
+  "<"
+  "<="
+  ">"
+  ">="
+  "=="
+  "!="
+  "<=>"
+  "==="
+  "!=="
+  "=~"
+  "==~"
+  "&"
+  "^"
+  "|"
+  "&&"
+  "||"
+  "?:"
+  ".&"
+  ".@"
+  "?."
+  "*."
+  "*:"
+  "++"
+  "--"
+  "!"
+] @operator
+
+(wildcard_import) @character.special
+
+(string
+  "/" @string)
+
+(ternary_op
+  ([
+    "?"
+    ":"
+  ]) @keyword.conditional.ternary)
+
+(map
+  (map_item
+    key: (identifier) @variable.parameter))
+
+(parameter
+  type: (identifier) @type
+  name: (identifier) @variable.parameter)
+
+(generic_param
+  name: (identifier) @variable.parameter)
+
+(declaration
+  type: (identifier) @type)
+
+(function_definition
+  type: (identifier) @type)
+
+(function_declaration
+  type: (identifier) @type)
+
+(class_definition
+  name: (identifier) @type)
+
+(class_definition
+  superclass: (identifier) @type)
+
+(generic_param
+  superclass: (identifier) @type)
+
+(type_with_generics
+  (identifier) @type)
+
+(type_with_generics
+  (generics
+    (identifier) @type))
+
+(generics
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+(generic_parameters
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+; TODO: Class literals with PascalCase
+(declaration
+  "=" @operator)
+
+(assignment
+  "=" @operator)
+
+(function_call
+  function: (identifier) @function)
+
+(function_call
+  function: (dotted_identifier
+    (identifier) @function .))
+
+(function_call
+  (argument_list
+    (map_item
+      key: (identifier) @variable.parameter)))
+
+(juxt_function_call
+  function: (identifier) @function)
+
+(juxt_function_call
+  function: (dotted_identifier
+    (identifier) @function .))
+
+(juxt_function_call
+  (argument_list
+    (map_item
+      key: (identifier) @variable.parameter)))
+
+(function_definition
+  function: (identifier) @function)
+
+(function_declaration
+  function: (identifier) @function)
+
+(annotation) @function.macro
+
+(annotation
+  (identifier) @function.macro)
+
+"@interface" @function.macro
+
+(groovy_doc) @comment.documentation @spell
+
+(groovy_doc
+  [
+    (groovy_doc_param)
+    (groovy_doc_throws)
+    (groovy_doc_tag)
+  ] @string.special @nospell)
+
+(groovy_doc
+  (groovy_doc_param
+    (identifier) @variable.parameter) @nospell)
+
+(groovy_doc
+  (groovy_doc_throws
+    (identifier) @type @nospell))

--- a/ThirdParty/treesitter-pack/queries/julia/highlights.scm
+++ b/ThirdParty/treesitter-pack/queries/julia/highlights.scm
@@ -1,0 +1,325 @@
+; Identifiers
+(identifier) @variable
+
+(field_expression
+  (identifier) @variable.member .)
+
+; Symbols
+(quote_expression
+  ":" @string.special.symbol
+  [
+    (identifier)
+    (operator)
+  ] @string.special.symbol)
+
+; Function calls
+(call_expression
+  (identifier) @function.call)
+
+(call_expression
+  (field_expression
+    (identifier) @function.call .))
+
+(broadcast_call_expression
+  (identifier) @function.call)
+
+(broadcast_call_expression
+  (field_expression
+    (identifier) @function.call .))
+
+; Macros
+(macro_identifier) @function.macro
+
+(macro_definition
+  (signature
+    (call_expression
+      .
+      (identifier) @function.macro)))
+
+; Built-in functions
+; filter(name -> Base.eval(Core, name) isa Core.Builtin, names(Core))
+((identifier) @function.builtin
+  (#any-of? @function.builtin
+    "applicable" "fieldtype" "getfield" "getglobal" "invoke" "isa" "isdefined" "modifyfield!"
+    "modifyglobal!" "nfields" "replacefield!" "replaceglobal!" "setfield!" "setfieldonce!"
+    "setglobal!" "setglobalonce!" "swapfield!" "swapglobal!" "throw" "tuple" "typeassert" "typeof"))
+
+; Type definitions
+(type_head (_) @type.definition)
+
+; Type annotations
+(parametrized_type_expression
+  [
+   (identifier) @type
+   (field_expression
+     (identifier) @type .)
+  ]
+  (curly_expression
+    (_) @type))
+
+(typed_expression
+  (identifier) @type .)
+
+(unary_typed_expression
+  (identifier) @type .)
+
+(where_expression
+  (_) @type .)
+
+(binary_expression
+  (_) @type
+  (operator) @operator
+  (_) @type
+  (#any-of? @operator "<:" ">:"))
+
+; Built-in types
+; filter(name -> typeof(Base.eval(Core, name)) in [DataType, UnionAll], names(Core))
+((identifier) @type.builtin
+  (#any-of? @type.builtin
+    "AbstractArray" "AbstractChar" "AbstractFloat" "AbstractString" "Any" "ArgumentError" "Array"
+    "AssertionError" "Bool" "BoundsError" "Char" "ConcurrencyViolationError" "Cvoid" "DataType"
+    "DenseArray" "DivideError" "DomainError" "ErrorException" "Exception" "Expr" "Float16" "Float32"
+    "Float64" "Function" "GlobalRef" "IO" "InexactError" "InitError" "Int" "Int128" "Int16" "Int32"
+    "Int64" "Int8" "Integer" "InterruptException" "LineNumberNode" "LoadError" "Method"
+    "MethodError" "Module" "NTuple" "NamedTuple" "Nothing" "Number" "OutOfMemoryError"
+    "OverflowError" "Pair" "Ptr" "QuoteNode" "ReadOnlyMemoryError" "Real" "Ref" "SegmentationFault"
+    "Signed" "StackOverflowError" "String" "Symbol" "Task" "Tuple" "Type" "TypeError" "TypeVar"
+    "UInt" "UInt128" "UInt16" "UInt32" "UInt64" "UInt8" "UndefInitializer" "UndefKeywordError"
+    "UndefRefError" "UndefVarError" "Union" "UnionAll" "Unsigned" "VecElement" "WeakRef"))
+
+; Keywords
+[
+  "const"
+  "global"
+  "local"
+] @keyword
+
+(compound_statement
+  [
+    "begin"
+    "end"
+  ] @keyword)
+
+(quote_statement
+  [
+    "quote"
+    "end"
+  ] @keyword)
+
+(let_statement
+  [
+    "let"
+    "end"
+  ] @keyword)
+
+(if_statement
+  [
+    "if"
+    "end"
+  ] @keyword.conditional)
+
+(elseif_clause
+  "elseif" @keyword.conditional)
+
+(else_clause
+  "else" @keyword.conditional)
+
+(ternary_expression
+  [
+    "?"
+    ":"
+  ] @keyword.conditional.ternary)
+
+(try_statement
+  [
+    "try"
+    "end"
+  ] @keyword.exception)
+
+(catch_clause
+  "catch" @keyword.exception)
+
+(finally_clause
+  "finally" @keyword.exception)
+
+(for_statement
+  [
+    "for"
+    "end"
+  ] @keyword.repeat)
+
+(for_binding
+  "outer" @keyword.repeat)
+
+; comprehensions
+(for_clause
+  "for" @keyword.repeat)
+
+(if_clause
+  "if" @keyword.conditional)
+
+(while_statement
+  [
+    "while"
+    "end"
+  ] @keyword.repeat)
+
+[
+  (break_statement)
+  (continue_statement)
+] @keyword.repeat
+
+(function_definition
+  [
+    "function"
+    "end"
+  ] @keyword.function)
+
+(do_clause
+  [
+    "do"
+    "end"
+  ] @keyword.function)
+
+(macro_definition
+  [
+    "macro"
+    "end"
+  ] @keyword)
+
+(return_statement
+  "return" @keyword.return)
+
+(module_definition
+  [
+    "module"
+    "baremodule"
+    "end"
+  ] @keyword.import)
+
+(export_statement
+  "export" @keyword.import)
+
+(public_statement
+  "public" @keyword.import)
+
+(import_statement
+  "import" @keyword.import)
+
+(using_statement
+  "using" @keyword.import)
+
+(import_alias
+  "as" @keyword.import)
+
+(selected_import
+  ":" @punctuation.delimiter)
+
+(struct_definition
+  [
+    "mutable"
+    "struct"
+    "end"
+  ] @keyword.type)
+
+(abstract_definition
+  [
+    "abstract"
+    "type"
+    "end"
+  ] @keyword.type)
+
+(primitive_definition
+  [
+    "primitive"
+    "type"
+    "end"
+  ] @keyword.type)
+
+; Operators & Punctuation
+(operator) @operator
+
+(adjoint_expression
+  "'" @operator)
+
+(range_expression
+  ":" @operator)
+
+(arrow_function_expression
+  "->" @operator)
+
+[
+  "."
+  "..."
+  "::"
+] @punctuation.special
+
+[
+  ","
+  ";"
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+; Keyword operators
+((operator) @keyword.operator
+  (#any-of? @keyword.operator "in" "isa"))
+
+(where_expression
+  "where" @keyword.operator)
+
+; Built-in constants
+((identifier) @constant.builtin
+  (#any-of? @constant.builtin "nothing" "missing"))
+
+((identifier) @variable.builtin
+  (#any-of? @variable.builtin "begin" "end")
+  (#has-ancestor? @variable.builtin index_expression))
+
+; Literals
+(boolean_literal) @boolean
+
+(integer_literal) @number
+
+(float_literal) @number.float
+
+((identifier) @number.float
+  (#any-of? @number.float "NaN" "NaN16" "NaN32" "Inf" "Inf16" "Inf32"))
+
+(character_literal) @character
+
+(escape_sequence) @string.escape
+
+(string_literal) @string
+
+(prefixed_string_literal
+  prefix: (identifier) @function.macro) @string
+
+(command_literal) @string.special
+
+(prefixed_command_literal
+  prefix: (identifier) @function.macro) @string.special
+
+((string_literal) @string.documentation
+  .
+  [
+    (abstract_definition)
+    (assignment)
+    (const_statement)
+    (function_definition)
+    (macro_definition)
+    (module_definition)
+    (struct_definition)
+  ])
+
+[
+  (line_comment)
+  (block_comment)
+] @comment

--- a/ThirdParty/treesitter-pack/queries/proto/highlights.scm
+++ b/ThirdParty/treesitter-pack/queries/proto/highlights.scm
@@ -1,0 +1,49 @@
+[
+  "syntax"
+  "edition"
+  "package"
+  "option"
+  "import"
+  "service"
+  "rpc"
+  "returns"
+  "message"
+  "enum"
+  "oneof"
+  "repeated"
+  "reserved"
+  "to"
+] @keyword
+
+[
+  (key_type)
+  (type)
+  (message_name)
+  (enum_name)
+  (service_name)
+  (rpc_name)
+]@type
+
+(string) @string
+
+[
+  (int_lit)
+  (float_lit)
+] @number
+
+[
+  (true)
+  (false)
+] @constant.builtin
+
+(comment) @comment
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+]  @punctuation.bracket
+

--- a/ThirdParty/treesitter-pack/src/lib.rs
+++ b/ThirdParty/treesitter-pack/src/lib.rs
@@ -7,8 +7,9 @@
 //! those are declared directly here and the drift never reaches this file.
 //!
 //! Each grammar crate is pulled into the link graph by its query const in
-//! `QUERIES`. HCL, Dockerfile, and Kotlin expose no query const and need the
-//! separate anchor below.
+//! `QUERIES`. The crates whose query is vendored here instead — because they
+//! expose no query const — reference nothing of their own, so they need the
+//! separate `LINK_ANCHORS` below.
 
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
@@ -16,29 +17,55 @@ use std::os::raw::{c_char, c_void};
 extern "C" {
     fn tree_sitter_bash() -> *const c_void;
     fn tree_sitter_c() -> *const c_void;
+    fn tree_sitter_c_sharp() -> *const c_void;
+    // tree-sitter-clojure-orchard names its entry point after the crate, not
+    // after the language.
+    fn tree_sitter_clojure_orchard() -> *const c_void;
+    fn tree_sitter_cmake() -> *const c_void;
     fn tree_sitter_cpp() -> *const c_void;
     fn tree_sitter_css() -> *const c_void;
+    fn tree_sitter_dart() -> *const c_void;
     fn tree_sitter_dockerfile() -> *const c_void;
+    fn tree_sitter_elixir() -> *const c_void;
+    fn tree_sitter_erlang() -> *const c_void;
     fn tree_sitter_go() -> *const c_void;
+    fn tree_sitter_graphql() -> *const c_void;
+    fn tree_sitter_groovy() -> *const c_void;
+    fn tree_sitter_haskell() -> *const c_void;
     fn tree_sitter_hcl() -> *const c_void;
     fn tree_sitter_html() -> *const c_void;
+    fn tree_sitter_ini() -> *const c_void;
     fn tree_sitter_java() -> *const c_void;
     fn tree_sitter_javascript() -> *const c_void;
     fn tree_sitter_json() -> *const c_void;
+    fn tree_sitter_julia() -> *const c_void;
     fn tree_sitter_kotlin() -> *const c_void;
     fn tree_sitter_lua() -> *const c_void;
+    fn tree_sitter_make() -> *const c_void;
     fn tree_sitter_markdown() -> *const c_void;
     fn tree_sitter_markdown_inline() -> *const c_void;
+    fn tree_sitter_objc() -> *const c_void;
     fn tree_sitter_php() -> *const c_void;
     fn tree_sitter_php_only() -> *const c_void;
+    fn tree_sitter_powershell() -> *const c_void;
+    fn tree_sitter_proto() -> *const c_void;
     fn tree_sitter_python() -> *const c_void;
+    fn tree_sitter_r() -> *const c_void;
     fn tree_sitter_ruby() -> *const c_void;
     fn tree_sitter_rust() -> *const c_void;
+    fn tree_sitter_scala() -> *const c_void;
+    fn tree_sitter_scss() -> *const c_void;
+    // The SQL grammar ships in the tree-sitter-sequel crate, but the grammar
+    // itself is named `sql`, so that is the symbol its parser.c defines.
+    fn tree_sitter_sql() -> *const c_void;
+    fn tree_sitter_svelte() -> *const c_void;
     fn tree_sitter_swift() -> *const c_void;
     fn tree_sitter_toml() -> *const c_void;
     fn tree_sitter_tsx() -> *const c_void;
     fn tree_sitter_typescript() -> *const c_void;
+    fn tree_sitter_xml() -> *const c_void;
     fn tree_sitter_yaml() -> *const c_void;
+    fn tree_sitter_zig() -> *const c_void;
 }
 
 /// Upstream tree-sitter-hcl ships no queries, so this one is maintained by
@@ -58,16 +85,35 @@ const DOCKERFILE_HIGHLIGHTS: &str = include_str!("../queries/dockerfile/highligh
 /// compiling it against this grammar, not just checking the text is present.
 const KOTLIN_HIGHLIGHTS: &str = include_str!("../queries/kotlin/highlights.scm");
 
-/// These three crates' queries are the local consts above, so nothing else
-/// here references the crates themselves and the linker is free to drop their
-/// objects — leaving `tree_sitter_hcl`, `tree_sitter_dockerfile`, and
-/// `tree_sitter_kotlin` unresolved. Touching one const each keeps them in the
-/// link graph.
+/// tree-sitter-julia and tree-sitter-proto both package `queries/highlights.scm`
+/// but expose no const for it, and a crate cannot `include_str!` another
+/// crate's sources. Copied verbatim from each crate at the pinned version;
+/// refresh them when the dependency moves.
+const JULIA_HIGHLIGHTS: &str = include_str!("../queries/julia/highlights.scm");
+const PROTO_HIGHLIGHTS: &str = include_str!("../queries/proto/highlights.scm");
+
+/// tree-sitter-graphql and tree-sitter-groovy package no `queries/` directory
+/// at all — their bindings carry the query consts commented out. These come
+/// from nvim-treesitter, which maintains the queries for both grammars, and
+/// are held to the same bar as every other query here: the
+/// `every_query_compiles_against_its_grammar` test compiles them for real.
+const GRAPHQL_HIGHLIGHTS: &str = include_str!("../queries/graphql/highlights.scm");
+const GROOVY_HIGHLIGHTS: &str = include_str!("../queries/groovy/highlights.scm");
+
+/// These crates' queries are the local consts above, so nothing else here
+/// references the crates themselves and the linker is free to drop their
+/// objects — leaving `tree_sitter_hcl`, `tree_sitter_dockerfile`,
+/// `tree_sitter_kotlin` and friends unresolved. Touching one const each keeps
+/// them in the link graph.
 #[used]
-static LINK_ANCHORS: [&str; 3] = [
+static LINK_ANCHORS: [&str; 7] = [
     tree_sitter_hcl::NODE_TYPES,
     tree_sitter_dockerfile::NODE_TYPES,
     tree_sitter_kotlin_ng::NODE_TYPES,
+    tree_sitter_julia::NODE_TYPES,
+    tree_sitter_proto::NODE_TYPES,
+    tree_sitter_graphql::NODE_TYPES,
+    tree_sitter_groovy::NODE_TYPES,
 ];
 
 type LanguageFn = unsafe extern "C" fn() -> *const c_void;
@@ -75,29 +121,51 @@ type LanguageFn = unsafe extern "C" fn() -> *const c_void;
 static LANGUAGES: &[(&str, LanguageFn)] = &[
     ("bash", tree_sitter_bash),
     ("c", tree_sitter_c),
+    ("clojure", tree_sitter_clojure_orchard),
+    ("cmake", tree_sitter_cmake),
     ("cpp", tree_sitter_cpp),
+    ("csharp", tree_sitter_c_sharp),
     ("css", tree_sitter_css),
+    ("dart", tree_sitter_dart),
     ("dockerfile", tree_sitter_dockerfile),
+    ("elixir", tree_sitter_elixir),
+    ("erlang", tree_sitter_erlang),
     ("go", tree_sitter_go),
+    ("graphql", tree_sitter_graphql),
+    ("groovy", tree_sitter_groovy),
+    ("haskell", tree_sitter_haskell),
     ("hcl", tree_sitter_hcl),
     ("html", tree_sitter_html),
+    ("ini", tree_sitter_ini),
     ("java", tree_sitter_java),
     ("javascript", tree_sitter_javascript),
     ("json", tree_sitter_json),
+    ("julia", tree_sitter_julia),
     ("kotlin", tree_sitter_kotlin),
     ("lua", tree_sitter_lua),
+    ("make", tree_sitter_make),
     ("markdown", tree_sitter_markdown),
     ("markdown_inline", tree_sitter_markdown_inline),
+    ("objc", tree_sitter_objc),
     ("php", tree_sitter_php),
     ("php_only", tree_sitter_php_only),
+    ("powershell", tree_sitter_powershell),
+    ("proto", tree_sitter_proto),
     ("python", tree_sitter_python),
+    ("r", tree_sitter_r),
     ("ruby", tree_sitter_ruby),
     ("rust", tree_sitter_rust),
+    ("scala", tree_sitter_scala),
+    ("scss", tree_sitter_scss),
+    ("sql", tree_sitter_sql),
+    ("svelte", tree_sitter_svelte),
     ("swift", tree_sitter_swift),
     ("toml", tree_sitter_toml),
     ("tsx", tree_sitter_tsx),
     ("typescript", tree_sitter_typescript),
+    ("xml", tree_sitter_xml),
     ("yaml", tree_sitter_yaml),
+    ("zig", tree_sitter_zig),
 ];
 
 /// Highlight queries, keyed by language id. `javascript_jsx` is the JSX
@@ -106,29 +174,51 @@ static LANGUAGES: &[(&str, LanguageFn)] = &[
 static QUERIES: &[(&str, &str)] = &[
     ("bash", tree_sitter_bash::HIGHLIGHT_QUERY),
     ("c", tree_sitter_c::HIGHLIGHT_QUERY),
+    ("clojure", tree_sitter_clojure_orchard::HIGHLIGHTS_QUERY),
+    ("cmake", tree_sitter_cmake::HIGHLIGHTS_QUERY),
     ("cpp", tree_sitter_cpp::HIGHLIGHT_QUERY),
+    ("csharp", tree_sitter_c_sharp::HIGHLIGHTS_QUERY),
     ("css", tree_sitter_css::HIGHLIGHTS_QUERY),
+    ("dart", tree_sitter_dart::HIGHLIGHTS_QUERY),
     ("dockerfile", DOCKERFILE_HIGHLIGHTS),
+    ("elixir", tree_sitter_elixir::HIGHLIGHTS_QUERY),
+    ("erlang", tree_sitter_erlang::HIGHLIGHTS_QUERY),
     ("go", tree_sitter_go::HIGHLIGHTS_QUERY),
+    ("graphql", GRAPHQL_HIGHLIGHTS),
+    ("groovy", GROOVY_HIGHLIGHTS),
+    ("haskell", tree_sitter_haskell::HIGHLIGHTS_QUERY),
     ("hcl", HCL_HIGHLIGHTS),
     ("html", tree_sitter_html::HIGHLIGHTS_QUERY),
+    ("ini", tree_sitter_ini::HIGHLIGHTS_QUERY),
     ("java", tree_sitter_java::HIGHLIGHTS_QUERY),
     ("javascript", tree_sitter_javascript::HIGHLIGHT_QUERY),
     ("javascript_jsx", tree_sitter_javascript::JSX_HIGHLIGHT_QUERY),
     ("json", tree_sitter_json::HIGHLIGHTS_QUERY),
+    ("julia", JULIA_HIGHLIGHTS),
     ("kotlin", KOTLIN_HIGHLIGHTS),
     ("lua", tree_sitter_lua::HIGHLIGHTS_QUERY),
+    ("make", tree_sitter_make::HIGHLIGHTS_QUERY),
     ("markdown", tree_sitter_md::HIGHLIGHT_QUERY_BLOCK),
     ("markdown_inline", tree_sitter_md::HIGHLIGHT_QUERY_INLINE),
+    ("objc", tree_sitter_objc::HIGHLIGHTS_QUERY),
     ("php", tree_sitter_php::HIGHLIGHTS_QUERY),
+    ("powershell", tree_sitter_powershell::HIGHLIGHTS_QUERY),
+    ("proto", PROTO_HIGHLIGHTS),
     ("python", tree_sitter_python::HIGHLIGHTS_QUERY),
+    ("r", tree_sitter_r::HIGHLIGHTS_QUERY),
     ("ruby", tree_sitter_ruby::HIGHLIGHTS_QUERY),
     ("rust", tree_sitter_rust::HIGHLIGHTS_QUERY),
+    ("scala", tree_sitter_scala::HIGHLIGHTS_QUERY),
+    ("scss", tree_sitter_scss::HIGHLIGHTS_QUERY),
+    ("sql", tree_sitter_sequel::HIGHLIGHTS_QUERY),
+    ("svelte", tree_sitter_svelte::HIGHLIGHT_QUERY),
     ("swift", tree_sitter_swift::HIGHLIGHTS_QUERY),
     ("toml", tree_sitter_toml_ng::HIGHLIGHTS_QUERY),
     ("tsx", tree_sitter_typescript::HIGHLIGHTS_QUERY),
     ("typescript", tree_sitter_typescript::HIGHLIGHTS_QUERY),
+    ("xml", tree_sitter_xml::XML_HIGHLIGHT_QUERY),
     ("yaml", tree_sitter_yaml::HIGHLIGHTS_QUERY),
+    ("zig", tree_sitter_zig::HIGHLIGHTS_QUERY),
 ];
 
 /// Returns the `TSLanguage *` for `id`, or null when `id` is unknown.
@@ -225,6 +315,93 @@ mod tests {
                 continue;
             }
             assert!(query(id).is_some(), "{id} has no query");
+        }
+    }
+
+    /// Turns one of our raw entry points back into a `tree_sitter::Language`
+    /// so a query can be compiled against it.
+    fn language_handle(entry: LanguageFn) -> tree_sitter::Language {
+        // `LanguageFn::from_raw` wants `-> *const ()` where our table stores
+        // `-> *const c_void`; the two are the same pointer, so this only
+        // reconciles the declared return type.
+        let raw: unsafe extern "C" fn() -> *const () = unsafe { std::mem::transmute(entry) };
+        unsafe { tree_sitter_language::LanguageFn::from_raw(raw) }.into()
+    }
+
+    /// The one test that would actually catch a broken grammar addition.
+    /// `every_query_is_non_empty` proves only that text is present;
+    /// this compiles each language's own query against its own `TSLanguage`,
+    /// so a query naming a node the grammar doesn't have — the normal failure
+    /// mode when a vendored `.scm` drifts from its grammar, or when a grammar
+    /// is bumped past its query — fails here instead of silently degrading
+    /// that language to plain text in the app.
+    ///
+    /// `php_only` is skipped: its query is derived from PHP's on the Alas side
+    /// (the `php_tag` pattern is stripped), so the unmodified text genuinely
+    /// does not compile against that grammar.
+    #[test]
+    fn every_query_compiles_against_its_grammar() {
+        for (id, entry) in LANGUAGES {
+            if *id == "php_only" {
+                continue;
+            }
+            let text = query(id).unwrap_or_else(|| panic!("{id} has no query"));
+            let language = language_handle(*entry);
+            let compiled = match tree_sitter::Query::new(&language, text) {
+                Ok(compiled) => compiled,
+                Err(error) => panic!("{id} query does not compile against its grammar: {error:?}"),
+            };
+            // A query can compile and still be inert — an `.scm` that lost its
+            // body, or one whose patterns were all stripped, highlights
+            // nothing while looking healthy to every other test here.
+            assert!(
+                compiled.pattern_count() > 0,
+                "{id} query compiles but contains no patterns"
+            );
+            assert!(
+                !compiled.capture_names().is_empty(),
+                "{id} query compiles but captures nothing"
+            );
+        }
+    }
+
+    /// Alas does not always highlight a language with its own query alone:
+    /// `LanguageRegistry.queryIDsByLanguageID` concatenates a base grammar's
+    /// query first for the grammars that extend another (an `; inherits:`
+    /// directive nothing in this path honors). Those concatenations have to
+    /// compile against the *extending* grammar, which is a stricter condition
+    /// than either query passing on its own — a node the base query names but
+    /// the extending grammar dropped fails only here.
+    ///
+    /// This list mirrors `queryIDsByLanguageID`; keep the two in step when
+    /// either changes. The Swift side proves the merge is actually wired by
+    /// asserting a base-grammar capture shows up in the extending language
+    /// (see `LanguageRegistryTests`).
+    #[test]
+    fn merged_queries_compile_against_the_extending_grammar() {
+        let merges: &[(&str, &[&str])] = &[
+            ("cpp", &["c", "cpp"]),
+            ("objc", &["c", "objc"]),
+            ("scss", &["css", "scss"]),
+            ("typescript", &["javascript", "typescript"]),
+            ("tsx", &["javascript", "javascript_jsx", "tsx"]),
+            ("javascript", &["javascript", "javascript_jsx"]),
+        ];
+
+        for (id, parts) in merges {
+            let combined = parts
+                .iter()
+                .map(|part| query(part).unwrap_or_else(|| panic!("{part} has no query")))
+                .collect::<Vec<_>>()
+                .join("\n");
+            let (_, entry) = LANGUAGES
+                .iter()
+                .find(|(name, _)| name == id)
+                .unwrap_or_else(|| panic!("{id} is not a registered language"));
+            let language = language_handle(*entry);
+            if let Err(error) = tree_sitter::Query::new(&language, &combined) {
+                panic!("merged query {parts:?} does not compile against {id}: {error:?}");
+            }
         }
     }
 

--- a/scripts/build-treesitter-pack.sh
+++ b/scripts/build-treesitter-pack.sh
@@ -191,9 +191,11 @@ symbol_dump="${build_root}/symbols.txt"
 nm -g "${cargo_output}" > "${symbol_dump}" 2>/dev/null || true
 missing=""
 for symbol in \
-    bash c cpp css dockerfile go hcl html java javascript json kotlin lua \
-    markdown markdown_inline php php_only python ruby rust swift toml tsx \
-    typescript yaml
+    bash c c_sharp clojure_orchard cmake cpp css dart dockerfile elixir \
+    erlang go graphql groovy haskell hcl html ini java javascript json \
+    julia kotlin lua make markdown markdown_inline objc php php_only \
+    powershell proto python r ruby rust scala scss sql svelte swift toml \
+    tsx typescript xml yaml zig
 do
     if ! grep -qE " T _tree_sitter_${symbol}\$" "${symbol_dump}"; then
         missing="${missing} tree_sitter_${symbol}"

--- a/scripts/tests/build-treesitter-pack/run.sh
+++ b/scripts/tests/build-treesitter-pack/run.sh
@@ -24,9 +24,11 @@ printf '; query\n' > "${pack_src}/queries/hcl/highlights.scm"
 # Every grammar the script asserts on. The fake nm below prints these back in
 # `nm -g` format so the happy path passes without a real cargo build.
 all_symbols=(
-    bash c cpp css dockerfile go hcl html java javascript json kotlin lua
-    markdown markdown_inline php php_only python ruby rust swift toml tsx
-    typescript yaml
+    bash c c_sharp clojure_orchard cmake cpp css dart dockerfile elixir
+    erlang go graphql groovy haskell hcl html ini java javascript json
+    julia kotlin lua make markdown markdown_inline objc php php_only
+    powershell proto python r ruby rust scala scss sql svelte swift toml
+    tsx typescript xml yaml zig
 )
 write_symbols() {
     : > "${symbols}"


### PR DESCRIPTION
## Summary

Extends the tree-sitter pack with grammars for the remaining top-50 languages and common repo formats: C#, Scala, R, Dart, Elixir, Erlang, Haskell, Clojure, Julia, Groovy, Objective-C, PowerShell, Zig, SQL, XML, GraphQL, Make, CMake, Protobuf, SCSS, Svelte, and INI.

## Details

- `ThirdParty/treesitter-pack`: new deps, extern C entry points, `LANGUAGES`/`QUERIES` entries. GraphQL, Groovy, Julia, and Proto vendor their queries (two ship no query const at all; two package the `.scm` without exposing it) the same way HCL/Dockerfile/Kotlin already do.
- `tree-sitter-clojure` is stale and pins `tree-sitter ^0.25.6`, which collides with the graph-wide `links = "tree-sitter"` constraint; `tree-sitter-clojure-orchard` is the maintained alternative and keeps `tree-sitter` to a dev-dependency.
- `tree-sitter-groovy` (crates.io) ships no highlight query and none exists for it; the only maintained Groovy query (nvim-treesitter's) targets a structurally different grammar. Pulled that grammar in via git, pinned to the revision nvim-treesitter itself pins, so query and grammar stay a matched pair.
- No Perl: the only published `tree-sitter-perl` version is a broken publish (its bindings `include_str!` a `queries/` directory the crate doesn't ship).
- Added `every_query_compiles_against_its_grammar` and `merged_queries_compile_against_the_extending_grammar` to the pack's test suite — compiling each query for real is what catches a grammar/query mismatch, not just presence. The first one immediately caught the Groovy query mismatch above.
- `LanguageRegistry`: extension mappings for the new grammars, plus filename-based dispatch (`Makefile`, `CMakeLists.txt`, `.editorconfig`) alongside the existing Dockerfile case. Objective-C and SCSS both extend a base grammar the way C++ already does, so they're added to `queryIDsByLanguageID`.
- `RegexFallbackHighlighter` is no longer `private`: `xml`/`scss`/`sql` now have real grammars, so a few existing fallback tests could no longer reach it through extension routing. Calling it directly restores their original intent without depending on some extension staying ungrammared.

`libalas_treesitter_pack.a` grows from 34.2 MB to 67.9 MB.

## Testing

- `cargo test` in `ThirdParty/treesitter-pack` — all 8 tests pass, including the new query-compiles-against-its-grammar check across all 46 registered languages.
- `AlasTests/Code/Highlight/LanguageRegistryTests` (new) and `AlasTests/Code/Highlight/TreeSitterHighlighterTests` — 51 tests pass locally on arm64.
- Full `xcodebuild` sweep left to CI.