### PR TITLE
feat(editor): render invisible and warning characters

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		02425EBF61592A01B1FCC7D0 /* DiffParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1703FC5CD7DF16F4450E274 /* DiffParser.swift */; };
 		026C8FB815E41D31C8E9421B /* AlasCLICommandRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */; };
 		027A326E7DAB6C6E133E5FD3 /* ACPSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0E1BF90CB3BE5BFDFA2EC7C /* ACPSessionStore.swift */; };
+		0294BEA9FB3A117314ED0C48 /* WarningCharacterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0005D9107053886C37A3AC /* WarningCharacterTests.swift */; };
 		02B055E21896C1C14D2D980D /* SectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934BCC470703CF2DF2303357 /* SectionHeader.swift */; };
 		02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */; };
 		02DF9E0F3A3C1BE39026AF28 /* DraftReviewRequestTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79624D3718BCE5CC605F0D6D /* DraftReviewRequestTabView.swift */; };
@@ -79,6 +80,7 @@
 		0CDC1232955139B230B6600C /* ReviewDraftCommentAgentModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7344582814CCAF81B0E354 /* ReviewDraftCommentAgentModelTests.swift */; };
 		0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */; };
 		0D17211026C6790B96CC6578 /* CopyFeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */; };
+		0D37A802776CF90B0CB2D556 /* AppConfigCodeTextRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA74519F0A93299751407753 /* AppConfigCodeTextRenderingTests.swift */; };
 		0D65F2B699E6B0CF0915D25D /* ImageDiffMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */; };
 		0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB91379591DA21D216A894 /* RelativeTime.swift */; };
 		0DA68649E5F3C0018C4309DA /* UpdateThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */; };
@@ -365,6 +367,7 @@
 		3C4FFC880170CDC72FD93BFD /* AppKitDiffRowHostingPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB13AAAE5C140D3A47CEC44F /* AppKitDiffRowHostingPoolTests.swift */; };
 		3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C1705E68E97111E85D83F3 /* RightPaneState.swift */; };
 		3C5E243B78F3461F75AB02A8 /* CodeTextViewCompletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */; };
+		3C831BFD39402F812755CAFB /* WarningCharacter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B366689CD72FE381471B90 /* WarningCharacter.swift */; };
 		3C8FAA4464E4D928F1DC6C91 /* session-new-response-with-config-options.json in Resources */ = {isa = PBXBuildFile; fileRef = E8A63557B4F06AA00761B547 /* session-new-response-with-config-options.json */; };
 		3C91EAB9AE55849DE5CF1BC7 /* DragOutSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99890AC2531648EB5E9716A8 /* DragOutSessionTests.swift */; };
 		3C9CA493D2D1B5BB77CC96AE /* ACPTranscriptMessageRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47B596B11F2D8B98E7E9532 /* ACPTranscriptMessageRows.swift */; };
@@ -707,6 +710,7 @@
 		74175A7BB07F7588E7B691F2 /* AppState+ReviewPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5734FB0E75909C5E9DBD7D /* AppState+ReviewPalette.swift */; };
 		7433DB9396574A02DBF9953D /* ACPLaunchSpecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B53E3E92FA696866F44FDD /* ACPLaunchSpecTests.swift */; };
 		7445A58BBCAC1DA8EDB0946B /* TextEditCoordinatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50737099AA490FAC6BD9F612 /* TextEditCoordinatesTests.swift */; };
+		749C6A3FE32576CB68A6BE46 /* WarningCharactersSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACA0D87BA93646BD5A24E91 /* WarningCharactersSheet.swift */; };
 		749E31491A48F84295CBE04C /* DiffReviewImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980DF534CC718ACEB60FCB6F /* DiffReviewImageProvider.swift */; };
 		74B3067AADDC09789BEDAFBE /* AddMissionLegModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B502A4E2FE26669AB2D4DF2C /* AddMissionLegModel.swift */; };
 		74B3955E1F94E39BED58EB7F /* HTTPRequestParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001E204C8DBD41063D806ECA /* HTTPRequestParserTests.swift */; };
@@ -714,6 +718,7 @@
 		74E1B2C42F77908AA597EF45 /* OKLCH.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A34259DE8E978943E8BE16 /* OKLCH.swift */; };
 		74F193BC4B2A1BD5AD58C6DA /* GitService+Pull.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9583B34B9AAD4454C558E5 /* GitService+Pull.swift */; };
 		7528D9FD7DCE1D6F7CF70C3F /* GGSplitTabsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F05845D656B4B93B09AF5C /* GGSplitTabsManagerTests.swift */; };
+		752E634D54ED2AA2C50D36B4 /* CodeEditorLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A903C69ED6A3B550CCDF477A /* CodeEditorLayoutManager.swift */; };
 		7556121D51C54458FCAFED2A /* ACPProtocolVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBCF3820A017BBF33B0AB07 /* ACPProtocolVersion.swift */; };
 		75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */; };
 		7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3855FBA3E4444960418639E9 /* FileIndexTests.swift */; };
@@ -2040,6 +2045,7 @@
 		489C9B383554D7DAB170C2F8 /* Seg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Seg.swift; sourceTree = "<group>"; };
 		48A27D9BBDE49BF3A41FAFB7 /* ACPBrokerClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBrokerClient.swift; sourceTree = "<group>"; };
 		48AFF324FEE695AE18065D5A /* ClaudeCodeACPInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCodeACPInstaller.swift; sourceTree = "<group>"; };
+		48B366689CD72FE381471B90 /* WarningCharacter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningCharacter.swift; sourceTree = "<group>"; };
 		490AFAD12616D61858A19A31 /* ACPSetupCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSetupCheckerTests.swift; sourceTree = "<group>"; };
 		4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationCard.swift; sourceTree = "<group>"; };
 		4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateDiscardPathsTests.swift; sourceTree = "<group>"; };
@@ -2603,6 +2609,7 @@
 		A7FB37A9430467B477E40819 /* ACPImageChipAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageChipAttachment.swift; sourceTree = "<group>"; };
 		A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailabilityTests.swift; sourceTree = "<group>"; };
 		A8EFC853C0D2EB4AC2B01D9E /* GitService+ImageDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+ImageDiff.swift"; sourceTree = "<group>"; };
+		A903C69ED6A3B550CCDF477A /* CodeEditorLayoutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorLayoutManager.swift; sourceTree = "<group>"; };
 		A919B8770029DBE7FCFF0EE2 /* AgentRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunner.swift; sourceTree = "<group>"; };
 		A9294E94F46763CC8DCD93A3 /* SpacePagerIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacePagerIndicator.swift; sourceTree = "<group>"; };
 		A948C5D9B5EB13DBAC21E538 /* GGStackModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackModelsTests.swift; sourceTree = "<group>"; };
@@ -2610,6 +2617,7 @@
 		AA6486CAD3FE633F9B6F4ABF /* MCPAttachmentPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPAttachmentPlanner.swift; sourceTree = "<group>"; };
 		AA6A933FA317E1B2F15EEEC4 /* AddMissionLegModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMissionLegModelTests.swift; sourceTree = "<group>"; };
 		AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotInstallerTests.swift; sourceTree = "<group>"; };
+		AACA0D87BA93646BD5A24E91 /* WarningCharactersSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningCharactersSheet.swift; sourceTree = "<group>"; };
 		AAEDACEB27E6AF219054496E /* DialogChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChrome.swift; sourceTree = "<group>"; };
 		AB260B63A88AF852906E2D2D /* MermaidRenderCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidRenderCache.swift; sourceTree = "<group>"; };
 		AB3DAB779A962AC2092A2879 /* CommitTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabViewTests.swift; sourceTree = "<group>"; };
@@ -2843,6 +2851,7 @@
 		CEC2AE8D8A358AC0F83252CD /* OpenCodeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeInstaller.swift; sourceTree = "<group>"; };
 		CED658A433AAE57984ACCD0D /* MermaidDiagramThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidDiagramThemeTests.swift; sourceTree = "<group>"; };
 		CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewView.swift; sourceTree = "<group>"; };
+		CF0005D9107053886C37A3AC /* WarningCharacterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningCharacterTests.swift; sourceTree = "<group>"; };
 		CF02DDF9183C6C8D28EC68C0 /* ACPPlanChecklist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanChecklist.swift; sourceTree = "<group>"; };
 		CF15D3E39502C1BA6618943B /* MergeConflictTabModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabModel.swift; sourceTree = "<group>"; };
 		CF41C5BD384265499AEEE4CF /* CompletionDocumentationRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDocumentationRendererTests.swift; sourceTree = "<group>"; };
@@ -3024,6 +3033,7 @@
 		E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionPickerTests.swift; sourceTree = "<group>"; };
 		E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabStateMarkdownCodableTests.swift; sourceTree = "<group>"; };
 		E9F849F92835C6A4EEA765B7 /* ACPTranscriptScroller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScroller.swift; sourceTree = "<group>"; };
+		EA74519F0A93299751407753 /* AppConfigCodeTextRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigCodeTextRenderingTests.swift; sourceTree = "<group>"; };
 		EAA78FF7BA562DC4423AC35D /* ACPSessionVisibleQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionVisibleQueueTests.swift; sourceTree = "<group>"; };
 		EAD81CB1D751F983C64191FF /* ACPRemoteAdapterManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteAdapterManagementTests.swift; sourceTree = "<group>"; };
 		EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPane.swift; sourceTree = "<group>"; };
@@ -3411,6 +3421,7 @@
 				A72E6086ED069AF65F890BBB /* AppConfigAgentsCodingTests.swift */,
 				333EA07C2BCA5E18F55E2613 /* AppConfigChangesTests.swift */,
 				D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */,
+				EA74519F0A93299751407753 /* AppConfigCodeTextRenderingTests.swift */,
 				EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */,
 				0A216C9D856D2A6C43964E74 /* AppConfigHarnessTests.swift */,
 				987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */,
@@ -3733,6 +3744,7 @@
 				D0A8DE0526D46C36C672213B /* TrackedRevisionTargetTests.swift */,
 				AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */,
 				708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */,
+				CF0005D9107053886C37A3AC /* WarningCharacterTests.swift */,
 				2F5959FF98A5105FF7B17894 /* WorkingTreeChangeGroupTests.swift */,
 				5F931B1EEA7F04855BAE5A43 /* WorkingTreeStageAllActionTests.swift */,
 				AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */,
@@ -4420,6 +4432,7 @@
 				6821B71680094791995C4975 /* ShortcutsPane.swift */,
 				57B7225443DF69C32D25338D /* SpacesPane.swift */,
 				FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */,
+				AACA0D87BA93646BD5A24E91 /* WarningCharactersSheet.swift */,
 				0F68A9692F85197ED9E16262 /* WorktreesPane.swift */,
 			);
 			path = Settings;
