### PR TITLE
fix(acp): resume imported session when load fails

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3418,6 +3418,13 @@ extension ACPSessionManager {
                             )
                         )
                     }
+                    func suppressFailedLoadReplayIfNeeded() {
+                        guard !shouldSuppressLoadReplay else { return }
+                        let target = connection.client.yieldedUpdateCount
+                        guard target > 0 else { return }
+                        runner.suppressLoadReplay(throughYieldedUpdateCount: target)
+                        startRunnerIfNeeded()
+                    }
                     func restoreStrictly() async throws -> (ACPSessionNewResult, resumed: Bool) {
                         do {
                             return (try await connection.loadSession(
@@ -3427,6 +3434,7 @@ extension ACPSessionManager {
                                 brokerOperationKey: loadOperationKey
                             ), false)
                         } catch {
+                            suppressFailedLoadReplayIfNeeded()
                             guard error is ACPBrokerDurableCompletionReplayError else {
                                 return (try await resumeAfterLoadFailure(error), true)
                             }
@@ -3444,6 +3452,7 @@ extension ACPSessionManager {
                             guard !(error is ACPBrokerDurableCompletionReplayError) else {
                                 throw error
                             }
+                            suppressFailedLoadReplayIfNeeded()
                             return (try await resumeAfterLoadFailure(error), true)
                         }
                     }
@@ -3455,9 +3464,11 @@ extension ACPSessionManager {
                             canSendTranscript: false
                         )
                     }
-                    runner.finishSuppressingLoadReplay(
-                        throughYieldedUpdateCount: connection.client.yieldedUpdateCount
-                    )
+                    if shouldSuppressLoadReplay {
+                        runner.finishSuppressingLoadReplay(
+                            throughYieldedUpdateCount: connection.client.yieldedUpdateCount
+                        )
+                    }
                     if !pendingRecovery {
                         session.contextRecoveryStatus = nil
                     }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3397,28 +3397,17 @@ extension ACPSessionManager {
                         }
                     }
                 case .loadStrict:
