### PR TITLE
feat(worktree): autocomplete issues in the attach issue dialog

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -949,6 +949,7 @@
 		9C73FEDF9B7B93D60FA3B51F /* ZmxClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C47AF847BD698EAB373D128B /* ZmxClient.swift */; };
 		9C78AF82EA26A9928865C5C6 /* ACPSessionManagerAttachRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */; };
 		9C9EC609F3ED8EFF1151D611 /* JSONRPCFramerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03C1E46A0853704E9B4449A /* JSONRPCFramerTests.swift */; };
+		9CB1C4A4B5567FC8894F8E80 /* IssueSuggestionLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9462CE78E6C7914B925C3ECE /* IssueSuggestionLoader.swift */; };
 		9CB593F0CB94D2EEF6DE8D0D /* ProjectMCPServerEditorPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C7B2268F3CE7A5FEDF8580 /* ProjectMCPServerEditorPolicy.swift */; };
 		9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */; };
 		9CF654B4AB74CC1A9FBCE55F /* ACPContextRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF522B02666DB6AC4C82339E /* ACPContextRing.swift */; };
@@ -1157,6 +1158,7 @@
 		BDBAA6601CA3FD8A5562E637 /* AppStateFocusMainWorktreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB4509E8835E63F9532E43 /* AppStateFocusMainWorktreeTests.swift */; };
 		BDEA5736B570C77CF4C965F5 /* DiffInlineAnnotationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1503D1CB549B39E499EFAB8 /* DiffInlineAnnotationCard.swift */; };
 		BE4E46595AF10611CE0B1C6B /* TabActivityPulse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */; };
+		BE5CF169DFE7BA086471C5BB /* IssueSuggestionLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6BCEC154CDA020B595E4703 /* IssueSuggestionLoaderTests.swift */; };
 		BE70DBB10DB7106860886AD7 /* WorkspaceLSPManagerStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */; };
 		BE7AAB0C61C7D1ED4B0479CA /* FileContextMenuActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF737AC27636853CA933B0E1 /* FileContextMenuActions.swift */; };
 		BE7FA8E07C4A1FC48267C64D /* ACPAdapterUpdateStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC298112812E38C99E0B71 /* ACPAdapterUpdateStoreTests.swift */; };
@@ -2484,6 +2486,7 @@
 		94255B602EB04BD063346B3E /* EditorFindHighlightRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindHighlightRenderer.swift; sourceTree = "<group>"; };
 		9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitInfoTests.swift; sourceTree = "<group>"; };
 		942B0DCA09E1297D9380C58C /* AppQuitAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppQuitAction.swift; sourceTree = "<group>"; };
+		9462CE78E6C7914B925C3ECE /* IssueSuggestionLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueSuggestionLoader.swift; sourceTree = "<group>"; };
 		949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailability.swift; sourceTree = "<group>"; };
 		94B123596E047E4CE0FAFE3E /* AdvancedSettingsVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsVisibility.swift; sourceTree = "<group>"; };
 		94D15758C7213FF407FD957B /* RightPaneGGLandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneGGLandTests.swift; sourceTree = "<group>"; };
@@ -2580,6 +2583,7 @@
 		A637073E5D65DAA4E0CF6EA4 /* ACPComposerImageExtractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerImageExtractTests.swift; sourceTree = "<group>"; };
 		A655F5AA40CA10A7685794F7 /* ACPSubmitIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSubmitIntent.swift; sourceTree = "<group>"; };
 		A6926DACD1903E1AAAF66F48 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		A6BCEC154CDA020B595E4703 /* IssueSuggestionLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueSuggestionLoaderTests.swift; sourceTree = "<group>"; };
 		A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimer.swift; sourceTree = "<group>"; };
 		A6C3E23DCE2A602A87915ECE /* MemoryReportWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryReportWindow.swift; sourceTree = "<group>"; };
 		A723CF5BB46FABA23D8C9543 /* DiffReviewRenderEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRenderEligibilityTests.swift; sourceTree = "<group>"; };
@@ -3354,6 +3358,7 @@
 				AD08CC47344CBCA5FC635822 /* IssuePromptBuilder.swift */,
 				0CFAAFA0205D70C328BF11A4 /* IssueProvider.swift */,
 				F55C4A7D3820C97CB1CD980D /* IssueResolver.swift */,
+				9462CE78E6C7914B925C3ECE /* IssueSuggestionLoader.swift */,
 				163616126043BC277DDE52F6 /* WebPageMetadataFetcher.swift */,
 			);
 			path = Issues;
@@ -4928,6 +4933,7 @@
 				8AD3C6DCEC447BEBA9F3911D /* IssueAttachmentTests.swift */,
 				368A1EF043B97B531F2C275D /* IssuePromptBuilderTests.swift */,
 				0E2A10683D1B7D0258F28E5F /* IssueResolverTests.swift */,
+				A6BCEC154CDA020B595E4703 /* IssueSuggestionLoaderTests.swift */,
 				1C0479721D1BC95DC664D4CB /* IssueWorktreeLaunchTests.swift */,
 				FDED017DE2DF29C817EF178C /* NewWorktreeIssueStateTests.swift */,
 				1BF0C3850E43BDA96ACA24F3 /* WebPageMetadataFetcherTests.swift */,
@@ -6524,6 +6530,7 @@
 				E54D3F52599B1C8FA6791D5F /* IssuePromptBuilder.swift in Sources */,
 				E7521AA3172D5BC6D82E63B3 /* IssueProvider.swift in Sources */,
 				69C69DECC8030B93F1AB7709 /* IssueResolver.swift in Sources */,
+				9CB1C4A4B5567FC8894F8E80 /* IssueSuggestionLoader.swift in Sources */,
 				255E9EAE89D521E08EB90918 /* JSONHookSettingsFile.swift in Sources */,
 				B13673C3423177C3431D758D /* JSONRPCFramer.swift in Sources */,
 				0871949C8A9030B15FA56FFF /* JSONRPCNewlineFramer.swift in Sources */,
@@ -7306,6 +7313,7 @@
 				90F70E227F10C03224E2EF87 /* IssueAttachmentTests.swift in Sources */,
 				DFC027A85CE6CB2EC6F1BC4E /* IssuePromptBuilderTests.swift in Sources */,
 				143B0E5F6377013544CC24E3 /* IssueResolverTests.swift in Sources */,
+				BE5CF169DFE7BA086471C5BB /* IssueSuggestionLoaderTests.swift in Sources */,
 				24F8FC4320CB8B8EA19809F6 /* IssueWorktreeLaunchTests.swift in Sources */,
 				9C9EC609F3ED8EFF1151D611 /* JSONRPCFramerTests.swift in Sources */,
 				524B70F03B9A934CEEA5FA61 /* LSPClientTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		0D65F2B699E6B0CF0915D25D /* ImageDiffMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */; };
 		0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB91379591DA21D216A894 /* RelativeTime.swift */; };
 		0DA68649E5F3C0018C4309DA /* UpdateThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */; };
+		0DD60B05B5698D2301D23168 /* IssueAutocompleteModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CE61111A4FCFAC4746CE7D /* IssueAutocompleteModelTests.swift */; };
 		0DFC9AB26DDCC406CEAA3825 /* ACPContextUsageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD22187C951174C9ECEC4C4 /* ACPContextUsageButton.swift */; };
 		0E054800F6B09275885CF5B6 /* GGMutationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70E37676F2A14E6C9E84B2D /* GGMutationCoordinatorTests.swift */; };
 		0E17E7251EC6EAB4B50B10D6 /* RunScriptCompletionMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0856147C5DC7F10944420ED /* RunScriptCompletionMonitorTests.swift */; };
@@ -231,6 +232,7 @@
 		25B497084FDEA8605FF8C5CA /* EditorFindController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */; };
 		25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */; };
 		25CD620AE7FFA7DE82937F7E /* Spinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E01930F1D95B8D17BCBAC1 /* Spinner.swift */; };
+		25E825CE77CC459FC3A95B4A /* IssueAutocompleteModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705E8882FDBB132BBBE72AC1 /* IssueAutocompleteModel.swift */; };
 		26265A75CED42D3C490DF8C2 /* RunScriptTemplateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200C4E9E9FBD356C8B051746 /* RunScriptTemplateTests.swift */; };
 		264DBAC7DCEBDDCB8A948C6A /* WebPageMetadataFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163616126043BC277DDE52F6 /* WebPageMetadataFetcher.swift */; };
 		2659BA65A6CABBE800A06AB3 /* tool-call-content-diff.json in Resources */ = {isa = PBXBuildFile; fileRef = 9A187BD52742E8F4A6E52667 /* tool-call-content-diff.json */; };
@@ -2274,6 +2276,7 @@
 		705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigSidebarChromeOverridesTests.swift; sourceTree = "<group>"; };
 		705B34DF3EE049FA52E8ECFB /* IconSymbolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconSymbolTests.swift; sourceTree = "<group>"; };
 		705D2002EB8BC3F1DDA0E93F /* ACPSessionForkAttachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionForkAttachTests.swift; sourceTree = "<group>"; };
+		705E8882FDBB132BBBE72AC1 /* IssueAutocompleteModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueAutocompleteModel.swift; sourceTree = "<group>"; };
 		708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateThrottleTests.swift; sourceTree = "<group>"; };
 		708FAE890F75BC58098E7DDC /* RunScriptTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptTemplate.swift; sourceTree = "<group>"; };
 		7094534860369BA79FC5A877 /* session-update-plan.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-plan.json"; sourceTree = "<group>"; };
@@ -2655,6 +2658,7 @@
 		B2F3473392B284B69E6621DB /* ACPBareURLLinkifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBareURLLinkifier.swift; sourceTree = "<group>"; };
 		B32762D888121D56722E03F5 /* GGInboxTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxTabView.swift; sourceTree = "<group>"; };
 		B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateLoadOlderTests.swift; sourceTree = "<group>"; };
+		B3CE61111A4FCFAC4746CE7D /* IssueAutocompleteModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueAutocompleteModelTests.swift; sourceTree = "<group>"; };
 		B3E9B2665E18F4C4BF3FB683 /* ACPThumbnailImageCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPThumbnailImageCacheTests.swift; sourceTree = "<group>"; };
 		B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneVisibilityTests.swift; sourceTree = "<group>"; };
 		B44D759586280250330A9A04 /* FontSizeCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCommands.swift; sourceTree = "<group>"; };
@@ -3771,6 +3775,7 @@
 				2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */,
 				AAEDACEB27E6AF219054496E /* DialogChrome.swift */,
 				B24ABE96ED3C62146A3CED62 /* EmptyState.swift */,
+				705E8882FDBB132BBBE72AC1 /* IssueAutocompleteModel.swift */,
 				EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */,
 				711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */,
 				5E76A376D202F7144C03F221 /* NewWorktreeIssueState.swift */,
@@ -4931,6 +4936,7 @@
 			children = (
 				D8FDA5449911989623B0F755 /* AttachIssueDialogModelTests.swift */,
 				8AD3C6DCEC447BEBA9F3911D /* IssueAttachmentTests.swift */,
+				B3CE61111A4FCFAC4746CE7D /* IssueAutocompleteModelTests.swift */,
 				368A1EF043B97B531F2C275D /* IssuePromptBuilderTests.swift */,
 				0E2A10683D1B7D0258F28E5F /* IssueResolverTests.swift */,
 				A6BCEC154CDA020B595E4703 /* IssueSuggestionLoaderTests.swift */,
@@ -6526,6 +6532,7 @@
 				6A386E5CF4C958D9F90DF692 /* InstallSplitButton.swift in Sources */,
 				0407824F9DA8EEFC5B5EEA8A /* InstallerHost.swift in Sources */,
 				847843D79763F873038C0C44 /* IssueAttachment.swift in Sources */,
+				25E825CE77CC459FC3A95B4A /* IssueAutocompleteModel.swift in Sources */,
 				F43BE2FD87E0788EE09EC15B /* IssueModels.swift in Sources */,
 				E54D3F52599B1C8FA6791D5F /* IssuePromptBuilder.swift in Sources */,
 				E7521AA3172D5BC6D82E63B3 /* IssueProvider.swift in Sources */,
@@ -7311,6 +7318,7 @@
 				814193F0CC55B784481AA40A /* InstallSourceTests.swift in Sources */,
 				32660CEE9955165AE3CCDFBE /* InstallerHostTests.swift in Sources */,
 				90F70E227F10C03224E2EF87 /* IssueAttachmentTests.swift in Sources */,
+				0DD60B05B5698D2301D23168 /* IssueAutocompleteModelTests.swift in Sources */,
 				DFC027A85CE6CB2EC6F1BC4E /* IssuePromptBuilderTests.swift in Sources */,
 				143B0E5F6377013544CC24E3 /* IssueResolverTests.swift in Sources */,
 				BE5CF169DFE7BA086471C5BB /* IssueSuggestionLoaderTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -628,6 +628,7 @@
 		6635C1BBE700E46738D5648F /* PaneDragMath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E467DCC037978A4942F8C8B /* PaneDragMath.swift */; };
 		664EEC1B4A18A02A49897FBA /* ACPTerminalCRLFTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF798A386DD56B4127D5272A /* ACPTerminalCRLFTests.swift */; };
 		6682233134C258D81E22D7AD /* ACPTranscriptMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5069EF396F2CB8E81B2AD11 /* ACPTranscriptMarkdownTests.swift */; };
