### PR TITLE
feat(chat): message quote action

### DIFF
--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -68,6 +68,10 @@ struct ACPInputField: NSViewRepresentable {
             guard let coord, let tv = coord.textView as? ACPNSTextView else { return }
             tv.presentImagePicker()
         }
+        actions.insertQuote = { [weak coord] message in
+            guard let coord, let textView = coord.textView else { return }
+            coord.insertQuote(message, into: textView)
+        }
         let scroll = NSScrollView()
         scroll.hasVerticalScroller = true
         scroll.drawsBackground = false
@@ -360,6 +364,36 @@ struct ACPInputField: NSViewRepresentable {
                 pendingSubmitID = submitID
                 clearVisibleDraft(in: textView)
             }
+        }
+
+        func insertQuote(_ message: String, into textView: NSTextView) {
+            guard !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+            if let textView = textView as? ACPNSTextView {
+                textView.dismissSlashPanel()
+            }
+
+            let selection = textView.selectedRange()
+            let source = textView.string as NSString
+            let needsLeadingNewline = selection.location > 0
+                && source.character(at: selection.location - 1) != 0x0A
+            let suffixLocation = NSMaxRange(selection)
+            let needsTrailingSpacer = suffixLocation < source.length
+                && source.character(at: suffixLocation) != 0x0A
+            let leading = needsLeadingNewline ? "\n" : ""
+            let quoted = ACPMessageQuote.markdown(message)
+            let caretPrefix = leading + quoted + "\n"
+            let replacement = caretPrefix + (needsTrailingSpacer ? "\n" : "")
+
+            textView.typingAttributes = [
+                .font: typography.appKitFont(),
+                .foregroundColor: NSColor.labelColor,
+            ]
+            textView.insertText(replacement, replacementRange: selection)
+            textView.setSelectedRange(NSRange(
+                location: selection.location + (caretPrefix as NSString).length,
+                length: 0
+            ))
+            textView.window?.makeFirstResponder(textView)
         }
 
         func beginPendingImageFileInsertion() -> Int {

--- a/Alas/Sources/ACP/UI/ACPComposerActions.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerActions.swift
@@ -1,15 +1,29 @@
 import Foundation
 
-/// Bridge object the SwiftUI composer chrome uses to fire submission
-/// through the AppKit textview's coordinator. The coordinator publishes
-/// `submitWithIntent` on `makeNSView`; the send button calls it with
-/// the resolved intent (auto vs steer based on ⌥ modifier).
+enum ACPMessageQuote {
+    static func canQuote(_ message: String) -> Bool {
+        !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    static func markdown(_ message: String) -> String {
+        message
+            .components(separatedBy: "\n")
+            .map { "> \($0)" }
+            .joined(separator: "\n")
+    }
+}
+
+/// Bridge object SwiftUI surfaces use to invoke commands on the AppKit
+/// text view. The coordinator publishes closures on `makeNSView`; transcript
+/// and composer controls call them without owning editor state.
 @MainActor
 final class ACPComposerActions: ObservableObject {
     var submitWithIntent: ((ACPSubmitIntent) -> Void)?
+    var insertQuote: ((String) -> Void)?
     /// Published by the coordinator; opens an image picker and inserts the
     /// chosen files as chips.
     var presentImagePicker: (() -> Void)?
     /// Convenience used by call sites that just want default submit.
     func submit() { submitWithIntent?(.auto) }
+    func quote(_ message: String) { insertQuote?(message) }
 }

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -105,12 +105,12 @@ struct ACPComposer: View {
     let placement: ACPComposerPlacement
     let contentMaxWidth: CGFloat
     let typography: ACPChatTypography
+    let actions: ACPComposerActions
     let onSubmit: ACPComposerSubmitHandler
     let filesProvider: (@Sendable () async -> [URL])?
 
     @Environment(\.theme) private var theme
     @State private var inputFocused = false
-    @StateObject private var actions = ACPComposerActions()
     @State private var hasText: Bool = false
     @State private var imageNotice: String?
 
@@ -125,6 +125,7 @@ struct ACPComposer: View {
         placement: ACPComposerPlacement = .bottom,
         contentMaxWidth: CGFloat = ACPChatLayout.defaultContentMaxWidth,
         typography: ACPChatTypography = .default,
+        actions: ACPComposerActions,
         filesProvider: (@Sendable () async -> [URL])? = nil,
         onSubmit: @escaping ACPComposerSubmitHandler
     ) {
@@ -139,6 +140,7 @@ struct ACPComposer: View {
         self.placement = placement
         self.contentMaxWidth = contentMaxWidth
         self.typography = typography
+        self.actions = actions
         self.filesProvider = filesProvider
         self.onSubmit = onSubmit
     }

--- a/Alas/Sources/ACP/UI/ACPMessageGutter.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageGutter.swift
@@ -3,9 +3,8 @@ import SwiftUI
 
 /// Reserves a hover-revealed action affordance in the right gutter of a
 /// transcript message. The "…" opens a native menu — the per-message action
-/// surface. Today it carries a single action ("Copy message"); future
-/// actions (e.g. fork-from-here) slot in as additional buttons with no
-/// structural change.
+/// surface. Text actions and fork-from-here share this menu without adding
+/// per-action buttons to the transcript row.
 ///
 /// Reusable across message kinds: currently wraps user and agent rows; other
 /// block types can opt in later by wrapping their content the same way.
@@ -38,6 +37,7 @@ struct ACPMessageGutter<Content: View>: View {
     let copySource: CopySource
     let forkBoundary: ACPForkMessageBoundary?
     let forkTargets: [ACPSessionForkTarget]
+    let onQuote: (String) -> Void
     let onFork: (ACPForkMessageBoundary, String) -> Void
     @ViewBuilder var content: Content
 
@@ -81,6 +81,7 @@ struct ACPMessageGutter<Content: View>: View {
             copySource: copySource,
             forkBoundary: forkBoundary,
             forkTargets: forkTargets,
+            onQuote: onQuote,
             onFork: onFork,
             tint: theme.color("fg-muted")
         )
@@ -100,6 +101,7 @@ private struct ACPMessageActionsButton: NSViewRepresentable {
     let copySource: ACPMessageCopySource
     let forkBoundary: ACPForkMessageBoundary?
     let forkTargets: [ACPSessionForkTarget]
+    let onQuote: (String) -> Void
     let onFork: (ACPForkMessageBoundary, String) -> Void
     let tint: Color
 
@@ -108,6 +110,7 @@ private struct ACPMessageActionsButton: NSViewRepresentable {
             copySource: copySource,
             forkBoundary: forkBoundary,
             forkTargets: forkTargets,
+            onQuote: onQuote,
             onFork: onFork
         )
     }
@@ -124,6 +127,7 @@ private struct ACPMessageActionsButton: NSViewRepresentable {
         context.coordinator.copySource = copySource
         context.coordinator.forkBoundary = forkBoundary
         context.coordinator.forkTargets = forkTargets
+        context.coordinator.onQuote = onQuote
         context.coordinator.onFork = onFork
         button.contentTintColor = NSColor(tint)
     }
@@ -133,17 +137,20 @@ private struct ACPMessageActionsButton: NSViewRepresentable {
         var copySource: ACPMessageCopySource
         var forkBoundary: ACPForkMessageBoundary?
         var forkTargets: [ACPSessionForkTarget]
+        var onQuote: (String) -> Void
         var onFork: (ACPForkMessageBoundary, String) -> Void
 
         init(
             copySource: ACPMessageCopySource,
             forkBoundary: ACPForkMessageBoundary?,
             forkTargets: [ACPSessionForkTarget],
+            onQuote: @escaping (String) -> Void,
             onFork: @escaping (ACPForkMessageBoundary, String) -> Void
         ) {
             self.copySource = copySource
             self.forkBoundary = forkBoundary
             self.forkTargets = forkTargets
+            self.onQuote = onQuote
             self.onFork = onFork
         }
 
@@ -156,6 +163,16 @@ private struct ACPMessageActionsButton: NSViewRepresentable {
             )
             copyItem.target = self
             menu.addItem(copyItem)
+            let markdown = copySource.markdown
+            if ACPMessageQuote.canQuote(markdown) {
+                let quoteItem = NSMenuItem(
+                    title: "Quote",
+                    action: #selector(quoteMessage(_:)),
+                    keyEquivalent: ""
+                )
+                quoteItem.target = self
+                menu.addItem(quoteItem)
+            }
             if forkBoundary != nil, !forkTargets.isEmpty {
                 menu.addItem(.separator())
                 let forkItem = NSMenuItem(title: "Fork from here", action: nil, keyEquivalent: "")
@@ -187,6 +204,12 @@ private struct ACPMessageActionsButton: NSViewRepresentable {
             let text = copySource.markdown
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(text, forType: .string)
+        }
+
+        @objc private func quoteMessage(_ sender: NSMenuItem) {
+            let markdown = copySource.markdown
+            guard ACPMessageQuote.canQuote(markdown) else { return }
+            onQuote(markdown)
         }
 
         @objc private func forkFromHere(_ sender: NSMenuItem) {

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -30,6 +30,7 @@ struct ACPMessageList: View {
     /// the row is gone or the payload is undecodable.
     let onLoadFullToolCallContent: (String) async -> String?
     let forkTargets: [ACPSessionForkTarget]
+    let onQuote: (String) -> Void
     let onFork: (ACPForkMessageBoundary, String) -> Void
     let onOpenForkSource: (String) -> Void
     let agentDisplayName: (String) -> String
@@ -55,6 +56,7 @@ struct ACPMessageList: View {
                 onOpenDiff: onOpenDiff,
                 onLoadFullToolCallContent: onLoadFullToolCallContent,
                 forkTargets: forkTargets,
+                onQuote: onQuote,
                 onFork: onFork,
                 rememberedScrollAnchor: rememberedScrollAnchor,
                 onRememberScrollAnchor: onRememberScrollAnchor,

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -104,6 +104,7 @@ private struct ACPSessionView: View {
     @Environment(\.theme) private var theme
     @State private var composerFocusRequest: Int = 0
     @StateObject private var composerDropRouter = ACPComposerDropRouter()
+    @StateObject private var composerActions = ACPComposerActions()
 
     private var adapterTarget: ACPAdapterTarget {
         guard let host = RemoteHostRegistry.shared.host(forPath: worktree.path.path) else {
@@ -438,6 +439,9 @@ private struct ACPSessionView: View {
                     sessionId: sessionId, toolCallId: toolCallId)
             },
             forkTargets: state.acpForkTargets(sourceAgentID: session.agentId),
+            onQuote: { message in
+                composerActions.quote(message)
+            },
             onFork: { boundary, targetAgentID in
                 state.forkACPSession(
                     worktree: worktree,
@@ -489,6 +493,7 @@ private struct ACPSessionView: View {
             placement: placement,
             contentMaxWidth: contentMaxWidth,
             typography: typography ?? chatTypography,
+            actions: composerActions,
             filesProvider: { [state, worktree] in
                 await state.fileIndex.invalidate(forWorktreePath: worktree.path)
                 async let entries = try? state.fileIndex.entries(forWorktreePath: worktree.path)

--- a/Alas/Sources/ACP/UI/ACPTranscriptRowContent.swift
+++ b/Alas/Sources/ACP/UI/ACPTranscriptRowContent.swift
@@ -21,7 +21,7 @@ struct ACPTranscriptRowContent: View, Equatable {
     // (`transcript`/`session` are `let` properties on `ACPSession`, never
     // reassigned), or closures whose behavior only depends on already-compared
     // data:
-    // - `onOpenDiff` / queue callbacks capture stable host references
+    // - `onOpenDiff` / `onQuote` / queue callbacks capture stable host references
     //   (`state`, `worktree`, `manager`, `sessionId`) wired once by
     //   `ACPTabView`, not per-render-varying state.
     // - `onLoadFullToolCallContent` is only ever invoked when
@@ -47,6 +47,7 @@ struct ACPTranscriptRowContent: View, Equatable {
     let onLoadFullToolCallContent: (String) async -> String?
     let isForkEligible: Bool
     let forkTargets: [ACPSessionForkTarget]
+    var onQuote: (String) -> Void = { _ in }
     let onFork: (ACPForkMessageBoundary, String) -> Void
 
     static func == (lhs: Self, rhs: Self) -> Bool {
@@ -99,6 +100,7 @@ struct ACPTranscriptRowContent: View, Equatable {
                 copySource: .text(text),
                 forkBoundary: forkBoundary(kind: .user),
                 forkTargets: forkTargets,
+                onQuote: onQuote,
                 onFork: onFork
             ) {
                 UserMessageRow(
@@ -114,6 +116,7 @@ struct ACPTranscriptRowContent: View, Equatable {
                 copySource: .streaming(buf),
                 forkBoundary: forkBoundary(kind: .agent),
                 forkTargets: forkTargets,
+                onQuote: onQuote,
                 onFork: onFork
             ) {
                 AgentMessageRow(

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -14,6 +14,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
     let onOpenDiff: (String) -> Void
     let onLoadFullToolCallContent: (String) async -> String?
     let forkTargets: [ACPSessionForkTarget]
+    var onQuote: (String) -> Void = { _ in }
     let onFork: (ACPForkMessageBoundary, String) -> Void
     let rememberedScrollAnchor: () -> String?
     let onRememberScrollAnchor: (String?, Int?, Bool) -> Void
@@ -403,6 +404,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 onLoadFullToolCallContent: host.onLoadFullToolCallContent,
                 isForkEligible: host.session.canForkMessage(at: row.index),
                 forkTargets: host.forkTargets,
+                onQuote: host.onQuote,
                 onFork: host.onFork
             )
             // Column framing (max width / horizontal padding / centering)

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -7,6 +7,74 @@ import Testing
 @MainActor
 @Suite("ACP composer draft bridge")
 struct ACPComposerDraftBridgeTests {
+    @Test("formats every message line as a Markdown quote")
+    func formatsMessageQuote() {
+        #expect(ACPMessageQuote.markdown("one\n\n**two**") == "> one\n> \n> **two**")
+    }
+
+    @Test("only non-whitespace messages can be quoted")
+    func messageQuoteEligibility() {
+        #expect(ACPMessageQuote.canQuote("hello"))
+        #expect(!ACPMessageQuote.canQuote(" \n\t"))
+    }
+
+    @Test("composer actions forward quote requests")
+    func composerActionsForwardQuoteRequests() {
+        let actions = ACPComposerActions()
+        var received: String?
+        actions.insertQuote = { received = $0 }
+
+        actions.quote("hello")
+
+        #expect(received == "hello")
+    }
+
+    @Test("quote insertion replaces selection and leaves caret on an empty line")
+    func quoteInsertionReplacesSelection() {
+        let textView = NSTextView()
+        textView.string = "Before replace after"
+        textView.setSelectedRange(NSRange(location: 7, length: 7))
+        let coordinator = makeCoordinator(sendOnEnter: true) { _, _, _, _, _ in true }
+        coordinator.textView = textView
+
+        coordinator.insertQuote("first\nsecond", into: textView)
+
+        #expect(textView.string == "Before \n> first\n> second\n\n after")
+        #expect(textView.selectedRange() == NSRange(location: 25, length: 0))
+    }
+
+    @Test("quote insertion preserves composer chips around the caret")
+    func quoteInsertionPreservesChips() {
+        let mention = ACPMentionChipAttachment(
+            displayName: "File.swift",
+            uri: "file:///tmp/File.swift"
+        )
+        let attributed = NSMutableAttributedString(attachment: mention)
+        attributed.addAttribute(
+            .attachmentURI,
+            value: "file:///tmp/File.swift",
+            range: NSRange(location: 0, length: attributed.length)
+        )
+        attributed.append(NSAttributedString(string: " tail"))
+        let textView = NSTextView()
+        textView.textStorage?.setAttributedString(attributed)
+        textView.setSelectedRange(NSRange(location: 1, length: 0))
+        let coordinator = makeCoordinator(sendOnEnter: true) { _, _, _, _, _ in true }
+        coordinator.textView = textView
+
+        coordinator.insertQuote("quoted", into: textView)
+
+        #expect(ACPInputField.Coordinator.draft(from: textView.attributedString()) == ACPComposerDraft(
+            segments: [
+                .mention(displayName: "File.swift", uri: "file:///tmp/File.swift"),
+                .text("\n"),
+                .text("> quoted\n\n"),
+                .text(" tail"),
+            ]
+        ))
+        #expect(textView.selectedRange() == NSRange(location: 11, length: 0))
+    }
+
     @Test("dismantling the composer preserves window undo actions")
     func dismantlingComposerPreservesWindowUndoActions() {
         let textView = ACPNSTextView()


### PR DESCRIPTION
## Summary
- Adds a Quote action to transcript message menus for non-empty messages.
- Inserts selected message text into the composer as Markdown block quotes, preserving selection behavior and composer chips.
- Shares composer actions so transcript rows can route quote requests into the active composer.

## Testing
- Added Swift Testing coverage for quote formatting, quote eligibility, action forwarding, quote insertion, and chip preservation.