-                    do {
-                        result = try await connection.loadSession(
-                            cwd: worktreePath,
-                            sessionId: remoteId,
-                            mcpServers: wireMCPServers,
-                            brokerOperationKey: Self.brokerStartupOperationKey(
-                                sessionId: sessionId,
-                                method: "session/load",
-                                remoteSessionId: remoteId
-                            )
-                        )
-                        runner.finishSuppressingLoadReplay(
-                            throughYieldedUpdateCount: connection.client.yieldedUpdateCount
-                        )
-                    } catch {
-                        runner.finishSuppressingLoadReplay(
-                            throughYieldedUpdateCount: connection.client.yieldedUpdateCount
-                        )
+                    let loadOperationKey = Self.brokerStartupOperationKey(
+                        sessionId: sessionId,
+                        method: "session/load",
+                        remoteSessionId: remoteId
+                    )
+                    func resumeAfterLoadFailure(_ error: any Error) async throws
+                        -> ACPSessionNewResult {
                         guard initialized.sessionCapabilities.supportsResume,
                               ACPAuthFailure.message(from: error) == nil
                         else { throw error }
-                        result = try await connection.resumeSession(
+                        return try await connection.resumeSession(
                             cwd: worktreePath,
                             sessionId: remoteId,
                             mcpServers: wireMCPServers,
@@ -3428,11 +3417,47 @@ extension ACPSessionManager {
                                 remoteSessionId: remoteId
                             )
                         )
+                    }
+                    func restoreStrictly() async throws -> (ACPSessionNewResult, resumed: Bool) {
+                        do {
+                            return (try await connection.loadSession(
+                                cwd: worktreePath,
+                                sessionId: remoteId,
+                                mcpServers: wireMCPServers,
+                                brokerOperationKey: loadOperationKey
+                            ), false)
+                        } catch {
+                            guard error is ACPBrokerDurableCompletionReplayError else {
+                                return (try await resumeAfterLoadFailure(error), true)
+                            }
+                        }
+                        do {
+                            // Reusing the stable key recovers successful results and lets
+                            // ACPBrokerClient consume terminal completion cursors.
+                            return (try await connection.loadSession(
+                                cwd: worktreePath,
+                                sessionId: remoteId,
+                                mcpServers: wireMCPServers,
+                                brokerOperationKey: loadOperationKey
+                            ), false)
+                        } catch {
+                            guard !(error is ACPBrokerDurableCompletionReplayError) else {
+                                throw error
+                            }
+                            return (try await resumeAfterLoadFailure(error), true)
+                        }
+                    }
+                    let restored = try await restoreStrictly()
+                    result = restored.0
+                    if restored.resumed {
                         restoreWarning = .init(
                             message: "Earlier messages remain in the agent and are not available in Alas.",
                             canSendTranscript: false
                         )
                     }
+                    runner.finishSuppressingLoadReplay(
+                        throughYieldedUpdateCount: connection.client.yieldedUpdateCount
+                    )
                     if !pendingRecovery {
                         session.contextRecoveryStatus = nil
                     }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3415,7 +3415,23 @@ extension ACPSessionManager {
                         runner.finishSuppressingLoadReplay(
                             throughYieldedUpdateCount: connection.client.yieldedUpdateCount
                         )
-                        throw error
+                        guard initialized.sessionCapabilities.supportsResume,
+                              ACPAuthFailure.message(from: error) == nil
+                        else { throw error }
+                        result = try await connection.resumeSession(
+                            cwd: worktreePath,
+                            sessionId: remoteId,
+                            mcpServers: wireMCPServers,
+                            brokerOperationKey: Self.brokerStartupOperationKey(
+                                sessionId: sessionId,
+                                method: "session/resume",
+                                remoteSessionId: remoteId
+                            )
+                        )
+                        restoreWarning = .init(
+                            message: "Earlier messages remain in the agent and are not available in Alas.",
+                            canSendTranscript: false
+                        )
                     }
                     if !pendingRecovery {
                         session.contextRecoveryStatus = nil

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -638,6 +638,15 @@ final class ACPSessionRunner {
     }
     #endif
 
+    func suppressLoadReplay(throughYieldedUpdateCount target: Int) {
+        guard target > observedUpdateCount else { return }
+        if !suppressingLoadReplay {
+            suppressingLoadReplay = true
+            session.beginSuppressedReplaySideEffects()
+        }
+        loadReplaySuppressionTarget = max(loadReplaySuppressionTarget ?? 0, target)
+    }
+
     func finishSuppressingLoadReplay(throughYieldedUpdateCount target: Int) {
         guard suppressingLoadReplay else { return }
         loadReplaySuppressionTarget = target

--- a/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
@@ -190,6 +190,40 @@ struct ACPSessionManagerRemoteRestoreTests {
         await manager.detach(sessionId: session.id)
     }
 
+    @Test("strict load fallback discards partial load replay before resume")
+    func importedSessionLoadFallbackDiscardsPartialLoadReplay() async throws {
+        let (manager, store, client, session) = try fixture(origin: .agentImported)
+        scriptInitialize(client, canLoad: true, canResume: true)
+        client.scriptAsync(method: "session/load") { _ in
+            client.emit(.init(
+                sessionId: "remote-id",
+                update: .agentMessageChunk(.text("partial failed load"))
+            ))
+            throw JSONRPCError(code: -32603, message: "Internal error", data: nil)
+        }
+        client.scriptAsync(method: "session/resume") { _ in
+            client.emit(.init(
+                sessionId: "remote-id",
+                update: .agentMessageChunk(.text("resumed history"))
+            ))
+            return Data("{}".utf8)
+        }
+
+        await manager.attach(to: session.id, freshlyCreated: false)
+        try await waitUntil { session.transcript.messages.count == 1 }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/load", "session/resume"])
+        #expect(session.transcript.messages.count == 1)
+        #expect(try store.messageCount(sessionId: session.id) == 1)
+        guard case .agent(_, _, let text) = session.transcript.messages[0] else {
+            Issue.record("Expected resumed history")
+            return
+        }
+        #expect(text.value == "resumed history")
+        await manager.detach(sessionId: session.id)
+    }
+
     @Test("imported sessions resume after their history has been persisted locally")
     func importedSessionWithLocalHistoryUsesResume() async throws {
         let (manager, store, client, session) = try fixture(

--- a/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
@@ -107,6 +107,25 @@ struct ACPSessionManagerRemoteRestoreTests {
         #expect(try store.loadSession(id: session.id)?.origin == .agentImported)
     }
 
+    @Test("imported sessions resume the same remote session when strict load fails")
+    func importedSessionResumesWhenLoadFails() async throws {
+        let (manager, _, client, session) = try fixture(origin: .agentImported)
+        scriptInitialize(client, canLoad: true, canResume: true)
+        client.script(method: "session/load") { _ in
+            throw JSONRPCError(code: -32603, message: "Internal error", data: nil)
+        }
+        client.script(method: "session/resume") { _ in Data("{}".utf8) }
+
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/load", "session/resume"])
+        #expect(session.agentState == .ready)
+        #expect(session.remoteSessionId == "remote-id")
+        #expect(session.contextRestoreWarning?.canSendTranscript == false)
+        #expect(session.contextRestoreWarning?.message.contains("remain in the agent") == true)
+        await manager.detach(sessionId: session.id)
+    }
+
     @Test("imported sessions resume after their history has been persisted locally")
     func importedSessionWithLocalHistoryUsesResume() async throws {
         let (manager, store, client, session) = try fixture(

--- a/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
@@ -126,6 +126,70 @@ struct ACPSessionManagerRemoteRestoreTests {
         await manager.detach(sessionId: session.id)
     }
 
+    @Test("imported sessions retry a durably completed load before resuming")
+    func importedSessionRetriesDurableLoadCompletion() async throws {
+        let (manager, _, client, session) = try fixture(origin: .agentImported)
+        scriptInitialize(client, canLoad: true, canResume: true)
+        var loadAttempts = 0
+        client.script(method: "session/load") { _ in
+            loadAttempts += 1
+            if loadAttempts == 1 {
+                throw ACPBrokerDurableCompletionReplayError(
+                    outcome: .init(result: .object(["sessionId": .string("remote-id")]), error: nil),
+                    underlying: JSONRPCError(code: -32603, message: "Replay failed", data: nil)
+                )
+            }
+            return Data("{}".utf8)
+        }
+
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/load", "session/load"])
+        #expect(session.agentState == .ready)
+        await manager.detach(sessionId: session.id)
+    }
+
+    @Test("strict load fallback keeps hydrated replay suppressed through resume")
+    func importedSessionLoadFallbackSuppressesResumeReplay() async throws {
+        let persistedToolCall = ACPMessage.toolCall(.init(
+            toolCallId: "tool-1",
+            title: "Read file",
+            kind: "read",
+            status: "completed",
+            content: "done"
+        ))
+        let (manager, store, client, session) = try fixture(
+            origin: .agentImported,
+            localMessage: persistedToolCall
+        )
+        scriptInitialize(client, canLoad: true, canResume: true)
+        client.script(method: "session/load") { _ in
+            throw JSONRPCError(code: -32603, message: "Internal error", data: nil)
+        }
+        client.scriptAsync(method: "session/resume") { _ in
+            client.emit(.init(sessionId: "remote-id", update: .toolCall(.init(
+                toolCallId: "tool-1",
+                title: "Read file",
+                kind: "read",
+                status: "completed",
+                content: [.content(.text("done"))],
+                locations: nil,
+                rawInput: nil,
+                rawOutput: nil
+            ))))
+            return Data("{}".utf8)
+        }
+
+        await manager.hydrateIfNeeded(id: session.id)
+        await manager.attach(to: session.id, freshlyCreated: false)
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/load", "session/resume"])
+        #expect(session.transcript.messages.count == 1)
+        #expect(try store.messageCount(sessionId: session.id) == 1)
+        await manager.detach(sessionId: session.id)
+    }
+
     @Test("imported sessions resume after their history has been persisted locally")
     func importedSessionWithLocalHistoryUsesResume() async throws {
         let (manager, store, client, session) = try fixture(


### PR DESCRIPTION
## Summary

- fall back to `session/resume` when strict loading an imported session fails and the agent advertises resume support
- preserve the remote session ID instead of creating an unrelated session
- keep authentication failures on the existing error path
- add regression coverage for Claude's `-32603 Internal error`

## Root cause

Imported terminal sessions prefer `session/load` so Alas can replay their history. Claude can reject that operation while the same session is still live in a terminal, even though the adapter supports reopening it with `session/resume`. Alas treated the load error as terminal instead of trying that safe same-session fallback.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `ACPSessionManagerRemoteRestoreTests`: 10/10 passed
- full local suite attempted; unrelated worktree-creation tests timed out under the combined run and Xcode later stalled in the Mermaid backend test. A representative worktree failure passed in isolation.