@@ -5153,6 +5166,7 @@
 				5DD723B8C15EF2413C5D935D /* BlockedLanguageServerNudgeResolver.swift */,
 				3C860C82F92CF8B7CC58FF4D /* BlockedNudgeBanner.swift */,
 				30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */,
+				A903C69ED6A3B550CCDF477A /* CodeEditorLayoutManager.swift */,
 				76B767602C3F8E5909A44B7C /* CodeEditorLineNumberRulerView.swift */,
 				FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */,
 				FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */,
@@ -5172,6 +5186,7 @@
 				41B7844FCFC1DD54B2B471F8 /* InstallNudgeBanner.swift */,
 				25CBAF6618B6D11EC3B9CC76 /* InstallNudgeResolver.swift */,
 				FC4A215AF2876091E31F6F8A /* LineEnding.swift */,
+				48B366689CD72FE381471B90 /* WarningCharacter.swift */,
 			);
 			path = Editor;
 			sourceTree = "<group>";
@@ -6311,6 +6326,7 @@
 				A2BB622FA93936FAE9A3719A /* ClosedTabHistory.swift in Sources */,
 				EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */,
 				41F6712EA71CC9AF6AB7ED94 /* CodeEditorCoordinator.swift in Sources */,
+				752E634D54ED2AA2C50D36B4 /* CodeEditorLayoutManager.swift in Sources */,
 				7324AD398C5F4168C067F4B0 /* CodeEditorLineNumberRulerView.swift in Sources */,
 				A9D0D8D94E1D46F35D17DDBA /* CodeEditorView.swift in Sources */,
 				DA0C1B28A1161C52F83C05DF /* CodeHostIssueProvider.swift in Sources */,
@@ -6864,6 +6880,8 @@
 				C245DDADA1D81810E9302134 /* VerdictSheet.swift in Sources */,
 				DAA0AFA398C02EC663708825 /* ViewDragOut.swift in Sources */,
 				B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */,
+				3C831BFD39402F812755CAFB /* WarningCharacter.swift in Sources */,
+				749C6A3FE32576CB68A6BE46 /* WarningCharactersSheet.swift in Sources */,
 				264DBAC7DCEBDDCB8A948C6A /* WebPageMetadataFetcher.swift in Sources */,
 				7C286DF876CD8F71D07B6A93 /* WebSocketFrame.swift in Sources */,
 				4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */,
@@ -7080,6 +7098,7 @@
 				CB6D9F5929D97FAB3A264F47 /* AppConfigAgentsCodingTests.swift in Sources */,
 				1DF096E0925EFA91B9033642 /* AppConfigChangesTests.swift in Sources */,
 				D1FF11465D1309A56FCFFAF0 /* AppConfigCodeInstallTests.swift in Sources */,
+				0D37A802776CF90B0CB2D556 /* AppConfigCodeTextRenderingTests.swift in Sources */,
 				CCB0C90ABC15D987D0EEB230 /* AppConfigFilesTests.swift in Sources */,
 				1F3AA3B31A896A0608970906 /* AppConfigHarnessMCPTests.swift in Sources */,
 				8D86580619CA83FE832ACB25 /* AppConfigHarnessTests.swift in Sources */,
@@ -7578,6 +7597,7 @@
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
 				9C4246D4FEE6C6A7D3C738A8 /* UnionCanvasGeometryTests.swift in Sources */,
 				0DA68649E5F3C0018C4309DA /* UpdateThrottleTests.swift in Sources */,