+		668E8A783D48B399E5986112 /* IssueCompletionGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9279A0417F44DF15BDD1E4A /* IssueCompletionGeometryTests.swift */; };
 		66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */; };
 		66D8C1574C3A58C9E959CEDB /* RunScriptFailureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D27AA18750DEA3843477D9 /* RunScriptFailureTests.swift */; };
 		66DCE2D5A6D886BAE5A6B9A0 /* PairedComposerTextControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B8003F90C5FD770A293717 /* PairedComposerTextControls.swift */; };
@@ -2800,6 +2801,7 @@
 		C8E1A57CB48427C32D4F1249 /* AlasMCPHTTPSupervisor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasMCPHTTPSupervisor.swift; sourceTree = "<group>"; };
 		C9042DA34C7025958BCFEE08 /* RemoteHelperHandshake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperHandshake.swift; sourceTree = "<group>"; };
 		C9126D442E8CDB093FA36BA5 /* RemoteServerPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteServerPane.swift; sourceTree = "<group>"; };
+		C9279A0417F44DF15BDD1E4A /* IssueCompletionGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCompletionGeometryTests.swift; sourceTree = "<group>"; };
 		C954F77AD0867F7FD39A5ED7 /* LineBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineBuffer.swift; sourceTree = "<group>"; };
 		C96C5E43E973803E6FD1528C /* CodeHostModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostModels.swift; sourceTree = "<group>"; };
 		C995611A6313FABE30508248 /* WorktreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRowView.swift; sourceTree = "<group>"; };
@@ -4940,6 +4942,7 @@
 				D8FDA5449911989623B0F755 /* AttachIssueDialogModelTests.swift */,
 				8AD3C6DCEC447BEBA9F3911D /* IssueAttachmentTests.swift */,
 				B3CE61111A4FCFAC4746CE7D /* IssueAutocompleteModelTests.swift */,
+				C9279A0417F44DF15BDD1E4A /* IssueCompletionGeometryTests.swift */,
 				368A1EF043B97B531F2C275D /* IssuePromptBuilderTests.swift */,
 				0E2A10683D1B7D0258F28E5F /* IssueResolverTests.swift */,
 				A6BCEC154CDA020B595E4703 /* IssueSuggestionLoaderTests.swift */,
@@ -7323,6 +7326,7 @@
 				32660CEE9955165AE3CCDFBE /* InstallerHostTests.swift in Sources */,
 				90F70E227F10C03224E2EF87 /* IssueAttachmentTests.swift in Sources */,
 				0DD60B05B5698D2301D23168 /* IssueAutocompleteModelTests.swift in Sources */,
+				668E8A783D48B399E5986112 /* IssueCompletionGeometryTests.swift in Sources */,
 				DFC027A85CE6CB2EC6F1BC4E /* IssuePromptBuilderTests.swift in Sources */,
 				143B0E5F6377013544CC24E3 /* IssueResolverTests.swift in Sources */,
 				BE5CF169DFE7BA086471C5BB /* IssueSuggestionLoaderTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		195102F7D680452476D70329 /* GitLabCLIProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */; };
 		199BE03E36D7202143D7547A /* MissionTestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90F265EBA9431630D56836C /* MissionTestFixtures.swift */; };
 		1A56FAF2DE8FFB95272EE948 /* ACPQuestionPromptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44ACE3DEC81C465524111058 /* ACPQuestionPromptTests.swift */; };
+		1A5FBA79B90A59F822C9B77C /* IssueAutocompleteField.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD3E9F5573DA60B2DDECF3B /* IssueAutocompleteField.swift */; };
 		1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */; };
 		1A6AF8939585038A3303B625 /* ReviewDraftModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67378DD93876E3840E367550 /* ReviewDraftModelsTests.swift */; };
 		1A9F0F653615306A723315B0 /* ImageDiffPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC4DF5F82BE5F73A7551EFE /* ImageDiffPresentation.swift */; };
@@ -2930,6 +2931,7 @@
 		DC73B8AC6AC57FB3A3253F40 /* ReviewScopeSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScopeSelectionTests.swift; sourceTree = "<group>"; };
 		DC76F9150CC29A324D785C29 /* ACPDelayedHoverVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDelayedHoverVisibilityTests.swift; sourceTree = "<group>"; };
 		DCD333CD0765908F6657E824 /* WorktreePathTemplateRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreePathTemplateRenderer.swift; sourceTree = "<group>"; };
+		DCD3E9F5573DA60B2DDECF3B /* IssueAutocompleteField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueAutocompleteField.swift; sourceTree = "<group>"; };
 		DD1F34E025D235A5CECCE36E /* ACPSessionUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUpdate.swift; sourceTree = "<group>"; };
 		DDBB557833D3939208D75FB7 /* PairedAuthoredContentSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedAuthoredContentSurfaceTests.swift; sourceTree = "<group>"; };
 		DDE8B45ECF898B83A616586D /* SubHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubHeader.swift; sourceTree = "<group>"; };
@@ -3775,6 +3777,7 @@
 				2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */,
 				AAEDACEB27E6AF219054496E /* DialogChrome.swift */,
 				B24ABE96ED3C62146A3CED62 /* EmptyState.swift */,
+				DCD3E9F5573DA60B2DDECF3B /* IssueAutocompleteField.swift */,
 				705E8882FDBB132BBBE72AC1 /* IssueAutocompleteModel.swift */,
 				EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */,
 				711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */,
@@ -6532,6 +6535,7 @@
 				6A386E5CF4C958D9F90DF692 /* InstallSplitButton.swift in Sources */,
 				0407824F9DA8EEFC5B5EEA8A /* InstallerHost.swift in Sources */,
 				847843D79763F873038C0C44 /* IssueAttachment.swift in Sources */,
