### PR TITLE
feat(lsp): add built-in presets for the newly bundled grammars

### DIFF
--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -614,7 +614,7 @@ struct CommitReviewBody: View {
         guard let worktreeId, let worktreePath, let appState else { return nil }
         let fileURL = worktreePath.appendingPathComponent(relativePath)
         guard FileManager.default.fileExists(atPath: fileURL.path),
-              let language = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
+              let language = appState.lsp.language(forPath: relativePath)
         else {
             return nil
         }

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -197,7 +197,7 @@ struct DiffTabView: View {
         else {
             return nil
         }
-        guard let language = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension) else {
+        guard let language = appState.lsp.language(forPath: relativePath) else {
             return nil
         }
         return DiffPaneLSPContext(

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -525,7 +525,7 @@ struct ReviewTabView: View {
     private func makeLSPContext(relativePath: String) -> DiffPaneLSPContext? {
         let fileURL = worktree.path.appendingPathComponent(relativePath)
         guard FileManager.default.fileExists(atPath: fileURL.path),
-              let language = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
+              let language = appState.lsp.language(forPath: relativePath)
         else {
             return nil
         }

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -351,7 +351,7 @@ struct ReviewChangesTabView: View {
     private func makeLSPContext(relativePath: String) -> DiffPaneLSPContext? {
         let fileURL = worktree.path.appendingPathComponent(relativePath)
         guard FileManager.default.fileExists(atPath: fileURL.path),
-              let language = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
+              let language = appState.lsp.language(forPath: relativePath)
         else {
             return nil
         }

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -626,7 +626,7 @@ struct DraftReviewRequestTabView: View {
     private func makeLSPContext(relativePath: String) -> DiffPaneLSPContext? {
         let fileURL = worktreePath.appendingPathComponent(relativePath)
         guard FileManager.default.fileExists(atPath: fileURL.path),
-              let language = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
+              let language = appState.lsp.language(forPath: relativePath)
         else {
             return nil
         }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -487,7 +487,7 @@ struct ReviewSessionTabView: View {
         let relativePath = file.summary.path
         let fileURL = worktree.path.appendingPathComponent(relativePath)
         guard FileManager.default.fileExists(atPath: fileURL.path),
-              let language = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
+              let language = appState.lsp.language(forPath: relativePath)
         else {
             return nil
         }

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -2356,7 +2356,7 @@ final class TabsManager {
         }
         guard let lsp else { return }
         for (tabId, entry) in externalTabURLs {
-            let ext = entry.url.pathExtension.lowercased()
+            let ext = LanguageServerRegistry.extensionKey(forPath: entry.url.path)
             guard normalized.contains(ext), lsp.language(forFileExtension: ext) == language else { continue }
             guard var info = externalLSPInfo[tabId] else { continue }
             guard info.language == nil || info.language == language else { continue }

--- a/Alas/Sources/Code/Editor/BlockedLanguageServerNudgeResolver.swift
+++ b/Alas/Sources/Code/Editor/BlockedLanguageServerNudgeResolver.swift
@@ -37,7 +37,7 @@ struct BlockedLanguageServerNudgeResolver {
     }
 
     func nudgeData(forAbsolutePath absolutePath: String) -> BlockedNudgeData? {
-        let ext = (absolutePath as NSString).pathExtension.lowercased()
+        let ext = LanguageServerRegistry.extensionKey(forPath: absolutePath)
         guard !ext.isEmpty else { return nil }
         guard let language = registry.language(forFileExtension: ext) else { return nil }
         guard let entry = registry.allEntries().first(where: { $0.language == language }) else { return nil }

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -301,9 +301,9 @@ final class CodeEditorCoordinator {
         // churning undo/selection state.
         let inferred: String?
         if let abs = externalAbsolutePath {
-            inferred = appState.lsp.language(forFileExtension: (abs as NSString).pathExtension)
+            inferred = appState.lsp.language(forPath: abs)
         } else {
-            inferred = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
+            inferred = appState.lsp.language(forPath: relativePath)
         }
         let nextLanguage: String?
         if let buf = self.buffer, currentWorktreeId == worktreeId, currentTabId == tabId {
@@ -470,7 +470,7 @@ final class CodeEditorCoordinator {
         self.buffer = buffer
         self.currentRoot = buffer.worktreeRoot
         self.currentRelativePath = buffer.relativePath
-        let ext = (buffer.relativePath as NSString).pathExtension
+        let ext = LanguageServerRegistry.extensionKey(forPath: buffer.relativePath)
         let freshlyInferred = appState.lsp.language(forFileExtension: ext)
         // Layer a pre-existing override on top of the freshly inferred
         // language. We don't read `buffer.effectiveLanguage` directly

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -367,9 +367,7 @@ final class CodeEditorCoordinator {
                 let originatingFileURL: URL? = originatingRelativePath.flatMap {
                     worktreeRoot.appendingPathComponent($0)
                 }
-                let language = appState.lsp.language(
-                    forFileExtension: (abs as NSString).pathExtension
-                )
+                let language = appState.lsp.language(forPath: abs)
                 nextBuffer = appState.tabs.externalBuffer(
                     worktreeId: worktreeId,
                     tabId: tabId,

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -154,8 +154,11 @@ struct CodeEditorView: NSViewRepresentable {
         let buffer: EditorBuffer
         if let abs = externalAbsolutePath {
             let absoluteURL = URL(fileURLWithPath: abs)
-            let ext = (abs as NSString).pathExtension
-            let language = appState.lsp.language(forFileExtension: ext)
+            // Path-based so filename-identified files (CMakeLists.txt) get a
+            // language here too. A nil language would be stored in
+            // ExternalLSPInfo and leave the tab permanently unregistered with
+            // the server, including after an install completes.
+            let language = appState.lsp.language(forPath: abs)
             let originatingFileURL: URL? = originatingRelativePath.map { worktreeRoot.appendingPathComponent($0) }
             buffer = appState.tabs.externalBuffer(
                 worktreeId: worktreeId,

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -392,7 +392,7 @@ final class EditorBuffer {
         self.worktreeId = worktreeId
         self.tabId = tabId
         self.lsp = lsp
-        self.language = lsp?.language(forFileExtension: (relativePath as NSString).pathExtension)
+        self.language = lsp?.language(forPath: relativePath)
         let delegate = BufferStorageDelegate { [weak self] edit in self?.handleEdit(edit: edit) }
         self.storageDelegate = delegate
         self.storage.delegate = delegate
@@ -933,7 +933,7 @@ final class EditorBuffer {
         languageReopenTask?.cancel()
         languageReopenTask = nil
         relativePath = newRelativePath
-        language = lsp?.language(forFileExtension: (newRelativePath as NSString).pathExtension)
+        language = lsp?.language(forPath: newRelativePath)
         if wasDirty {
             updateOriginalFileIdentity(from: newURL)
             let differsFromOriginal = movedFileDiffersFromOriginal ?? Self.movedFileDiffersFromOriginal(
@@ -1164,7 +1164,7 @@ final class EditorBuffer {
         do {
             try write(canonical: canonical, to: newURL, createDirectories: true)
             relativePath = newRelativePath
-            language = lsp?.language(forFileExtension: (newRelativePath as NSString).pathExtension)
+            language = lsp?.language(forPath: newRelativePath)
             originalText = canonical
             updateOriginalMtime(from: newURL)
             updateOriginalFileIdentity(from: newURL)
@@ -1204,7 +1204,7 @@ final class EditorBuffer {
                 try FileManager.default.moveItem(at: oldURL, to: newURL)
             }
             relativePath = newRelativePath
-            language = lsp?.language(forFileExtension: (newRelativePath as NSString).pathExtension)
+            language = lsp?.language(forPath: newRelativePath)
             updateOriginalMtime(from: newURL)
             updateOriginalFileIdentity(from: newURL)
             if dirty {
@@ -1258,7 +1258,7 @@ final class EditorBuffer {
                 host: host, path: newURL.path, content: lineEnding.normalize(canonical)
             )
             relativePath = newRelativePath
-            language = lsp?.language(forFileExtension: (newRelativePath as NSString).pathExtension)
+            language = lsp?.language(forPath: newRelativePath)
             originalText = canonical
             originalMtime = mtime
             discardSnapshot()
@@ -1297,7 +1297,7 @@ final class EditorBuffer {
                 ])
             }
             relativePath = newRelativePath
-            language = lsp?.language(forFileExtension: (newRelativePath as NSString).pathExtension)
+            language = lsp?.language(forPath: newRelativePath)
             if dirty { snapshotNow() } else { discardSnapshot() }
             notifyDidClose(url: oldURL)
             notifyDidOpen(url: newURL, text: storage.string)
@@ -1678,7 +1678,7 @@ final class EditorBuffer {
         let resolvedLanguage = languageOverride
             ?? openedLanguage
             ?? language
-            ?? lsp.language(forFileExtension: ((relativePath as NSString).pathExtension))
+            ?? lsp.language(forPath: relativePath)
         guard let resolvedLanguage else {
             try await saveAwaitingRemote()
             return
@@ -1778,7 +1778,7 @@ final class EditorBuffer {
         if oldRelativePath != snap.relativePath {
             pendingRestoredPathChange = (oldRelativePath, snap.relativePath)
         }
-        language = lsp?.language(forFileExtension: (snap.relativePath as NSString).pathExtension)
+        language = lsp?.language(forPath: snap.relativePath)
         withLoadEditTrackingSuppressed {
             storage.setAttributedString(NSAttributedString(string: snap.content))
         }

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -541,7 +541,7 @@ final class EditorBuffer {
 
     func reopenLSPDocument(afterRegistering language: String, forFileExtensions extensions: Set<String>) {
         guard !isExternal, let lsp else { return }
-        let ext = (relativePath as NSString).pathExtension.lowercased()
+        let ext = LanguageServerRegistry.extensionKey(forPath: relativePath)
         guard extensions.contains(ext) else { return }
         guard lsp.language(forFileExtension: ext) == language else { return }
         self.language = language

--- a/Alas/Sources/Code/Editor/EditorLSPStatusResolver.swift
+++ b/Alas/Sources/Code/Editor/EditorLSPStatusResolver.swift
@@ -26,7 +26,7 @@ struct EditorLSPStatusResolver {
     let registry: RegistryProbe
 
     func resolve(absolutePath: String, override: String?, worktreeRoot: URL) -> EditorLSPStatus {
-        let ext = (absolutePath as NSString).pathExtension.lowercased()
+        let ext = LanguageServerRegistry.extensionKey(forPath: absolutePath)
         let inferred = registry.language(forFileExtension: ext)
         guard let language = override ?? inferred else {
             return .noLanguage(fileExtension: ext)

--- a/Alas/Sources/Code/Editor/InstallNudgeResolver.swift
+++ b/Alas/Sources/Code/Editor/InstallNudgeResolver.swift
@@ -64,7 +64,7 @@ struct InstallNudgeResolver {
     }
 
     func nudgeData(forAbsolutePath absolutePath: String) -> InstallNudgeData? {
-        let ext = (absolutePath as NSString).pathExtension.lowercased()
+        let ext = LanguageServerRegistry.extensionKey(forPath: absolutePath)
         guard !ext.isEmpty else { return nil }
 
         if registry.language(forFileExtension: ext) != nil {

--- a/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
@@ -234,6 +234,134 @@ struct LanguageServerRegistry {
             env: [:],
             rootMarkers: [".luarc.json", ".luarc.jsonc", "stylua.toml", ".git"],
             enabled: true
+        ),
+        // clangd already ships with the Xcode command line tools and is
+        // already the C/C++ preset, so Objective-C costs no new dependency.
+        // The LSP spec's IDs are `objective-c` / `objective-cpp`; clangd
+        // switches dialect on them, so `.mm` must not be folded into the
+        // `objective-c` entry.
+        LanguageServerConfig(
+            language: "objective-c",
+            extensions: ["m"],
+            command: "clangd",
+            args: [],
+            env: [:],
+            rootMarkers: ["compile_commands.json", "CMakeLists.txt", "Makefile", ".git"],
+            enabled: true
+        ),
+        LanguageServerConfig(
+            language: "objective-cpp",
+            extensions: ["mm"],
+            command: "clangd",
+            args: [],
+            env: [:],
+            rootMarkers: ["compile_commands.json", "CMakeLists.txt", "Makefile", ".git"],
+            enabled: true
+        ),
+        // CSS/SCSS/HTML all come from vscode-langservers-extracted, which is
+        // already the recommended install for the JSON preset above — so for
+        // anyone who took that nudge these light up with nothing further to
+        // install. The CSS server handles both dialects but keys off the
+        // document's languageId, so `scss` needs its own entry rather than
+        // being an extension on the `css` one.
+        LanguageServerConfig(
+            language: "css",
+            extensions: ["css"],
+            command: "vscode-css-language-server",
+            args: ["--stdio"],
+            env: [:],
+            rootMarkers: ["package.json", ".git"],
+            enabled: true
+        ),
+        LanguageServerConfig(
+            language: "scss",
+            extensions: ["scss"],
+            command: "vscode-css-language-server",
+            args: ["--stdio"],
+            env: [:],
+            rootMarkers: ["package.json", ".git"],
+            enabled: true
+        ),
+        LanguageServerConfig(
+            language: "html",
+            extensions: ["html", "htm"],
+            command: "vscode-html-language-server",
+            args: ["--stdio"],
+            env: [:],
+            rootMarkers: ["package.json", ".git"],
+            enabled: true
+        ),
+        LanguageServerConfig(
+            language: "scala",
+            extensions: ["scala", "sbt", "sc"],
+            command: "metals",
+            args: [],
+            env: [:],
+            rootMarkers: ["build.sbt", "build.sc", "build.gradle", "pom.xml", ".git"],
+            enabled: true
+        ),
+        LanguageServerConfig(
+            language: "clojure",
+            extensions: ["clj", "cljs", "cljc", "edn"],
+            command: "clojure-lsp",
+            args: [],
+            env: [:],
+            rootMarkers: ["deps.edn", "project.clj", "shadow-cljs.edn", "bb.edn", ".git"],
+            enabled: true
+        ),
+        LanguageServerConfig(
+            language: "zig",
+            extensions: ["zig"],
+            command: "zls",
+            args: [],
+            env: [:],
+            rootMarkers: ["build.zig", "build.zig.zon", ".git"],
+            enabled: true
+        ),
+        LanguageServerConfig(
+            language: "elixir",
+            extensions: ["ex", "exs"],
+            command: "elixir-ls",
+            args: [],
+            env: [:],
+            rootMarkers: ["mix.exs", ".git"],
+            enabled: true
+        ),
+        LanguageServerConfig(
+            language: "cmake",
+            extensions: ["cmake"],
+            command: "cmake-language-server",
+            args: [],
+            env: [:],
+            rootMarkers: ["CMakeLists.txt", ".git"],
+            enabled: true
+        ),
+        // The LSP is a subcommand of the Dart SDK's own driver rather than a
+        // standalone binary, and it speaks the legacy analysis-server
+        // protocol unless `--protocol=lsp` is passed.
+        LanguageServerConfig(
+            language: "dart",
+            extensions: ["dart"],
+            command: "dart",
+            args: ["language-server", "--protocol=lsp"],
+            env: [:],
+            rootMarkers: ["pubspec.yaml", ".git"],
+            enabled: true
+        ),
+        // `haskell-language-server-wrapper`, not `haskell-language-server`:
+        // Homebrew ships only GHC-version-suffixed binaries
+        // (`haskell-language-server-9.12`, `-9.14`, …) plus this wrapper,
+        // which picks the one matching the project's GHC. There is no
+        // unsuffixed binary, so the obvious command name would resolve to
+        // nothing and report "not installed" forever.
+        LanguageServerConfig(
+            language: "haskell",
+            extensions: ["hs", "lhs"],
+            command: "haskell-language-server-wrapper",
+            args: ["--lsp"],
+            env: [:],
+            rootMarkers: ["*.cabal", "stack.yaml", "cabal.project", "package.yaml", ".git"],
+            enabled: true
         )
     ]
 

--- a/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
@@ -374,6 +374,36 @@ struct LanguageServerRegistry {
         return merged.first(where: { $0.language == language && $0.enabled })
     }
 
+    /// Files whose *name* identifies the language, because their extension
+    /// either doesn't exist or actively misleads. `CMakeLists.txt` is the
+    /// motivating case: its `pathExtension` is `txt`, so extension-only
+    /// lookup would never reach the `cmake` server for the one file every
+    /// CMake project is guaranteed to have.
+    ///
+    /// Values are extension keys, not language IDs, so a filename resolves
+    /// through exactly the same table as a normal extension.
+    /// `LanguageRegistry.extensionsByFilename` is the highlighting side's
+    /// equivalent; this one is deliberately narrower — it lists only
+    /// filenames whose language has a built-in server.
+    private static let extensionsByFilename: [String: String] = [
+        "cmakelists.txt": "cmake"
+    ]
+
+    /// The extension key to look a path up by. Identical to `pathExtension`
+    /// apart from the filenames above, so it is a safe drop-in wherever a
+    /// path was previously reduced with `pathExtension`.
+    static func extensionKey(forPath path: String) -> String {
+        let filename = (path as NSString).lastPathComponent.lowercased()
+        if let mapped = extensionsByFilename[filename] { return mapped }
+        return (path as NSString).pathExtension.lowercased()
+    }
+
+    /// Language for `path`, honouring filename-identified files. Prefer this
+    /// over `language(forFileExtension:)` whenever a full path is in hand.
+    func language(forPath path: String) -> String? {
+        language(forFileExtension: Self.extensionKey(forPath: path))
+    }
+
     func language(forFileExtension ext: String) -> String? {
         let lower = ext.lowercased()
         // Skip disabled entries so a stale disabled config can't mask an

--- a/Alas/Sources/Code/LSP/RecommendedLanguageCatalog.swift
+++ b/Alas/Sources/Code/LSP/RecommendedLanguageCatalog.swift
@@ -174,6 +174,123 @@ enum RecommendedLanguageCatalog {
                 InstallRecipe(installer: .brew, package: "JetBrains/utils/kotlin-lsp"),
             ]
         ),
+        // Objective-C rides on clangd, so it inherits C's (deliberately
+        // empty) recipes for the keg-only-llvm reason documented above.
+        RecommendedLanguage(
+            language: "objective-c",
+            displayName: "Objective-C",
+            masonId: nil,
+            aliasOf: "c",
+            recipes: []
+        ),
+        RecommendedLanguage(
+            language: "objective-cpp",
+            displayName: "Objective-C",
+            masonId: nil,
+            aliasOf: "c",
+            recipes: []
+        ),
+        // Same package as the JSON entry above — one install covers
+        // JSON + CSS + SCSS + HTML.
+        RecommendedLanguage(
+            language: "css",
+            displayName: "CSS / SCSS",
+            masonId: "css-lsp",
+            aliasOf: nil,
+            recipes: [
+                InstallRecipe(installer: .brew, package: "vscode-langservers-extracted"),
+                InstallRecipe(installer: .npm, package: "vscode-langservers-extracted"),
+            ]
+        ),
+        RecommendedLanguage(
+            language: "scss",
+            displayName: "CSS / SCSS",
+            masonId: nil,
+            aliasOf: "css",
+            recipes: []
+        ),
+        RecommendedLanguage(
+            language: "html",
+            displayName: "HTML",
+            masonId: "html-lsp",
+            aliasOf: nil,
+            recipes: [
+                InstallRecipe(installer: .brew, package: "vscode-langservers-extracted"),
+                InstallRecipe(installer: .npm, package: "vscode-langservers-extracted"),
+            ]
+        ),
+        RecommendedLanguage(
+            language: "scala",
+            displayName: "Scala",
+            masonId: "metals",
+            aliasOf: nil,
+            recipes: [
+                InstallRecipe(installer: .brew, package: "metals"),
+            ]
+        ),
+        RecommendedLanguage(
+            language: "clojure",
+            displayName: "Clojure",
+            masonId: "clojure-lsp",
+            aliasOf: nil,
+            recipes: [
+                InstallRecipe(installer: .brew, package: "clojure-lsp"),
+            ]
+        ),
+        RecommendedLanguage(
+            language: "zig",
+            displayName: "Zig",
+            masonId: "zls",
+            aliasOf: nil,
+            recipes: [
+                InstallRecipe(installer: .brew, package: "zls"),
+            ]
+        ),
+        RecommendedLanguage(
+            language: "elixir",
+            displayName: "Elixir",
+            masonId: "elixir-ls",
+            aliasOf: nil,
+            recipes: [
+                InstallRecipe(installer: .brew, package: "elixir-ls"),
+            ]
+        ),
+        RecommendedLanguage(
+            language: "cmake",
+            displayName: "CMake",
+            masonId: "cmake-language-server",
+            aliasOf: nil,
+            recipes: [
+                InstallRecipe(installer: .brew, package: "cmake-language-server"),
+                InstallRecipe(installer: .pipx, package: "cmake-language-server"),
+            ]
+        ),
+        // The language server is a subcommand of the SDK, so the install is
+        // the whole SDK rather than a standalone server package.
+        RecommendedLanguage(
+            language: "dart",
+            displayName: "Dart",
+            masonId: nil,
+            aliasOf: nil,
+            recipes: [
+                InstallRecipe(installer: .brew, package: "dart-sdk"),
+            ]
+        ),
+        // Homebrew's haskell-language-server is built against specific GHC
+        // versions and does not bring one: its own caveat says "You need to
+        // provide your own GHC or install one with `brew install ghc`".
+        // Installing this alone gets a server that completes the LSP
+        // handshake but cannot type-check a project until a matching GHC is
+        // present — worth knowing before treating a green install as done.
+        RecommendedLanguage(
+            language: "haskell",
+            displayName: "Haskell",
+            masonId: "haskell-language-server",
+            aliasOf: nil,
+            recipes: [
+                InstallRecipe(installer: .brew, package: "haskell-language-server"),
+            ]
+        ),
     ]
 
     private static let byLanguage: [String: RecommendedLanguage] = Dictionary(

--- a/Alas/Sources/Code/LSP/RecommendedLanguageCatalog.swift
+++ b/Alas/Sources/Code/LSP/RecommendedLanguageCatalog.swift
@@ -301,12 +301,26 @@ enum RecommendedLanguageCatalog {
         byLanguage[language]
     }
 
-    /// All language IDs that share the same install recipes as `language` —
-    /// i.e. the canonical language plus every entry that aliases to it. Used
-    /// after an install completes to re-fire `didOpen` for buffers in every
-    /// language served by the just-installed binary (e.g. installing
+    /// All language IDs served by the same install as `language`. Used after
+    /// an install completes to re-fire `didOpen` for buffers in every
+    /// language the just-installed package covers (e.g. installing
     /// typescript-language-server from a `.tsx` banner should also revive
     /// open `.ts`/`.js`/`.jsx` tabs).
+    ///
+    /// Membership is two things, not one:
+    ///
+    /// 1. the alias chain — the canonical language plus everything aliasing
+    ///    to it, which covers the TypeScript family and C/C++/Objective-C;
+    /// 2. any *other* canonical language whose resolved recipes are
+    ///    identical, because one package can supply several servers that are
+    ///    not aliases of each other. `vscode-langservers-extracted` is the
+    ///    case in point: it installs the JSON, CSS and HTML binaries in one
+    ///    go, so installing it from a CSS banner has to revive open HTML and
+    ///    JSON tabs too — they are equally un-blocked by that install.
+    ///
+    /// Recipe matching is skipped for entries with no recipes at all, or
+    /// every bundled/unprovisioned language (swift, c, …) would collapse
+    /// into one group on the strength of being equally empty.
     ///
     /// If `language` is not in the catalog, returns `[language]` unchanged.
     static func aliasGroup(forLanguage language: String) -> [String] {
@@ -317,6 +331,13 @@ enum RecommendedLanguageCatalog {
         let canonical = entry.aliasOf ?? entry.language
         var group = [canonical]
         for other in allEntries where other.aliasOf == canonical && other.language != canonical {
+            group.append(other.language)
+        }
+
+        let recipes = entry.resolvedRecipes
+        guard !recipes.isEmpty else { return group }
+        for other in allEntries
+        where !group.contains(other.language) && other.resolvedRecipes == recipes {
             group.append(other.language)
         }
         return group

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -11,8 +11,17 @@ extension Notification.Name {
 @MainActor
 protocol DocumentFormatter: AnyObject {
     func language(forFileExtension ext: String) -> String?
+    func language(forPath path: String) -> String?
     func formatting(for fileURL: URL, languageId: String, options: LSPFormattingOptions) async -> [LSPTextEdit]?
     func didChange(worktreeRoot: URL, fileURL: URL, languageId: String, text: String, edits: [EditorTextEdit]?) async
+}
+
+extension DocumentFormatter {
+    /// Reduces the path to its lookup key and defers to the extension-based
+    /// requirement, so a conformance only has to implement one of the two.
+    func language(forPath path: String) -> String? {
+        language(forFileExtension: LanguageServerRegistry.extensionKey(forPath: path))
+    }
 }
 
 @Observable

--- a/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
@@ -137,4 +137,90 @@ struct LanguageServerRegistryTests {
         #expect(entry?.command == "lua-language-server")
         #expect(entry?.extensions == ["lua"])
     }
+
+    @Test("Objective-C built-ins reuse clangd with distinct language IDs")
+    func objectiveCBuiltIns() {
+        let m = LanguageServerRegistry.builtIns.first(where: { $0.language == "objective-c" })
+        let mm = LanguageServerRegistry.builtIns.first(where: { $0.language == "objective-cpp" })
+        #expect(m?.command == "clangd")
+        #expect(mm?.command == "clangd")
+        // clangd picks its dialect from the languageId, so `.mm` must not be
+        // folded into the objective-c entry.
+        #expect(m?.extensions == ["m"])
+        #expect(mm?.extensions == ["mm"])
+    }
+
+    @Test("css, scss and html built-ins use the vscode-langservers binaries")
+    func webBuiltIns() {
+        let css = LanguageServerRegistry.builtIns.first(where: { $0.language == "css" })
+        let scss = LanguageServerRegistry.builtIns.first(where: { $0.language == "scss" })
+        let html = LanguageServerRegistry.builtIns.first(where: { $0.language == "html" })
+        #expect(css?.command == "vscode-css-language-server")
+        // One server, two languageIds: it keys off the document's languageId
+        // rather than re-deriving the dialect from the extension.
+        #expect(scss?.command == "vscode-css-language-server")
+        #expect(html?.command == "vscode-html-language-server")
+        for entry in [css, scss, html] {
+            #expect(entry?.args == ["--stdio"])
+        }
+    }
+
+    @Test("haskell built-in uses the wrapper binary, not the bare name")
+    func haskellUsesWrapper() {
+        let entry = LanguageServerRegistry.builtIns.first(where: { $0.language == "haskell" })
+        // Homebrew ships only GHC-version-suffixed binaries plus this
+        // wrapper — there is no plain `haskell-language-server` on PATH, so
+        // the obvious name would report "not installed" forever.
+        #expect(entry?.command == "haskell-language-server-wrapper")
+        #expect(entry?.args == ["--lsp"])
+    }
+
+    @Test("dart built-in selects the LSP protocol explicitly")
+    func dartBuiltIn() {
+        let entry = LanguageServerRegistry.builtIns.first(where: { $0.language == "dart" })
+        // The server is an SDK subcommand and speaks the legacy analysis
+        // protocol without `--protocol=lsp`.
+        #expect(entry?.command == "dart")
+        #expect(entry?.args == ["language-server", "--protocol=lsp"])
+    }
+
+    @Test("new presets are reachable by extension")
+    func newPresetsByExtension() {
+        let r = LanguageServerRegistry(userDefined: [])
+        let expected: [String: String] = [
+            "m": "objective-c",
+            "mm": "objective-cpp",
+            "css": "css",
+            "scss": "scss",
+            "html": "html",
+            "htm": "html",
+            "scala": "scala",
+            "sbt": "scala",
+            "clj": "clojure",
+            "edn": "clojure",
+            "zig": "zig",
+            "ex": "elixir",
+            "exs": "elixir",
+            "cmake": "cmake",
+            "dart": "dart",
+            "hs": "haskell",
+            "lhs": "haskell",
+        ]
+        for (ext, language) in expected {
+            #expect(r.language(forFileExtension: ext) == language,
+                    "\(ext) should resolve to \(language)")
+        }
+    }
+
+    @Test("no two built-ins claim the same extension")
+    func builtInExtensionsAreDisjoint() {
+        var owner: [String: String] = [:]
+        for entry in LanguageServerRegistry.builtIns {
+            for ext in entry.extensions {
+                #expect(owner[ext] == nil,
+                        "extension '\(ext)' claimed by both \(owner[ext] ?? "?") and \(entry.language)")
+                owner[ext] = entry.language
+            }
+        }
+    }
 }

--- a/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
@@ -212,6 +212,39 @@ struct LanguageServerRegistryTests {
         }
     }
 
+    @Test("CMakeLists.txt resolves to cmake despite its .txt extension")
+    func cmakeListsResolvesByFilename() {
+        let r = LanguageServerRegistry(userDefined: [])
+        // The one file every CMake project has; extension-only lookup sees
+        // "txt" and would never reach the cmake server.
+        #expect(r.language(forPath: "/repo/CMakeLists.txt") == "cmake")
+        #expect(r.language(forPath: "/repo/nested/CMakeLists.txt") == "cmake")
+        #expect(LanguageServerRegistry.extensionKey(forPath: "/repo/CMakeLists.txt") == "cmake")
+        // Case-insensitive, like every other lookup here.
+        #expect(r.language(forPath: "/repo/cmakelists.txt") == "cmake")
+    }
+
+    @Test("extensionKey is a drop-in for pathExtension elsewhere")
+    func extensionKeyMatchesPathExtension() {
+        // Everything that is not a filename special case must behave exactly
+        // as the `pathExtension` it replaced, or migrating the call sites
+        // would have changed unrelated languages.
+        for path in ["/a/b/App.swift", "/a/b/main.rs", "/a/b/notes.txt",
+                     "/a/b/script.PY", "/a/b/no-extension", "/a/CMakeLists.txt.bak"] {
+            let expected = (path as NSString).pathExtension.lowercased()
+            #expect(LanguageServerRegistry.extensionKey(forPath: path) == expected,
+                    "\(path) should reduce to \(expected)")
+        }
+    }
+
+    @Test("a plain .txt file still resolves to no language")
+    func plainTextStillUnmapped() {
+        let r = LanguageServerRegistry(userDefined: [])
+        // Guards against the filename table swallowing every .txt file.
+        #expect(r.language(forPath: "/repo/notes.txt") == nil)
+        #expect(r.language(forPath: "/repo/CMakeLists.txt.bak") == nil)
+    }
+
     @Test("no two built-ins claim the same extension")
     func builtInExtensionsAreDisjoint() {
         var owner: [String: String] = [:]

--- a/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
@@ -245,6 +245,19 @@ struct LanguageServerRegistryTests {
         #expect(r.language(forPath: "/repo/CMakeLists.txt.bak") == nil)
     }
 
+    @MainActor
+    @Test("DocumentFormatter's default routes filenames through the key")
+    func documentFormatterDefaultResolvesFilenames() {
+        // External tabs and formatAndSave reach the registry through this
+        // protocol, and conformances implement only the extension-based
+        // requirement — so the default has to do the filename normalisation
+        // or those paths silently regress to a nil language.
+        let formatter = RegistryBackedFormatter()
+        #expect(formatter.language(forPath: "/repo/CMakeLists.txt") == "cmake")
+        #expect(formatter.language(forPath: "/repo/App.swift") == "swift")
+        #expect(formatter.language(forPath: "/repo/notes.txt") == nil)
+    }
+
     @Test("no two built-ins claim the same extension")
     func builtInExtensionsAreDisjoint() {
         var owner: [String: String] = [:]
@@ -256,4 +269,22 @@ struct LanguageServerRegistryTests {
             }
         }
     }
+}
+
+/// Implements only the extension-based requirement, exactly as the real
+/// conformances and test fakes do, so `language(forPath:)` exercises the
+/// protocol's default implementation rather than a bespoke override.
+@MainActor
+private final class RegistryBackedFormatter: DocumentFormatter, @unchecked Sendable {
+    private let registry = LanguageServerRegistry(userDefined: [])
+
+    func language(forFileExtension ext: String) -> String? {
+        registry.language(forFileExtension: ext)
+    }
+
+    func formatting(for fileURL: URL, languageId: String, options: LSPFormattingOptions) async -> [LSPTextEdit]? {
+        nil
+    }
+
+    func didChange(worktreeRoot: URL, fileURL: URL, languageId: String, text: String, edits: [EditorTextEdit]?) async {}
 }

--- a/AlasTests/Code/LSP/RecommendedLanguageCatalogTests.swift
+++ b/AlasTests/Code/LSP/RecommendedLanguageCatalogTests.swift
@@ -76,6 +76,48 @@ struct RecommendedLanguageCatalogTests {
         }
     }
 
+    @Test("objective-c and objective-cpp alias to c (clangd)")
+    func objectiveCAliases() {
+        for lang in ["objective-c", "objective-cpp"] {
+            let entry = RecommendedLanguageCatalog.entry(forLanguage: lang)
+            #expect(entry?.aliasOf == "c", "\(lang) should alias to c")
+            // Inherits c's deliberately empty recipes (keg-only llvm).
+            #expect(entry?.resolvedRecipes.isEmpty == true)
+        }
+    }
+
+    @Test("scss aliases to css; both install vscode-langservers-extracted")
+    func scssAliasesToCSS() {
+        let scss = RecommendedLanguageCatalog.entry(forLanguage: "scss")
+        #expect(scss?.aliasOf == "css")
+        // Same package the JSON entry installs, so one install covers
+        // JSON + CSS + SCSS + HTML.
+        for lang in ["css", "scss", "html"] {
+            let entry = RecommendedLanguageCatalog.entry(forLanguage: lang)
+            #expect(entry?.resolvedRecipes.first?.package == "vscode-langservers-extracted",
+                    "\(lang) should install vscode-langservers-extracted")
+        }
+    }
+
+    @Test("brew-core presets name a real formula")
+    func brewCorePresets() {
+        let expected: [String: String] = [
+            "scala": "metals",
+            "clojure": "clojure-lsp",
+            "zig": "zls",
+            "elixir": "elixir-ls",
+            "cmake": "cmake-language-server",
+            "dart": "dart-sdk",
+            "haskell": "haskell-language-server",
+        ]
+        for (lang, formula) in expected {
+            let entry = RecommendedLanguageCatalog.entry(forLanguage: lang)
+            #expect(entry != nil, "missing catalog entry for \(lang)")
+            let brew = entry?.resolvedRecipes.first(where: { $0.installer == .brew })
+            #expect(brew?.package == formula, "\(lang) should brew-install \(formula)")
+        }
+    }
+
     @Test("alias entries carry empty own recipes")
     func aliasOwnRecipesEmpty() {
         let alias = RecommendedLanguageCatalog.allEntries.first(where: { $0.language == "typescriptreact" })

--- a/AlasTests/Code/LSP/RecommendedLanguageCatalogTests.swift
+++ b/AlasTests/Code/LSP/RecommendedLanguageCatalogTests.swift
@@ -118,6 +118,45 @@ struct RecommendedLanguageCatalogTests {
         }
     }
 
+    @Test("one install's languages are grouped together for reopen")
+    func aliasGroupSpansSharedInstalls() {
+        // vscode-langservers-extracted ships the JSON, CSS and HTML servers
+        // in one package, so installing it from any one of their banners has
+        // to revive open tabs in all of them — they are equally un-blocked.
+        for entryPoint in ["css", "scss", "html", "json", "jsonc"] {
+            let group = Set(RecommendedLanguageCatalog.aliasGroup(forLanguage: entryPoint))
+            for expected in ["css", "scss", "html", "json", "jsonc"] {
+                #expect(group.contains(expected),
+                        "installing from \(entryPoint) should also refresh \(expected)")
+            }
+        }
+    }
+
+    @Test("shared-install grouping does not merge unrelated languages")
+    func aliasGroupDoesNotOvermerge() {
+        // Languages with no recipes at all (bundled or unprovisionable) must
+        // not collapse into one group on the strength of being equally empty.
+        let swift = Set(RecommendedLanguageCatalog.aliasGroup(forLanguage: "swift"))
+        #expect(swift == ["swift"])
+
+        let c = Set(RecommendedLanguageCatalog.aliasGroup(forLanguage: "c"))
+        #expect(c.contains("c") && c.contains("cpp"))
+        #expect(c.contains("objective-c") && c.contains("objective-cpp"))
+        #expect(!c.contains("swift"))
+
+        // Distinct packages stay distinct.
+        let rust = Set(RecommendedLanguageCatalog.aliasGroup(forLanguage: "rust"))
+        #expect(rust == ["rust"])
+        let scala = Set(RecommendedLanguageCatalog.aliasGroup(forLanguage: "scala"))
+        #expect(scala == ["scala"])
+    }
+
+    @Test("typescript family still groups as before")
+    func typescriptGroupUnchanged() {
+        let group = Set(RecommendedLanguageCatalog.aliasGroup(forLanguage: "typescript"))
+        #expect(group == ["typescript", "typescriptreact", "javascript", "javascriptreact"])
+    }
+
     @Test("alias entries carry empty own recipes")
     func aliasOwnRecipesEmpty() {
         let alias = RecommendedLanguageCatalog.allEntries.first(where: { $0.language == "typescriptreact" })


### PR DESCRIPTION
## Summary

Follow-up to #1033: the grammars landed, but those languages had no default-on language server, so they highlighted without diagnostics or completion. Adds 12 presets to `LanguageServerRegistry.builtIns` plus the matching `RecommendedLanguageCatalog` entries that drive the install nudge.

| language | extensions | command |
|---|---|---|
| `objective-c` / `objective-cpp` | `.m` / `.mm` | `clangd` |
| `css` / `scss` | `.css` / `.scss` | `vscode-css-language-server --stdio` |
| `html` | `.html`, `.htm` | `vscode-html-language-server --stdio` |
| `scala` | `.scala`, `.sbt`, `.sc` | `metals` |
| `clojure` | `.clj`, `.cljs`, `.cljc`, `.edn` | `clojure-lsp` |
| `zig` | `.zig` | `zls` |
| `elixir` | `.ex`, `.exs` | `elixir-ls` |
| `cmake` | `.cmake` | `cmake-language-server` |
| `dart` | `.dart` | `dart language-server --protocol=lsp` |
| `haskell` | `.hs`, `.lhs` | `haskell-language-server-wrapper --lsp` |

## Five of these need no new dependency

- **Objective-C** reuses `clangd`, already the C/C++ preset and already present via the Xcode command line tools. `objective-c` and `objective-cpp` need separate entries because clangd picks its dialect from the `languageId`, not the extension.
- **CSS / SCSS / HTML** come from `vscode-langservers-extracted`, which is already the recommended install for the JSON preset — so one existing install now covers JSON + CSS + SCSS + HTML. CSS and HTML had grammars but no server, so this closes that gap too.

The rest are verified brew-core formulae.

## Every command/args pair was verified against a live server

Each entry was checked by installing the server and driving a real LSP `initialize` handshake against a project fixture, rather than transcribing documentation. That caught two entries the obvious spelling gets wrong:

- Homebrew ships **no** plain `haskell-language-server` binary — only GHC-version-suffixed ones (`-9.12`, `-9.14`, …) plus `haskell-language-server-wrapper`. The bare name would have reported "not installed" forever.
- `dart language-server` speaks the legacy analysis-server protocol unless `--protocol=lsp` is passed.

## Known caveat

Homebrew's `haskell-language-server` does not bring its own GHC (its formula caveat says so explicitly). Installing it alone yields a server that completes the handshake but cannot type-check until a matching GHC is present. Recorded in a comment on the catalog entry.

## Deliberately excluded

C#, XML, SQL, Erlang, Groovy, PowerShell, R, Julia, Make, INI — no server in brew core (C# additionally needs dotnet; `lemminx`/`sqls` aren't packaged). These stay reachable through the existing Mason-backed Add-language picker, so nothing regresses for them.

## Testing

- 137 tests pass across `LanguageServerRegistryTests`, `RecommendedLanguageCatalogTests`, `InstallNudgeResolverTests`, `WorkspaceLSPManagerStatusTests`, `DiffPaneLSPTests`, and `EditorBufferTests`.
- New coverage for each preset's command/args, extension resolution, the alias wiring, and a guard that no two built-ins claim the same extension.
- The existing `driftGuard` test keeps the catalog and registry in sync.
- Full `xcodebuild` sweep left to CI.

## Noted but not fixed here

Two pre-existing `mason-lsps.json` snapshot issues, out of scope for this change: the `css-lsp` entry lists extensions `["css"]` only (so `.scss` won't match it in the Add-language picker despite the server handling SCSS), and `metals` / `haskell-language-server` / `jdtls` are absent from the snapshot entirely because their `pkg:github` source relies on a `brew search` probe that didn't match at generation time. Regenerating that snapshot is a separate, heavier change.