### PR TITLE
fix: keep remote address picker compact

### DIFF
--- a/Alas/Sources/Remote/Settings/RemoteServerPane.swift
+++ b/Alas/Sources/Remote/Settings/RemoteServerPane.swift
@@ -78,8 +78,9 @@ struct RemoteServerPane: View {
                                         Text(pickerAddressLabel(address)).tag(address.id)
                                     }
                                 }
-                                .pickerStyle(.segmented)
+                                .pickerStyle(.menu)
                                 .labelsHidden()
+                                .settingsDropdownFrame()
                             }
                         }
                         SettingsRow(


### PR DESCRIPTION
## Summary

- replace the Remote pairing-address segmented control with a compact menu picker
- reuse the standard settings dropdown width

## Why

Long LAN and IPv6 labels gave the segmented control a large intrinsic width. In the two-column settings row, that squeezed the description column down to only a few characters on smaller screens.

## Validation

- `xcodegen`
- `xcrun swiftc -frontend -parse Alas/Sources/Remote/Settings/RemoteServerPane.swift`
- `git diff --check`

The full local build and test commands were attempted, but zmx dependency setup was blocked by GitHub returning HTTP 429 for its pinned `zigimg` archive. CI remains the authoritative full verification.