+				1A5FBA79B90A59F822C9B77C /* IssueAutocompleteField.swift in Sources */,
 				25E825CE77CC459FC3A95B4A /* IssueAutocompleteModel.swift in Sources */,
 				F43BE2FD87E0788EE09EC15B /* IssueModels.swift in Sources */,
 				E54D3F52599B1C8FA6791D5F /* IssuePromptBuilder.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1334,6 +1334,16 @@ final class AppState {
         ))
     }
 
+    func makeIssueSuggestionLoader() -> IssueSuggestionLoader {
+        IssueSuggestionLoader(environment: .init(
+            projects: { [weak self] in self?.projects ?? [] },
+            remotes: { project in
+                try await GitService().remotes(worktreePath: URL(fileURLWithPath: project.path))
+            },
+            providers: .live()
+        ))
+    }
+
     private func refreshMissionSource(
         _ source: IssueSnapshot,
         projectID: String

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1336,7 +1336,7 @@ final class AppState {
 
     func makeIssueSuggestionLoader() -> IssueSuggestionLoader {
         let projects = projects
-        IssueSuggestionLoader(environment: .init(
+        return IssueSuggestionLoader(environment: .init(
             projects: { projects },
             remotes: { project in
                 try await GitService().remotes(worktreePath: URL(fileURLWithPath: project.path))

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1335,8 +1335,9 @@ final class AppState {
     }
 
     func makeIssueSuggestionLoader() -> IssueSuggestionLoader {
+        let projects = projects
         IssueSuggestionLoader(environment: .init(
-            projects: { [weak self] in self?.projects ?? [] },
+            projects: { projects },
             remotes: { project in
                 try await GitService().remotes(worktreePath: URL(fileURLWithPath: project.path))
             },

--- a/Alas/Sources/Code/LSP/Features/EditorOverlayPanel.swift
+++ b/Alas/Sources/Code/LSP/Features/EditorOverlayPanel.swift
@@ -30,12 +30,12 @@ final class EditorOverlayPanel {
         contentViewController: NSViewController,
         size: NSSize,
         anchor: NSRect,
-        in textView: NSTextView
+        in hostView: NSView
     ) {
         let panel = ensurePanel(size: size)
         panel.contentViewController = contentViewController
-        panel.setFrame(frame(for: size, anchor: anchor, in: textView), display: true, animate: false)
-        attach(panel, to: textView.window)
+        panel.setFrame(frame(for: size, anchor: anchor, in: hostView), display: true, animate: false)
+        attach(panel, to: hostView.window)
         if !panel.isVisible {
             panel.orderFront(nil)
         }
@@ -80,12 +80,12 @@ final class EditorOverlayPanel {
         panel.level = parentWindow.level
     }
 
-    func frame(for size: NSSize, anchor: NSRect, in textView: NSTextView) -> NSRect {
-        guard let window = textView.window else {
+    func frame(for size: NSSize, anchor: NSRect, in hostView: NSView) -> NSRect {
+        guard let window = hostView.window else {
             return NSRect(origin: .zero, size: size)
         }
 
-        let windowRect = textView.convert(anchor, to: nil)
+        let windowRect = hostView.convert(anchor, to: nil)
         let screenRect = window.convertToScreen(windowRect)
         let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame ?? screenRect
         let x = min(
@@ -112,7 +112,7 @@ final class EditorOverlayPanel {
 
 enum EditorOverlayPanelTesting {
     @MainActor
-    static func frame(for panel: EditorOverlayPanel, size: NSSize, anchor: NSRect, in textView: NSTextView) -> NSRect {
-        panel.frame(for: size, anchor: anchor, in: textView)
+    static func frame(for panel: EditorOverlayPanel, size: NSSize, anchor: NSRect, in hostView: NSView) -> NSRect {
+        panel.frame(for: size, anchor: anchor, in: hostView)
     }
 }

--- a/Alas/Sources/Dialogs/AttachIssueDialog.swift
+++ b/Alas/Sources/Dialogs/AttachIssueDialog.swift
@@ -26,11 +26,13 @@ struct AttachIssueDialog: View {
     }
 
     var body: some View {
-        switch model.phase {
-        case .entry, .resolving:
-            entrySheet
-        case .confirmation:
-            confirmationSheet
+        Group {
+            switch model.phase {
+            case .entry, .resolving:
+                entrySheet
+            case .confirmation:
+                confirmationSheet
+            }
         }
         .onChange(of: model.phase) { _, phase in
             guard phase != .entry else { return }
@@ -68,7 +70,10 @@ struct AttachIssueDialog: View {
                             model.reference = accepted
                         },
                         onDismiss: autocomplete.dismiss,
-                        onFocusLost: autocomplete.dismiss
+                        onFocusLost: {
+                            autocomplete.dismiss()
+                            autocomplete.cancelInFlightLoad()
+                        }
                     )
                 }
                 if model.phase == .resolving {

--- a/Alas/Sources/Dialogs/AttachIssueDialog.swift
+++ b/Alas/Sources/Dialogs/AttachIssueDialog.swift
@@ -10,6 +10,7 @@ struct AttachIssueDialog: View {
     let onAttach: (AttachedIssueDraft) -> Void
 
     @State private var model: AttachIssueDialogModel
+    @State private var autocomplete: IssueAutocompleteModel
     @Environment(\.theme) private var theme
 
     init(
@@ -19,6 +20,7 @@ struct AttachIssueDialog: View {
         onAttach: @escaping (AttachedIssueDraft) -> Void
     ) {
         _model = State(initialValue: AttachIssueDialogModel(environment: environment, initialDraft: initialDraft))
+        _autocomplete = State(initialValue: IssueAutocompleteModel(load: environment.loadSuggestions))
         self.onCancel = onCancel
         self.onAttach = onAttach
     }
@@ -30,6 +32,15 @@ struct AttachIssueDialog: View {
         case .confirmation:
             confirmationSheet
         }
+        .onChange(of: model.phase) { _, phase in
+            guard phase != .entry else { return }
+            autocomplete.dismiss()
+            autocomplete.cancel()
+        }
+        .onDisappear {
+            autocomplete.dismiss()
+            autocomplete.cancel()
+        }
     }
 
     private var entrySheet: some View {
@@ -38,13 +49,27 @@ struct AttachIssueDialog: View {
             subtitle: "Resolve an issue and prepare the first Chat prompt.",
             content: {
                 DialogField(label: "Issue link") {
-                    AlasField(
-                        text: Bindable(model).reference,
-                        placeholder: "#42 or https://...",
+                    IssueAutocompleteField(
+                        text: autocompleteReferenceBinding,
+                        state: autocomplete.state,
+                        suggestions: autocomplete.filteredSuggestions,
+                        selectedIndex: autocomplete.selectedIndex,
+                        isPresented: autocomplete.isPresented,
                         focusOnAppear: true,
-                        onSubmit: resolve
+                        isEnabled: model.phase != .resolving,
+                        onTextChange: { reference in
+                            model.reference = reference
+                            autocomplete.referenceChanged(reference, projectID: model.autocompleteProjectID)
+                        },
+                        onSubmit: resolve,
+                        onMoveSelection: autocomplete.moveSelection,
+                        onAcceptSelection: {
+                            guard let accepted = autocomplete.acceptSelection() else { return }
+                            model.reference = accepted
+                        },
+                        onDismiss: autocomplete.dismiss,
+                        onFocusLost: autocomplete.dismiss
                     )
-                    .disabled(model.phase == .resolving)
                 }
                 if model.phase == .resolving {
                     HStack(spacing: 8) {
@@ -78,6 +103,9 @@ struct AttachIssueDialog: View {
                 && !model.reference.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         )
         .interactiveDismissDisabled(model.phase == .resolving)
+        .onAppear {
+            autocomplete.referenceChanged(model.reference, projectID: model.autocompleteProjectID)
+        }
     }
 
     private var confirmationSheet: some View {
@@ -131,6 +159,16 @@ struct AttachIssueDialog: View {
         )
     }
 
+    private var autocompleteReferenceBinding: Binding<String> {
+        Binding(
+            get: { model.reference },
+            set: { reference in
+                model.reference = reference
+                autocomplete.referenceChanged(reference, projectID: model.autocompleteProjectID)
+            }
+        )
+    }
+
     private func textEditor(text: Binding<String>, minHeight: CGFloat, maxHeight: CGFloat) -> some View {
         TextEditor(text: text)
             .font(.system(size: 12))
@@ -146,6 +184,8 @@ struct AttachIssueDialog: View {
     }
 
     private func resolve() {
+        autocomplete.dismiss()
+        autocomplete.cancel()
         Task { await model.resolve() }
     }
 

--- a/Alas/Sources/Dialogs/AttachIssueDialog.swift
+++ b/Alas/Sources/Dialogs/AttachIssueDialog.swift
@@ -35,11 +35,11 @@ struct AttachIssueDialog: View {
         .onChange(of: model.phase) { _, phase in
             guard phase != .entry else { return }
             autocomplete.dismiss()
-            autocomplete.cancel()
+            autocomplete.cancelInFlightLoad()
         }
         .onDisappear {
             autocomplete.dismiss()
-            autocomplete.cancel()
+            autocomplete.cancelInFlightLoad()
         }
     }
 
@@ -185,7 +185,7 @@ struct AttachIssueDialog: View {
 
     private func resolve() {
         autocomplete.dismiss()
-        autocomplete.cancel()
+        autocomplete.cancelInFlightLoad()
         Task { await model.resolve() }
     }
 

--- a/Alas/Sources/Dialogs/AttachIssueDialogModel.swift
+++ b/Alas/Sources/Dialogs/AttachIssueDialogModel.swift
@@ -12,6 +12,8 @@ final class AttachIssueDialogModel {
 
     struct Environment {
         let resolve: (String) async throws -> ResolvedIssue
+        let loadSuggestions: @Sendable (String, Int) async throws -> [CodeHostIssueSuggestion]
+        let selectedProjectID: String
         let projects: () -> [ProjectConfig]
         let configuredBranchPrefix: (String) -> String
     }
@@ -80,6 +82,10 @@ final class AttachIssueDialogModel {
             title: source.title,
             prefix: environment.configuredBranchPrefix(projectID ?? "")
         )
+    }
+
+    var autocompleteProjectID: String {
+        environment.selectedProjectID
     }
 
     func resolve() async {

--- a/Alas/Sources/Dialogs/IssueAutocompleteField.swift
+++ b/Alas/Sources/Dialogs/IssueAutocompleteField.swift
@@ -6,6 +6,7 @@ struct IssueAutocompleteField: View {
     let state: IssueAutocompleteModel.State
     let suggestions: [CodeHostIssueSuggestion]
     let selectedIndex: Int
+    let isPresented: Bool
     let focusOnAppear: Bool
     let isEnabled: Bool
     let onTextChange: (String) -> Void
@@ -23,6 +24,7 @@ struct IssueAutocompleteField: View {
             state: state,
             suggestions: suggestions,
             selectedIndex: selectedIndex,
+            isPresented: isPresented,
             focusOnAppear: focusOnAppear,
             isEnabled: isEnabled,
             theme: theme,
@@ -42,6 +44,7 @@ private struct IssueAutocompleteTextField: NSViewRepresentable {
     let state: IssueAutocompleteModel.State
     let suggestions: [CodeHostIssueSuggestion]
     let selectedIndex: Int
+    let isPresented: Bool
     let focusOnAppear: Bool
     let isEnabled: Bool
     let theme: Theme
@@ -100,8 +103,6 @@ private struct IssueAutocompleteTextField: NSViewRepresentable {
     final class Coordinator: NSObject, NSTextFieldDelegate {
         var parent: IssueAutocompleteTextField
         private let popup = IssueCompletionWindowController()
-        private var dismissedText: String?
-
         init(_ parent: IssueAutocompleteTextField) {
             self.parent = parent
         }
@@ -112,7 +113,6 @@ private struct IssueAutocompleteTextField: NSViewRepresentable {
 
         func controlTextDidChange(_ notification: Notification) {
             guard let field = notification.object as? NSTextField else { return }
-            dismissedText = nil
             if field.stringValue != parent.text {
                 parent.onTextChange(field.stringValue)
             }
@@ -144,7 +144,6 @@ private struct IssueAutocompleteTextField: NSViewRepresentable {
                 return true
             case #selector(NSResponder.cancelOperation(_:)):
                 let wasVisible = popupIsVisible
-                dismissedText = parent.text
                 parent.onDismiss()
                 hidePopup()
                 return wasVisible
@@ -184,9 +183,7 @@ private struct IssueAutocompleteTextField: NSViewRepresentable {
         }
 
         private var popupIsVisible: Bool {
-            parent.text.hasPrefix("#")
-                && dismissedText != parent.text
-                && parent.state != .idle
+            parent.isPresented && parent.state != .idle
         }
 
         private var popupHasSelectableRows: Bool {

--- a/Alas/Sources/Dialogs/IssueAutocompleteField.swift
+++ b/Alas/Sources/Dialogs/IssueAutocompleteField.swift
@@ -1,0 +1,319 @@
+import AppKit
+import SwiftUI
+
+struct IssueAutocompleteField: View {
+    @Binding var text: String
+    let state: IssueAutocompleteModel.State
+    let suggestions: [CodeHostIssueSuggestion]
+    let selectedIndex: Int
+    let focusOnAppear: Bool
+    let isEnabled: Bool
+    let onTextChange: (String) -> Void
+    let onSubmit: () -> Void
+    let onMoveSelection: (Int) -> Void
+    let onAcceptSelection: () -> Void
+    let onDismiss: () -> Void
+    let onFocusLost: () -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        IssueAutocompleteTextField(
+            text: $text,
+            state: state,
+            suggestions: suggestions,
+            selectedIndex: selectedIndex,
+            focusOnAppear: focusOnAppear,
+            isEnabled: isEnabled,
+            theme: theme,
+            onTextChange: onTextChange,
+            onSubmit: onSubmit,
+            onMoveSelection: onMoveSelection,
+            onAcceptSelection: onAcceptSelection,
+            onDismiss: onDismiss,
+            onFocusLost: onFocusLost
+        )
+        .alasFieldChrome(theme: theme)
+    }
+}
+
+private struct IssueAutocompleteTextField: NSViewRepresentable {
+    @Binding var text: String
+    let state: IssueAutocompleteModel.State
+    let suggestions: [CodeHostIssueSuggestion]
+    let selectedIndex: Int
+    let focusOnAppear: Bool
+    let isEnabled: Bool
+    let theme: Theme
+    let onTextChange: (String) -> Void
+    let onSubmit: () -> Void
+    let onMoveSelection: (Int) -> Void
+    let onAcceptSelection: () -> Void
+    let onDismiss: () -> Void
+    let onFocusLost: () -> Void
+
+    func makeNSView(context: Context) -> IssueAutocompleteNSTextField {
+        let field = IssueAutocompleteNSTextField()
+        field.isBordered = false
+        field.isBezeled = false
+        field.drawsBackground = false
+        field.font = .systemFont(ofSize: 12)
+        field.focusRingType = .none
+        field.stringValue = text
+        field.isEnabled = isEnabled
+        field.delegate = context.coordinator
+        field.target = context.coordinator
+        field.action = #selector(Coordinator.submit(_:))
+        field.focusOnAppear = focusOnAppear
+        return field
+    }
+
+    func updateNSView(_ nsView: IssueAutocompleteNSTextField, context: Context) {
+        context.coordinator.parent = self
+        nsView.isEnabled = isEnabled
+        if nsView.stringValue != text {
+            nsView.stringValue = text
+        }
+
+        if focusOnAppear, nsView.focusOnAppear, let window = nsView.window {
+            window.makeFirstResponder(nsView)
+            nsView.focusOnAppear = false
+            DispatchQueue.main.async {
+                guard let editor = window.fieldEditor(false, for: nsView) as? NSTextView else { return }
+                editor.setSelectedRange(NSRange(location: nsView.stringValue.count, length: 0))
+            }
+        }
+
+        context.coordinator.updatePopup(for: nsView)
+    }
+
+    static func dismantleNSView(_ nsView: IssueAutocompleteNSTextField, coordinator: Coordinator) {
+        coordinator.hidePopup()
+        nsView.delegate = nil
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var parent: IssueAutocompleteTextField
+        private let popup = IssueCompletionWindowController()
+        private var dismissedText: String?
+
+        init(_ parent: IssueAutocompleteTextField) {
+            self.parent = parent
+        }
+
+        @objc func submit(_ sender: NSTextField) {
+            parent.onSubmit()
+        }
+
+        func controlTextDidChange(_ notification: Notification) {
+            guard let field = notification.object as? NSTextField else { return }
+            dismissedText = nil
+            if field.stringValue != parent.text {
+                parent.onTextChange(field.stringValue)
+            }
+        }
+
+        func controlTextDidEndEditing(_ notification: Notification) {
+            hidePopup()
+            parent.onFocusLost()
+        }
+
+        func control(
+            _ control: NSControl,
+            textView: NSTextView,
+            doCommandBy selector: Selector
+        ) -> Bool {
+            switch selector {
+            case #selector(NSResponder.moveUp(_:)):
+                parent.onMoveSelection(-1)
+                return popupHasSelectableRows
+            case #selector(NSResponder.moveDown(_:)):
+                parent.onMoveSelection(1)
+                return popupHasSelectableRows
+            case #selector(NSResponder.insertNewline(_:)):
+                if popupHasSelectableRows {
+                    parent.onAcceptSelection()
+                } else {
+                    parent.onSubmit()
+                }
+                return true
+            case #selector(NSResponder.cancelOperation(_:)):
+                dismissedText = parent.text
+                parent.onDismiss()
+                hidePopup()
+                return popupIsVisible
+            default:
+                return false
+            }
+        }
+
+        func updatePopup(for field: IssueAutocompleteNSTextField) {
+            guard field.window != nil, popupIsVisible else {
+                hidePopup()
+                return
+            }
+
+            let root = IssueCompletionPopup(
+                state: parent.state,
+                suggestions: parent.suggestions,
+                selectedIndex: parent.selectedIndex,
+                theme: parent.theme,
+                onChoose: { [weak self] index in
+                    guard let self else { return }
+                    self.parent.onMoveSelection(index - self.parent.selectedIndex)
+                    self.parent.onAcceptSelection()
+                }
+            )
+            popup.show(
+                root: root,
+                width: max(field.bounds.width, 1),
+                rowCount: popupRowCount,
+                anchor: field.bounds,
+                in: field
+            )
+        }
+
+        func hidePopup() {
+            popup.hide()
+        }
+
+        private var popupIsVisible: Bool {
+            parent.text.hasPrefix("#")
+                && dismissedText != parent.text
+                && parent.state != .idle
+        }
+
+        private var popupHasSelectableRows: Bool {
+            popupIsVisible && !parent.suggestions.isEmpty
+        }
+
+        private var popupRowCount: Int {
+            max(parent.suggestions.count, 1)
+        }
+    }
+}
+
+private final class IssueAutocompleteNSTextField: NSTextField {
+    var focusOnAppear = false
+}
+
+@MainActor
+private final class IssueCompletionWindowController {
+    private static let rowHeight: CGFloat = 28
+    private static let maxHeight: CGFloat = 260
+
+    private let overlay = EditorOverlayPanel()
+    private var hostingController: NSHostingController<IssueCompletionPopup>?
+
+    func show(
+        root: IssueCompletionPopup,
+        width: CGFloat,
+        rowCount: Int,
+        anchor: NSRect,
+        in hostView: NSView
+    ) {
+        if let hostingController {
+            hostingController.rootView = root
+        } else {
+            hostingController = NSHostingController(rootView: root)
+        }
+        guard let hostingController else { return }
+        let height = min(Self.maxHeight, CGFloat(rowCount) * Self.rowHeight)
+        overlay.show(
+            contentViewController: hostingController,
+            size: NSSize(width: width, height: height),
+            anchor: anchor,
+            in: hostView
+        )
+    }
+
+    func hide() {
+        overlay.hide()
+    }
+}
+
+private struct IssueCompletionPopup: View {
+    let state: IssueAutocompleteModel.State
+    let suggestions: [CodeHostIssueSuggestion]
+    let selectedIndex: Int
+    let theme: Theme
+    let onChoose: (Int) -> Void
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    if suggestions.isEmpty {
+                        statusRow
+                    } else {
+                        ForEach(Array(suggestions.enumerated()), id: \.element.id) { index, suggestion in
+                            suggestionRow(suggestion, selected: index == selectedIndex)
+                                .id(suggestion.id)
+                                .contentShape(Rectangle())
+                                .onTapGesture { onChoose(index) }
+                        }
+                    }
+                }
+            }
+            .onAppear { scrollSelection(using: proxy) }
+            .onChange(of: selectedIndex) { _, _ in scrollSelection(using: proxy) }
+        }
+        .background(Color(nsColor: NSColor(theme.color("bg-1"))))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    @ViewBuilder
+    private var statusRow: some View {
+        Group {
+            switch state {
+        case .loading:
+            Text("Loading issues...")
+        case .failed:
+            Text("Could not load issues")
+        case .loaded:
+            Text("No matching issues")
+        case .idle:
+            EmptyView()
+            }
+        }
+        .font(.system(size: 12))
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
+        .padding(.horizontal, 10)
+    }
+
+    private func suggestionRow(_ suggestion: CodeHostIssueSuggestion, selected: Bool) -> some View {
+        HStack(spacing: 8) {
+            Text("#\(suggestion.number)")
+                .font(.system(size: 12, design: .monospaced))
+                .frame(width: 52, alignment: .trailing)
+            Text(suggestion.title)
+                .font(.system(size: 12))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 28)
+        .background(selected ? Color.accentColor.opacity(0.24) : .clear)
+    }
+
+    private func scrollSelection(using proxy: ScrollViewProxy) {
+        guard suggestions.indices.contains(selectedIndex) else { return }
+        let id = suggestions[selectedIndex].id
+        DispatchQueue.main.async {
+            withAnimation(nil) {
+                proxy.scrollTo(id, anchor: .center)
+            }
+        }
+    }
+}

--- a/Alas/Sources/Dialogs/IssueAutocompleteField.swift
+++ b/Alas/Sources/Dialogs/IssueAutocompleteField.swift
@@ -143,10 +143,11 @@ private struct IssueAutocompleteTextField: NSViewRepresentable {
                 }
                 return true
             case #selector(NSResponder.cancelOperation(_:)):
+                let wasVisible = popupIsVisible
                 dismissedText = parent.text
                 parent.onDismiss()
                 hidePopup()
-                return popupIsVisible
+                return wasVisible
             default:
                 return false
             }
@@ -171,9 +172,9 @@ private struct IssueAutocompleteTextField: NSViewRepresentable {
             )
             popup.show(
                 root: root,
-                width: max(field.bounds.width, 1),
+                width: max(IssueCompletionGeometry.popupAnchor(for: field.bounds).width, 1),
                 rowCount: popupRowCount,
-                anchor: field.bounds,
+                anchor: IssueCompletionGeometry.popupAnchor(for: field.bounds),
                 in: field
             )
         }
@@ -200,6 +201,14 @@ private struct IssueAutocompleteTextField: NSViewRepresentable {
 
 private final class IssueAutocompleteNSTextField: NSTextField {
     var focusOnAppear = false
+}
+
+enum IssueCompletionGeometry {
+    static let chromeHorizontalInset: CGFloat = 10
+
+    static func popupAnchor(for fieldBounds: NSRect) -> NSRect {
+        fieldBounds.insetBy(dx: -chromeHorizontalInset, dy: 0)
+    }
 }
 
 @MainActor

--- a/Alas/Sources/Dialogs/IssueAutocompleteModel.swift
+++ b/Alas/Sources/Dialogs/IssueAutocompleteModel.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class IssueAutocompleteModel {
+    enum State: Equatable {
+        case idle
+        case loading
+        case loaded([CodeHostIssueSuggestion])
+        case failed(String)
+    }
+
+    typealias Load = @Sendable (String, Int) async throws -> [CodeHostIssueSuggestion]
+
+    private(set) var state: State = .idle
+    private(set) var reference = ""
+    private(set) var selectedIndex = 0
+    private(set) var dismissedReference: String?
+    private var projectID: String?
+    private var generation = 0
+    private var task: Task<Void, Never>?
+    private let load: Load
+
+    init(load: @escaping Load) {
+        self.load = load
+    }
+
+    var filteredSuggestions: [CodeHostIssueSuggestion] {
+        guard case .loaded(let suggestions) = state,
+              let query = Self.query(in: reference)
+        else {
+            return []
+        }
+        guard !query.isEmpty else { return suggestions }
+        let numeric = query.allSatisfy(\.isNumber)
+        return suggestions.filter {
+            (numeric && String($0.number).hasPrefix(query))
+                || $0.title.localizedCaseInsensitiveContains(query)
+        }
+    }
+
+    var isPresented: Bool {
+        Self.query(in: reference) != nil && dismissedReference != reference
+    }
+
+    static func query(in reference: String) -> String? {
+        guard reference.hasPrefix("#") else { return nil }
+        return String(reference.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func referenceChanged(_ reference: String, projectID: String) {
+        let referenceChanged = self.reference != reference
+        let projectChanged = self.projectID != projectID
+
+        self.reference = reference
+        selectedIndex = 0
+
+        if referenceChanged {
+            dismissedReference = nil
+        }
+
+        if projectChanged {
+            task?.cancel()
+            task = nil
+            generation &+= 1
+            self.projectID = projectID
+            state = .idle
+        }
+
+        guard Self.query(in: reference) != nil else { return }
+        guard state == .idle else { return }
+
+        startLoad(projectID: projectID)
+    }
+
+    func moveSelection(_ delta: Int) {
+        guard !filteredSuggestions.isEmpty else {
+            selectedIndex = 0
+            return
+        }
+        let lastIndex = filteredSuggestions.count - 1
+        selectedIndex = min(lastIndex, max(0, selectedIndex + delta))
+    }
+
+    func acceptSelection() -> String? {
+        let suggestions = filteredSuggestions
+        guard suggestions.indices.contains(selectedIndex) else { return nil }
+        let accepted = "#\(suggestions[selectedIndex].number)"
+        reference = accepted
+        selectedIndex = 0
+        dismiss()
+        return accepted
+    }
+
+    func dismiss() {
+        dismissedReference = reference
+    }
+
+    func waitForCurrentLoadForTesting() async {
+        await task?.value
+    }
+
+    private func startLoad(projectID: String) {
+        generation &+= 1
+        let capturedGeneration = generation
+        state = .loading
+
+        task = Task { [load] in
+            do {
+                let suggestions = try await load(projectID, 50)
+                guard !Task.isCancelled,
+                      self.accepts(capturedGeneration, projectID: projectID)
+                else {
+                    return
+                }
+                self.state = .loaded(suggestions)
+            } catch {
+                guard !Task.isCancelled,
+                      self.accepts(capturedGeneration, projectID: projectID)
+                else {
+                    return
+                }
+                self.state = .failed(error.localizedDescription)
+            }
+        }
+    }
+
+    private func accepts(_ capturedGeneration: Int, projectID: String) -> Bool {
+        generation == capturedGeneration && self.projectID == projectID
+    }
+}

--- a/Alas/Sources/Dialogs/IssueAutocompleteModel.swift
+++ b/Alas/Sources/Dialogs/IssueAutocompleteModel.swift
@@ -97,11 +97,13 @@ final class IssueAutocompleteModel {
         dismissedReference = reference
     }
 
-    func cancel() {
+    func cancelInFlightLoad() {
         task?.cancel()
         task = nil
         generation &+= 1
-        state = .idle
+        if case .loading = state {
+            state = .idle
+        }
     }
 
     func waitForCurrentLoadForTesting() async {

--- a/Alas/Sources/Dialogs/IssueAutocompleteModel.swift
+++ b/Alas/Sources/Dialogs/IssueAutocompleteModel.swift
@@ -97,6 +97,13 @@ final class IssueAutocompleteModel {
         dismissedReference = reference
     }
 
+    func cancel() {
+        task?.cancel()
+        task = nil
+        generation &+= 1
+        state = .idle
+    }
+
     func waitForCurrentLoadForTesting() async {
         await task?.value
     }

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -426,10 +426,15 @@ struct NewWorktreeDialog: View {
     }
 
     private func attachIssueEnvironment() -> AttachIssueDialogModel.Environment {
-        .init(
+        let loader = state.makeIssueSuggestionLoader()
+        return .init(
             resolve: { reference in
                 try await state.makeIssueResolver(selectedProjectID: projectId).resolve(reference)
             },
+            loadSuggestions: { projectID, limit in
+                try await loader.suggestions(projectID: projectID, limit: limit)
+            },
+            selectedProjectID: projectId,
             projects: { state.projects },
             configuredBranchPrefix: { _ in state.config.worktrees.branchPrefix }
         )

--- a/Alas/Sources/Integrations/CodeHost/CodeHostIssueProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostIssueProvider.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+struct CodeHostIssueSuggestion: Equatable, Sendable, Identifiable {
+    let provider: CodeHostKind
+    let number: Int
+    let title: String
+    let canonicalURL: URL
+    let createdAt: Date
+
+    var id: String { "\(provider.rawValue):\(canonicalURL.absoluteString)" }
+}
+
 protocol CodeHostIssueProviding: Sendable {
     var kind: CodeHostKind { get }
     var executable: String { get }
@@ -7,6 +17,7 @@ protocol CodeHostIssueProviding: Sendable {
     func isAvailable(cwd: URL) async -> Bool
     func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool
     func issue(remote: CodeHostRemote, number: Int, cwd: URL) async throws -> CodeHostIssueSnapshot
+    func openIssues(remote: CodeHostRemote, limit: Int, cwd: URL) async throws -> [CodeHostIssueSuggestion]
 }
 
 enum CodeHostIssueProviderError: LocalizedError, Equatable, Sendable {

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -289,6 +289,24 @@ struct GitHubCLIProvider: CodeHostProvider, CodeHostIssueProviding {
         return try Self.parseIssue(result.stdout, remote: remote, requestedNumber: number)
     }
 
+    func openIssues(remote: CodeHostRemote, limit: Int, cwd: URL) async throws -> [CodeHostIssueSuggestion] {
+        guard limit > 0 else { return [] }
+        let result = try await runner.run(
+            executable,
+            args: [
+                "api", "--hostname", remote.host, "--method", "GET",
+                "repos/\(remote.repositorySlug)/issues",
+                "-f", "state=open", "-f", "sort=created", "-f", "direction=desc",
+                "-f", "per_page=\(limit)",
+            ],
+            cwd: cwd
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "gh api issues", stderr: result.stderr)
+        }
+        return try Self.parseOpenIssues(result.stdout, remote: remote, limit: limit)
+    }
+
     func currentReviewRequest(
         remote: CodeHostRemote,
         branch: String,
@@ -1912,6 +1930,36 @@ struct GitHubCLIProvider: CodeHostProvider, CodeHostIssueProviding {
         )
     }
 
+    static func parseOpenIssues(_ json: String, remote: CodeHostRemote, limit: Int) throws -> [CodeHostIssueSuggestion] {
+        let responses: [GitHubOpenIssueResponse]
+        do {
+            responses = try JSONDecoder().decode([GitHubOpenIssueResponse].self, from: Data(json.utf8))
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse GitHub issue list output.")
+        }
+
+        let suggestions = try responses.compactMap { response -> CodeHostIssueSuggestion? in
+            guard response.pullRequest == nil else { return nil }
+            guard response.number > 0,
+                  !response.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  let url = try parseOptionalHTTPURL(response.htmlURL, context: "GitHub issue output is missing a valid URL."),
+                  let createdAt = parseDate(response.createdAt, formatOptions: [.withInternetDateTime]) ?? parseDate(response.createdAt, formatOptions: [.withInternetDateTime, .withFractionalSeconds]),
+                  case .url(let kind, let host, let repositorySlug, let number) = try CodeHostIssueInput.parse(url.absoluteString),
+                  kind == .github,
+                  host.caseInsensitiveCompare(remote.host) == .orderedSame,
+                  repositorySlug.caseInsensitiveCompare(remote.repositorySlug) == .orderedSame,
+                  number == response.number
+            else {
+                throw CodeHostProviderError.malformedOutput("GitHub issue output is missing required fields.")
+            }
+            return CodeHostIssueSuggestion(provider: .github, number: response.number, title: response.title, canonicalURL: url, createdAt: createdAt)
+        }
+        return suggestions.sorted {
+            if $0.createdAt != $1.createdAt { return $0.createdAt > $1.createdAt }
+            return $0.number > $1.number
+        }.prefix(limit).map { $0 }
+    }
+
     private static func parseOptionalHTTPURL(_ value: String?, context: String) throws -> URL? {
         guard let value,
               !value.isEmpty
@@ -2354,6 +2402,24 @@ private struct ReviewThreadCommentNode: Decodable {
     let author: ReviewThreadAuthor?
     let viewerDidAuthor: Bool?
 }
+
+private struct GitHubOpenIssueResponse: Decodable {
+    let number: Int
+    let title: String
+    let htmlURL: String
+    let createdAt: String
+    let pullRequest: GitHubPullRequestMarker?
+
+    enum CodingKeys: String, CodingKey {
+        case number
+        case title
+        case htmlURL = "html_url"
+        case createdAt = "created_at"
+        case pullRequest = "pull_request"
+    }
+}
+
+private struct GitHubPullRequestMarker: Decodable {}
 
 private struct ReviewThreadAuthor: Decodable {
     let login: String

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -294,10 +294,10 @@ struct GitHubCLIProvider: CodeHostProvider, CodeHostIssueProviding {
         let result = try await runner.run(
             executable,
             args: [
-                "api", "--hostname", remote.host, "--method", "GET",
+                "api", "--hostname", remote.host, "--method", "GET", "--paginate", "--slurp",
                 "repos/\(remote.repositorySlug)/issues",
                 "-f", "state=open", "-f", "sort=created", "-f", "direction=desc",
-                "-f", "per_page=\(limit)",
+                "-f", "per_page=100",
             ],
             cwd: cwd
         )
@@ -1933,7 +1933,12 @@ struct GitHubCLIProvider: CodeHostProvider, CodeHostIssueProviding {
     static func parseOpenIssues(_ json: String, remote: CodeHostRemote, limit: Int) throws -> [CodeHostIssueSuggestion] {
         let responses: [GitHubOpenIssueResponse]
         do {
-            responses = try JSONDecoder().decode([GitHubOpenIssueResponse].self, from: Data(json.utf8))
+            let data = Data(json.utf8)
+            if let pages = try? JSONDecoder().decode([[GitHubOpenIssueResponse]].self, from: data) {
+                responses = pages.flatMap { $0 }
+            } else {
+                responses = try JSONDecoder().decode([GitHubOpenIssueResponse].self, from: data)
+            }
         } catch {
             throw CodeHostProviderError.malformedOutput("Unable to parse GitHub issue list output.")
         }
@@ -1947,7 +1952,6 @@ struct GitHubCLIProvider: CodeHostProvider, CodeHostIssueProviding {
                   case .url(let kind, let host, let repositorySlug, let number) = try CodeHostIssueInput.parse(url.absoluteString),
                   kind == .github,
                   host.caseInsensitiveCompare(remote.host) == .orderedSame,
-                  repositorySlug.caseInsensitiveCompare(remote.repositorySlug) == .orderedSame,
                   number == response.number
             else {
                 throw CodeHostProviderError.malformedOutput("GitHub issue output is missing required fields.")

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -57,6 +57,10 @@ struct GitLabCLIProvider: CodeHostProvider, CodeHostIssueProviding {
         return try Self.parseIssue(result.stdout, remote: remote, requestedNumber: number)
     }
 
+    func openIssues(remote: CodeHostRemote, limit: Int, cwd: URL) async throws -> [CodeHostIssueSuggestion] {
+        throw CodeHostProviderError.unsupportedProvider(.gitlab)
+    }
+
     func currentReviewRequest(
         remote: CodeHostRemote,
         branch: String,

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -58,7 +58,21 @@ struct GitLabCLIProvider: CodeHostProvider, CodeHostIssueProviding {
     }
 
     func openIssues(remote: CodeHostRemote, limit: Int, cwd: URL) async throws -> [CodeHostIssueSuggestion] {
-        throw CodeHostProviderError.unsupportedProvider(.gitlab)
+        guard limit > 0 else { return [] }
+        let result = try await runner.run(
+            executable,
+            args: [
+                "api", "projects/\(Self.encodedProjectPath(remote.repositorySlug))/issues",
+                "--hostname", remote.host, "--output", "json", "--method", "GET",
+                "-f", "state=opened", "-f", "order_by=created_at", "-f", "sort=desc",
+                "-f", "per_page=\(limit)",
+            ],
+            cwd: cwd
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab api issues", stderr: result.stderr)
+        }
+        return try Self.parseOpenIssues(result.stdout, remote: remote, limit: limit)
     }
 
     func currentReviewRequest(
@@ -1722,6 +1736,35 @@ struct GitLabCLIProvider: CodeHostProvider, CodeHostIssueProviding {
         )
     }
 
+    static func parseOpenIssues(_ json: String, remote: CodeHostRemote, limit: Int) throws -> [CodeHostIssueSuggestion] {
+        let responses: [GitLabOpenIssueResponse]
+        do {
+            responses = try JSONDecoder().decode([GitLabOpenIssueResponse].self, from: Data(json.utf8))
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse GitLab issue list output.")
+        }
+
+        let suggestions = try responses.map { response in
+            guard response.iid > 0,
+                  !response.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  let url = try parseOptionalHTTPURL(response.webURL, context: "GitLab issue output is missing a valid URL."),
+                  let createdAt = try parseOptionalGitLabDate(response.createdAt),
+                  case .url(let kind, let host, let repositorySlug, let number) = try CodeHostIssueInput.parse(url.absoluteString),
+                  kind == .gitlab,
+                  host.caseInsensitiveCompare(remote.host) == .orderedSame,
+                  repositorySlug.caseInsensitiveCompare(remote.repositorySlug) == .orderedSame,
+                  number == response.iid
+            else {
+                throw CodeHostProviderError.malformedOutput("GitLab issue output is missing required fields.")
+            }
+            return CodeHostIssueSuggestion(provider: .gitlab, number: response.iid, title: response.title, canonicalURL: url, createdAt: createdAt)
+        }
+        return suggestions.sorted {
+            if $0.createdAt != $1.createdAt { return $0.createdAt > $1.createdAt }
+            return $0.number > $1.number
+        }.prefix(limit).map { $0 }
+    }
+
     private static func parseDate(_ value: String, formatOptions: ISO8601DateFormatter.Options) -> Date? {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = formatOptions
@@ -2045,6 +2088,19 @@ private struct GitLabIssueResponse: Decodable {
     }
 
     struct Assignee: Decodable { let username: String? }
+}
+
+private struct GitLabOpenIssueResponse: Decodable {
+    let iid: Int
+    let title: String
+    let webURL: String?
+    let createdAt: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case iid, title
+        case webURL = "web_url"
+        case createdAt = "created_at"
+    }
 }
 
 private struct GitLabPipeline: Decodable {

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -1752,7 +1752,6 @@ struct GitLabCLIProvider: CodeHostProvider, CodeHostIssueProviding {
                   case .url(let kind, let host, let repositorySlug, let number) = try CodeHostIssueInput.parse(url.absoluteString),
                   kind == .gitlab,
                   host.caseInsensitiveCompare(remote.host) == .orderedSame,
-                  repositorySlug.caseInsensitiveCompare(remote.repositorySlug) == .orderedSame,
                   number == response.iid
             else {
                 throw CodeHostProviderError.malformedOutput("GitLab issue output is missing required fields.")

--- a/Alas/Sources/Issues/IssueSuggestionLoader.swift
+++ b/Alas/Sources/Issues/IssueSuggestionLoader.swift
@@ -14,10 +14,7 @@ struct IssueSuggestionLoader: Sendable {
             throw CodeHostProviderError.malformedOutput("The selected project is no longer available.")
         }
         let remotes = try await environment.remotes(project)
-        guard let remote = CodeHostRemoteDetector.detect(
-            from: remotes,
-            supportedKinds: environment.providers.supportedKinds
-        ) else {
+        guard let remote = candidateRemotes(remotes).first else {
             throw CodeHostProviderError.malformedOutput("The selected project has no supported code host remote.")
         }
         guard let provider = environment.providers.provider(for: remote.kind) else {
@@ -31,5 +28,24 @@ struct IssueSuggestionLoader: Sendable {
             throw CodeHostProviderError.unauthenticated(remote.host)
         }
         return try await provider.openIssues(remote: remote, limit: limit, cwd: cwd)
+    }
+
+    private func candidateRemotes(_ remotes: [GitRemote]) -> [CodeHostRemote] {
+        var candidates: [CodeHostRemote] = []
+        if let detected = CodeHostRemoteDetector.detect(
+            from: remotes,
+            supportedKinds: environment.providers.supportedKinds
+        ) {
+            candidates.append(detected)
+        }
+        for remote in remotes {
+            for kind in environment.providers.supportedKinds.sorted(by: { $0.rawValue < $1.rawValue }) {
+                guard let detected = CodeHostRemoteDetector.detect(from: [remote], matching: kind),
+                      !candidates.contains(detected)
+                else { continue }
+                candidates.append(detected)
+            }
+        }
+        return candidates
     }
 }

--- a/Alas/Sources/Issues/IssueSuggestionLoader.swift
+++ b/Alas/Sources/Issues/IssueSuggestionLoader.swift
@@ -14,20 +14,25 @@ struct IssueSuggestionLoader: Sendable {
             throw CodeHostProviderError.malformedOutput("The selected project is no longer available.")
         }
         let remotes = try await environment.remotes(project)
-        guard let remote = candidateRemotes(remotes).first else {
+        let candidates = candidateRemotes(remotes)
+        guard !candidates.isEmpty else {
             throw CodeHostProviderError.malformedOutput("The selected project has no supported code host remote.")
         }
-        guard let provider = environment.providers.provider(for: remote.kind) else {
-            throw CodeHostProviderError.unsupportedProvider(remote.kind)
-        }
         let cwd = URL(fileURLWithPath: project.path)
-        guard await provider.isAvailable(cwd: cwd) else {
-            throw CodeHostProviderError.cliMissing(provider.executable)
+        var lastError: Error?
+        for remote in candidates {
+            guard let provider = environment.providers.provider(for: remote.kind) else { continue }
+            guard await provider.isAvailable(cwd: cwd) else {
+                lastError = CodeHostProviderError.cliMissing(provider.executable)
+                continue
+            }
+            guard await provider.isAuthenticated(remote: remote, cwd: cwd) else {
+                lastError = CodeHostProviderError.unauthenticated(remote.host)
+                continue
+            }
+            return try await provider.openIssues(remote: remote, limit: limit, cwd: cwd)
         }
-        guard await provider.isAuthenticated(remote: remote, cwd: cwd) else {
-            throw CodeHostProviderError.unauthenticated(remote.host)
-        }
-        return try await provider.openIssues(remote: remote, limit: limit, cwd: cwd)
+        throw lastError ?? CodeHostProviderError.malformedOutput("The selected project has no supported code host remote.")
     }
 
     private func candidateRemotes(_ remotes: [GitRemote]) -> [CodeHostRemote] {

--- a/Alas/Sources/Issues/IssueSuggestionLoader.swift
+++ b/Alas/Sources/Issues/IssueSuggestionLoader.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct IssueSuggestionLoader: Sendable {
+    struct Environment: Sendable {
+        let projects: @Sendable () -> [ProjectConfig]
+        let remotes: @Sendable (ProjectConfig) async throws -> [GitRemote]
+        let providers: CodeHostIssueProviderRegistry
+    }
+
+    let environment: Environment
+
+    func suggestions(projectID: String, limit: Int = 50) async throws -> [CodeHostIssueSuggestion] {
+        guard let project = environment.projects().first(where: { $0.id == projectID }) else {
+            throw CodeHostProviderError.malformedOutput("The selected project is no longer available.")
+        }
+        let remotes = try await environment.remotes(project)
+        guard let remote = CodeHostRemoteDetector.detect(
+            from: remotes,
+            supportedKinds: environment.providers.supportedKinds
+        ) else {
+            throw CodeHostProviderError.malformedOutput("The selected project has no supported code host remote.")
+        }
+        guard let provider = environment.providers.provider(for: remote.kind) else {
+            throw CodeHostProviderError.unsupportedProvider(remote.kind)
+        }
+        let cwd = URL(fileURLWithPath: project.path)
+        guard await provider.isAvailable(cwd: cwd) else {
+            throw CodeHostProviderError.cliMissing(provider.executable)
+        }
+        guard await provider.isAuthenticated(remote: remote, cwd: cwd) else {
+            throw CodeHostProviderError.unauthenticated(remote.host)
+        }
+        return try await provider.openIssues(remote: remote, limit: limit, cwd: cwd)
+    }
+}

--- a/AlasTests/EditorOverlayPanelTests.swift
+++ b/AlasTests/EditorOverlayPanelTests.swift
@@ -5,25 +5,15 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct EditorOverlayPanelTests {
-    private func makeTextView(in window: NSWindow) -> CodeTextView {
-        let storage = NSTextStorage(string: "hello world")
-        let layoutManager = NSLayoutManager()
-        let container = NSTextContainer(size: NSSize(width: 800, height: 600))
-        layoutManager.addTextContainer(container)
-        storage.addLayoutManager(layoutManager)
-        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: container)
-        window.contentView = textView
-        return textView
+    private func makeHostView(in window: NSWindow) -> NSView {
+        let hostView = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        window.contentView = hostView
+        return hostView
     }
 
     @Test func frameReturnsZeroSizedWhenViewHasNoWindow() {
-        let storage = NSTextStorage(string: "x")
-        let layoutManager = NSLayoutManager()
-        let container = NSTextContainer(size: NSSize(width: 100, height: 100))
-        layoutManager.addTextContainer(container)
-        storage.addLayoutManager(layoutManager)
-        let textView = CodeTextView(frame: .zero, textContainer: container)
-        #expect(textView.window == nil)
+        let hostView = NSView(frame: .zero)
+        #expect(hostView.window == nil)
         let panel = EditorOverlayPanel()
         let size = NSSize(width: 200, height: 120)
 
@@ -31,7 +21,7 @@ struct EditorOverlayPanelTests {
             for: panel,
             size: size,
             anchor: NSRect(x: 50, y: 80, width: 20, height: 20),
-            in: textView
+            in: hostView
         )
 
         #expect(frame.size == size)
@@ -45,7 +35,7 @@ struct EditorOverlayPanelTests {
             backing: .buffered,
             defer: true
         )
-        let textView = makeTextView(in: window)
+        let hostView = makeHostView(in: window)
         let panel = EditorOverlayPanel()
         let size = NSSize(width: 300, height: 100)
         let anchor = NSRect(x: 50, y: 300, width: 40, height: 16)
@@ -54,10 +44,10 @@ struct EditorOverlayPanelTests {
             for: panel,
             size: size,
             anchor: anchor,
-            in: textView
+            in: hostView
         )
 
-        let anchorScreen = window.convertToScreen(textView.convert(anchor, to: nil))
+        let anchorScreen = window.convertToScreen(hostView.convert(anchor, to: nil))
         #expect(frame.maxY < anchorScreen.minY)
         #expect(frame.size == size)
     }

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -25,10 +25,10 @@ struct GitHubCLIProviderTests {
         #expect(issues.map(\.number) == [42, 40])
         #expect(issues.map(\.title) == ["Newest issue", "Older issue"])
         #expect(await runner.commands.first?.args == [
-            "api", "--hostname", "github.example.com", "--method", "GET",
+            "api", "--hostname", "github.example.com", "--method", "GET", "--paginate", "--slurp",
             "repos/mrmans0n/alas/issues",
             "-f", "state=open", "-f", "sort=created", "-f", "direction=desc",
-            "-f", "per_page=2",
+            "-f", "per_page=100",
         ])
     }
 

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -3,6 +3,51 @@ import Testing
 @testable import Alas
 
 struct GitHubCLIProviderTests {
+    @Test func openIssuesRequestsNewestOpenIssuesAndExcludesPullRequests() async throws {
+        let runner = FakeRunner(results: [ProcessResult(
+            exitCode: 0,
+            stdout: """
+            [
+              {"number":40,"title":"Older issue","html_url":"https://github.example.com/mrmans0n/alas/issues/40","created_at":"2026-08-10T08:00:00Z"},
+              {"number":41,"title":"Pull request","html_url":"https://github.example.com/mrmans0n/alas/pull/41","created_at":"2026-08-12T08:00:00Z","pull_request":{"url":"https://api.github.example.com/repos/mrmans0n/alas/pulls/41","merged_at":null}},
+              {"number":42,"title":"Newest issue","html_url":"https://github.example.com/mrmans0n/alas/issues/42","created_at":"2026-08-15T08:00:00Z"}
+            ]
+            """,
+            stderr: ""
+        )])
+
+        let issues = try await GitHubCLIProvider(runner: runner).openIssues(
+            remote: Self.enterpriseRemote,
+            limit: 2,
+            cwd: Self.cwd
+        )
+
+        #expect(issues.map(\.number) == [42, 40])
+        #expect(issues.map(\.title) == ["Newest issue", "Older issue"])
+        #expect(await runner.commands.first?.args == [
+            "api", "--hostname", "github.example.com", "--method", "GET",
+            "repos/mrmans0n/alas/issues",
+            "-f", "state=open", "-f", "sort=created", "-f", "direction=desc",
+            "-f", "per_page=2",
+        ])
+    }
+
+    @Test func openIssuesRejectsMalformedCanonicalURL() async {
+        let runner = FakeRunner(results: [ProcessResult(
+            exitCode: 0,
+            stdout: "[{\"number\":42,\"title\":\"Broken\",\"html_url\":\"https:///missing-host\",\"created_at\":\"2026-08-15T08:00:00Z\"}]",
+            stderr: ""
+        )])
+
+        await #expect(throws: CodeHostProviderError.self) {
+            try await GitHubCLIProvider(runner: runner).openIssues(
+                remote: Self.enterpriseRemote,
+                limit: 50,
+                cwd: Self.cwd
+            )
+        }
+    }
+
     @Test func issueUsesHostAwareAPIAndMapsSnapshot() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.issueOutput, stderr: ""),

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -4,6 +4,53 @@ import Testing
 @testable import Alas
 
 struct GitLabCLIProviderTests {
+    @Test func openIssuesRequestsNewestOpenedIssuesAndNormalizesOrder() async throws {
+        let runner = FakeRunner(results: [ProcessResult(
+            exitCode: 0,
+            stdout: """
+            [
+              {"iid":77,"title":"Older issue","web_url":"https://gitlab.example.com/platform/mobile/alas/-/issues/77","created_at":"2026-08-10T08:00:00Z"},
+              {"iid":81,"title":"Newest issue","web_url":"https://gitlab.example.com/platform/mobile/alas/-/issues/81","created_at":"2026-08-15T08:00:00Z"}
+            ]
+            """,
+            stderr: ""
+        )])
+
+        let issues = try await GitLabCLIProvider(runner: runner).openIssues(
+            remote: Self.remote,
+            limit: 50,
+            cwd: Self.cwd
+        )
+
+        #expect(issues.map(\.number) == [81, 77])
+        #expect(await runner.commands.first?.args == [
+            "api", "projects/platform%2Fmobile%2Falas/issues",
+            "--hostname", "gitlab.example.com", "--output", "json", "--method", "GET",
+            "-f", "state=opened", "-f", "order_by=created_at", "-f", "sort=desc",
+            "-f", "per_page=50",
+        ])
+    }
+
+    @Test func openIssuesReportsCommandFailure() async {
+        let runner = FakeRunner(results: [ProcessResult(exitCode: 1, stdout: "", stderr: "permission denied")])
+
+        await #expect(throws: CodeHostProviderError.commandFailed(command: "glab api issues", stderr: "permission denied")) {
+            try await GitLabCLIProvider(runner: runner).openIssues(remote: Self.remote, limit: 50, cwd: Self.cwd)
+        }
+    }
+
+    @Test func openIssuesRejectsMalformedWebURL() async {
+        let runner = FakeRunner(results: [ProcessResult(
+            exitCode: 0,
+            stdout: "[{\"iid\":77,\"title\":\"Issue\",\"web_url\":\"not-a-url\",\"created_at\":\"2026-08-10T08:00:00Z\"}]",
+            stderr: ""
+        )])
+
+        await #expect(throws: CodeHostProviderError.malformedOutput("GitLab issue output is missing a valid URL.")) {
+            try await GitLabCLIProvider(runner: runner).openIssues(remote: Self.remote, limit: 50, cwd: Self.cwd)
+        }
+    }
+
     @Test func issueUsesEncodedSubgroupProjectAndMapsSnapshot() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.issueOutput, stderr: ""),

--- a/AlasTests/Issues/AttachIssueDialogModelTests.swift
+++ b/AlasTests/Issues/AttachIssueDialogModelTests.swift
@@ -261,6 +261,7 @@ private final class Fixture {
     let resolutionFailure: IssueResolutionFailure?
     let projects: [ProjectConfig]
     let suspendResolution: Bool
+    let selectedProjectID: String
     private var continuation: CheckedContinuation<Void, Never>?
 
     init(
@@ -280,6 +281,7 @@ private final class Fixture {
         self.resolution = resolution ?? Self.resolvedIssue(candidateProjectIDs: candidateProjectIDs)
         self.resolutionFailure = resolutionFailure
         self.suspendResolution = suspendResolution
+        self.selectedProjectID = selectedProjectID
     }
 
     var environment: AttachIssueDialogModel.Environment {

--- a/AlasTests/Issues/AttachIssueDialogModelTests.swift
+++ b/AlasTests/Issues/AttachIssueDialogModelTests.swift
@@ -5,6 +5,14 @@ import Testing
 @MainActor
 @Suite("Attach Issue dialog model")
 struct AttachIssueDialogModelTests {
+    @Test("the selected project is exposed for issue autocomplete")
+    func exposesSelectedProjectForIssueAutocomplete() {
+        let fixture = Fixture(selectedProjectID: "alas")
+        let model = AttachIssueDialogModel(environment: fixture.environment)
+
+        #expect(model.autocompleteProjectID == "alas")
+    }
+
     @Test("resolving a URL preselects its exact candidate project and seeds the draft")
     func resolvesURLAndSeedsDraft() async {
         let fixture = Fixture()
@@ -130,6 +138,8 @@ struct AttachIssueDialogModelTests {
                     ? Fixture.resolvedIssue(displayReference: "#43", title: "Fix second issue")
                     : Fixture.resolvedIssue(displayReference: "#42", title: "Fix first issue")
             },
+            loadSuggestions: { _, _ in [] },
+            selectedProjectID: "alas",
             projects: { [project] },
             configuredBranchPrefix: { _ in "feature/" }
         ))
@@ -257,7 +267,8 @@ private final class Fixture {
         resolution: ResolvedIssue? = nil,
         resolutionFailure: IssueResolutionFailure? = nil,
         candidateProjectIDs: [String] = ["alas"],
-        suspendResolution: Bool = false
+        suspendResolution: Bool = false,
+        selectedProjectID: String = "alas"
     ) {
         projects = [ProjectConfig(
             id: "alas",
@@ -282,6 +293,8 @@ private final class Fixture {
                 if let resolutionFailure { throw resolutionFailure }
                 return resolution
             },
+            loadSuggestions: { _, _ in [] },
+            selectedProjectID: selectedProjectID,
             projects: { [self] in projects },
             configuredBranchPrefix: { _ in "feature/" }
         )

--- a/AlasTests/Issues/IssueAutocompleteModelTests.swift
+++ b/AlasTests/Issues/IssueAutocompleteModelTests.swift
@@ -139,6 +139,22 @@ struct IssueAutocompleteModelTests {
         #expect(model.isPresented)
     }
 
+    @Test func completedSuggestionsRemainCachedAfterResolvingAndReturningToEntry() async {
+        let loader = ControlledLoader()
+        let model = IssueAutocompleteModel(load: loader.load)
+
+        model.referenceChanged("#", projectID: "alas")
+        await loader.waitUntilCalled()
+        await loader.finish(with: [Self.issue42])
+        await model.waitForCurrentLoadForTesting()
+
+        model.cancelInFlightLoad()
+        model.referenceChanged("#", projectID: "alas")
+
+        #expect(model.filteredSuggestions == [Self.issue42])
+        #expect(await loader.callCount == 1)
+    }
+
     @Test func changingProjectInvalidatesCacheAndLoadsForNewProject() async {
         let loader = ControlledLoader()
         let model = IssueAutocompleteModel(load: loader.load)

--- a/AlasTests/Issues/IssueAutocompleteModelTests.swift
+++ b/AlasTests/Issues/IssueAutocompleteModelTests.swift
@@ -1,0 +1,266 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct IssueAutocompleteModelTests {
+    @Test func hashLoadsOnceAndFiltersByNumberPrefixOrTitle() async {
+        let loader = ControlledLoader()
+        let model = IssueAutocompleteModel(load: loader.load)
+
+        model.referenceChanged("#", projectID: "alas")
+        await loader.waitUntilCalled()
+        await loader.finish(with: [Self.issue142, Self.issue42, Self.issue7])
+        await model.waitForCurrentLoadForTesting()
+        #expect(model.filteredSuggestions.map(\.number) == [142, 42, 7])
+
+        model.referenceChanged("#42", projectID: "alas")
+        #expect(model.filteredSuggestions.map(\.number) == [42])
+
+        model.referenceChanged("#sync", projectID: "alas")
+        #expect(model.filteredSuggestions.map(\.number) == [142, 7])
+        #expect(await loader.callCount == 1)
+    }
+
+    @Test func URLsAndPlainTextNeverLoadOrPresent() async {
+        let loader = ControlledLoader()
+        let model = IssueAutocompleteModel(load: loader.load)
+
+        model.referenceChanged("https://example.com/tickets/42", projectID: "alas")
+        model.referenceChanged("42", projectID: "alas")
+
+        #expect(!model.isPresented)
+        #expect(await loader.callCount == 0)
+    }
+
+    @Test func filteringMatchesTitlesCaseInsensitivelyIncludingNumericText() async {
+        let loader = ControlledLoader()
+        let model = IssueAutocompleteModel(load: loader.load)
+
+        model.referenceChanged("#", projectID: "alas")
+        await loader.waitUntilCalled()
+        await loader.finish(with: [Self.issue142, Self.issue42, Self.issue7])
+        await model.waitForCurrentLoadForTesting()
+
+        model.referenceChanged("#SYNC", projectID: "alas")
+        #expect(model.filteredSuggestions.map(\.number) == [142, 7])
+
+        model.referenceChanged("#42", projectID: "alas")
+        #expect(model.filteredSuggestions.map(\.number) == [42])
+
+        model.referenceChanged("#7", projectID: "alas")
+        #expect(model.filteredSuggestions.map(\.number) == [42, 7])
+    }
+
+    @Test func emptySuccessfulResultsRemainPresented() async {
+        let loader = ControlledLoader()
+        let model = IssueAutocompleteModel(load: loader.load)
+
+        model.referenceChanged("#", projectID: "alas")
+        await loader.waitUntilCalled()
+        await loader.finish(with: [])
+        await model.waitForCurrentLoadForTesting()
+
+        #expect(model.state == .loaded([]))
+        #expect(model.filteredSuggestions.isEmpty)
+        #expect(model.isPresented)
+    }
+
+    @Test func loadingAndFailureRemainPresented() async {
+        let loader = ControlledLoader()
+        let model = IssueAutocompleteModel(load: loader.load)
+
+        model.referenceChanged("#", projectID: "alas")
+        await loader.waitUntilCalled()
+        #expect(model.state == .loading)
+        #expect(model.isPresented)
+
+        await loader.finish(throwing: LoadFailure.unavailable)
+        await model.waitForCurrentLoadForTesting()
+        guard case .failed = model.state else {
+            Issue.record("Expected a failed state, got \(model.state)")
+            return
+        }
+        #expect(model.isPresented)
+    }
+
+    @Test func selectionClampsToFilteredSuggestions() async {
+        let loader = ControlledLoader()
+        let model = IssueAutocompleteModel(load: loader.load)
+
+        model.referenceChanged("#", projectID: "alas")
+        await loader.waitUntilCalled()
+        await loader.finish(with: [Self.issue142, Self.issue42, Self.issue7])
+        await model.waitForCurrentLoadForTesting()
+
+        model.moveSelection(8)
+        #expect(model.selectedIndex == 2)
+        model.moveSelection(-8)
+        #expect(model.selectedIndex == 0)
+
+        model.referenceChanged("#42", projectID: "alas")
+        #expect(model.selectedIndex == 0)
+        model.moveSelection(1)
+        #expect(model.selectedIndex == 1)
+        model.referenceChanged("#missing", projectID: "alas")
+        model.moveSelection(1)
+        #expect(model.selectedIndex == 0)
+    }
+
+    @Test func acceptingSelectionReturnsReferenceAndDismisses() async {
+        let loader = ControlledLoader()
+        let model = IssueAutocompleteModel(load: loader.load)
+
+        model.referenceChanged("#", projectID: "alas")
+        await loader.waitUntilCalled()
+        await loader.finish(with: [Self.issue142, Self.issue42])
+        await model.waitForCurrentLoadForTesting()
+        model.moveSelection(1)
+
+        #expect(model.acceptSelection() == "#42")
+        #expect(model.reference == "#42")
+        #expect(!model.isPresented)
+    }
+
+    @Test func dismissalPersistsUntilReferenceChanges() async {
+        let loader = ControlledLoader()
+        let model = IssueAutocompleteModel(load: loader.load)
+
+        model.referenceChanged("#", projectID: "alas")
+        await loader.waitUntilCalled()
+        await loader.finish(with: [Self.issue42])
+        await model.waitForCurrentLoadForTesting()
+
+        model.dismiss()
+        #expect(!model.isPresented)
+        model.referenceChanged("#", projectID: "alas")
+        #expect(!model.isPresented)
+        model.referenceChanged("#4", projectID: "alas")
+        #expect(model.isPresented)
+    }
+
+    @Test func changingProjectInvalidatesCacheAndLoadsForNewProject() async {
+        let loader = ControlledLoader()
+        let model = IssueAutocompleteModel(load: loader.load)
+
+        model.referenceChanged("#", projectID: "alas")
+        await loader.waitUntilCalled(1)
+        await loader.finish(call: 1, with: [Self.issue42])
+        await model.waitForCurrentLoadForTesting()
+
+        model.referenceChanged("#", projectID: "other")
+        await loader.waitUntilCalled(2)
+        #expect(model.state == .loading)
+        await loader.finish(call: 2, with: [Self.issue7])
+        await model.waitForCurrentLoadForTesting()
+        #expect(model.filteredSuggestions.map(\.number) == [7])
+        #expect(await loader.projectIDs == ["alas", "other"])
+    }
+
+    @Test func projectChangeCancelsOldLoadAndRejectsLateResult() async {
+        let loader = ControlledLoader()
+        let model = IssueAutocompleteModel(load: loader.load)
+
+        model.referenceChanged("#", projectID: "alas")
+        await loader.waitUntilCalled(1)
+        model.referenceChanged("#", projectID: "other")
+        await loader.waitUntilCalled(2)
+        await loader.waitUntilCancelled(1)
+
+        await loader.finish(call: 2, with: [Self.issue7])
+        await model.waitForCurrentLoadForTesting()
+        await loader.finish(call: 1, with: [Self.issue42])
+        await Self.drainMainActor()
+
+        #expect(model.state == .loaded([Self.issue7]))
+        #expect(model.filteredSuggestions.map(\.number) == [7])
+    }
+
+    private static let issue142 = issue(142, "Fix sync latency")
+    private static let issue42 = issue(42, "Improve 7 search")
+    private static let issue7 = issue(7, "Sync jobs")
+
+    private static func issue(_ number: Int, _ title: String) -> CodeHostIssueSuggestion {
+        CodeHostIssueSuggestion(
+            provider: .github,
+            number: number,
+            title: title,
+            canonicalURL: URL(string: "https://github.com/acme/alas/issues/\(number)")!,
+            createdAt: .distantPast
+        )
+    }
+
+    private static func drainMainActor() async {
+        for _ in 0..<10 { await Task.yield() }
+    }
+}
+
+private enum LoadFailure: LocalizedError {
+    case unavailable
+
+    var errorDescription: String? { "Issue suggestions are unavailable." }
+}
+
+private actor ControlledLoader {
+    private var calls: [(projectID: String, limit: Int)] = []
+    private var cancelledCalls: Set<Int> = []
+    private var callWaiters: [Int: [CheckedContinuation<Void, Never>]] = [:]
+    private var cancellationWaiters: [Int: [CheckedContinuation<Void, Never>]] = [:]
+    private var continuations: [Int: CheckedContinuation<[CodeHostIssueSuggestion], Error>] = [:]
+
+    nonisolated func load(projectID: String, limit: Int) async throws -> [CodeHostIssueSuggestion] {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                Task { await self.begin(projectID: projectID, limit: limit, continuation: continuation) }
+            }
+        } onCancel: {
+            Task { await self.cancelCall(for: projectID) }
+        }
+    }
+
+    var callCount: Int { calls.count }
+    var projectIDs: [String] { calls.map(\.projectID) }
+
+    func waitUntilCalled(_ call: Int = 1) async {
+        guard calls.count < call else { return }
+        await withCheckedContinuation { continuation in
+            callWaiters[call, default: []].append(continuation)
+        }
+    }
+
+    func waitUntilCancelled(_ call: Int) async {
+        guard !cancelledCalls.contains(call) else { return }
+        await withCheckedContinuation { continuation in
+            cancellationWaiters[call, default: []].append(continuation)
+        }
+    }
+
+    func finish(call: Int = 1, with suggestions: [CodeHostIssueSuggestion]) {
+        continuations.removeValue(forKey: call)?.resume(returning: suggestions)
+    }
+
+    func finish(call: Int = 1, throwing error: Error) {
+        continuations.removeValue(forKey: call)?.resume(throwing: error)
+    }
+
+    private func begin(
+        projectID: String,
+        limit: Int,
+        continuation: CheckedContinuation<[CodeHostIssueSuggestion], Error>
+    ) {
+        calls.append((projectID, limit))
+        let call = calls.count
+        continuations[call] = continuation
+        let waiters = callWaiters.removeValue(forKey: call) ?? []
+        waiters.forEach { $0.resume() }
+    }
+
+    private func cancelCall(for projectID: String) {
+        guard let call = calls.lastIndex(where: { $0.projectID == projectID }).map({ $0 + 1 }) else {
+            return
+        }
+        cancelledCalls.insert(call)
+        let waiters = cancellationWaiters.removeValue(forKey: call) ?? []
+        waiters.forEach { $0.resume() }
+    }
+}

--- a/AlasTests/Issues/IssueCompletionGeometryTests.swift
+++ b/AlasTests/Issues/IssueCompletionGeometryTests.swift
@@ -1,0 +1,15 @@
+import AppKit
+import Testing
+@testable import Alas
+
+struct IssueCompletionGeometryTests {
+    @Test func popupAnchorExpandsToTheFieldChrome() {
+        let anchor = IssueCompletionGeometry.popupAnchor(
+            for: NSRect(x: 0, y: 0, width: 180, height: 28)
+        )
+
+        #expect(anchor.origin.x == -10)
+        #expect(anchor.width == 200)
+        #expect(anchor.height == 28)
+    }
+}

--- a/AlasTests/Issues/IssueResolverTests.swift
+++ b/AlasTests/Issues/IssueResolverTests.swift
@@ -505,6 +505,7 @@ struct IssueResolverTests {
 
         func isAvailable(cwd: URL) async -> Bool { isAvailable }
         func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { isAuthenticated }
+        func openIssues(remote: CodeHostRemote, limit: Int, cwd: URL) async throws -> [CodeHostIssueSuggestion] { [] }
 
         func issue(remote: CodeHostRemote, number: Int, cwd: URL) async throws -> CodeHostIssueSnapshot {
             await recorder?.recordResolve()

--- a/AlasTests/Issues/IssueSuggestionLoaderTests.swift
+++ b/AlasTests/Issues/IssueSuggestionLoaderTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct IssueSuggestionLoaderTests {
+    @Test func loadsOnlyOriginWhenMultipleSupportedRemotesExist() async throws {
+        let provider = FakeProvider(kind: .github, suggestions: [Self.issue42])
+        let loader = Self.loader(
+            remotes: [
+                GitRemote(name: "upstream", url: "git@gitlab.com:acme/upstream.git"),
+                GitRemote(name: "origin", url: "git@github.com:acme/alas.git"),
+            ],
+            providers: [provider]
+        )
+
+        let result = try await loader.suggestions(projectID: Self.project.id, limit: 50)
+
+        #expect(result == [Self.issue42])
+        #expect(await provider.requestedRemotes.map(\.remoteName) == ["origin"])
+    }
+
+    @Test func throwsMalformedOutputWhenProjectIsUnknown() async {
+        let loader = Self.loader(remotes: [], providers: [])
+
+        await #expect(throws: CodeHostProviderError.malformedOutput(
+            "The selected project is no longer available."
+        )) {
+            try await loader.suggestions(projectID: "unknown")
+        }
+    }
+
+    @Test func throwsMalformedOutputWhenProjectHasNoSupportedRemote() async {
+        let provider = FakeProvider(kind: .github)
+        let loader = Self.loader(
+            remotes: [GitRemote(name: "origin", url: "git@example.com:acme/alas.git")],
+            providers: [provider]
+        )
+
+        await #expect(throws: CodeHostProviderError.malformedOutput(
+            "The selected project has no supported code host remote."
+        )) {
+            try await loader.suggestions(projectID: Self.project.id)
+        }
+    }
+
+    @Test func throwsCLIMissingWhenProviderIsUnavailable() async {
+        let provider = FakeProvider(kind: .github, isAvailable: false)
+        let loader = Self.loader(remotes: [Self.origin], providers: [provider])
+
+        await #expect(throws: CodeHostProviderError.cliMissing("fake-host")) {
+            try await loader.suggestions(projectID: Self.project.id)
+        }
+    }
+
+    @Test func throwsUnauthenticatedWhenProviderIsNotAuthenticated() async {
+        let provider = FakeProvider(kind: .github, isAuthenticated: false)
+        let loader = Self.loader(remotes: [Self.origin], providers: [provider])
+
+        await #expect(throws: CodeHostProviderError.unauthenticated("github.com")) {
+            try await loader.suggestions(projectID: Self.project.id)
+        }
+    }
+
+    @Test func forwardsRequestedLimitToProvider() async throws {
+        let provider = FakeProvider(kind: .github, suggestions: [Self.issue42])
+        let loader = Self.loader(remotes: [Self.origin], providers: [provider])
+
+        let result = try await loader.suggestions(projectID: Self.project.id, limit: 7)
+
+        #expect(result == [Self.issue42])
+        #expect(await provider.requestedLimits == [7])
+    }
+
+    @Test func doesNotFallThroughWhenPreferredRemoteFails() async {
+        let provider = FakeProvider(
+            kind: .github,
+            error: CodeHostProviderError.commandFailed(command: "fake-host", stderr: "failed")
+        )
+        let loader = Self.loader(
+            remotes: [
+                GitRemote(name: "backup", url: "git@github.com:acme/backup.git"),
+                Self.origin,
+            ],
+            providers: [provider]
+        )
+
+        await #expect(throws: CodeHostProviderError.commandFailed(
+            command: "fake-host", stderr: "failed"
+        )) {
+            try await loader.suggestions(projectID: Self.project.id)
+        }
+        #expect(await provider.requestedRemotes.map(\.remoteName) == ["origin"])
+    }
+
+    private static let project = ProjectConfig(
+        id: "alas",
+        name: "Alas",
+        path: "/tmp/alas",
+        color: "blue",
+        addedAt: .distantPast
+    )
+
+    private static let origin = GitRemote(name: "origin", url: "git@github.com:acme/alas.git")
+
+    private static let issue42 = CodeHostIssueSuggestion(
+        provider: .github,
+        number: 42,
+        title: "Fix sync",
+        canonicalURL: URL(string: "https://github.com/acme/alas/issues/42")!,
+        createdAt: .distantPast
+    )
+
+    private static func loader(
+        remotes: [GitRemote],
+        providers: [any CodeHostIssueProviding]
+    ) -> IssueSuggestionLoader {
+        IssueSuggestionLoader(environment: .init(
+            projects: { [Self.project] },
+            remotes: { _ in remotes },
+            providers: CodeHostIssueProviderRegistry(providers)
+        ))
+    }
+
+    private actor RequestedIssueCalls {
+        private(set) var remotes: [CodeHostRemote] = []
+        private(set) var limits: [Int] = []
+
+        func record(remote: CodeHostRemote, limit: Int) {
+            remotes.append(remote)
+            limits.append(limit)
+        }
+    }
+
+    private struct FakeProvider: CodeHostIssueProviding {
+        let kind: CodeHostKind
+        let executable = "fake-host"
+        let isAvailable: Bool
+        let isAuthenticated: Bool
+        let suggestions: [CodeHostIssueSuggestion]
+        let error: Error?
+        private let calls = RequestedIssueCalls()
+
+        init(
+            kind: CodeHostKind,
+            isAvailable: Bool = true,
+            isAuthenticated: Bool = true,
+            suggestions: [CodeHostIssueSuggestion] = [],
+            error: Error? = nil
+        ) {
+            self.kind = kind
+            self.isAvailable = isAvailable
+            self.isAuthenticated = isAuthenticated
+            self.suggestions = suggestions
+            self.error = error
+        }
+
+        var requestedRemotes: [CodeHostRemote] {
+            get async { await calls.remotes }
+        }
+
+        var requestedLimits: [Int] {
+            get async { await calls.limits }
+        }
+
+        func isAvailable(cwd: URL) async -> Bool { isAvailable }
+        func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { isAuthenticated }
+
+        func issue(remote: CodeHostRemote, number: Int, cwd: URL) async throws -> CodeHostIssueSnapshot {
+            throw CodeHostProviderError.malformedOutput("Fake provider does not resolve issues.")
+        }
+
+        func openIssues(remote: CodeHostRemote, limit: Int, cwd: URL) async throws -> [CodeHostIssueSuggestion] {
+            await calls.record(remote: remote, limit: limit)
+            if let error { throw error }
+            return suggestions
+        }
+    }
+}

--- a/docs/superpowers/specs/2026-08-15-new-worktree-issue-autocomplete-design.md
+++ b/docs/superpowers/specs/2026-08-15-new-worktree-issue-autocomplete-design.md
@@ -1,0 +1,212 @@
+# New Worktree Issue Autocomplete Design
+
+## Summary
+
+Add optional issue autocomplete to the **Attach issue** entry field opened from
+the new worktree dialog. Typing `#` lists the newest open issues from the
+selected project's preferred GitHub or GitLab remote. The user can filter the
+list by issue number or title and select a result without losing the existing
+ability to enter an issue number or arbitrary HTTP(S) URL.
+
+The completion path is advisory. The existing issue resolver remains the
+authority for resolving the selected `#<number>` and preparing the worktree's
+issue context, branch name, and initial Chat prompt.
+
+## Goals
+
+- Offer autocomplete when the reference begins with `#`.
+- Support GitHub and GitLab issues through the existing authenticated CLI
+  providers.
+- Use only the selected project's preferred supported remote so a short issue
+  number remains unambiguous.
+- Show open issues newest-first and limit the initial result set to 50.
+- Filter the cached results by issue-number prefix and case-insensitive title
+  text.
+- Support keyboard and mouse selection without changing the dialog layout.
+- Preserve manual issue numbers, arbitrary HTTP(S) URLs, and fallback ticket
+  metadata behavior.
+
+## Non-Goals
+
+- Pull request or merge request autocomplete.
+- The GitLab `!` reference syntax.
+- Provider discovery beyond GitHub and GitLab.
+- Pagination beyond the newest 50 open issues.
+- Persistent or cross-dialog issue caching.
+- Changes to the issue confirmation and editing screen.
+- Changes to issue resolution semantics.
+
+## Existing Flow
+
+`NewWorktreeDialog` opens `AttachIssueDialog`, whose entry field accepts either
+`#42` (or `42`) or an absolute HTTP(S) URL. `AttachIssueDialogModel` passes the
+reference to `IssueResolver`. GitHub and GitLab resolution delegates to
+`CodeHostIssueProviding` implementations backed by `gh` and `glab`; other URLs
+fall through to the manual metadata provider.
+
+The code-host providers currently fetch one issue by number but cannot list
+issues. The editor's completion popup is tied to LSP candidates and editor
+documentation, although its non-activating AppKit panel establishes the desired
+interaction pattern.
+
+## Architecture
+
+### Suggestion Model
+
+Introduce `CodeHostIssueSuggestion`, a small sendable value containing:
+
+- provider kind
+- issue number
+- title
+- canonical URL
+- creation date
+
+The creation date is retained so provider responses can be normalized to a
+deterministic newest-first order even if a CLI or server returns an unexpected
+ordering.
+
+### Provider Listing
+
+Extend `CodeHostIssueProviding` with an asynchronous operation that returns the
+newest open issue suggestions for a remote and a caller-provided limit.
+
+`GitHubCLIProvider` will request open repository issues through `gh api`, sorted
+by creation time descending. GitHub's issues endpoint also returns pull
+requests, so entries containing pull-request metadata must be discarded before
+the limit is applied.
+
+`GitLabCLIProvider` will request opened project issues through `glab api`, with
+`created_at` descending and the same limit.
+
+Both implementations decode only the fields required by
+`CodeHostIssueSuggestion`. They validate positive issue numbers, non-empty
+titles, valid canonical URLs, and creation timestamps. Malformed command output
+uses the existing provider error conventions.
+
+### Suggestion Loader
+
+Add an `IssueSuggestionLoader` with injected project, remote, and provider
+dependencies. For the selected project it:
+
+1. Reads fetch remotes through `GitService`.
+2. Uses `CodeHostRemoteDetector.detect` with the supported provider kinds. This
+   preserves the existing remote priority, including `origin` preference.
+3. Checks that the provider CLI is available and authenticated.
+4. Requests up to 50 open issues from that one remote.
+
+The loader does not fall through to a second remote after selecting the
+preferred one. This prevents a chosen `#<number>` from resolving against a
+different repository later.
+
+### Autocomplete State
+
+Add a main-actor observable model owned by the entry phase of
+`AttachIssueDialog`. The model owns:
+
+- the selected project identity
+- cached suggestions for that project
+- loading and non-blocking failure state
+- the filtered rows and selected row index
+- the active asynchronous task and request generation
+
+The first reference beginning with `#` starts a load if there is no cache.
+Repeated edits filter the cached values without additional provider requests.
+Changing project cancels the active task, increments the generation, clears the
+cache, and closes the popup. A late result is accepted only when its generation
+and project still match.
+
+## Filtering
+
+The query is the text after the first `#`, with surrounding whitespace removed.
+
+- An empty query shows all cached suggestions.
+- A numeric query matches issue numbers whose decimal representation begins
+  with the query. It also matches titles containing the query.
+- A non-numeric query matches titles case-insensitively.
+- Filtering never changes the cached newest-first relative order.
+- Input that does not begin with `#`, including every URL, closes autocomplete
+  and performs no load.
+
+## User Interface
+
+Use a focused AppKit-backed issue autocomplete field. It retains the existing
+Alas field chrome and focus behavior while exposing the field view as an anchor
+for a non-activating popup panel. The popup follows the LSP completion visual
+language but uses issue-specific rows rather than LSP models.
+
+Each suggestion row shows `#<number>` and the issue title. The panel width
+matches the field, has a capped height, scrolls when necessary, and opens below
+the field unless screen bounds require it to open above. Showing it must not
+resize or reflow the sheet.
+
+Interaction rules:
+
+- Up and Down move the selected row and keep it visible.
+- Return accepts the selected row while the popup has results.
+- Return invokes the existing Resolve action when the popup is closed or has no
+  selectable result.
+- Escape closes the popup without clearing the field.
+- Clicking a row accepts it.
+- Accepting a row replaces the entire reference with `#<number>` and closes the
+  popup.
+- Losing focus, leaving the entry phase, or dismissing the sheet closes the
+  popup and cancels view-owned work.
+
+While a request is active, the popup contains a compact loading row. CLI,
+authentication, network, provider, or decoding failures appear only as a
+compact unavailable/error row in the popup. They do not set the dialog's
+resolution error and do not disable the field or Resolve button. The existing
+resolver remains available and will provide its normal actionable error if the
+user submits the reference.
+
+## Data Flow
+
+1. The user opens **Attach issue** for a selected project.
+2. The user types `#`.
+3. The autocomplete model asks the loader for suggestions if its cache is
+   empty.
+4. The loader resolves the preferred supported remote and invokes its CLI
+   provider.
+5. The provider returns normalized open-issue suggestions newest-first.
+6. The model caches the result and applies the current number/title filter.
+7. The user selects a row, inserting `#<number>`.
+8. The user resolves the issue through the existing `IssueResolver` flow.
+
+## Testing
+
+Use Swift Testing for focused behavior coverage.
+
+Provider tests cover:
+
+- GitHub and GitLab command construction.
+- Successful decoding and canonical URLs.
+- GitHub pull-request exclusion.
+- Open-state request parameters.
+- Limit enforcement and newest-first normalization.
+- Malformed output and command failures.
+
+Loader and model tests cover:
+
+- Preferred-remote selection, including `origin` priority.
+- Unsupported remotes, missing CLIs, and authentication failures.
+- Trigger recognition and non-triggering URLs.
+- One-load dialog caching.
+- Project-change cancellation and stale-result rejection.
+- Empty, numeric, and title filtering while preserving order.
+- Selection movement, clamping, acceptance, and dismissal.
+
+UI utility tests cover deterministic popup anchoring geometry where the existing
+overlay test hooks allow it. Existing issue parsing, resolution, and new
+worktree attachment suites provide regression coverage for short references and
+arbitrary URLs.
+
+## Verification
+
+Run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+


### PR DESCRIPTION
## Summary
- Adds `#`-triggered issue autocomplete for the attach issue flow in the new worktree dialog.
- Loads newest open GitHub and GitLab issue suggestions from the selected project’s preferred supported remote.
- Adds model, loader, provider, popup geometry, and lifecycle coverage for filtering, selection, caching, dismissal, and cancellation.

## Testing
- Added Swift Testing coverage for GitHub and GitLab issue suggestion listing.
- Added tests for `IssueSuggestionLoader`, `IssueAutocompleteModel`, popup geometry, and attach-dialog project propagation.