+				0294BEA9FB3A117314ED0C48 /* WarningCharacterTests.swift in Sources */,
 				61E502981D902F018F464831 /* WebPageMetadataFetcherTests.swift in Sources */,
 				2DDF8175D7490F505AED7DF4 /* WebSocketFrameTests.swift in Sources */,
 				175AA2192F1DBD9836E08E77 /* WorkingTreeChangeGroupTests.swift in Sources */,

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -156,6 +156,7 @@ struct EditorTabView: View {
                     fontFamily: appState.config.code.fontFamily,
                     fontSize: appState.config.code.fontSize,
                     showLineNumbers: appState.config.code.showLineNumbers,
+                    textRendering: CodeEditorTextRenderingConfiguration(code: appState.config.code),
                     onTextViewAttached: { attachFindController(to: $0) },
                     onTextViewDetached: { detachFindController(from: $0) }
                 )

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -22,6 +22,7 @@ final class CodeEditorCoordinator {
     private var currentWorktreeId: String?
 
     var tabId: TabID? { currentTabId }
+    var currentBufferReadOnly: Bool { buffer?.readOnly ?? true }
     private var currentRoot: URL?
     private var currentRelativePath: String?
     private var currentLanguage: String?

--- a/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
@@ -121,8 +121,13 @@ final class CodeEditorLayoutManager: NSLayoutManager {
         var rect = boundingRect(forGlyphRange: NSRange(location: glyph, length: 1), in: container)
         if scalar.map(Self.usesInsertionMarker) == true || rect.width <= 1 {
             let line = lineFragmentRect(forGlyphAt: glyph, effectiveRange: nil)
-            let nextGlyph = glyphIndexForCharacter(at: NSMaxRange(range))
-            let x = nextGlyph < numberOfGlyphs ? location(forGlyphAt: nextGlyph).x : rect.maxX
+            let x: CGFloat
+            if scalar.map(Self.usesInsertionMarker) == true {
+                let nextGlyph = glyphIndexForCharacter(at: NSMaxRange(range))
+                x = nextGlyph < numberOfGlyphs ? location(forGlyphAt: nextGlyph).x : rect.maxX
+            } else {
+                x = location(forGlyphAt: glyph).x
+            }
             rect = NSRect(x: x, y: line.minY, width: 8, height: line.height)
         }
         return rect

--- a/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
@@ -84,7 +84,9 @@ final class CodeEditorLayoutManager: NSLayoutManager {
             let scalar = text.unicodeScalars[index]
             let next = text.unicodeScalars.index(after: index)
             let range = NSRange(index..<next, in: text)
-            if NSIntersectionRange(range, characters).length > 0 {
+            if NSIntersectionRange(range, characters).length > 0,
+               !(configuration.showWarningCharacters && warnings[scalar.value] != nil)
+            {
                 let rect = decorationRect(forCharacterRange: range).offsetBy(dx: origin.x, dy: origin.y)
                     let marker: String?
                     switch scalar.value { case 0x20 where configuration.showSpaces: marker = "·"

--- a/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
@@ -123,7 +123,9 @@ final class CodeEditorLayoutManager: NSLayoutManager {
             let line = lineFragmentRect(forGlyphAt: glyph, effectiveRange: nil)
             let x: CGFloat
             if scalar.map(Self.usesInsertionMarker) == true {
-                let nextGlyph = glyphIndexForCharacter(at: NSMaxRange(range))
+                let nextGlyph = NSMaxRange(range) < (textStorage?.length ?? 0)
+                    ? glyphIndexForCharacter(at: NSMaxRange(range))
+                    : numberOfGlyphs
                 x = nextGlyph < numberOfGlyphs ? location(forGlyphAt: nextGlyph).x : rect.maxX
             } else {
                 x = location(forGlyphAt: glyph).x

--- a/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
@@ -41,10 +41,11 @@ final class CodeEditorLayoutManager: NSLayoutManager {
         let string = textView.string as NSString
         let containerPoint = NSPoint(x: point.x - textView.textContainerInset.width, y: point.y - textView.textContainerInset.height)
         for location in [index, index - 1] where location >= 0 && location < string.length {
-            let range = string.rangeOfComposedCharacterSequence(at: location)
-            let value = string.substring(with: range).unicodeScalars.first?.value
-            guard let value, let warning = scalars[value], decorationRect(forCharacterRange: range).contains(containerPoint) else { continue }
-            return warning.note.isEmpty ? warning.code : "\(warning.code) — \(warning.note)"
+            let composedRange = string.rangeOfComposedCharacterSequence(at: location)
+            for (value, range) in Self.warningCharacterRanges(in: string, composedRange: composedRange, warningScalars: Set(scalars.keys)) {
+                guard let warning = scalars[value], decorationRect(forCharacterRange: range).contains(containerPoint) else { continue }
+                return warning.note.isEmpty ? warning.code : "\(warning.code) — \(warning.note)"
+            }
         }
         return nil
     }
@@ -58,23 +59,38 @@ final class CodeEditorLayoutManager: NSLayoutManager {
         })
         let start = String.Index(utf16Offset: characters.location, in: text)
         let end = String.Index(utf16Offset: NSMaxRange(characters), in: text)
-        for index in text.unicodeScalars.indices where index >= start && index < end {
+        var index = start
+        while index < end {
             let scalar = text.unicodeScalars[index]
-            let range = NSRange(index..<text.unicodeScalars.index(after: index), in: text)
-            guard NSIntersectionRange(range, characters).length > 0 else { continue }
-            let rect = decorationRect(forCharacterRange: range).offsetBy(dx: origin.x, dy: origin.y)
-            if configuration.showWarningCharacters, let warning = warnings[scalar.value] {
-                NSColor.systemRed.withAlphaComponent(0.28).setFill()
-                rect.insetBy(dx: 1, dy: 1).fill()
-                _ = warning
-            } else if configuration.showInvisibleCharacters {
-                let marker: String?
-                switch scalar.value { case 0x20 where configuration.showSpaces: marker = "·"
-                case 0x09 where configuration.showTabs: marker = "→"
-                case 0x0A where configuration.showLineEndings: marker = "↵"
-                default: marker = nil }
-                if let marker { marker.draw(at: NSPoint(x: rect.minX, y: rect.minY), withAttributes: [.font: textStorage?.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont ?? .monospacedSystemFont(ofSize: 13, weight: .regular), .foregroundColor: markerColor]) }
+            let next = text.unicodeScalars.index(after: index)
+            let range = NSRange(index..<next, in: text)
+            if NSIntersectionRange(range, characters).length > 0 {
+                let rect = decorationRect(forCharacterRange: range).offsetBy(dx: origin.x, dy: origin.y)
+                if configuration.showWarningCharacters, let warning = warnings[scalar.value] {
+                    NSColor.systemRed.withAlphaComponent(0.28).setFill()
+                    rect.insetBy(dx: 1, dy: 1).fill()
+                    _ = warning
+                } else if configuration.showInvisibleCharacters {
+                    let marker: String?
+                    switch scalar.value { case 0x20 where configuration.showSpaces: marker = "·"
+                    case 0x09 where configuration.showTabs: marker = "→"
+                    case 0x0A where configuration.showLineEndings: marker = "↵"
+                    default: marker = nil }
+                    if let marker { marker.draw(at: NSPoint(x: rect.minX, y: rect.minY), withAttributes: [.font: textStorage?.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont ?? .monospacedSystemFont(ofSize: 13, weight: .regular), .foregroundColor: markerColor]) }
+                }
             }
+            index = next
+        }
+    }
+
+    static func warningCharacterRanges(in text: NSString, composedRange: NSRange, warningScalars: Set<UInt32>) -> [(UInt32, NSRange)] {
+        let substring = text.substring(with: composedRange)
+        return substring.unicodeScalars.indices.compactMap { index in
+            let scalar = substring.unicodeScalars[index]
+            guard warningScalars.contains(scalar.value) else { return nil }
+            let next = substring.unicodeScalars.index(after: index)
+            let range = NSRange(index..<next, in: substring)
+            return (scalar.value, NSRange(location: composedRange.location + range.location, length: range.length))
         }
     }
 

--- a/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
@@ -111,7 +111,8 @@ final class CodeEditorLayoutManager: NSLayoutManager {
     }
 
     static func usesInsertionMarker(for scalar: Unicode.Scalar) -> Bool {
-        switch scalar.properties.generalCategory {
+        if [0x0009, 0x000A, 0x000D].contains(scalar.value) { return false }
+        return switch scalar.properties.generalCategory {
         case .control, .enclosingMark, .format, .nonspacingMark: true
         default: false
         }

--- a/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
@@ -30,6 +30,12 @@ final class CodeEditorLayoutManager: NSLayoutManager {
         invalidateDisplay(forCharacterRange: NSRange(location: 0, length: textStorage?.length ?? 0))
     }
 
+    func disableRendering() {
+        guard configuration != nil else { return }
+        configuration = nil
+        invalidateDisplay(forCharacterRange: NSRange(location: 0, length: textStorage?.length ?? 0))
+    }
+
     @MainActor func warningToolTip(at point: NSPoint, in textView: NSTextView) -> String? {
         guard let configuration, configuration.showWarningCharacters,
               let container = textView.textContainer else { return nil }

--- a/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
@@ -1,0 +1,72 @@
+import AppKit
+
+struct CodeEditorTextRenderingConfiguration: Equatable {
+    var showInvisibleCharacters: Bool
+    var showSpaces: Bool
+    var showTabs: Bool
+    var showLineEndings: Bool
+    var showWarningCharacters: Bool
+    var warningCharacters: [WarningCharacter]
+
+    init(code: AppConfig.Code) {
+        showInvisibleCharacters = code.showInvisibleCharacters
+        showSpaces = code.showSpaces
+        showTabs = code.showTabs
+        showLineEndings = code.showLineEndings
+        showWarningCharacters = code.showWarningCharacters
+        warningCharacters = code.warningCharacters
+    }
+}
+
+final class CodeEditorLayoutManager: NSLayoutManager {
+    private var configuration: CodeEditorTextRenderingConfiguration?
+    private var markerColor = NSColor.secondaryLabelColor.withAlphaComponent(0.42)
+
+    func update(configuration: CodeEditorTextRenderingConfiguration, theme: Theme) {
+        let color = NSColor(theme.color("fg-1")).withAlphaComponent(0.42)
+        guard self.configuration != configuration || !markerColor.isEqual(color) else { return }
+        self.configuration = configuration
+        markerColor = color
+        invalidateDisplay(forCharacterRange: NSRange(location: 0, length: textStorage?.length ?? 0))
+    }
+
+    @MainActor func warningToolTip(at point: NSPoint, in textView: NSTextView) -> String? {
+        guard let configuration, configuration.showWarningCharacters,
+              let container = textView.textContainer else { return nil }
+        var fraction: CGFloat = 0
+        let index = characterIndex(for: NSPoint(x: point.x - textView.textContainerInset.width, y: point.y - textView.textContainerInset.height), in: container, fractionOfDistanceBetweenInsertionPoints: &fraction)
+        let scalars = Dictionary(uniqueKeysWithValues: configuration.warningCharacters.compactMap { warning in
+            warning.scalar.map { ($0.value, warning) }
+        })
+        let string = textView.string as NSString
+        for location in [index, index - 1] where location >= 0 && location < string.length {
+            let value = string.substring(with: NSRange(location: location, length: 1)).unicodeScalars.first?.value
+            if let value, let warning = scalars[value] { return warning.note.isEmpty ? warning.code : "\(warning.code) — \(warning.note)" }
+        }
+        return nil
+    }
+
+    override func drawGlyphs(forGlyphRange glyphsToShow: NSRange, at origin: NSPoint) {
+        super.drawGlyphs(forGlyphRange: glyphsToShow, at: origin)
+        guard let configuration, let text = textStorage?.string else { return }
+        let characters = characterRange(forGlyphRange: glyphsToShow, actualGlyphRange: nil)
+        let warnings = Dictionary(uniqueKeysWithValues: configuration.warningCharacters.compactMap { warning in
+            warning.scalar.map { ($0.value, warning) }
+        })
+        for index in text.unicodeScalars.indices {
+            let scalar = text.unicodeScalars[index]
+            let range = NSRange(index..<text.unicodeScalars.index(after: index), in: text)
+            guard NSIntersectionRange(range, characters).length > 0 else { continue }
+            let glyph = glyphIndexForCharacter(at: range.location)
+            let rect = boundingRect(forGlyphRange: NSRange(location: glyph, length: 1), in: textContainers.first!).offsetBy(dx: origin.x, dy: origin.y)
+            if configuration.showWarningCharacters, let warning = warnings[scalar.value] {
+                NSColor.systemRed.withAlphaComponent(0.28).setFill(); rect.insetBy(dx: 1, dy: 1).fill()
+                _ = warning
+            } else if configuration.showInvisibleCharacters {
+                let marker: String?
+                switch scalar.value { case 0x20 where configuration.showSpaces: marker = "·"; case 0x09 where configuration.showTabs: marker = "→"; case 0x0A where configuration.showLineEndings: marker = "↵"; default: marker = nil }
+                if let marker { marker.draw(at: NSPoint(x: rect.minX, y: rect.minY), withAttributes: [.font: textStorage?.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont ?? .monospacedSystemFont(ofSize: 13, weight: .regular), .foregroundColor: markerColor]) }
+            }
+        }
+    }
+}

--- a/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
@@ -118,11 +118,19 @@ final class CodeEditorLayoutManager: NSLayoutManager {
         }
     }
 
+    static func usesScalarMarker(for scalar: Unicode.Scalar?, range: NSRange, glyphCharacterRange: NSRange) -> Bool {
+        scalar.map(Self.usesInsertionMarker) == true
+            || glyphCharacterRange.location != range.location
+            || glyphCharacterRange.length != range.length
+    }
+
     private func decorationRect(forCharacterRange range: NSRange, scalar: Unicode.Scalar? = nil) -> NSRect {
         guard let container = textContainers.first else { return .zero }
         let glyph = glyphIndexForCharacter(at: range.location)
         var rect = boundingRect(forGlyphRange: NSRange(location: glyph, length: 1), in: container)
-        if scalar.map(Self.usesInsertionMarker) == true || rect.width <= 1 {
+        let glyphCharacters = characterRange(forGlyphRange: NSRange(location: glyph, length: 1), actualGlyphRange: nil)
+        let usesScalarMarker = Self.usesScalarMarker(for: scalar, range: range, glyphCharacterRange: glyphCharacters)
+        if usesScalarMarker || rect.width <= 1 {
             let line = lineFragmentRect(forGlyphAt: glyph, effectiveRange: nil)
             let x: CGFloat
             if scalar.map(Self.usesInsertionMarker) == true {
@@ -130,6 +138,9 @@ final class CodeEditorLayoutManager: NSLayoutManager {
                     ? glyphIndexForCharacter(at: NSMaxRange(range))
                     : numberOfGlyphs
                 x = nextGlyph < numberOfGlyphs ? location(forGlyphAt: nextGlyph).x : rect.maxX
+            } else if usesScalarMarker {
+                let offset = CGFloat(range.location - glyphCharacters.location)
+                x = rect.minX + rect.width * offset / CGFloat(max(glyphCharacters.length, 1))
             } else {
                 x = location(forGlyphAt: glyph).x
             }

--- a/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
@@ -60,11 +60,15 @@ final class CodeEditorLayoutManager: NSLayoutManager {
             let glyph = glyphIndexForCharacter(at: range.location)
             let rect = boundingRect(forGlyphRange: NSRange(location: glyph, length: 1), in: textContainers.first!).offsetBy(dx: origin.x, dy: origin.y)
             if configuration.showWarningCharacters, let warning = warnings[scalar.value] {
-                NSColor.systemRed.withAlphaComponent(0.28).setFill(); rect.insetBy(dx: 1, dy: 1).fill()
+                NSColor.systemRed.withAlphaComponent(0.28).setFill()
+                rect.insetBy(dx: 1, dy: 1).fill()
                 _ = warning
             } else if configuration.showInvisibleCharacters {
                 let marker: String?
-                switch scalar.value { case 0x20 where configuration.showSpaces: marker = "·"; case 0x09 where configuration.showTabs: marker = "→"; case 0x0A where configuration.showLineEndings: marker = "↵"; default: marker = nil }
+                switch scalar.value { case 0x20 where configuration.showSpaces: marker = "·"
+                case 0x09 where configuration.showTabs: marker = "→"
+                case 0x0A where configuration.showLineEndings: marker = "↵"
+                default: marker = nil }
                 if let marker { marker.draw(at: NSPoint(x: rect.minX, y: rect.minY), withAttributes: [.font: textStorage?.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont ?? .monospacedSystemFont(ofSize: 13, weight: .regular), .foregroundColor: markerColor]) }
             }
         }

--- a/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
@@ -43,7 +43,7 @@ final class CodeEditorLayoutManager: NSLayoutManager {
         for location in [index, index - 1] where location >= 0 && location < string.length {
             let composedRange = string.rangeOfComposedCharacterSequence(at: location)
             for (value, range) in Self.warningCharacterRanges(in: string, composedRange: composedRange, warningScalars: Set(scalars.keys)) {
-                guard let warning = scalars[value], decorationRect(forCharacterRange: range).contains(containerPoint) else { continue }
+                guard let warning = scalars[value], let scalar = Unicode.Scalar(value), decorationRect(forCharacterRange: range, scalar: scalar).contains(containerPoint) else { continue }
                 return warning.note.isEmpty ? warning.code : "\(warning.code) — \(warning.note)"
             }
         }
@@ -51,14 +51,34 @@ final class CodeEditorLayoutManager: NSLayoutManager {
     }
 
     override func drawGlyphs(forGlyphRange glyphsToShow: NSRange, at origin: NSPoint) {
-        super.drawGlyphs(forGlyphRange: glyphsToShow, at: origin)
-        guard let configuration, let text = textStorage?.string else { return }
+        guard let configuration, let text = textStorage?.string else {
+            super.drawGlyphs(forGlyphRange: glyphsToShow, at: origin)
+            return
+        }
         let characters = characterRange(forGlyphRange: glyphsToShow, actualGlyphRange: nil)
         let warnings = Dictionary(uniqueKeysWithValues: configuration.warningCharacters.compactMap { warning in
             warning.scalar.map { ($0.value, warning) }
         })
         let start = String.Index(utf16Offset: characters.location, in: text)
         let end = String.Index(utf16Offset: NSMaxRange(characters), in: text)
+        if configuration.showWarningCharacters {
+            var index = start
+            while index < end {
+                let scalar = text.unicodeScalars[index]
+                let next = text.unicodeScalars.index(after: index)
+                let range = NSRange(index..<next, in: text)
+                if NSIntersectionRange(range, characters).length > 0, warnings[scalar.value] != nil {
+                    let rect = decorationRect(forCharacterRange: range, scalar: scalar).offsetBy(dx: origin.x, dy: origin.y)
+                    NSColor.systemRed.withAlphaComponent(0.28).setFill()
+                    rect.insetBy(dx: 1, dy: 1).fill()
+                }
+                index = next
+            }
+        }
+
+        super.drawGlyphs(forGlyphRange: glyphsToShow, at: origin)
+
+        guard configuration.showInvisibleCharacters else { return }
         var index = start
         while index < end {
             let scalar = text.unicodeScalars[index]
@@ -66,18 +86,12 @@ final class CodeEditorLayoutManager: NSLayoutManager {
             let range = NSRange(index..<next, in: text)
             if NSIntersectionRange(range, characters).length > 0 {
                 let rect = decorationRect(forCharacterRange: range).offsetBy(dx: origin.x, dy: origin.y)
-                if configuration.showWarningCharacters, let warning = warnings[scalar.value] {
-                    NSColor.systemRed.withAlphaComponent(0.28).setFill()
-                    rect.insetBy(dx: 1, dy: 1).fill()
-                    _ = warning
-                } else if configuration.showInvisibleCharacters {
                     let marker: String?
                     switch scalar.value { case 0x20 where configuration.showSpaces: marker = "·"
                     case 0x09 where configuration.showTabs: marker = "→"
                     case 0x0A where configuration.showLineEndings: marker = "↵"
                     default: marker = nil }
                     if let marker { marker.draw(at: NSPoint(x: rect.minX, y: rect.minY), withAttributes: [.font: textStorage?.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont ?? .monospacedSystemFont(ofSize: 13, weight: .regular), .foregroundColor: markerColor]) }
-                }
             }
             index = next
         }
@@ -94,13 +108,22 @@ final class CodeEditorLayoutManager: NSLayoutManager {
         }
     }
 
-    private func decorationRect(forCharacterRange range: NSRange) -> NSRect {
+    static func usesInsertionMarker(for scalar: Unicode.Scalar) -> Bool {
+        switch scalar.properties.generalCategory {
+        case .control, .enclosingMark, .format, .nonspacingMark: true
+        default: false
+        }
+    }
+
+    private func decorationRect(forCharacterRange range: NSRange, scalar: Unicode.Scalar? = nil) -> NSRect {
         guard let container = textContainers.first else { return .zero }
         let glyph = glyphIndexForCharacter(at: range.location)
         var rect = boundingRect(forGlyphRange: NSRange(location: glyph, length: 1), in: container)
-        if rect.width <= 1 {
+        if scalar.map(Self.usesInsertionMarker) == true || rect.width <= 1 {
             let line = lineFragmentRect(forGlyphAt: glyph, effectiveRange: nil)
-            rect = NSRect(x: location(forGlyphAt: glyph).x, y: line.minY, width: 8, height: line.height)
+            let nextGlyph = glyphIndexForCharacter(at: NSMaxRange(range))
+            let x = nextGlyph < numberOfGlyphs ? location(forGlyphAt: nextGlyph).x : rect.maxX
+            rect = NSRect(x: x, y: line.minY, width: 8, height: line.height)
         }
         return rect
     }

--- a/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
@@ -39,9 +39,12 @@ final class CodeEditorLayoutManager: NSLayoutManager {
             warning.scalar.map { ($0.value, warning) }
         })
         let string = textView.string as NSString
+        let containerPoint = NSPoint(x: point.x - textView.textContainerInset.width, y: point.y - textView.textContainerInset.height)
         for location in [index, index - 1] where location >= 0 && location < string.length {
-            let value = string.substring(with: NSRange(location: location, length: 1)).unicodeScalars.first?.value
-            if let value, let warning = scalars[value] { return warning.note.isEmpty ? warning.code : "\(warning.code) — \(warning.note)" }
+            let range = string.rangeOfComposedCharacterSequence(at: location)
+            let value = string.substring(with: range).unicodeScalars.first?.value
+            guard let value, let warning = scalars[value], decorationRect(forCharacterRange: range).contains(containerPoint) else { continue }
+            return warning.note.isEmpty ? warning.code : "\(warning.code) — \(warning.note)"
         }
         return nil
     }
@@ -53,12 +56,13 @@ final class CodeEditorLayoutManager: NSLayoutManager {
         let warnings = Dictionary(uniqueKeysWithValues: configuration.warningCharacters.compactMap { warning in
             warning.scalar.map { ($0.value, warning) }
         })
-        for index in text.unicodeScalars.indices {
+        let start = String.Index(utf16Offset: characters.location, in: text)
+        let end = String.Index(utf16Offset: NSMaxRange(characters), in: text)
+        for index in text.unicodeScalars.indices where index >= start && index < end {
             let scalar = text.unicodeScalars[index]
             let range = NSRange(index..<text.unicodeScalars.index(after: index), in: text)
             guard NSIntersectionRange(range, characters).length > 0 else { continue }
-            let glyph = glyphIndexForCharacter(at: range.location)
-            let rect = boundingRect(forGlyphRange: NSRange(location: glyph, length: 1), in: textContainers.first!).offsetBy(dx: origin.x, dy: origin.y)
+            let rect = decorationRect(forCharacterRange: range).offsetBy(dx: origin.x, dy: origin.y)
             if configuration.showWarningCharacters, let warning = warnings[scalar.value] {
                 NSColor.systemRed.withAlphaComponent(0.28).setFill()
                 rect.insetBy(dx: 1, dy: 1).fill()
@@ -72,5 +76,16 @@ final class CodeEditorLayoutManager: NSLayoutManager {
                 if let marker { marker.draw(at: NSPoint(x: rect.minX, y: rect.minY), withAttributes: [.font: textStorage?.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont ?? .monospacedSystemFont(ofSize: 13, weight: .regular), .foregroundColor: markerColor]) }
             }
         }
+    }
+
+    private func decorationRect(forCharacterRange range: NSRange) -> NSRect {
+        guard let container = textContainers.first else { return .zero }
+        let glyph = glyphIndexForCharacter(at: range.location)
+        var rect = boundingRect(forGlyphRange: NSRange(location: glyph, length: 1), in: container)
+        if rect.width <= 1 {
+            let line = lineFragmentRect(forGlyphAt: glyph, effectiveRange: nil)
+            rect = NSRect(x: location(forGlyphAt: glyph).x, y: line.minY, width: 8, height: line.height)
+        }
+        return rect
     }
 }

--- a/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLayoutManager.swift
@@ -143,7 +143,14 @@ final class CodeEditorLayoutManager: NSLayoutManager {
                 let nextGlyph = NSMaxRange(range) < (textStorage?.length ?? 0)
                     ? glyphIndexForCharacter(at: NSMaxRange(range))
                     : numberOfGlyphs
-                x = nextGlyph < numberOfGlyphs ? location(forGlyphAt: nextGlyph).x : rect.maxX
+                if nextGlyph < numberOfGlyphs, nextGlyph != glyph {
+                    x = location(forGlyphAt: nextGlyph).x
+                } else if usesScalarMarker {
+                    let offset = CGFloat(NSMaxRange(range) - glyphCharacters.location)
+                    x = rect.minX + rect.width * offset / CGFloat(max(glyphCharacters.length, 1))
+                } else {
+                    x = rect.maxX
+                }
             } else if usesScalarMarker {
                 let offset = CGFloat(range.location - glyphCharacters.location)
                 x = rect.minX + rect.width * offset / CGFloat(max(glyphCharacters.length, 1))

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -183,15 +183,7 @@ struct CodeEditorView: NSViewRepresentable {
         // storage<->layoutManager binding (see `bindBuffer`) so that swapping
         // buffers across tab switches can rebind onto the new storage; we
         // pass an unattached layout manager here.
-        let rendersTextDecorations = externalAbsolutePath == nil || externalEditable
-        let layoutManager: NSLayoutManager
-        if rendersTextDecorations {
-            let manager = CodeEditorLayoutManager()
-            manager.update(configuration: textRendering, theme: theme)
-            layoutManager = manager
-        } else {
-            layoutManager = NSLayoutManager()
-        }
+        let layoutManager = CodeEditorLayoutManager()
         let containerSize = NSSize(
             width: CGFloat.greatestFiniteMagnitude,
             height: CGFloat.greatestFiniteMagnitude
@@ -214,12 +206,7 @@ struct CodeEditorView: NSViewRepresentable {
         textView.isHorizontallyResizable = true
         textView.isVerticallyResizable = true
         textView.autoresizingMask = []
-        if let layoutManager = layoutManager as? CodeEditorLayoutManager {
-            textView.warningToolTipProvider = { [weak layoutManager, weak textView] point in
-                guard let layoutManager, let textView else { return nil }
-                return layoutManager.warningToolTip(at: point, in: textView)
-            }
-        }
+        configureTextRendering(on: textView, layoutManager: layoutManager, theme: theme)
 
         scroll.documentView = textView
         configureLineNumberRuler(for: scroll, textView: textView)
@@ -263,7 +250,7 @@ struct CodeEditorView: NSViewRepresentable {
 
         if let textView = nsView.documentView as? CodeTextView {
             configureLineNumberRuler(for: nsView, textView: textView)
-            (textView.layoutManager as? CodeEditorLayoutManager)?.update(configuration: textRendering, theme: theme)
+            configureTextRendering(on: textView, layoutManager: textView.layoutManager, theme: theme)
         }
     }
 
@@ -286,6 +273,26 @@ struct CodeEditorView: NSViewRepresentable {
             DispatchQueue.main.async {
                 onTextViewDetached(textView)
             }
+        }
+    }
+
+    private func configureTextRendering(on textView: CodeTextView, layoutManager: NSLayoutManager?, theme: Theme) {
+        guard let layoutManager = layoutManager as? CodeEditorLayoutManager else {
+            textView.warningToolTipProvider = nil
+            return
+        }
+
+        let rendersTextDecorations = externalAbsolutePath == nil || externalEditable
+        guard rendersTextDecorations else {
+            layoutManager.disableRendering()
+            textView.warningToolTipProvider = nil
+            return
+        }
+
+        layoutManager.update(configuration: textRendering, theme: theme)
+        textView.warningToolTipProvider = { [weak layoutManager, weak textView] point in
+            guard let layoutManager, let textView else { return nil }
+            return layoutManager.warningToolTip(at: point, in: textView)
         }
     }
 

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -206,7 +206,7 @@ struct CodeEditorView: NSViewRepresentable {
         textView.isHorizontallyResizable = true
         textView.isVerticallyResizable = true
         textView.autoresizingMask = []
-        configureTextRendering(on: textView, layoutManager: layoutManager, theme: theme)
+        configureTextRendering(on: textView, layoutManager: layoutManager, theme: theme, rendersTextDecorations: !buffer.readOnly)
 
         scroll.documentView = textView
         configureLineNumberRuler(for: scroll, textView: textView)
@@ -250,7 +250,12 @@ struct CodeEditorView: NSViewRepresentable {
 
         if let textView = nsView.documentView as? CodeTextView {
             configureLineNumberRuler(for: nsView, textView: textView)
-            configureTextRendering(on: textView, layoutManager: textView.layoutManager, theme: theme)
+            configureTextRendering(
+                on: textView,
+                layoutManager: textView.layoutManager,
+                theme: theme,
+                rendersTextDecorations: !context.coordinator.currentBufferReadOnly
+            )
         }
     }
 
@@ -276,13 +281,12 @@ struct CodeEditorView: NSViewRepresentable {
         }
     }
 
-    private func configureTextRendering(on textView: CodeTextView, layoutManager: NSLayoutManager?, theme: Theme) {
+    private func configureTextRendering(on textView: CodeTextView, layoutManager: NSLayoutManager?, theme: Theme, rendersTextDecorations: Bool) {
         guard let layoutManager = layoutManager as? CodeEditorLayoutManager else {
             textView.warningToolTipProvider = nil
             return
         }
 
-        let rendersTextDecorations = externalAbsolutePath == nil || externalEditable
         guard rendersTextDecorations else {
             layoutManager.disableRendering()
             textView.warningToolTipProvider = nil

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -127,6 +127,7 @@ struct CodeEditorView: NSViewRepresentable {
     let fontFamily: String
     let fontSize: Int
     let showLineNumbers: Bool
+    let textRendering: CodeEditorTextRenderingConfiguration
     var onTextViewAttached: (CodeTextView) -> Void = { _ in }
     var onTextViewDetached: (CodeTextView?) -> Void = { _ in }
     @Environment(\.theme) var theme
@@ -182,7 +183,8 @@ struct CodeEditorView: NSViewRepresentable {
         // storage<->layoutManager binding (see `bindBuffer`) so that swapping
         // buffers across tab switches can rebind onto the new storage; we
         // pass an unattached layout manager here.
-        let layoutManager = NSLayoutManager()
+        let layoutManager = CodeEditorLayoutManager()
+        layoutManager.update(configuration: textRendering, theme: theme)
         let containerSize = NSSize(
             width: CGFloat.greatestFiniteMagnitude,
             height: CGFloat.greatestFiniteMagnitude
@@ -205,6 +207,10 @@ struct CodeEditorView: NSViewRepresentable {
         textView.isHorizontallyResizable = true
         textView.isVerticallyResizable = true
         textView.autoresizingMask = []
+        textView.warningToolTipProvider = { [weak layoutManager, weak textView] point in
+            guard let layoutManager, let textView else { return nil }
+            return layoutManager.warningToolTip(at: point, in: textView)
+        }
 
         scroll.documentView = textView
         configureLineNumberRuler(for: scroll, textView: textView)
@@ -248,6 +254,7 @@ struct CodeEditorView: NSViewRepresentable {
 
         if let textView = nsView.documentView as? CodeTextView {
             configureLineNumberRuler(for: nsView, textView: textView)
+            (textView.layoutManager as? CodeEditorLayoutManager)?.update(configuration: textRendering, theme: theme)
         }
     }
 

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -183,8 +183,15 @@ struct CodeEditorView: NSViewRepresentable {
         // storage<->layoutManager binding (see `bindBuffer`) so that swapping
         // buffers across tab switches can rebind onto the new storage; we
         // pass an unattached layout manager here.
-        let layoutManager = CodeEditorLayoutManager()
-        layoutManager.update(configuration: textRendering, theme: theme)
+        let rendersTextDecorations = externalAbsolutePath == nil || externalEditable
+        let layoutManager: NSLayoutManager
+        if rendersTextDecorations {
+            let manager = CodeEditorLayoutManager()
+            manager.update(configuration: textRendering, theme: theme)
+            layoutManager = manager
+        } else {
+            layoutManager = NSLayoutManager()
+        }
         let containerSize = NSSize(
             width: CGFloat.greatestFiniteMagnitude,
             height: CGFloat.greatestFiniteMagnitude
@@ -207,9 +214,11 @@ struct CodeEditorView: NSViewRepresentable {
         textView.isHorizontallyResizable = true
         textView.isVerticallyResizable = true
         textView.autoresizingMask = []
-        textView.warningToolTipProvider = { [weak layoutManager, weak textView] point in
-            guard let layoutManager, let textView else { return nil }
-            return layoutManager.warningToolTip(at: point, in: textView)
+        if let layoutManager = layoutManager as? CodeEditorLayoutManager {
+            textView.warningToolTipProvider = { [weak layoutManager, weak textView] point in
+                guard let layoutManager, let textView else { return nil }
+                return layoutManager.warningToolTip(at: point, in: textView)
+            }
         }
 
         scroll.documentView = textView

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -81,6 +81,11 @@ final class CodeTextView: NSTextView, FontSizeResponder {
 
     required init?(coder: NSCoder) { fatalError("not used") }
 
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        refreshWarningToolTip()
+    }
+
     private func refreshWarningToolTip() {
         if let warningToolTipTag { removeToolTip(warningToolTipTag) }
         warningToolTipTag = warningToolTipProvider == nil ? nil : addToolTip(bounds, owner: self, userData: nil)

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -25,6 +25,8 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     var escapeHandler: (() -> Bool)?
     var completionKeyHandler: ((CompletionKeyAction) -> Bool)?
     var indentationMode: IndentationMode = .plain
+    var warningToolTipProvider: ((NSPoint) -> String?)? { didSet { refreshWarningToolTip() } }
+    private var warningToolTipTag: NSView.ToolTipTag?
 
     var autoPairDisabled: Bool = false
 
@@ -78,6 +80,15 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     }
 
     required init?(coder: NSCoder) { fatalError("not used") }
+
+    private func refreshWarningToolTip() {
+        if let warningToolTipTag { removeToolTip(warningToolTipTag) }
+        warningToolTipTag = warningToolTipProvider == nil ? nil : addToolTip(bounds, owner: self, userData: nil)
+    }
+
+    func view(_ view: NSView, stringForToolTip tag: NSView.ToolTipTag, point: NSPoint, userData data: UnsafeMutableRawPointer?) -> String {
+        warningToolTipProvider?(point) ?? ""
+    }
 
     // MARK: - Multi-cursor editing
 
@@ -692,6 +703,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
 
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
+        refreshWarningToolTip()
         for area in trackingAreas { removeTrackingArea(area) }
         let area = NSTrackingArea(
             rect: bounds,

--- a/Alas/Sources/Code/Editor/WarningCharacter.swift
+++ b/Alas/Sources/Code/Editor/WarningCharacter.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+struct WarningCharacter: Codable, Equatable, Identifiable, Sendable {
+    let scalarValue: UInt32
+    var note: String
+
+    var id: UInt32 { scalarValue }
+    var scalar: Unicode.Scalar? { Unicode.Scalar(scalarValue) }
+    var code: String { String(format: "U+%04X", scalarValue) }
+
+    static func parse(_ input: String, note: String) -> WarningCharacter? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        let value: UInt32?
+        if trimmed.lowercased().hasPrefix("u+") {
+            value = UInt32(trimmed.dropFirst(2), radix: 16)
+        } else if input.unicodeScalars.count == 1 {
+            value = input.unicodeScalars.first?.value
+        } else if trimmed.unicodeScalars.count == 1 {
+            value = trimmed.unicodeScalars.first?.value
+        } else {
+            value = nil
+        }
+        guard let value, Unicode.Scalar(value) != nil else { return nil }
+        return .init(scalarValue: value, note: note.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    static func sanitized(_ entries: [WarningCharacter]) -> [WarningCharacter] {
+        var seen = Set<UInt32>()
+        return entries.filter { $0.scalar != nil && seen.insert($0.scalarValue).inserted }
+    }
+
+    static let defaults: [WarningCharacter] = [
+        .init(scalarValue: 0x0003, note: "End of text"), .init(scalarValue: 0x00A0, note: "Non-breaking space"),
+        .init(scalarValue: 0x00AD, note: "Soft hyphen"), .init(scalarValue: 0x034F, note: "Combining grapheme joiner"),
+        .init(scalarValue: 0x037E, note: "Greek question mark"), .init(scalarValue: 0x061C, note: "Arabic letter mark"),
+        .init(scalarValue: 0x180E, note: "Mongolian vowel separator"), .init(scalarValue: 0x200B, note: "Zero-width space"),
+        .init(scalarValue: 0x200C, note: "Zero-width non-joiner"), .init(scalarValue: 0x200D, note: "Zero-width joiner"),
+        .init(scalarValue: 0x200E, note: "Left-to-right mark"), .init(scalarValue: 0x200F, note: "Right-to-left mark"),
+        .init(scalarValue: 0x2013, note: "En dash"), .init(scalarValue: 0x2018, note: "Left single quote"),
+        .init(scalarValue: 0x2019, note: "Right single quote"), .init(scalarValue: 0x201C, note: "Left double quote"),
+        .init(scalarValue: 0x201D, note: "Right double quote"), .init(scalarValue: 0x2029, note: "Paragraph separator"),
+        .init(scalarValue: 0x202A, note: "Left-to-right embedding"), .init(scalarValue: 0x202B, note: "Right-to-left embedding"),
+        .init(scalarValue: 0x202C, note: "Pop directional formatting"), .init(scalarValue: 0x202D, note: "Left-to-right override"),
+        .init(scalarValue: 0x202E, note: "Right-to-left override"), .init(scalarValue: 0x202F, note: "Narrow non-breaking space"),
+        .init(scalarValue: 0x2060, note: "Word joiner"), .init(scalarValue: 0x2061, note: "Function application"),
+        .init(scalarValue: 0x2062, note: "Invisible times"), .init(scalarValue: 0x2063, note: "Invisible separator"),
+        .init(scalarValue: 0x2064, note: "Invisible plus"), .init(scalarValue: 0x2066, note: "Left-to-right isolate"),
+        .init(scalarValue: 0x2067, note: "Right-to-left isolate"), .init(scalarValue: 0x2068, note: "First strong isolate"),
+        .init(scalarValue: 0x2069, note: "Pop directional isolate"), .init(scalarValue: 0xFEFF, note: "Zero-width no-break space / byte-order mark"),
+    ]
+}

--- a/Alas/Sources/Code/Editor/WarningCharacter.swift
+++ b/Alas/Sources/Code/Editor/WarningCharacter.swift
@@ -12,7 +12,10 @@ struct WarningCharacter: Codable, Equatable, Identifiable, Sendable {
         let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
         let value: UInt32?
         if trimmed.lowercased().hasPrefix("u+") {
-            value = UInt32(trimmed.dropFirst(2), radix: 16)
+            let digits = trimmed.dropFirst(2)
+            value = (4...6).contains(digits.count) && digits.allSatisfy(\.isHexDigit)
+                ? UInt32(digits, radix: 16)
+                : nil
         } else if input.unicodeScalars.count == 1 {
             value = input.unicodeScalars.first?.value
         } else if trimmed.unicodeScalars.count == 1 {

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -188,7 +188,8 @@ struct MarkdownTabView: View {
             originatingRelativePath: originatingRelativePath,
             fontFamily: appState.config.code.fontFamily,
             fontSize: appState.config.code.fontSize,
-            showLineNumbers: appState.config.code.showLineNumbers
+            showLineNumbers: appState.config.code.showLineNumbers,
+            textRendering: CodeEditorTextRenderingConfiguration(code: appState.config.code)
         )
     }
 

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -668,9 +668,18 @@ extension AppConfig {
             let showTabs = (try? codeContainer.decode(Bool.self, forKey: .showTabs)) ?? true
             let showLineEndings = (try? codeContainer.decode(Bool.self, forKey: .showLineEndings)) ?? true
             let showWarningCharacters = (try? codeContainer.decode(Bool.self, forKey: .showWarningCharacters)) ?? true
-            let warningCharacters = WarningCharacter.sanitized(
-                (try? codeContainer.decode([WarningCharacter].self, forKey: .warningCharacters)) ?? WarningCharacter.defaults
-            )
+            let warningCharacters: [WarningCharacter]
+            if var warnings = try? codeContainer.nestedUnkeyedContainer(forKey: .warningCharacters) {
+                var decoded: [WarningCharacter] = []
+                while !warnings.isAtEnd {
+                    if let decoder = try? warnings.superDecoder(), let warning = try? WarningCharacter(from: decoder) {
+                        decoded.append(warning)
+                    }
+                }
+                warningCharacters = WarningCharacter.sanitized(decoded)
+            } else {
+                warningCharacters = WarningCharacter.defaults
+            }
             code = Code(
                 fontFamily: fontFamily,
                 fontSize: fontSize,

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -297,10 +297,18 @@ struct AppConfig: Codable, Equatable {
         var languageServers: [LanguageServerConfig]
         var dismissedInstallNudges: [String]
         var userDefinedRecipes: [String: [InstallRecipe]]
+        var showInvisibleCharacters: Bool = false
+        var showSpaces: Bool = true
+        var showTabs: Bool = true
+        var showLineEndings: Bool = true
+        var showWarningCharacters: Bool = true
+        var warningCharacters: [WarningCharacter] = WarningCharacter.defaults
 
         enum CodingKeys: String, CodingKey {
             case fontFamily, fontSize, formatOnSave, showLineNumbers,
-                 languageServers, dismissedInstallNudges, userDefinedRecipes
+                 languageServers, dismissedInstallNudges, userDefinedRecipes,
+                 showInvisibleCharacters, showSpaces, showTabs, showLineEndings,
+                 showWarningCharacters, warningCharacters
         }
     }
 
@@ -655,6 +663,14 @@ extension AppConfig {
             let servers = (try? codeContainer.decode([LanguageServerConfig].self, forKey: .languageServers)) ?? []
             let dismissed = (try? codeContainer.decode([String].self, forKey: .dismissedInstallNudges)) ?? []
             let userRecipes = (try? codeContainer.decode([String: [InstallRecipe]].self, forKey: .userDefinedRecipes)) ?? [:]
+            let showInvisibleCharacters = (try? codeContainer.decode(Bool.self, forKey: .showInvisibleCharacters)) ?? false
+            let showSpaces = (try? codeContainer.decode(Bool.self, forKey: .showSpaces)) ?? true
+            let showTabs = (try? codeContainer.decode(Bool.self, forKey: .showTabs)) ?? true
+            let showLineEndings = (try? codeContainer.decode(Bool.self, forKey: .showLineEndings)) ?? true
+            let showWarningCharacters = (try? codeContainer.decode(Bool.self, forKey: .showWarningCharacters)) ?? true
+            let warningCharacters = WarningCharacter.sanitized(
+                (try? codeContainer.decode([WarningCharacter].self, forKey: .warningCharacters)) ?? WarningCharacter.defaults
+            )
             code = Code(
                 fontFamily: fontFamily,
                 fontSize: fontSize,
@@ -662,7 +678,13 @@ extension AppConfig {
                 showLineNumbers: showLineNumbers,
                 languageServers: servers,
                 dismissedInstallNudges: dismissed,
-                userDefinedRecipes: userRecipes
+                userDefinedRecipes: userRecipes,
+                showInvisibleCharacters: showInvisibleCharacters,
+                showSpaces: showSpaces,
+                showTabs: showTabs,
+                showLineEndings: showLineEndings,
+                showWarningCharacters: showWarningCharacters,
+                warningCharacters: warningCharacters
             )
         } else {
             code = Code(

--- a/Alas/Sources/Settings/CodePane.swift
+++ b/Alas/Sources/Settings/CodePane.swift
@@ -52,7 +52,8 @@ struct CodePane: View {
                     SettingsRow(name: "Tabs") { AlasToggle(on: state.bind(\.code.showTabs)).disabled(!state.config.code.showInvisibleCharacters) }
                     SettingsRow(name: "Line Endings") { AlasToggle(on: state.bind(\.code.showLineEndings)).disabled(!state.config.code.showInvisibleCharacters) }
                     SettingsRow(name: "Show Warning Characters") {
-                        HStack { AlasToggle(on: state.bind(\.code.showWarningCharacters)); AlasButton(title: "Configure…", style: .subtle) { warningCharactersVisible = true }.disabled(!state.config.code.showWarningCharacters) }
+                        HStack { AlasToggle(on: state.bind(\.code.showWarningCharacters))
+                        AlasButton(title: "Configure…", style: .subtle) { warningCharactersVisible = true }.disabled(!state.config.code.showWarningCharacters) }
                     }
                 }
 

--- a/Alas/Sources/Settings/CodePane.swift
+++ b/Alas/Sources/Settings/CodePane.swift
@@ -7,6 +7,7 @@ struct CodePane: View {
     @State private var selected: LanguageServerConfig?
     @State private var creatingNew = false
     @State private var installSheetVisible = false
+    @State private var warningCharactersVisible = false
 
     var body: some View {
         ScrollView {
@@ -40,6 +41,18 @@ struct CodePane: View {
                     SettingsRow(name: "Format on save",
                                 desc: "Request document formatting from the language server before writing to disk.") {
                         AlasToggle(on: state.bind(\.code.formatOnSave))
+                    }
+                }
+
+                SettingsGroup(title: "Text Rendering") {
+                    SettingsRow(name: "Show Invisible Characters") {
+                        AlasToggle(on: state.bind(\.code.showInvisibleCharacters))
+                    }
+                    SettingsRow(name: "Spaces") { AlasToggle(on: state.bind(\.code.showSpaces)).disabled(!state.config.code.showInvisibleCharacters) }
+                    SettingsRow(name: "Tabs") { AlasToggle(on: state.bind(\.code.showTabs)).disabled(!state.config.code.showInvisibleCharacters) }
+                    SettingsRow(name: "Line Endings") { AlasToggle(on: state.bind(\.code.showLineEndings)).disabled(!state.config.code.showInvisibleCharacters) }
+                    SettingsRow(name: "Show Warning Characters") {
+                        HStack { AlasToggle(on: state.bind(\.code.showWarningCharacters)); AlasButton(title: "Configure…", style: .subtle) { warningCharactersVisible = true }.disabled(!state.config.code.showWarningCharacters) }
                     }
                 }
 
@@ -89,6 +102,9 @@ struct CodePane: View {
                 onSave: { saved, recipes in save(originalLanguage: nil, saved, recipes: recipes) },
                 onCancel: { creatingNew = false }
             )
+        }
+        .sheet(isPresented: $warningCharactersVisible) {
+            WarningCharactersSheet(warnings: state.bind(\.code.warningCharacters))
         }
         .sheet(isPresented: $installSheetVisible, onDismiss: {
             // Interactive dismiss (Escape, click-out) bypasses the sheet's

--- a/Alas/Sources/Settings/WarningCharactersSheet.swift
+++ b/Alas/Sources/Settings/WarningCharactersSheet.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct WarningCharactersSheet: View {
+    @Binding var warnings: [WarningCharacter]
+    @Environment(\.dismiss) private var dismiss
+    @State private var selection: WarningCharacter.ID?
+    @State private var code = ""
+    @State private var note = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Warning Characters").font(.title2.bold())
+            Text("Alas highlights invisible or ambiguous characters in red.").foregroundStyle(.secondary)
+            List(selection: $selection) { ForEach(warnings) { warning in HStack { Text(warning.code).monospaced(); Text(warning.note) }.tag(warning.id) } }
+            HStack { TextField("U+200B or character", text: $code); TextField("Note", text: $note); Button("Add") { if let warning = WarningCharacter.parse(code, note: note), !warnings.contains(where: { $0.id == warning.id }) { warnings.append(warning); code = ""; note = "" } }.disabled(WarningCharacter.parse(code, note: note) == nil) }
+            HStack { Button("Remove") { warnings.removeAll { $0.id == selection }; selection = nil }.disabled(selection == nil); Button("Restore Defaults") { warnings = WarningCharacter.defaults }; Spacer(); Button("Done") { dismiss() }.keyboardShortcut(.defaultAction) }
+        }.padding().frame(minWidth: 560, minHeight: 420)
+    }
+}

--- a/Alas/Sources/Settings/WarningCharactersSheet.swift
+++ b/Alas/Sources/Settings/WarningCharactersSheet.swift
@@ -11,9 +11,18 @@ struct WarningCharactersSheet: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Warning Characters").font(.title2.bold())
             Text("Alas highlights invisible or ambiguous characters in red.").foregroundStyle(.secondary)
-            List(selection: $selection) { ForEach(warnings) { warning in HStack { Text(warning.code).monospaced(); Text(warning.note) }.tag(warning.id) } }
-            HStack { TextField("U+200B or character", text: $code); TextField("Note", text: $note); Button("Add") { if let warning = WarningCharacter.parse(code, note: note), !warnings.contains(where: { $0.id == warning.id }) { warnings.append(warning); code = ""; note = "" } }.disabled(WarningCharacter.parse(code, note: note) == nil) }
-            HStack { Button("Remove") { warnings.removeAll { $0.id == selection }; selection = nil }.disabled(selection == nil); Button("Restore Defaults") { warnings = WarningCharacter.defaults }; Spacer(); Button("Done") { dismiss() }.keyboardShortcut(.defaultAction) }
+            List(selection: $selection) { ForEach(warnings) { warning in HStack { Text(warning.code).monospaced()
+            Text(warning.note) }.tag(warning.id) } }
+            HStack { TextField("U+200B or character", text: $code)
+            TextField("Note", text: $note)
+            Button("Add") { if let warning = WarningCharacter.parse(code, note: note), !warnings.contains(where: { $0.id == warning.id }) { warnings.append(warning)
+            code = ""
+            note = "" } }.disabled(WarningCharacter.parse(code, note: note) == nil) }
+            HStack { Button("Remove") { warnings.removeAll { $0.id == selection }
+            selection = nil }.disabled(selection == nil)
+            Button("Restore Defaults") { warnings = WarningCharacter.defaults }
+            Spacer()
+            Button("Done") { dismiss() }.keyboardShortcut(.defaultAction) }
         }.padding().frame(minWidth: 560, minHeight: 420)
     }
 }

--- a/AlasTests/AppConfigCodeTextRenderingTests.swift
+++ b/AlasTests/AppConfigCodeTextRenderingTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("AppConfig code text rendering")
+struct AppConfigCodeTextRenderingTests {
+    private func decode(mutatingCode mutate: (inout [String: Any]) -> Void) throws -> AppConfig {
+        let encoded = try JSONEncoder().encode(AppConfig.defaults)
+        var root = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        var code = try #require(root["code"] as? [String: Any])
+        mutate(&code)
+        root["code"] = code
+        let data = try JSONSerialization.data(withJSONObject: root)
+        return try JSONDecoder().decode(AppConfig.self, from: data)
+    }
+
+    @Test func missingKeysUseProductDefaults() throws {
+        let decoded = try decode { code in
+            [
+                "showInvisibleCharacters",
+                "showSpaces",
+                "showTabs",
+                "showLineEndings",
+                "showWarningCharacters",
+                "warningCharacters",
+            ].forEach { code.removeValue(forKey: $0) }
+        }
+
+        #expect(!decoded.code.showInvisibleCharacters)
+        #expect(decoded.code.showSpaces && decoded.code.showTabs && decoded.code.showLineEndings)
+        #expect(decoded.code.showWarningCharacters)
+        #expect(decoded.code.warningCharacters == WarningCharacter.defaults)
+    }
+
+    @Test func explicitEmptyWarningListStaysEmpty() throws {
+        let decoded = try decode { code in
+            code["warningCharacters"] = []
+        }
+
+        #expect(decoded.code.warningCharacters.isEmpty)
+    }
+
+    @Test func decodedWarningsAreSanitized() throws {
+        let decoded = try decode { code in
+            code["warningCharacters"] = [
+                ["scalarValue": 0x200B, "note": "First"],
+                ["scalarValue": 0x110000, "note": "Invalid"],
+                ["scalarValue": 0x200B, "note": "Second"],
+            ]
+        }
+
+        #expect(decoded.code.warningCharacters == [WarningCharacter(scalarValue: 0x200B, note: "First")])
+    }
+
+    @Test func settingsRoundTrip() throws {
+        var config = AppConfig.defaults
+        config.code.showInvisibleCharacters = true
+        config.code.showSpaces = false
+        config.code.warningCharacters = [.init(scalarValue: 0x200B, note: "ZWSP")]
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: JSONEncoder().encode(config))
+        #expect(decoded.code == config.code)
+    }
+}

--- a/AlasTests/AppConfigCodeTextRenderingTests.swift
+++ b/AlasTests/AppConfigCodeTextRenderingTests.swift
@@ -52,6 +52,17 @@ struct AppConfigCodeTextRenderingTests {
         #expect(decoded.code.warningCharacters == [WarningCharacter(scalarValue: 0x200B, note: "First")])
     }
 
+    @Test func malformedWarningDoesNotDiscardValidEntries() throws {
+        let decoded = try decode { code in
+            code["warningCharacters"] = [
+                ["scalarValue": 0x200B, "note": "Valid"],
+                ["scalarValue": "not a number", "note": "Invalid"],
+            ]
+        }
+
+        #expect(decoded.code.warningCharacters == [WarningCharacter(scalarValue: 0x200B, note: "Valid")])
+    }
+
     @Test func settingsRoundTrip() throws {
         var config = AppConfig.defaults
         config.code.showInvisibleCharacters = true

--- a/AlasTests/WarningCharacterTests.swift
+++ b/AlasTests/WarningCharacterTests.swift
@@ -15,6 +15,8 @@ struct WarningCharacterTests {
         #expect(WarningCharacter.parse("ab", note: "") == nil)
         #expect(WarningCharacter.parse("U+D800", note: "") == nil)
         #expect(WarningCharacter.parse("U+110000", note: "") == nil)
+        #expect(WarningCharacter.parse("U+1", note: "") == nil)
+        #expect(WarningCharacter.parse("U+00000041", note: "") == nil)
     }
 
     @Test func sanitizesEntries() {

--- a/AlasTests/WarningCharacterTests.swift
+++ b/AlasTests/WarningCharacterTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import Alas
+
+@Suite("Warning character")
+struct WarningCharacterTests {
+    @Test func parsesCodePointAndLiteralScalar() {
+        #expect(WarningCharacter.parse("u+200b", note: " Zero-width space ") ==
+            WarningCharacter(scalarValue: 0x200B, note: "Zero-width space"))
+        #expect(WarningCharacter.parse("\u{00A0}", note: "NBSP")?.scalarValue == 0x00A0)
+        #expect(WarningCharacter.parse("💩", note: "")?.code == "U+1F4A9")
+    }
+
+    @Test func rejectsInvalidInput() {
+        #expect(WarningCharacter.parse("", note: "") == nil)
+        #expect(WarningCharacter.parse("ab", note: "") == nil)
+        #expect(WarningCharacter.parse("U+D800", note: "") == nil)
+        #expect(WarningCharacter.parse("U+110000", note: "") == nil)
+    }
+
+    @Test func sanitizesEntries() {
+        let entries = [
+            WarningCharacter(scalarValue: 0x200B, note: "First"),
+            WarningCharacter(scalarValue: 0x110000, note: "Invalid"),
+            WarningCharacter(scalarValue: 0x200B, note: "Second"),
+        ]
+        #expect(WarningCharacter.sanitized(entries) == [
+            WarningCharacter(scalarValue: 0x200B, note: "First")
+        ])
+    }
+
+    @Test func defaultsCoverAmbiguousAndBidiCharacters() {
+        #expect(WarningCharacter.defaults.contains { $0.scalarValue == 0x2013 && $0.note == "En dash" })
+        #expect(WarningCharacter.defaults.contains { $0.scalarValue == 0x202E })
+        #expect(WarningCharacter.defaults.contains { $0.scalarValue == 0x2069 })
+        #expect(WarningCharacter.defaults.map(\.scalarValue).count == Set(WarningCharacter.defaults.map(\.scalarValue)).count)
+    }
+}

--- a/AlasTests/WarningCharacterTests.swift
+++ b/AlasTests/WarningCharacterTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Alas
 
@@ -35,5 +36,15 @@ struct WarningCharacterTests {
         #expect(WarningCharacter.defaults.contains { $0.scalarValue == 0x202E })
         #expect(WarningCharacter.defaults.contains { $0.scalarValue == 0x2069 })
         #expect(WarningCharacter.defaults.map(\.scalarValue).count == Set(WarningCharacter.defaults.map(\.scalarValue)).count)
+    }
+
+    @Test func findsWarningsWithinComposedCharacterSequences() {
+        let text = "a\u{034F}"
+
+        #expect(CodeEditorLayoutManager.warningCharacterRanges(
+            in: text as NSString,
+            composedRange: NSRange(location: 0, length: 2),
+            warningScalars: [0x034F]
+        ) == [(0x034F, NSRange(location: 1, length: 1))])
     }
 }

--- a/AlasTests/WarningCharacterTests.swift
+++ b/AlasTests/WarningCharacterTests.swift
@@ -59,4 +59,9 @@ struct WarningCharacterTests {
         #expect(!CodeEditorLayoutManager.usesInsertionMarker(for: "\n".unicodeScalars.first!))
         #expect(!CodeEditorLayoutManager.usesInsertionMarker(for: Unicode.Scalar(0x2013)!))
     }
+
+    @Test func usesScalarMarkerForPartialCompositeGlyphWarnings() {
+        #expect(CodeEditorLayoutManager.usesScalarMarker(for: Unicode.Scalar(0x1F3FD), range: NSRange(location: 2, length: 2), glyphCharacterRange: NSRange(location: 0, length: 4)))
+        #expect(!CodeEditorLayoutManager.usesScalarMarker(for: Unicode.Scalar(0x2013), range: NSRange(location: 0, length: 1), glyphCharacterRange: NSRange(location: 0, length: 1)))
+    }
 }

--- a/AlasTests/WarningCharacterTests.swift
+++ b/AlasTests/WarningCharacterTests.swift
@@ -41,10 +41,20 @@ struct WarningCharacterTests {
     @Test func findsWarningsWithinComposedCharacterSequences() {
         let text = "a\u{034F}"
 
-        #expect(CodeEditorLayoutManager.warningCharacterRanges(
+        let ranges = CodeEditorLayoutManager.warningCharacterRanges(
             in: text as NSString,
             composedRange: NSRange(location: 0, length: 2),
             warningScalars: [0x034F]
-        ) == [(0x034F, NSRange(location: 1, length: 1))])
+        )
+
+        #expect(ranges.count == 1)
+        #expect(ranges.first?.0 == 0x034F)
+        #expect(ranges.first?.1 == NSRange(location: 1, length: 1))
+    }
+
+    @Test func usesInsertionMarkersForZeroWidthWarnings() {
+        #expect(CodeEditorLayoutManager.usesInsertionMarker(for: Unicode.Scalar(0x034F)!))
+        #expect(CodeEditorLayoutManager.usesInsertionMarker(for: Unicode.Scalar(0x200D)!))
+        #expect(!CodeEditorLayoutManager.usesInsertionMarker(for: Unicode.Scalar(0x2013)!))
     }
 }

--- a/AlasTests/WarningCharacterTests.swift
+++ b/AlasTests/WarningCharacterTests.swift
@@ -55,6 +55,8 @@ struct WarningCharacterTests {
     @Test func usesInsertionMarkersForZeroWidthWarnings() {
         #expect(CodeEditorLayoutManager.usesInsertionMarker(for: Unicode.Scalar(0x034F)!))
         #expect(CodeEditorLayoutManager.usesInsertionMarker(for: Unicode.Scalar(0x200D)!))
+        #expect(!CodeEditorLayoutManager.usesInsertionMarker(for: "\t".unicodeScalars.first!))
+        #expect(!CodeEditorLayoutManager.usesInsertionMarker(for: "\n".unicodeScalars.first!))
         #expect(!CodeEditorLayoutManager.usesInsertionMarker(for: Unicode.Scalar(0x2013)!))
     }
 }

--- a/docs/superpowers/specs/2026-08-17-editor-invisible-warning-characters-design.md
+++ b/docs/superpowers/specs/2026-08-17-editor-invisible-warning-characters-design.md
@@ -1,0 +1,268 @@
+# Editor Invisible and Warning Characters Design
+
+Date: 2026-08-17
+
+## Summary
+
+Add global text-rendering preferences for editable file tabs. Alas will render
+fixed markers for ordinary invisible characters and highlight a configurable
+set of suspicious Unicode scalars without changing the editor buffer. This is
+the first implementation slice from a broader audit of Agentastic's Text
+Editing settings.
+
+## Goals
+
+- Make spaces, tabs, and logical line endings optionally visible.
+- Highlight suspicious Unicode scalars by default.
+- Explain each highlighted scalar through a native hover tooltip.
+- Let users add, remove, and restore warning entries.
+- Apply settings live to every mounted editable file tab.
+- Preserve copied text, saved text, undo history, syntax styling, diagnostics,
+  selections, and LSP offsets.
+- Remain responsive on large files by decorating only requested glyph ranges.
+
+## Non-goals
+
+- Read-only diffs, merge panes, Markdown previews, chat code blocks, or prompt
+  editors.
+- Workspace-specific or language-specific overrides.
+- Arbitrary replacement glyphs for invisible characters.
+- A menu item or keyboard shortcut for toggling these settings.
+- Minimap, folding, overscroll, bracket highlighting, or indentation-policy
+  changes.
+
+## Current Alas behavior
+
+Alas uses an AppKit `NSTextView` and TextKit 1 chain built in
+`CodeEditorView`. Each tab owns an `EditorBuffer` whose `NSTextStorage` is
+shared across view remounts. `CodeEditorCoordinator` reapplies base,
+tree-sitter, diagnostic, and reveal styling. `CodeEditorView` already receives
+font and line-number settings as explicit inputs so SwiftUI calls
+`updateNSView` when they change.
+
+Line endings are canonicalized to LF in memory. `EditorBuffer` separately
+records whether the file uses LF or CRLF and restores that style on save.
+Consequently, the editor cannot meaningfully draw distinct in-memory LF and CR
+characters. It will display one logical line-ending marker.
+
+## Settings UI
+
+Add a **Text Rendering** group to Settings > Code.
+
+1. **Show invisible characters** defaults to off.
+2. Three inline subordinate toggles show their fixed markers:
+   - **Spaces** `·`
+   - **Tabs** `→`
+   - **Line endings** `↵`
+3. The subordinate toggles default to on. They remain persisted but appear
+   disabled while the master toggle is off.
+4. **Show warning characters** defaults to on and has a **Configure…** button.
+5. **Configure…** opens a sheet containing an ordered table with Unicode code,
+   note, add, remove, **Restore Defaults**, and **Done** controls.
+6. Table changes save immediately. **Done** only closes the sheet.
+7. Adding an entry accepts either `U+XXXX` notation or one pasted Unicode
+   scalar, plus an optional note.
+
+The invisible-character configuration sheet shown by Agentastic is omitted:
+with fixed markers it would contain only the same three toggles already visible
+inline.
+
+## Configuration model
+
+Extend global `AppConfig.Code` with:
+
+- `showInvisibleCharacters: Bool` (default `false`)
+- `showSpaces: Bool` (default `true`)
+- `showTabs: Bool` (default `true`)
+- `showLineEndings: Bool` (default `true`)
+- `showWarningCharacters: Bool` (default `true`)
+- `warningCharacters: [WarningCharacter]` (default list below)
+
+`WarningCharacter` is a small Codable, Equatable value containing a Unicode
+scalar value and a note. Order is preserved for the settings table; rendering
+builds a scalar-keyed lookup dictionary.
+
+Missing keys decode to defaults. During decode, invalid scalar values are
+discarded individually and duplicate values keep their first occurrence. An
+empty warning list is valid and remains empty. **Restore Defaults** replaces
+the list with the complete default list.
+
+## Default warning characters
+
+The defaults retain the characters shown by Agentastic, correct U+2013's name
+to En dash, and add common zero-width and bidirectional controls.
+
+| Code | Note |
+|---|---|
+| U+0003 | End of text |
+| U+00A0 | Non-breaking space |
+| U+00AD | Soft hyphen |
+| U+034F | Combining grapheme joiner |
+| U+037E | Greek question mark |
+| U+061C | Arabic letter mark |
+| U+180E | Mongolian vowel separator |
+| U+200B | Zero-width space |
+| U+200C | Zero-width non-joiner |
+| U+200D | Zero-width joiner |
+| U+200E | Left-to-right mark |
+| U+200F | Right-to-left mark |
+| U+2013 | En dash |
+| U+2018 | Left single quote |
+| U+2019 | Right single quote |
+| U+201C | Left double quote |
+| U+201D | Right double quote |
+| U+2029 | Paragraph separator |
+| U+202A | Left-to-right embedding |
+| U+202B | Right-to-left embedding |
+| U+202C | Pop directional formatting |
+| U+202D | Left-to-right override |
+| U+202E | Right-to-left override |
+| U+202F | Narrow non-breaking space |
+| U+2060 | Word joiner |
+| U+2061 | Function application |
+| U+2062 | Invisible times |
+| U+2063 | Invisible separator |
+| U+2064 | Invisible plus |
+| U+2066 | Left-to-right isolate |
+| U+2067 | Right-to-left isolate |
+| U+2068 | First strong isolate |
+| U+2069 | Pop directional isolate |
+| U+FEFF | Zero-width no-break space / byte-order mark |
+
+This intentionally does not warn on all non-ASCII text. Legitimate
+multilingual source remains usable.
+
+## Rendering architecture
+
+Replace the plain layout manager created by `CodeEditorView` with a small
+`CodeEditorLayoutManager` subclass. It owns the current rendering settings,
+warning lookup, and theme colors.
+
+The layout manager lets TextKit draw text normally, then decorates only the
+glyph range TextKit requested:
+
+- Enabled spaces, tabs, and logical newlines receive their fixed marker in the
+  theme's faint foreground color.
+- A visible warning scalar keeps its syntax foreground color and receives a
+  theme-aware red background based on the existing deletion color.
+- A zero-width warning receives a one-character-width red marker at its
+  insertion position without changing layout.
+- Warning treatment takes precedence when a scalar also belongs to an enabled
+  invisible category.
+
+Decoration never adds attributes to `NSTextStorage` and never substitutes its
+characters. Text edits continue through the existing buffer/coordinator path;
+TextKit invalidates affected layout naturally.
+
+`CodeEditorView` receives the rendering configuration as explicit value inputs.
+In `updateNSView`, it updates the layout manager and invalidates display if the
+configuration or theme changed. This makes every currently mounted editor
+react immediately while preserving the existing SwiftUI/AppKit boundary.
+
+## Warning hover behavior
+
+`CodeTextView`'s existing mouse tracking also asks the layout manager for a
+warning decoration at the pointer location. The hit region is the normal glyph
+bounds for visible characters and the drawn marker bounds for zero-width
+characters.
+
+AppKit's native tooltip displays:
+
+```text
+U+200B — Zero-width space
+```
+
+If the note is empty, it displays only the normalized code. The warning tooltip
+wins only while the pointer is directly over a warning decoration and does not
+disable LSP hover elsewhere. The tooltip contains no actions or links.
+
+## Input validation
+
+- Trim surrounding whitespace.
+- Accept case-insensitive `U+` notation with four to six hexadecimal digits,
+  or a literal containing exactly one Unicode scalar.
+- Reject surrogate values, values above U+10FFFF, empty input, multiple
+  scalars, and duplicates.
+- Normalize displayed codes to uppercase `U+` notation with at least four
+  hexadecimal digits.
+- Allow an empty note.
+
+Validation occurs before mutating or saving the table.
+
+## Performance
+
+Rendering scans only the character range corresponding to the glyph range
+TextKit already asked to draw. Warning membership is an O(1) dictionary lookup.
+No document-wide scan, background task, decoration cache, observer graph, or
+new dependency is introduced.
+
+Supplementary-plane scalars are treated as one warning even though their
+TextKit character range contains two UTF-16 code units.
+
+## Tests
+
+Automated tests use Swift Testing and cover:
+
+- Decoding old configuration without the new keys.
+- Configuration round trips and default restoration.
+- Per-entry filtering of invalid persisted values and first-entry duplicate
+  handling.
+- Parsing `U+` notation and literal scalars, including supplementary-plane
+  values.
+- Rejecting malformed, surrogate, multi-scalar, and duplicate input.
+- Decoration ranges for enabled spaces, tabs, and newlines.
+- Independent category and master-toggle behavior.
+- Visible and zero-width warnings, including warning precedence.
+- UTF-16 range correctness for supplementary-plane scalars.
+- Rendering configuration changes without any mutation to storage text.
+
+Manual verification covers live changes across multiple tabs, warning
+tooltips, syntax highlighting, diagnostics, selections, light and dark themes,
+CRLF save preservation, and scrolling/editing a large file.
+
+## Acceptance criteria
+
+1. Existing users receive invisible characters off and warning characters on
+   without a migration failure.
+2. The three invisible categories can be toggled independently and update open
+   editable file tabs immediately.
+3. Disabling and re-enabling the invisible master toggle preserves category
+   choices.
+4. LF and CRLF files show the same logical line marker and retain their original
+   disk line-ending style after save.
+5. Warning defaults match the table in this document.
+6. Users can add entries using normalized code notation or a literal scalar,
+   remove any entry, and restore defaults.
+7. Warning matches appear in code, comments, and strings.
+8. Visible warning characters receive a red background; zero-width warning
+   characters receive a visible red marker.
+9. Hovering either treatment shows its normalized code and configured note.
+10. Copy, save, undo, highlighting, diagnostics, selection, and LSP positions
+    behave as they did before the feature.
+11. Read-only and non-file editor surfaces are unchanged.
+
+## Broader Text Editing audit
+
+| Agentastic option | Alas status and follow-up |
+|---|---|
+| Font and Markdown mode | Already supported; retain existing locations |
+| Use System Cursor | Native `NSTextView` behavior; no setting needed |
+| Show Gutter | Existing Show Line Numbers setting is sufficient |
+| Autocomplete braces and type-over | Already implemented and always on; optional future toggles |
+| Indent style, indent width, tab width | Current editor auto-detects; design separately with possible EditorConfig support |
+| Line wrapping | Small editor-preferences follow-up |
+| Reformatting guide and column | Small editor-preferences follow-up |
+| Overscroll | Independent follow-up |
+| Bracket-pair highlight | Independent editor feature |
+| Minimap and folding ribbon | Substantial features requiring dedicated designs |
+| Invisible and warning characters | This implementation slice |
+
+After this slice, wrapping, delimiter toggles, and a column guide may be grouped
+into one small editor-preferences change. Indentation policy, minimap, and
+folding remain separate until explicitly prioritized.
+
+## References
+
+- Apple `NSLayoutManager`: https://developer.apple.com/documentation/appkit/nslayoutmanager
+- CodeEdit release notes describing customizable invisible and warning
+  characters: https://www.codeedit.app/whats-new


### PR DESCRIPTION
Summary: Persist global invisible and warning-character settings; render whitespace and warning markers in editable file editors; add Code settings, warning configuration, and hover tooltips. Validation: app build succeeded; focused warning-character persistence tests passed (8 tests).