### PR TITLE
fix: recover from interrupted startup

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 		27F842092C9CA4D871B6127A /* DraftReviewRequestDiffSessionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615B4D8618F0BDEAEB216942 /* DraftReviewRequestDiffSessionBuilder.swift */; };
 		281C65FD7F2B509B963B74ED /* AlasHookCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */; };
 		2843F603A4D71AEEA4C09317 /* CloseTabConfirmationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78D0715973BD840FDE95AA2 /* CloseTabConfirmationPolicy.swift */; };
+		285BEFDF742866D620398EB3 /* StartupRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB18B529D24C1BAE68B443B /* StartupRecoveryTests.swift */; };
 		28710B18EF9FAE100B99E0A7 /* ACPThumbnailImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E9B2665E18F4C4BF3FB683 /* ACPThumbnailImageCacheTests.swift */; };
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
 		28D8C1BBA0B577679782AA68 /* ACPMarkdownInlineTextViewMeasurementCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D73156DBE6DB95469D4D80 /* ACPMarkdownInlineTextViewMeasurementCacheTests.swift */; };
@@ -2491,6 +2492,7 @@
 		9B1E93FE66457A82A3348EDA /* GGMCPInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGMCPInjection.swift; sourceTree = "<group>"; };
 		9B3DCDC9F76F91CE1071471C /* StagedDiffSelectionBridgingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedDiffSelectionBridgingTests.swift; sourceTree = "<group>"; };
 		9B44E54236211F972F3D1C24 /* RemoteFileOps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileOps.swift; sourceTree = "<group>"; };
+		9BB18B529D24C1BAE68B443B /* StartupRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupRecoveryTests.swift; sourceTree = "<group>"; };
 		9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneTransitionalView.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
 		9C4B3503EDFD4AAEAA6894FE /* PairedDelimiterEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedDelimiterEditing.swift; sourceTree = "<group>"; };
@@ -3645,6 +3647,7 @@
 				CEA8BA11A167DA43E22E7D2D /* SpacesManagerTests.swift */,
 				99CD99C81057F377C5E249B7 /* StagedDiffLoaderTests.swift */,
 				9B3DCDC9F76F91CE1071471C /* StagedDiffSelectionBridgingTests.swift */,
+				9BB18B529D24C1BAE68B443B /* StartupRecoveryTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
 				9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */,
 				DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */,
@@ -7413,6 +7416,7 @@
 				D87EC73A848929FFB819888C /* SpacesManagerTests.swift in Sources */,
 				4FD9E5FFB4C75850CF7B2FE7 /* StagedDiffLoaderTests.swift in Sources */,
 				249E943D5C46A84496390B31 /* StagedDiffSelectionBridgingTests.swift in Sources */,
+				285BEFDF742866D620398EB3 /* StartupRecoveryTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,
 				771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */,
 				FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -11,6 +11,7 @@ struct ACPTabView: View {
     let sessionId: ACPSession.ID
     let state: AppState
     let worktree: Worktree
+    var onStartupRecoveryReady: () -> Void = {}
 
     var body: some View {
         if let manager = state.acpManager(for: worktree) {
@@ -18,6 +19,7 @@ struct ACPTabView: View {
                 sessionId: sessionId,
                 state: state,
                 worktree: worktree,
+                onStartupRecoveryReady: onStartupRecoveryReady,
                 manager: manager
             )
         } else {
@@ -39,6 +41,7 @@ private struct ACPManagedTabView: View {
     let sessionId: ACPSession.ID
     let state: AppState
     let worktree: Worktree
+    let onStartupRecoveryReady: () -> Void
     @ObservedObject var manager: ACPSessionManager
 
     var body: some View {
@@ -49,6 +52,7 @@ private struct ACPManagedTabView: View {
                 worktree: worktree,
                 manager: manager,
                 session: session,
+                onStartupRecoveryReady: onStartupRecoveryReady,
                 transcript: session.transcript
             )
             // Refcount this tab's hold on the cached `ACPSession`. When the
@@ -93,6 +97,7 @@ private struct ACPSessionView: View {
     let worktree: Worktree
     let manager: ACPSessionManager
     @ObservedObject var session: ACPSession
+    let onStartupRecoveryReady: () -> Void
     /// Observed so the body re-evaluates when pending user action arrives.
     /// `scopeKey(for:)` reads the permission value through this and passes
     /// it down to `ACPMessageList`; otherwise the message list gets a stale
@@ -156,7 +161,7 @@ private struct ACPSessionView: View {
         }
         .task(id: sessionId) {
             await hydrateAndAttach()
-            state.completeStartupRecovery()
+            onStartupRecoveryReady()
         }
         .onExitCommand {
             handleEscape()

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -156,6 +156,7 @@ private struct ACPSessionView: View {
         }
         .task(id: sessionId) {
             await hydrateAndAttach()
+            state.completeStartupRecovery()
         }
         .onExitCommand {
             handleEscape()

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -76,6 +76,9 @@ private struct ACPManagedTabView: View {
                     Spacer()
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .task {
+                    onStartupRecoveryReady()
+                }
             } else {
                 ProgressView()
                     .controlSize(.small)

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 @main
 struct AlasApp: App {
     @NSApplicationDelegateAdaptor(AlasApplicationDelegate.self) private var appDelegate
-    @State private var state = AppState()
+    @State private var state: AppState
 
     private static var isRunningUnitTests: Bool {
         let environment = ProcessInfo.processInfo.environment
@@ -20,6 +20,15 @@ struct AlasApp: App {
     }
 
     init() {
+        if Self.isRunningUnitTests {
+            _state = State(initialValue: AppState())
+        } else {
+            let recovery = StartupRecovery()
+            _state = State(initialValue: AppState(
+                restoreActiveTabsOnStartup: !recovery.begin()
+            ))
+            AlasTerminationCoordinator.shared.finish = recovery.finish
+        }
         BundledFontRegistrar.registerFonts()
         // Refresh Gatekeeper cache when the user returns from System Settings
         // after granting permission to a blocked LSP binary.

--- a/Alas/Sources/App/AlasApplicationDelegate.swift
+++ b/Alas/Sources/App/AlasApplicationDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Darwin
 
 @MainActor
 final class AlasTerminationCoordinator {
@@ -35,20 +36,59 @@ final class AlasApplicationDelegate: NSObject, NSApplicationDelegate {
 }
 
 struct StartupRecovery {
+    let markerDirectory: URL
     let markerURL: URL
+    private let processID: Int32
+    private let isProcessAlive: (Int32) -> Bool
 
-    init(markerURL: URL = Paths.appSupportRoot.appendingPathComponent("launching")) {
-        self.markerURL = markerURL
+    init(
+        markerDirectory: URL = Paths.appSupportRoot,
+        processID: Int32 = getpid(),
+        isProcessAlive: @escaping (Int32) -> Bool = StartupRecovery.processIsAlive
+    ) {
+        self.markerDirectory = markerDirectory
+        self.processID = processID
+        self.isProcessAlive = isProcessAlive
+        markerURL = markerDirectory.appendingPathComponent("launching-\(processID)-\(UUID().uuidString)")
     }
 
     func begin() -> Bool {
-        let previousLaunchDidNotFinish = FileManager.default.fileExists(atPath: markerURL.path)
-        try? Paths.ensureDirectoryExists(markerURL.deletingLastPathComponent())
+        try? Paths.ensureDirectoryExists(markerDirectory)
+        let previousLaunchDidNotFinish = removeAbandonedMarkers()
         _ = FileManager.default.createFile(atPath: markerURL.path, contents: Data())
         return previousLaunchDidNotFinish
     }
 
     func finish() {
         try? FileManager.default.removeItem(at: markerURL)
+    }
+
+    private func removeAbandonedMarkers() -> Bool {
+        guard let markerNames = try? FileManager.default.contentsOfDirectory(atPath: markerDirectory.path) else {
+            return false
+        }
+        var foundAbandonedMarker = false
+        for markerName in markerNames {
+            let marker = markerDirectory.appendingPathComponent(markerName)
+            if markerName == "launching" {
+                try? FileManager.default.removeItem(at: marker)
+                foundAbandonedMarker = true
+                continue
+            }
+            let components = markerName.split(separator: "-", maxSplits: 2)
+            guard components.count == 3,
+                  components[0] == "launching",
+                  let markerPID = Int32(components[1]),
+                  !isProcessAlive(markerPID) else { continue }
+            try? FileManager.default.removeItem(at: marker)
+            foundAbandonedMarker = true
+        }
+        return foundAbandonedMarker
+    }
+
+    private static func processIsAlive(_ pid: Int32) -> Bool {
+        guard pid > 0 else { return false }
+        if Darwin.kill(pid, 0) == 0 { return true }
+        return errno == EPERM
     }
 }

--- a/Alas/Sources/App/AlasApplicationDelegate.swift
+++ b/Alas/Sources/App/AlasApplicationDelegate.swift
@@ -5,6 +5,7 @@ final class AlasTerminationCoordinator {
     static let shared = AlasTerminationCoordinator()
 
     var flush: (() async -> Void)?
+    var finish: (() -> Void)?
 
     private init() {}
 }
@@ -26,8 +27,28 @@ final class AlasApplicationDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        AlasTerminationCoordinator.shared.finish?()
         // Synchronous and non-isolated: a detached Task would need to hop onto
         // the actor before running, and the process exits before that happens.
         try? FileManager.default.removeItem(at: RevisionSnapshotCache.shared.sessionDirectory)
+    }
+}
+
+struct StartupRecovery {
+    let markerURL: URL
+
+    init(markerURL: URL = Paths.appSupportRoot.appendingPathComponent("launching")) {
+        self.markerURL = markerURL
+    }
+
+    func begin() -> Bool {
+        let previousLaunchDidNotFinish = FileManager.default.fileExists(atPath: markerURL.path)
+        try? Paths.ensureDirectoryExists(markerURL.deletingLastPathComponent())
+        _ = FileManager.default.createFile(atPath: markerURL.path, contents: Data())
+        return previousLaunchDidNotFinish
+    }
+
+    func finish() {
+        try? FileManager.default.removeItem(at: markerURL)
     }
 }

--- a/Alas/Sources/App/AlasApplicationDelegate.swift
+++ b/Alas/Sources/App/AlasApplicationDelegate.swift
@@ -16,6 +16,7 @@ final class AlasApplicationDelegate: NSObject, NSApplicationDelegate {
     private var terminationInProgress = false
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        AlasTerminationCoordinator.shared.finish?()
         guard !terminationInProgress, let flush = AlasTerminationCoordinator.shared.flush else {
             return .terminateNow
         }
@@ -28,6 +29,7 @@ final class AlasApplicationDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        AlasTerminationCoordinator.shared.finish?()
         // Synchronous and non-isolated: a detached Task would need to hop onto
         // the actor before running, and the process exits before that happens.
         try? FileManager.default.removeItem(at: RevisionSnapshotCache.shared.sessionDirectory)

--- a/Alas/Sources/App/AlasApplicationDelegate.swift
+++ b/Alas/Sources/App/AlasApplicationDelegate.swift
@@ -28,7 +28,6 @@ final class AlasApplicationDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
-        AlasTerminationCoordinator.shared.finish?()
         // Synchronous and non-isolated: a detached Task would need to hop onto
         // the actor before running, and the process exits before that happens.
         try? FileManager.default.removeItem(at: RevisionSnapshotCache.shared.sessionDirectory)

--- a/Alas/Sources/App/AlasApplicationDelegate.swift
+++ b/Alas/Sources/App/AlasApplicationDelegate.swift
@@ -40,16 +40,20 @@ struct StartupRecovery {
     let markerURL: URL
     private let processID: Int32
     private let isProcessAlive: (Int32) -> Bool
+    private let processStartTime: (Int32) -> TimeInterval?
 
     init(
         markerDirectory: URL = Paths.appSupportRoot,
         processID: Int32 = getpid(),
-        isProcessAlive: @escaping (Int32) -> Bool = StartupRecovery.processIsAlive
+        isProcessAlive: @escaping (Int32) -> Bool = StartupRecovery.processIsAlive,
+        processStartTime: @escaping (Int32) -> TimeInterval? = StartupRecovery.processStartTime
     ) {
         self.markerDirectory = markerDirectory
         self.processID = processID
         self.isProcessAlive = isProcessAlive
-        markerURL = markerDirectory.appendingPathComponent("launching-\(processID)-\(UUID().uuidString)")
+        self.processStartTime = processStartTime
+        let startTime = processStartTime(processID).map { Int64($0 * 1_000_000) } ?? 0
+        markerURL = markerDirectory.appendingPathComponent("launching-\(processID)-\(startTime)-\(UUID().uuidString)")
     }
 
     func begin() -> Bool {
@@ -75,11 +79,16 @@ struct StartupRecovery {
                 foundAbandonedMarker = true
                 continue
             }
-            let components = markerName.split(separator: "-", maxSplits: 2)
-            guard components.count == 3,
+            let components = markerName.split(separator: "-", maxSplits: 3)
+            guard components.count == 4,
                   components[0] == "launching",
                   let markerPID = Int32(components[1]),
-                  !isProcessAlive(markerPID) else { continue }
+                  let markerStartTime = Int64(components[2]) else { continue }
+            if isProcessAlive(markerPID),
+               let currentStartTime = processStartTime(markerPID).map({ Int64($0 * 1_000_000) }),
+               currentStartTime == markerStartTime {
+                continue
+            }
             try? FileManager.default.removeItem(at: marker)
             foundAbandonedMarker = true
         }
@@ -90,5 +99,17 @@ struct StartupRecovery {
         guard pid > 0 else { return false }
         if Darwin.kill(pid, 0) == 0 { return true }
         return errno == EPERM
+    }
+
+    private static func processStartTime(_ pid: Int32) -> TimeInterval? {
+        var info = proc_bsdinfo()
+        let size = MemoryLayout<proc_bsdinfo>.stride
+        let read = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: UInt8.self, capacity: size) {
+                proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, $0, Int32(size))
+            }
+        }
+        guard read == Int32(size) else { return nil }
+        return TimeInterval(info.pbi_start_tvsec) + TimeInterval(info.pbi_start_tvusec) / 1_000_000
     }
 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -554,6 +554,8 @@ final class AppState {
     @ObservationIgnored
     private let store: any PersistenceStoreProtocol
     @ObservationIgnored
+    private var restoreActiveTabsOnNextReload: Bool
+    @ObservationIgnored
     private let persistenceErrorHandler: (String, String) -> Void
     @ObservationIgnored
     private let fileActionErrorHandler: (String, String) -> Void
@@ -585,9 +587,11 @@ final class AppState {
         remoteAccelerationPreparer: RemoteAccelerationPreparer? = nil,
         projectGitWatcherFactory: @escaping @MainActor (URL) -> ProjectGitWatcher = { ProjectGitWatcher(repoPath: $0) },
         runScriptCompletionWaiter: @escaping RunScriptCompletionWaiter = RunScriptCompletionMonitor.wait(for:),
-        tabsManager: TabsManager? = nil
+        tabsManager: TabsManager? = nil,
+        restoreActiveTabsOnStartup: Bool = true
     ) {
         self.store = store
+        restoreActiveTabsOnNextReload = restoreActiveTabsOnStartup
         _tabs = tabsManager
         self.persistenceErrorHandler = persistenceErrorHandler ?? { title, message in
             AppState.showWarningAlert(title: title, message: message)
@@ -918,7 +922,11 @@ final class AppState {
         let allWorktreeIds = projectsManager.projects.flatMap {
             projectsManager.worktrees(projectId: $0.id).map(\.id)
         }
-        tabs.loadAll(worktreeIds: allWorktreeIds)
+        tabs.loadAll(
+            worktreeIds: allWorktreeIds,
+            restoringActiveTabs: restoreActiveTabsOnNextReload
+        )
+        restoreActiveTabsOnNextReload = true
         // When cross-quit persistence is disabled, drop every persisted
         // terminal tab right after load — across all worktrees, before
         // any lazy-display path could observe them — so orphan zmx

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -953,6 +953,7 @@ final class AppState {
         Task { [weak self] in
             await self?.reconcileInterruptedDelegations()
         }
+        AlasTerminationCoordinator.shared.finish?()
     }
 
     /// Compute (knownWorktreeIds, knownLeafIds) from in-memory state and

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -922,10 +922,11 @@ final class AppState {
         let allWorktreeIds = projectsManager.projects.flatMap {
             projectsManager.worktrees(projectId: $0.id).map(\.id)
         }
-        tabs.loadAll(
-            worktreeIds: allWorktreeIds,
-            restoringActiveTabs: restoreActiveTabsOnNextReload
-        )
+        if restoreActiveTabsOnNextReload {
+            tabs.loadAll(worktreeIds: allWorktreeIds)
+        } else {
+            tabs.loadAllPersisted(restoringActiveTabs: false)
+        }
         restoreActiveTabsOnNextReload = true
         // When cross-quit persistence is disabled, drop every persisted
         // terminal tab right after load — across all worktrees, before

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -60,7 +60,7 @@ final class AppState {
     private var unpersistedGGWorktreeModes: [String: [String: GGWorktreeMode]] = [:]
     var spacesManager: SpacesManager
     var selectedWorktreeId: String?
-    private(set) var isRecoveringFromAbandonedStartup: Bool
+    let suppressesRestoredRightPaneAfterAbandonedStartup: Bool
     private(set) var isRefreshingProjectTopologies = false
     var pendingSettingsSection: SettingsSection?
     @ObservationIgnored
@@ -593,7 +593,7 @@ final class AppState {
     ) {
         self.store = store
         restoreActiveTabsOnNextReload = restoreActiveTabsOnStartup
-        isRecoveringFromAbandonedStartup = !restoreActiveTabsOnStartup
+        suppressesRestoredRightPaneAfterAbandonedStartup = !restoreActiveTabsOnStartup
         _tabs = tabsManager
         self.persistenceErrorHandler = persistenceErrorHandler ?? { title, message in
             AppState.showWarningAlert(title: title, message: message)
@@ -958,7 +958,6 @@ final class AppState {
     }
 
     func completeStartupRecovery() {
-        isRecoveringFromAbandonedStartup = false
         AlasTerminationCoordinator.shared.finish?()
     }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -953,6 +953,9 @@ final class AppState {
         Task { [weak self] in
             await self?.reconcileInterruptedDelegations()
         }
+    }
+
+    func completeStartupRecovery() {
         AlasTerminationCoordinator.shared.finish?()
     }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -60,6 +60,7 @@ final class AppState {
     private var unpersistedGGWorktreeModes: [String: [String: GGWorktreeMode]] = [:]
     var spacesManager: SpacesManager
     var selectedWorktreeId: String?
+    private(set) var isRecoveringFromAbandonedStartup: Bool
     private(set) var isRefreshingProjectTopologies = false
     var pendingSettingsSection: SettingsSection?
     @ObservationIgnored
@@ -592,6 +593,7 @@ final class AppState {
     ) {
         self.store = store
         restoreActiveTabsOnNextReload = restoreActiveTabsOnStartup
+        isRecoveringFromAbandonedStartup = !restoreActiveTabsOnStartup
         _tabs = tabsManager
         self.persistenceErrorHandler = persistenceErrorHandler ?? { title, message in
             AppState.showWarningAlert(title: title, message: message)
@@ -956,6 +958,7 @@ final class AppState {
     }
 
     func completeStartupRecovery() {
+        isRecoveringFromAbandonedStartup = false
         AlasTerminationCoordinator.shared.finish?()
     }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -959,6 +959,17 @@ final class AppState {
         AlasTerminationCoordinator.shared.finish?()
     }
 
+    func completeStartupRecoveryIfCenterPaneWillNotAppear() {
+        let resolver = CenterSelectionStateResolver(
+            selectedWorktreeId: selectedWorktreeId,
+            projects: activeSpaceProjects,
+            projectsManager: projectsManager,
+            isRefreshingProjectTopologies: isRefreshingProjectTopologies
+        )
+        if case .worktree = resolver.resolve() { return }
+        completeStartupRecovery()
+    }
+
     /// Compute (knownWorktreeIds, knownLeafIds) from in-memory state and
     /// hand them to `TerminalService.sweepOrphans`. Run after `reloadTabs`
     /// so persisted leaves are visible; without this, sessions leaked by

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -2135,8 +2135,9 @@ final class AppState {
         remoteProjectWatchers.removeValue(forKey: projectId)?.stop()
     }
 
-    func startAllProjectGitWatchers() {
+    func startAllProjectGitWatchers(includeRemoteProjects: Bool = true) {
         for project in projectsManager.projects {
+            if !includeRemoteProjects, project.host != nil { continue }
             startProjectGitWatcher(for: project)
         }
     }
@@ -2153,10 +2154,11 @@ final class AppState {
         let reportedPaths = Set(branchByWorktreePath.keys.map {
             Self.canonicalWorktreePath($0.path)
         })
-        projectsManager.applyHeadUpdates(
+        let changedPaths = projectsManager.applyHeadUpdates(
             projectId: projectId,
             branchByWorktreePath: branchByWorktreePath
         )
+        if !changedPaths.isEmpty { saveProjects() }
         for worktree in projectsManager.worktrees(projectId: projectId)
             where reportedPaths.contains(Self.canonicalWorktreePath(worktree.path.path))
         {

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -262,6 +262,33 @@ final class ProjectsManager {
         applyWorktreeOrdering(projectId: projectId)
     }
 
+    func populateConfiguredProjectWorktreesForRecovery() {
+        for project in projects where worktreesByProject[project.id, default: []].isEmpty {
+            let cachedWorktrees = project.cachedWorktrees.filter {
+                project.host != nil || FileManager.default.fileExists(atPath: $0.path.path)
+            }
+            if !cachedWorktrees.isEmpty {
+                reconcileRemoteHostRegistrations(project: project, previous: [], reconciled: cachedWorktrees)
+                worktreesByProject[project.id] = cachedWorktrees
+                applyWorktreeOrdering(projectId: project.id)
+                continue
+            }
+            let path = URL(fileURLWithPath: project.path)
+            guard project.host != nil || FileManager.default.fileExists(atPath: path.path) else { continue }
+            let branch = WorktreeService.localBranchName(forWorktreeAt: path) ?? ""
+            insertOptimisticWorktree(Worktree(
+                id: Worktree.makeId(path: path),
+                projectId: project.id,
+                name: branch.isEmpty ? project.name : branch,
+                branch: branch,
+                path: path,
+                isMainWorktree: true,
+                status: .clean,
+                lastActivity: WorktreeService.lastActivity(forWorktreeAt: path) ?? Date()
+            ))
+        }
+    }
+
     func removeOptimisticWorktree(id: String, projectId: String) {
         worktreesByProject[projectId]?.removeAll { $0.id == id }
         worktreeOperationStates.removeValue(forKey: id)
@@ -464,6 +491,8 @@ final class ProjectsManager {
         let reconciledIds = Set(reconciled.map(\.id))
         let previousGGWorktreeModes = projects[idx].ggWorktreeModes
         let previousIssueAttachments = projects[idx].issueAttachments
+        let previousCachedWorktrees = projects[idx].cachedWorktrees
+        projects[idx].cachedWorktrees = reconciled
         for (id, mode) in resolvedCreateModes {
             if mode == .inherit {
                 projects[idx].ggWorktreeModes.removeValue(forKey: id)
@@ -479,6 +508,7 @@ final class ProjectsManager {
         }
         return anchorChanged
             || orderChanged
+            || projects[idx].cachedWorktrees != previousCachedWorktrees
             || projects[idx].hiddenWorktreePaths.count != before
             || projects[idx].ggWorktreeModes != previousGGWorktreeModes
             || projects[idx].issueAttachments != previousIssueAttachments
@@ -547,31 +577,53 @@ final class ProjectsManager {
     /// correspond to real git worktrees, so git's branch is still the truth.
     @discardableResult
     func applyHeadUpdates(projectId: String, branchByWorktreePath: [URL: String]) -> Set<String> {
-        guard var rows = worktreesByProject[projectId], !rows.isEmpty else { return [] }
+        guard let projectIndex = projects.firstIndex(where: { $0.id == projectId }),
+              !branchByWorktreePath.isEmpty
+        else { return [] }
         let lookup: [String: String] = Dictionary(uniqueKeysWithValues:
             branchByWorktreePath.map { (canonical($0.key), $0.value) }
         )
         var changed = false
         var changedPaths: Set<String> = []
-        for i in rows.indices {
-            let key = canonical(rows[i].path)
-            guard let newBranch = lookup[key] else { continue }
-            if let op = worktreeOperationStates[rows[i].id] {
+        func canUpdate(_ worktree: Worktree) -> Bool {
+            if let op = worktreeOperationStates[worktree.id] {
                 switch op {
-                case .creating, .createFailed: continue
-                case .preparingDelete, .deleting, .deleteFailed: break
+                case .creating, .createFailed: return false
+                case .preparingDelete, .deleting, .deleteFailed: return true
                 }
             }
-            if rows[i].branch != newBranch || rows[i].name != newBranch {
-                rows[i].branch = newBranch
-                rows[i].name = newBranch
-                changed = true
-                changedPaths.insert(rows[i].path.path)
+            return true
+        }
+        if var rows = worktreesByProject[projectId], !rows.isEmpty {
+            for i in rows.indices {
+                let key = canonical(rows[i].path)
+                guard let newBranch = lookup[key], canUpdate(rows[i]) else { continue }
+                if rows[i].branch != newBranch || rows[i].name != newBranch {
+                    rows[i].branch = newBranch
+                    rows[i].name = newBranch
+                    changed = true
+                    changedPaths.insert(rows[i].path.path)
+                }
+            }
+            if changed {
+                worktreesByProject[projectId] = rows
+                applyWorktreeOrdering(projectId: projectId)
             }
         }
-        if changed {
-            worktreesByProject[projectId] = rows
-            applyWorktreeOrdering(projectId: projectId)
+        var cachedRows = projects[projectIndex].cachedWorktrees
+        var cachedChanged = false
+        for i in cachedRows.indices {
+            let key = canonical(cachedRows[i].path)
+            guard let newBranch = lookup[key], canUpdate(cachedRows[i]) else { continue }
+            if cachedRows[i].branch != newBranch || cachedRows[i].name != newBranch {
+                cachedRows[i].branch = newBranch
+                cachedRows[i].name = newBranch
+                cachedChanged = true
+                changedPaths.insert(cachedRows[i].path.path)
+            }
+        }
+        if cachedChanged {
+            projects[projectIndex].cachedWorktrees = cachedRows
         }
         return changedPaths
     }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -71,10 +71,14 @@ struct RootView: View {
             }
             .task {
                 state.startHarness()
-                _ = await state.refreshAllProjectTopologies()
+                if Self.shouldRefreshProjectTopologiesOnStartup(
+                    isRecoveringFromAbandonedStartup: state.suppressesRestoredRightPaneAfterAbandonedStartup
+                ) {
+                    _ = await state.refreshAllProjectTopologies()
+                }
                 guard !Task.isCancelled else { return }
-                // Worktrees now exist — load any persisted tab files for them. Init
-                // can't do this because refreshAll runs async after init.
+                // Normal launch refreshes worktrees first; recovery launch uses
+                // persisted topology so it does not replay the failed refresh.
                 state.reloadTabs()
                 if state.selectedWorktreeId == nil {
                     state.selectInitialWorktree(
@@ -99,6 +103,12 @@ struct RootView: View {
             ReviewTargetDialog(appState: state)
             RunScriptDialog(appState: state, selectedWorktree: selectedWorktree)
         }
+    }
+
+    static func shouldRefreshProjectTopologiesOnStartup(
+        isRecoveringFromAbandonedStartup: Bool
+    ) -> Bool {
+        !isRecoveringFromAbandonedStartup
     }
 
     @ViewBuilder

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -81,6 +81,7 @@ struct RootView: View {
                         id: state.resolvedSelectionForActiveSpaceForStartup()
                     )
                 }
+                state.completeStartupRecoveryIfCenterPaneWillNotAppear()
                 state.startAllProjectGitWatchers()
                 state.rescanAgents()
             }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -123,7 +123,7 @@ struct RootView: View {
                 sidebarVisible: state.config.sidebarVisible,
                 rightVisible: state.config.rightPaneVisible
                     && rightPaneSelection.showsRightPane
-                    && !state.isRecoveringFromAbandonedStartup,
+                    && !state.suppressesRestoredRightPaneAfterAbandonedStartup,
                 onWidthsChanged: { state.saveConfig() },
                 sidebar: { sidebarContent },
                 center: { effectiveRightPaneVisible in

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -121,7 +121,9 @@ struct RootView: View {
                     set: { state.config.rightPaneWidth = $0 }
                 ),
                 sidebarVisible: state.config.sidebarVisible,
-                rightVisible: state.config.rightPaneVisible && rightPaneSelection.showsRightPane,
+                rightVisible: state.config.rightPaneVisible
+                    && rightPaneSelection.showsRightPane
+                    && !state.isRecoveringFromAbandonedStartup,
                 onWidthsChanged: { state.saveConfig() },
                 sidebar: { sidebarContent },
                 center: { effectiveRightPaneVisible in

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -85,6 +85,9 @@ struct RootView: View {
                 state.startAllProjectGitWatchers()
                 state.rescanAgents()
             }
+            .onChange(of: state.selectedWorktreeId) { _, _ in
+                state.completeStartupRecoveryIfCenterPaneWillNotAppear()
+            }
     }
 
     private var rootContent: some View {

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -124,7 +124,9 @@ struct RootView: View {
                 rightVisible: state.config.rightPaneVisible && rightPaneSelection.showsRightPane,
                 onWidthsChanged: { state.saveConfig() },
                 sidebar: { sidebarContent },
-                center: { centerContent() },
+                center: { effectiveRightPaneVisible in
+                    centerContent(effectiveRightPaneVisible: effectiveRightPaneVisible)
+                },
                 right: { rightContent(selection: rightPaneSelection) }
             )
         }
@@ -210,7 +212,7 @@ struct RootView: View {
     }
 
     @ViewBuilder
-    private func centerContent() -> some View {
+    private func centerContent(effectiveRightPaneVisible: Bool) -> some View {
         let resolver = CenterSelectionStateResolver(
             selectedWorktreeId: state.selectedWorktreeId,
             projects: state.activeSpaceProjects,
@@ -222,7 +224,8 @@ struct RootView: View {
             CenterPaneView(
                 state: state,
                 worktree: wt,
-                allowsPaneFocus: !state.isKeyboardOverlayOpen
+                allowsPaneFocus: !state.isKeyboardOverlayOpen,
+                effectiveRightPaneVisible: effectiveRightPaneVisible
             )
         case .deleting(let wt):
             DeletingWorktreeView(worktree: wt)

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -71,14 +71,15 @@ struct RootView: View {
             }
             .task {
                 state.startHarness()
-                if Self.shouldRefreshProjectTopologiesOnStartup(
-                    isRecoveringFromAbandonedStartup: state.suppressesRestoredRightPaneAfterAbandonedStartup
-                ) {
+                let isRecovering = state.suppressesRestoredRightPaneAfterAbandonedStartup
+                if Self.shouldRefreshProjectTopologiesOnStartup(isRecoveringFromAbandonedStartup: isRecovering) {
                     _ = await state.refreshAllProjectTopologies()
+                } else {
+                    state.projectsManager.populateConfiguredProjectWorktreesForRecovery()
                 }
                 guard !Task.isCancelled else { return }
-                // Normal launch refreshes worktrees first; recovery launch uses
-                // persisted topology so it does not replay the failed refresh.
+                // Recovery launch avoids replaying the failed refresh, but still
+                // seeds project roots so tab and selection resolution can recover.
                 state.reloadTabs()
                 if state.selectedWorktreeId == nil {
                     state.selectInitialWorktree(
@@ -86,7 +87,7 @@ struct RootView: View {
                     )
                 }
                 state.completeStartupRecoveryIfCenterPaneWillNotAppear()
-                state.startAllProjectGitWatchers()
+                state.startAllProjectGitWatchers(includeRemoteProjects: !isRecovering)
                 state.rescanAgents()
             }
             .onChange(of: state.selectedWorktreeId) { _, _ in

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -83,6 +83,7 @@ struct CenterPaneView: View {
     @Bindable var state: AppState
     let worktree: Worktree
     var allowsPaneFocus: Bool = true
+    var effectiveRightPaneVisible: Bool = true
     @Environment(\.theme) var theme
     @State private var startupRecoveryReadyKey: String?
 
@@ -655,7 +656,7 @@ struct CenterPaneView: View {
     private var rightPaneStartupRecoveryReady: Bool {
         let rightPaneState = state.rightPaneStore.activeState(worktreeId: worktree.id)
         return Self.shouldCompleteStartupRecoveryForRightPane(
-            isRightPaneVisible: state.config.rightPaneVisible,
+            isRightPaneVisible: effectiveRightPaneVisible,
             hasLoadedSnapshot: rightPaneState?.hasLoadedSnapshot ?? false,
             isLoading: rightPaneState?.loading ?? false
         )
@@ -698,12 +699,26 @@ struct CenterPaneView: View {
     }
 
     private var startupRecoveryActiveKey: String? {
-        guard let tabID = state.tabs.activeTabId(forWorktree: worktree.id) else { return nil }
-        return [
-            tabID,
-            state.rightPaneStore.activeState(worktreeId: worktree.id)
-                .map(ReviewChangesLoadKey.fingerprint) ?? "no-right-pane-state",
-        ].joined(separator: "\u{0}")
+        let composition = CenterTabComposition(
+            worktreeTabs: state.tabs.tabs(forWorktree: worktree.id),
+            activeWorktreeTabId: state.tabs.activeTabId(forWorktree: worktree.id)
+        )
+        return Self.startupRecoveryActiveKey(
+            activeTab: composition.activeTab,
+            rightPaneState: state.rightPaneStore.activeState(worktreeId: worktree.id)
+        )
+    }
+
+    static func startupRecoveryActiveKey(activeTab: Tab?, rightPaneState: RightPaneState?) -> String? {
+        guard let activeTab else { return nil }
+        let loadKey: String
+        switch activeTab {
+        case .draftCommit, .reviewChanges, .reviewPR, .ggSplitCommit:
+            loadKey = rightPaneState.map(ReviewChangesLoadKey.fingerprint) ?? "no-right-pane-state"
+        default:
+            loadKey = "tab"
+        }
+        return [activeTab.id, loadKey].joined(separator: "\u{0}")
     }
 
     private var rightPaneActivationKey: String {

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -431,7 +431,8 @@ struct CenterPaneView: View {
                             worktreePath: worktree.path,
                             worktreeId: worktree.id,
                             tabState: draftState,
-                            appState: state
+                            appState: state,
+                            onStartupRecoveryReady: { completeStartupRecoveryIfActive(draftState.id) }
                         )
                         .id(draftState.presentationID)
                         .task(id: rightPaneActivationKey) {
@@ -449,7 +450,8 @@ struct CenterPaneView: View {
                         ReviewChangesTabView(
                             worktree: worktree,
                             tabState: reviewState,
-                            appState: state
+                            appState: state,
+                            onStartupRecoveryReady: { completeStartupRecoveryIfActive(reviewState.id) }
                         )
                         .id(reviewState.id)
                         .task(id: rightPaneActivationKey) {
@@ -469,7 +471,8 @@ struct CenterPaneView: View {
                         ReviewSessionTabView(
                             worktree: worktree,
                             tabState: sessionState,
-                            appState: state
+                            appState: state,
+                            onStartupRecoveryReady: { completeStartupRecoveryIfActive(sessionState.id) }
                         )
                         .id(sessionState.viewID)
                     case .imagePreview(let s):

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -413,7 +413,8 @@ struct CenterPaneView: View {
                             worktreePath: worktree.path,
                             tabState: s,
                             worktreeId: worktree.id,
-                            appState: state
+                            appState: state,
+                            onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) }
                         )
                         .id(s.viewID)
                     case .commitEditor(let s):

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -370,7 +370,8 @@ struct CenterPaneView: View {
                                           externalAbsolutePath: s.externalAbsolutePath,
                                           externalEditable: s.isExternalEditable,
                                           originatingRelativePath: s.originatingRelativePath,
-                                          onRevealInFiles: { path in state.revealInFiles(worktreeId: worktree.id, path: path) })
+                                          onRevealInFiles: { path in state.revealInFiles(worktreeId: worktree.id, path: path) },
+                                          onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) })
                         }
                     case .diff(let s):
                         let openAvailable = DiffOpenFileAvailability.isAvailable(

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -18,7 +18,7 @@ struct CenterTabComposition {
         if worktreeTabs.contains(where: { $0.id == activeWorktreeTabId }) {
             activeId = activeWorktreeTabId
         } else {
-            activeId = worktreeTabs.first?.id
+            activeId = nil
         }
     }
 
@@ -535,6 +535,12 @@ struct CenterPaneView: View {
                                 }
                         }
                     }
+                } else {
+                    ContentUnavailableView(
+                        "Choose a Tab",
+                        systemImage: "rectangle.stack",
+                        description: Text("No tab was reopened after the previous session ended unexpectedly.")
+                    )
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -556,8 +556,12 @@ struct CenterPaneView: View {
                                 capabilities: capabilities,
                                 workflowAvailable: workflowAvailable,
                                 hasBlockingGitOperation: hasBlockingGitOperation,
-                                completesStartupRecoveryWhenUnavailable: rightPaneState.hasLoadedSnapshot
-                                    && rightPaneState.ggStackLoadState != .loading,
+                                completesStartupRecoveryWhenUnavailable: Self
+                                    .shouldCompleteGGSplitStartupRecoveryWhenUnavailable(
+                                        hasLoadedSnapshot: rightPaneState.hasLoadedSnapshot,
+                                        ggStackLoadState: rightPaneState.ggStackLoadState,
+                                        ggAvailabilityHasProbed: GGAvailability.shared.hasProbed
+                                    ),
                                 initialDraft: state.tabs.ggSplitCommitDraft(worktreeId: worktree.id, tabId: s.id),
                                 codeFontFamily: state.config.code.fontFamily,
                                 codeFontSize: CGFloat(state.config.code.fontSize),
@@ -632,6 +636,14 @@ struct CenterPaneView: View {
         )
         guard StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: composition.activeTab) else { return }
         state.completeStartupRecovery()
+    }
+
+    static func shouldCompleteGGSplitStartupRecoveryWhenUnavailable(
+        hasLoadedSnapshot: Bool,
+        ggStackLoadState: GGStackLoadState,
+        ggAvailabilityHasProbed: Bool
+    ) -> Bool {
+        hasLoadedSnapshot && ggAvailabilityHasProbed && ggStackLoadState != .loading
     }
 
     private func completeStartupRecoveryIfActive(_ tabID: TabID) {

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -386,6 +386,7 @@ struct CenterPaneView: View {
                             appState: state,
                             codeFontFamily: state.config.code.fontFamily,
                             codeFontSize: CGFloat(state.config.code.fontSize),
+                            onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) },
                             onOpenFile: openAvailable
                                 ? { state.openFile(relativePath: s.relativePath, worktreeId: worktree.id) }
                                 : nil,

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -535,7 +535,7 @@ struct CenterPaneView: View {
                                 .task(id: rightPaneActivationKey) {
                                     activateRightPaneStateForCenterTab()
                                 }
-                        }
+                            }
                     }
                 } else {
                     ContentUnavailableView(
@@ -560,6 +560,16 @@ struct CenterPaneView: View {
                     }
                     .padding(12)
                 }
+            }
+        }
+        .onAppear {
+            if state.tabs.hasLoaded {
+                state.completeStartupRecovery()
+            }
+        }
+        .onChange(of: state.tabs.hasLoaded) { _, hasLoaded in
+            if hasLoaded {
+                state.completeStartupRecovery()
             }
         }
         .background(theme.color("bg-1"))

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -658,16 +658,18 @@ struct CenterPaneView: View {
         return Self.shouldCompleteStartupRecoveryForRightPane(
             isRightPaneVisible: effectiveRightPaneVisible,
             hasLoadedSnapshot: rightPaneState?.hasLoadedSnapshot ?? false,
-            isLoading: rightPaneState?.loading ?? false
+            isLoading: rightPaneState?.loading ?? false,
+            ggStackLoadState: rightPaneState?.ggStackLoadState ?? .inactive
         )
     }
 
     static func shouldCompleteStartupRecoveryForRightPane(
         isRightPaneVisible: Bool,
         hasLoadedSnapshot: Bool,
-        isLoading: Bool
+        isLoading: Bool,
+        ggStackLoadState: GGStackLoadState
     ) -> Bool {
-        !isRightPaneVisible || (hasLoadedSnapshot && !isLoading)
+        !isRightPaneVisible || (hasLoadedSnapshot && !isLoading && ggStackLoadState != .loading)
     }
 
     static func shouldCompleteStartupRecoveryForCenterPane(

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -598,6 +598,9 @@ struct CenterPaneView: View {
         .onChange(of: state.tabs.hasLoaded) { _, _ in
             completeStartupRecoveryIfPaneIsStable()
         }
+        .onChange(of: state.tabs.activeTabId(forWorktree: worktree.id)) { _, _ in
+            completeStartupRecoveryIfPaneIsStable()
+        }
         .background(theme.color("bg-1"))
         .sheet(item: $state.selectedRunScriptFailure) { failure in
             RunScriptFailureDetailView(failure: failure)

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -542,20 +542,19 @@ struct CenterPaneView: View {
                                         tabId: s.id,
                                         draft: draft
                                     )
-                                }
+                                },
+                                onStartupRecoveryReady: { state.completeStartupRecovery() }
                             )
                             .id("\(s.id):\(capabilities.structuredSplit):\(workflowAvailable):\(hasBlockingGitOperation)")
                             .task(id: rightPaneActivationKey) {
                                 activateRightPaneStateForCenterTab()
-                                state.completeStartupRecovery()
                             }
                         } else {
                             ProgressView()
                                 .task(id: rightPaneActivationKey) {
                                     activateRightPaneStateForCenterTab()
-                                    state.completeStartupRecovery()
                                 }
-                            }
+                        }
                     }
                 } else {
                     ContentUnavailableView(

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -336,7 +336,8 @@ struct CenterPaneView: View {
                         TerminalTabView(state: state,
                                         worktreeId: worktree.id,
                                         tabId: tab.id,
-                                        allowsPaneFocus: allowsPaneFocus)
+                                        allowsPaneFocus: allowsPaneFocus,
+                                        onStartupRecoveryReady: { completeStartupRecoveryIfActive(tab.id) })
                     case .editor(let s):
                         if MarkdownFileType.supportsRichPreview(relativePath: s.isExternal
                                                                  ? (s.externalAbsolutePath ?? "")
@@ -353,7 +354,8 @@ struct CenterPaneView: View {
                                             revealCharacter: s.revealCharacter,
                                             revealRevision: s.revealRevision,
                                             appState: state,
-                                            onRevealInFiles: { path in state.revealInFiles(worktreeId: worktree.id, path: path) })
+                                            onRevealInFiles: { path in state.revealInFiles(worktreeId: worktree.id, path: path) },
+                                            onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) })
                         } else {
                             EditorTabView(worktree: worktree,
                                           worktreePath: worktree.path,
@@ -403,7 +405,7 @@ struct CenterPaneView: View {
                             state: s,
                             codeFontFamily: state.config.code.fontFamily,
                             codeFontSize: CGFloat(state.config.code.fontSize),
-                            onStartupRecoveryReady: { state.completeStartupRecovery() }
+                            onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) }
                         )
                         .id(s.id)
                     case .commit(let s):
@@ -472,7 +474,7 @@ struct CenterPaneView: View {
                         ImagePreviewTabView(worktreePath: worktree.path,
                                              relativePath: s.relativePath,
                                              onRevealInFiles: { path in state.revealInFiles(worktreeId: worktree.id, path: path) },
-                                             onStartupRecoveryReady: { state.completeStartupRecovery() })
+                                             onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) })
                     case .binaryPreview(let s):
                         BinaryPreviewTabView(worktreePath: worktree.path,
                                              relativePath: s.relativePath,
@@ -490,7 +492,7 @@ struct CenterPaneView: View {
                             state: s,
                             codeFontFamily: state.config.code.fontFamily,
                             codeFontSize: CGFloat(state.config.code.fontSize),
-                            onStartupRecoveryReady: { state.completeStartupRecovery() }
+                            onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) }
                         )
                     case .fileHistory(let s):
                         FileHistoryTabView(
@@ -498,7 +500,7 @@ struct CenterPaneView: View {
                             state: s,
                             onSelectCommit: { state.openCommitTab(worktreeId: worktree.id, commit: $0) },
                             onCopySHA: { Clipboard.copy($0.sha) },
-                            onStartupRecoveryReady: { state.completeStartupRecovery() }
+                            onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) }
                         )
                     case .acpSession(let s):
                         ACPTabView(sessionId: s.sessionId, state: state, worktree: worktree)
@@ -507,7 +509,7 @@ struct CenterPaneView: View {
                         GGInboxTabView(
                             state: state,
                             tabState: s,
-                            onStartupRecoveryReady: { state.completeStartupRecovery() }
+                            onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) }
                         )
                             .id(s.id)
                     case .ggSplitCommit(let s):
@@ -554,7 +556,7 @@ struct CenterPaneView: View {
                                         draft: draft
                                     )
                                 },
-                                onStartupRecoveryReady: { state.completeStartupRecovery() }
+                                onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) }
                             )
                             .id("\(s.id):\(capabilities.structuredSplit):\(workflowAvailable):\(hasBlockingGitOperation)")
                             .task(id: rightPaneActivationKey) {
@@ -614,6 +616,15 @@ struct CenterPaneView: View {
             activeWorktreeTabId: state.tabs.activeTabId(forWorktree: worktree.id)
         )
         guard StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: composition.activeTab) else { return }
+        state.completeStartupRecovery()
+    }
+
+    private func completeStartupRecoveryIfActive(_ tabID: TabID) {
+        let composition = CenterTabComposition(
+            worktreeTabs: state.tabs.tabs(forWorktree: worktree.id),
+            activeWorktreeTabId: state.tabs.activeTabId(forWorktree: worktree.id)
+        )
+        guard composition.activeId == tabID else { return }
         state.completeStartupRecovery()
     }
 

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -17,6 +17,8 @@ struct CenterTabComposition {
         tabs = worktreeTabs
         if worktreeTabs.contains(where: { $0.id == activeWorktreeTabId }) {
             activeId = activeWorktreeTabId
+        } else if activeWorktreeTabId != nil {
+            activeId = worktreeTabs.first?.id
         } else {
             activeId = nil
         }

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -84,7 +84,7 @@ struct CenterPaneView: View {
     let worktree: Worktree
     var allowsPaneFocus: Bool = true
     @Environment(\.theme) var theme
-    @State private var startupRecoveryReadyTabID: TabID?
+    @State private var startupRecoveryReadyKey: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -621,7 +621,11 @@ struct CenterPaneView: View {
             completeStartupRecoveryIfPaneIsStable()
         }
         .onChange(of: state.tabs.activeTabId(forWorktree: worktree.id)) { _, _ in
-            startupRecoveryReadyTabID = nil
+            startupRecoveryReadyKey = nil
+            completeStartupRecoveryIfPaneIsStable()
+        }
+        .onChange(of: startupRecoveryActiveKey) { _, _ in
+            startupRecoveryReadyKey = nil
             completeStartupRecoveryIfPaneIsStable()
         }
         .onChange(of: rightPaneStartupRecoveryReady) { _, _ in
@@ -641,7 +645,8 @@ struct CenterPaneView: View {
         )
         guard Self.shouldCompleteStartupRecoveryForCenterPane(
             activeTab: composition.activeTab,
-            readyTabID: startupRecoveryReadyTabID
+            readyKey: startupRecoveryReadyKey,
+            currentKey: startupRecoveryActiveKey
         ) else { return }
         guard rightPaneStartupRecoveryReady else { return }
         state.completeStartupRecovery()
@@ -666,9 +671,10 @@ struct CenterPaneView: View {
 
     static func shouldCompleteStartupRecoveryForCenterPane(
         activeTab: Tab?,
-        readyTabID: TabID?
+        readyKey: String?,
+        currentKey: String?
     ) -> Bool {
-        StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: activeTab) || activeTab?.id == readyTabID
+        StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: activeTab) || (readyKey != nil && readyKey == currentKey)
     }
 
     static func shouldCompleteGGSplitStartupRecoveryWhenUnavailable(
@@ -686,9 +692,18 @@ struct CenterPaneView: View {
             activeWorktreeTabId: state.tabs.activeTabId(forWorktree: worktree.id)
         )
         guard composition.activeId == tabID else { return }
-        startupRecoveryReadyTabID = tabID
+        startupRecoveryReadyKey = startupRecoveryActiveKey
         guard rightPaneStartupRecoveryReady else { return }
         state.completeStartupRecovery()
+    }
+
+    private var startupRecoveryActiveKey: String? {
+        guard let tabID = state.tabs.activeTabId(forWorktree: worktree.id) else { return nil }
+        return [
+            tabID,
+            state.rightPaneStore.activeState(worktreeId: worktree.id)
+                .map(ReviewChangesLoadKey.fingerprint) ?? "no-right-pane-state",
+        ].joined(separator: "\u{0}")
     }
 
     private var rightPaneActivationKey: String {

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -659,7 +659,8 @@ struct CenterPaneView: View {
             isRightPaneVisible: effectiveRightPaneVisible,
             hasLoadedSnapshot: rightPaneState?.hasLoadedSnapshot ?? false,
             isLoading: rightPaneState?.loading ?? false,
-            ggStackLoadState: rightPaneState?.ggStackLoadState ?? .inactive
+            ggStackLoadState: rightPaneState?.ggStackLoadState ?? .inactive,
+            ggAvailabilityHasProbed: GGAvailability.shared.hasProbed
         )
     }
 
@@ -667,9 +668,10 @@ struct CenterPaneView: View {
         isRightPaneVisible: Bool,
         hasLoadedSnapshot: Bool,
         isLoading: Bool,
-        ggStackLoadState: GGStackLoadState
+        ggStackLoadState: GGStackLoadState,
+        ggAvailabilityHasProbed: Bool
     ) -> Bool {
-        !isRightPaneVisible || (hasLoadedSnapshot && !isLoading && ggStackLoadState != .loading)
+        !isRightPaneVisible || (hasLoadedSnapshot && !isLoading && ggAvailabilityHasProbed && ggStackLoadState != .loading)
     }
 
     static func shouldCompleteStartupRecoveryForCenterPane(

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -60,6 +60,17 @@ struct CenterTabClosurePlan {
     }
 }
 
+enum StartupRecoveryPaneCompletionPolicy {
+    static func shouldComplete(activeTab: Tab?) -> Bool {
+        switch activeTab {
+        case .terminal, .acpSession:
+            false
+        default:
+            true
+        }
+    }
+}
+
 struct CenterPaneView: View {
     @Bindable var state: AppState
     let worktree: Worktree
@@ -563,19 +574,22 @@ struct CenterPaneView: View {
             }
         }
         .onAppear {
-            if state.tabs.hasLoaded {
-                state.completeStartupRecovery()
-            }
+            completeStartupRecoveryIfPaneIsStable()
         }
-        .onChange(of: state.tabs.hasLoaded) { _, hasLoaded in
-            if hasLoaded {
-                state.completeStartupRecovery()
-            }
+        .onChange(of: state.tabs.hasLoaded) { _, _ in
+            completeStartupRecoveryIfPaneIsStable()
         }
         .background(theme.color("bg-1"))
         .sheet(item: $state.selectedRunScriptFailure) { failure in
             RunScriptFailureDetailView(failure: failure)
         }
+    }
+
+    private func completeStartupRecoveryIfPaneIsStable() {
+        guard state.tabs.hasLoaded else { return }
+        let activeTab = state.tabs.activeTab(forWorktree: worktree.id)
+        guard StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: activeTab) else { return }
+        state.completeStartupRecovery()
     }
 
     private var rightPaneActivationKey: String {

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -63,7 +63,7 @@ struct CenterTabClosurePlan {
 enum StartupRecoveryPaneCompletionPolicy {
     static func shouldComplete(activeTab: Tab?) -> Bool {
         switch activeTab {
-        case .terminal, .diff, .stashDiff, .commit, .commitEditor, .draftCommit,
+        case .terminal, .editor, .diff, .stashDiff, .commit, .commitEditor, .draftCommit,
              .draftReviewRequest, .reviewChanges, .reviewSession, .imagePreview,
              .mergeConflict, .acpSession, .reviewPR, .fileSnapshot, .fileHistory,
              .ggSplitCommit:

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -24,6 +24,11 @@ struct CenterTabComposition {
         }
     }
 
+    var activeTab: Tab? {
+        guard let activeId else { return nil }
+        return tabs.first { $0.id == activeId }
+    }
+
     func adjacentTabID(in direction: CenterTabNavigationDirection) -> TabID? {
         guard tabs.count > 1,
               let activeId,
@@ -534,6 +539,8 @@ struct CenterPaneView: View {
                                 capabilities: capabilities,
                                 workflowAvailable: workflowAvailable,
                                 hasBlockingGitOperation: hasBlockingGitOperation,
+                                completesStartupRecoveryWhenUnavailable: rightPaneState.hasLoadedSnapshot
+                                    && rightPaneState.ggStackLoadState != .loading,
                                 initialDraft: state.tabs.ggSplitCommitDraft(worktreeId: worktree.id, tabId: s.id),
                                 codeFontFamily: state.config.code.fontFamily,
                                 codeFontSize: CGFloat(state.config.code.fontSize),
@@ -599,8 +606,11 @@ struct CenterPaneView: View {
 
     private func completeStartupRecoveryIfPaneIsStable() {
         guard state.tabs.hasLoaded else { return }
-        let activeTab = state.tabs.activeTab(forWorktree: worktree.id)
-        guard StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: activeTab) else { return }
+        let composition = CenterTabComposition(
+            worktreeTabs: state.tabs.tabs(forWorktree: worktree.id),
+            activeWorktreeTabId: state.tabs.activeTabId(forWorktree: worktree.id)
+        )
+        guard StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: composition.activeTab) else { return }
         state.completeStartupRecovery()
     }
 

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -443,7 +443,8 @@ struct CenterPaneView: View {
                             worktreePath: worktree.path,
                             worktreeId: worktree.id,
                             tabState: draftState,
-                            appState: state
+                            appState: state,
+                            onStartupRecoveryReady: { completeStartupRecoveryIfActive(draftState.id) }
                         )
                         .id(draftState.id)
                     case .reviewChanges(let reviewState):
@@ -488,7 +489,8 @@ struct CenterPaneView: View {
                         MergeConflictTabView(
                             state: state,
                             worktree: worktree,
-                            tabState: s
+                            tabState: s,
+                            onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) }
                         )
                         .id(s.id)
                     case .fileSnapshot(let s):
@@ -508,7 +510,12 @@ struct CenterPaneView: View {
                             onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) }
                         )
                     case .acpSession(let s):
-                        ACPTabView(sessionId: s.sessionId, state: state, worktree: worktree)
+                        ACPTabView(
+                            sessionId: s.sessionId,
+                            state: state,
+                            worktree: worktree,
+                            onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) }
+                        )
                             .id(s.id)
                     case .ggInbox(let s):
                         GGInboxTabView(

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -66,7 +66,7 @@ enum StartupRecoveryPaneCompletionPolicy {
         case .terminal, .editor, .diff, .stashDiff, .commit, .commitEditor, .draftCommit,
              .draftReviewRequest, .reviewChanges, .reviewSession, .imagePreview,
              .mergeConflict, .acpSession, .reviewPR, .fileSnapshot, .fileHistory,
-             .ggSplitCommit:
+             .ggInbox, .ggSplitCommit:
             false
         default:
             true
@@ -499,7 +499,11 @@ struct CenterPaneView: View {
                         ACPTabView(sessionId: s.sessionId, state: state, worktree: worktree)
                             .id(s.id)
                     case .ggInbox(let s):
-                        GGInboxTabView(state: state, tabState: s)
+                        GGInboxTabView(
+                            state: state,
+                            tabState: s,
+                            onStartupRecoveryReady: { state.completeStartupRecovery() }
+                        )
                             .id(s.id)
                     case .ggSplitCommit(let s):
                         let capabilities = GGAvailability.shared.capabilities

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -423,7 +423,8 @@ struct CenterPaneView: View {
                             worktreePath: worktree.path,
                             worktreeId: worktree.id,
                             tabState: s,
-                            appState: state
+                            appState: state,
+                            onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) }
                         )
                         .id(s.id)
                     case .draftCommit(let draftState):
@@ -462,7 +463,8 @@ struct CenterPaneView: View {
                         ReviewTabView(
                             worktree: worktree,
                             tabState: prState,
-                            appState: state
+                            appState: state,
+                            onStartupRecoveryReady: { completeStartupRecoveryIfActive(prState.id) }
                         )
                         .id(prState.id)
                         .task(id: rightPaneActivationKey) {
@@ -632,6 +634,7 @@ struct CenterPaneView: View {
     }
 
     private func completeStartupRecoveryIfActive(_ tabID: TabID) {
+        guard state.selectedWorktreeId == worktree.id else { return }
         let composition = CenterTabComposition(
             worktreeTabs: state.tabs.tabs(forWorktree: worktree.id),
             activeWorktreeTabId: state.tabs.activeTabId(forWorktree: worktree.id)

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -622,6 +622,9 @@ struct CenterPaneView: View {
         .onChange(of: state.tabs.activeTabId(forWorktree: worktree.id)) { _, _ in
             completeStartupRecoveryIfPaneIsStable()
         }
+        .onChange(of: rightPaneStartupRecoveryReady) { _, _ in
+            completeStartupRecoveryIfPaneIsStable()
+        }
         .background(theme.color("bg-1"))
         .sheet(item: $state.selectedRunScriptFailure) { failure in
             RunScriptFailureDetailView(failure: failure)
@@ -635,7 +638,25 @@ struct CenterPaneView: View {
             activeWorktreeTabId: state.tabs.activeTabId(forWorktree: worktree.id)
         )
         guard StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: composition.activeTab) else { return }
+        guard rightPaneStartupRecoveryReady else { return }
         state.completeStartupRecovery()
+    }
+
+    private var rightPaneStartupRecoveryReady: Bool {
+        let rightPaneState = state.rightPaneStore.activeState(worktreeId: worktree.id)
+        return Self.shouldCompleteStartupRecoveryForRightPane(
+            isRightPaneVisible: state.config.rightPaneVisible,
+            hasLoadedSnapshot: rightPaneState?.hasLoadedSnapshot ?? false,
+            isLoading: rightPaneState?.loading ?? false
+        )
+    }
+
+    static func shouldCompleteStartupRecoveryForRightPane(
+        isRightPaneVisible: Bool,
+        hasLoadedSnapshot: Bool,
+        isLoading: Bool
+    ) -> Bool {
+        !isRightPaneVisible || (hasLoadedSnapshot && !isLoading)
     }
 
     static func shouldCompleteGGSplitStartupRecoveryWhenUnavailable(
@@ -653,6 +674,7 @@ struct CenterPaneView: View {
             activeWorktreeTabId: state.tabs.activeTabId(forWorktree: worktree.id)
         )
         guard composition.activeId == tabID else { return }
+        guard rightPaneStartupRecoveryReady else { return }
         state.completeStartupRecovery()
     }
 

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -84,6 +84,7 @@ struct CenterPaneView: View {
     let worktree: Worktree
     var allowsPaneFocus: Bool = true
     @Environment(\.theme) var theme
+    @State private var startupRecoveryReadyTabID: TabID?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -620,6 +621,7 @@ struct CenterPaneView: View {
             completeStartupRecoveryIfPaneIsStable()
         }
         .onChange(of: state.tabs.activeTabId(forWorktree: worktree.id)) { _, _ in
+            startupRecoveryReadyTabID = nil
             completeStartupRecoveryIfPaneIsStable()
         }
         .onChange(of: rightPaneStartupRecoveryReady) { _, _ in
@@ -637,7 +639,10 @@ struct CenterPaneView: View {
             worktreeTabs: state.tabs.tabs(forWorktree: worktree.id),
             activeWorktreeTabId: state.tabs.activeTabId(forWorktree: worktree.id)
         )
-        guard StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: composition.activeTab) else { return }
+        guard Self.shouldCompleteStartupRecoveryForCenterPane(
+            activeTab: composition.activeTab,
+            readyTabID: startupRecoveryReadyTabID
+        ) else { return }
         guard rightPaneStartupRecoveryReady else { return }
         state.completeStartupRecovery()
     }
@@ -659,6 +664,13 @@ struct CenterPaneView: View {
         !isRightPaneVisible || (hasLoadedSnapshot && !isLoading)
     }
 
+    static func shouldCompleteStartupRecoveryForCenterPane(
+        activeTab: Tab?,
+        readyTabID: TabID?
+    ) -> Bool {
+        StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: activeTab) || activeTab?.id == readyTabID
+    }
+
     static func shouldCompleteGGSplitStartupRecoveryWhenUnavailable(
         hasLoadedSnapshot: Bool,
         ggStackLoadState: GGStackLoadState,
@@ -674,6 +686,7 @@ struct CenterPaneView: View {
             activeWorktreeTabId: state.tabs.activeTabId(forWorktree: worktree.id)
         )
         guard composition.activeId == tabID else { return }
+        startupRecoveryReadyTabID = tabID
         guard rightPaneStartupRecoveryReady else { return }
         state.completeStartupRecovery()
     }

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -63,7 +63,10 @@ struct CenterTabClosurePlan {
 enum StartupRecoveryPaneCompletionPolicy {
     static func shouldComplete(activeTab: Tab?) -> Bool {
         switch activeTab {
-        case .terminal, .acpSession:
+        case .terminal, .diff, .stashDiff, .commit, .commitEditor, .draftCommit,
+             .draftReviewRequest, .reviewChanges, .reviewSession, .imagePreview,
+             .mergeConflict, .acpSession, .reviewPR, .fileSnapshot, .fileHistory,
+             .ggSplitCommit:
             false
         default:
             true
@@ -394,7 +397,8 @@ struct CenterPaneView: View {
                             worktreePath: worktree.path,
                             state: s,
                             codeFontFamily: state.config.code.fontFamily,
-                            codeFontSize: CGFloat(state.config.code.fontSize)
+                            codeFontSize: CGFloat(state.config.code.fontSize),
+                            onStartupRecoveryReady: { state.completeStartupRecovery() }
                         )
                         .id(s.id)
                     case .commit(let s):
@@ -462,7 +466,8 @@ struct CenterPaneView: View {
                     case .imagePreview(let s):
                         ImagePreviewTabView(worktreePath: worktree.path,
                                              relativePath: s.relativePath,
-                                             onRevealInFiles: { path in state.revealInFiles(worktreeId: worktree.id, path: path) })
+                                             onRevealInFiles: { path in state.revealInFiles(worktreeId: worktree.id, path: path) },
+                                             onStartupRecoveryReady: { state.completeStartupRecovery() })
                     case .binaryPreview(let s):
                         BinaryPreviewTabView(worktreePath: worktree.path,
                                              relativePath: s.relativePath,
@@ -479,14 +484,16 @@ struct CenterPaneView: View {
                             worktreePath: worktree.path,
                             state: s,
                             codeFontFamily: state.config.code.fontFamily,
-                            codeFontSize: CGFloat(state.config.code.fontSize)
+                            codeFontSize: CGFloat(state.config.code.fontSize),
+                            onStartupRecoveryReady: { state.completeStartupRecovery() }
                         )
                     case .fileHistory(let s):
                         FileHistoryTabView(
                             worktreePath: worktree.path,
                             state: s,
                             onSelectCommit: { state.openCommitTab(worktreeId: worktree.id, commit: $0) },
-                            onCopySHA: { Clipboard.copy($0.sha) }
+                            onCopySHA: { Clipboard.copy($0.sha) },
+                            onStartupRecoveryReady: { state.completeStartupRecovery() }
                         )
                     case .acpSession(let s):
                         ACPTabView(sessionId: s.sessionId, state: state, worktree: worktree)
@@ -540,11 +547,13 @@ struct CenterPaneView: View {
                             .id("\(s.id):\(capabilities.structuredSplit):\(workflowAvailable):\(hasBlockingGitOperation)")
                             .task(id: rightPaneActivationKey) {
                                 activateRightPaneStateForCenterTab()
+                                state.completeStartupRecovery()
                             }
                         } else {
                             ProgressView()
                                 .task(id: rightPaneActivationKey) {
                                     activateRightPaneStateForCenterTab()
+                                    state.completeStartupRecovery()
                                 }
                             }
                     }

--- a/Alas/Sources/Center/Commit/CommitEditorTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitEditorTabView.swift
@@ -51,7 +51,15 @@ struct CommitEditorTabView: View {
     }
 
     private var diffTaskKey: String {
-        "\(tabState.currentSha):\(selectedPath ?? "")"
+        Self.diffTaskKey(
+            currentSha: tabState.currentSha,
+            selectedPath: selectedPath,
+            loadingDetails: loadingDetails
+        )
+    }
+
+    static func diffTaskKey(currentSha: String, selectedPath: String?, loadingDetails: Bool) -> String {
+        "\(currentSha):\(selectedPath ?? ""):\(loadingDetails)"
     }
 
     var body: some View {
@@ -98,10 +106,11 @@ struct CommitEditorTabView: View {
         }
         .task(id: tabState.currentSha) {
             await loadDetails()
-            onStartupRecoveryReady()
         }
         .task(id: diffTaskKey) {
+            guard !loadingDetails else { return }
             await loadDiffIfNeeded()
+            onStartupRecoveryReady()
         }
         .confirmationDialog("Drop file from commit?", isPresented: Binding(
             get: { pendingDropFile != nil },

--- a/Alas/Sources/Center/Commit/CommitEditorTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitEditorTabView.swift
@@ -5,6 +5,7 @@ struct CommitEditorTabView: View {
     let worktreeId: String
     let tabState: CommitEditorTabState
     @Bindable var appState: AppState
+    var onStartupRecoveryReady: () -> Void = {}
 
     @State private var details: CommitDetails?
     @State private var loadingDetails = true
@@ -98,7 +99,7 @@ struct CommitEditorTabView: View {
         .task(id: tabState.currentSha) {
             await loadDetails()
             await loadDiffIfNeeded()
-            appState.completeStartupRecovery()
+            onStartupRecoveryReady()
         }
         .task(id: diffTaskKey) {
             await loadDiffIfNeeded()

--- a/Alas/Sources/Center/Commit/CommitEditorTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitEditorTabView.swift
@@ -95,8 +95,14 @@ struct CommitEditorTabView: View {
                 Color.clear
             }
         }
-        .task(id: tabState.currentSha) { await loadDetails() }
-        .task(id: diffTaskKey) { await loadDiffIfNeeded() }
+        .task(id: tabState.currentSha) {
+            await loadDetails()
+            appState.completeStartupRecovery()
+        }
+        .task(id: diffTaskKey) {
+            await loadDiffIfNeeded()
+            appState.completeStartupRecovery()
+        }
         .confirmationDialog("Drop file from commit?", isPresented: Binding(
             get: { pendingDropFile != nil },
             set: { if !$0 { pendingDropFile = nil } }

--- a/Alas/Sources/Center/Commit/CommitEditorTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitEditorTabView.swift
@@ -98,7 +98,6 @@ struct CommitEditorTabView: View {
         }
         .task(id: tabState.currentSha) {
             await loadDetails()
-            await loadDiffIfNeeded()
             onStartupRecoveryReady()
         }
         .task(id: diffTaskKey) {

--- a/Alas/Sources/Center/Commit/CommitEditorTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitEditorTabView.swift
@@ -62,6 +62,14 @@ struct CommitEditorTabView: View {
         "\(currentSha):\(selectedPath ?? ""):\(loadingDetails)"
     }
 
+    static func shouldReportStartupRecoveryReady(
+        requestedDiffTaskKey: String,
+        currentDiffTaskKey: String,
+        isCancelled: Bool
+    ) -> Bool {
+        !isCancelled && requestedDiffTaskKey == currentDiffTaskKey
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             if let details {
@@ -109,7 +117,13 @@ struct CommitEditorTabView: View {
         }
         .task(id: diffTaskKey) {
             guard !loadingDetails else { return }
+            let requestedDiffTaskKey = diffTaskKey
             await loadDiffIfNeeded()
+            guard Self.shouldReportStartupRecoveryReady(
+                requestedDiffTaskKey: requestedDiffTaskKey,
+                currentDiffTaskKey: diffTaskKey,
+                isCancelled: Task.isCancelled
+            ) else { return }
             onStartupRecoveryReady()
         }
         .confirmationDialog("Drop file from commit?", isPresented: Binding(

--- a/Alas/Sources/Center/Commit/CommitEditorTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitEditorTabView.swift
@@ -97,11 +97,11 @@ struct CommitEditorTabView: View {
         }
         .task(id: tabState.currentSha) {
             await loadDetails()
+            await loadDiffIfNeeded()
             appState.completeStartupRecovery()
         }
         .task(id: diffTaskKey) {
             await loadDiffIfNeeded()
-            appState.completeStartupRecovery()
         }
         .confirmationDialog("Drop file from commit?", isPresented: Binding(
             get: { pendingDropFile != nil },

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -6,6 +6,7 @@ struct CommitTabView: View {
     let tabState: CommitTabState
     let worktreeId: String
     @Bindable var appState: AppState
+    var onStartupRecoveryReady: () -> Void = {}
 
     @State private var details: CommitDetails?
     @State private var loadingDetails = true
@@ -104,7 +105,7 @@ struct CommitTabView: View {
         }
         .task(id: loadTaskID) {
             await loadDetails()
-            appState.completeStartupRecovery()
+            onStartupRecoveryReady()
         }
     }
 

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -102,7 +102,10 @@ struct CommitTabView: View {
                 Color.clear
             }
         }
-        .task(id: loadTaskID) { await loadDetails() }
+        .task(id: loadTaskID) {
+            await loadDetails()
+            appState.completeStartupRecovery()
+        }
     }
 
     @ViewBuilder

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -104,8 +104,9 @@ struct CommitTabView: View {
             }
         }
         .task(id: loadTaskID) {
-            await loadDetails()
-            onStartupRecoveryReady()
+            if await loadDetails() {
+                onStartupRecoveryReady()
+            }
         }
     }
 
@@ -204,7 +205,8 @@ struct CommitTabView: View {
         .background(theme.color("bg-2"))
     }
 
-    private func loadDetails() async {
+    @discardableResult
+    private func loadDetails() async -> Bool {
         let requestedToken = CommitReviewLoadToken.next(key: loadTaskID)
         activeDetailsKey = requestedToken.key
         activeDetailsID = requestedToken.id
@@ -249,23 +251,23 @@ struct CommitTabView: View {
                 resolved = (tracked.resolvedSHA, nil, false)
                 refreshError = error.localizedDescription
             }
-            guard !Task.isCancelled, requestedToken.isActive(activeKey: activeDetailsKey, activeID: activeDetailsID) else { return }
+            guard !Task.isCancelled, requestedToken.isActive(activeKey: activeDetailsKey, activeID: activeDetailsID) else { return false }
             if resolved.reusesCurrentSnapshot {
                 if let tracked = resolved.trackedRevision {
                     appState.tabs.updateCommit(worktreeId: worktreeId, tabId: tabState.id) {
                         $0.revision = .following(tracked)
                     }
                 }
-                return
+                return true
             }
             let d = try await git.commitDetails(at: worktreePath, sha: resolved.sha)
-            guard !Task.isCancelled, requestedToken.isActive(activeKey: activeDetailsKey, activeID: activeDetailsID) else { return }
+            guard !Task.isCancelled, requestedToken.isActive(activeKey: activeDetailsKey, activeID: activeDetailsID) else { return false }
             let loaded = try await loadReviewSession(
                 details: d,
                 sha: resolved.sha,
                 preservesPublishedSession: isTrackedRefresh
             )
-            guard !Task.isCancelled, requestedToken.isActive(activeKey: activeDetailsKey, activeID: activeDetailsID) else { return }
+            guard !Task.isCancelled, requestedToken.isActive(activeKey: activeDetailsKey, activeID: activeDetailsID) else { return false }
             self.details = d
             detailsError = refreshError
             publishReviewSession(loaded, preservingSelectionByPathFrom: selectedReviewFileID)
@@ -275,9 +277,11 @@ struct CommitTabView: View {
                     $0.title = d.info.subject
                 }
             }
+            return true
         } catch {
-            guard !Task.isCancelled, requestedToken.isActive(activeKey: activeDetailsKey, activeID: activeDetailsID) else { return }
+            guard !Task.isCancelled, requestedToken.isActive(activeKey: activeDetailsKey, activeID: activeDetailsID) else { return false }
             self.detailsError = (error as NSError).localizedDescription
+            return true
         }
     }
 

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -5,6 +5,7 @@ struct DraftCommitTabView: View {
     let worktreeId: String
     let tabState: DraftCommitTabState
     @Bindable var appState: AppState
+    var onStartupRecoveryReady: () -> Void = {}
 
     @State private var subject: String = ""
     @State private var bodyText: String = ""
@@ -176,7 +177,7 @@ struct DraftCommitTabView: View {
         .onChange(of: busy) { _, _ in refreshActionsOverlay() }
         .task(id: stagedKey) {
             await loadStagedSession()
-            appState.completeStartupRecovery()
+            onStartupRecoveryReady()
         }
     }
 

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -174,7 +174,10 @@ struct DraftCommitTabView: View {
         }
         .onChange(of: selectedFileID) { _, new in persist(selectedPath: new?.path) }
         .onChange(of: busy) { _, _ in refreshActionsOverlay() }
-        .task(id: stagedKey) { await loadStagedSession() }
+        .task(id: stagedKey) {
+            await loadStagedSession()
+            appState.completeStartupRecovery()
+        }
     }
 
     @ViewBuilder

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -176,8 +176,9 @@ struct DraftCommitTabView: View {
         .onChange(of: selectedFileID) { _, new in persist(selectedPath: new?.path) }
         .onChange(of: busy) { _, _ in refreshActionsOverlay() }
         .task(id: stagedKey) {
-            await loadStagedSession()
-            onStartupRecoveryReady()
+            if await loadStagedSession() {
+                onStartupRecoveryReady()
+            }
         }
     }
 
@@ -341,7 +342,8 @@ struct DraftCommitTabView: View {
     }
 
     @MainActor
-    private func loadStagedSession() async {
+    @discardableResult
+    private func loadStagedSession() async -> Bool {
         let token = stagedKey
         loadingSession = true
         error = nil
@@ -350,16 +352,18 @@ struct DraftCommitTabView: View {
         }
         do {
             let session = try await StagedDiffLoader().load(worktreePath: worktreePath)
-            guard !Task.isCancelled, stagedKey == token else { return }
+            guard !Task.isCancelled, stagedKey == token else { return false }
             publishLoadedSession(session)
             synchronizeSelection(with: session)
+            return true
         } catch is CancellationError {
-            // ignore
+            return false
         } catch {
-            guard stagedKey == token else { return }
+            guard stagedKey == token else { return false }
             stagedSession = nil
             sessionWithActions = nil
             self.error = (error as NSError).localizedDescription
+            return true
         }
     }
 

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -89,7 +89,10 @@ struct DiffTabView: View {
             }
         }
         .background(theme.color("bg-1"))
-        .task(id: imageLoadKey) { await loadImagePair() }
+        .task(id: imageLoadKey) {
+            await loadImagePair()
+            appState.completeStartupRecovery()
+        }
     }
 
     private var imageLoadKey: String {
@@ -152,7 +155,10 @@ struct DiffTabView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(theme.color("bg-1"))
         .onChange(of: loadKey, initial: true) { _, _ in loadDraftCommentController() }
-        .task(id: loadKey) { await load() }
+        .task(id: loadKey) {
+            await load()
+            appState.completeStartupRecovery()
+        }
         .onReceive(NotificationCenter.default.publisher(for: .alasReviewDraftCommentsDidChangeExternally)) { _ in
             try? draftCommentController?.load()
         }

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -23,6 +23,7 @@ struct DiffTabView: View {
     let appState: AppState
     var codeFontFamily: String = ""
     var codeFontSize: CGFloat = 13
+    var onStartupRecoveryReady: () -> Void = {}
     let onOpenFile: (() -> Void)?
     let onRequestDiscardFile: (() -> Void)?
     @Environment(\.theme) var theme
@@ -91,7 +92,7 @@ struct DiffTabView: View {
         .background(theme.color("bg-1"))
         .task(id: imageLoadKey) {
             await loadImagePair()
-            appState.completeStartupRecovery()
+            onStartupRecoveryReady()
         }
     }
 
@@ -157,7 +158,7 @@ struct DiffTabView: View {
         .onChange(of: loadKey, initial: true) { _, _ in loadDraftCommentController() }
         .task(id: loadKey) {
             await load()
-            appState.completeStartupRecovery()
+            onStartupRecoveryReady()
         }
         .onReceive(NotificationCenter.default.publisher(for: .alasReviewDraftCommentsDidChangeExternally)) { _ in
             try? draftCommentController?.load()

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -464,6 +464,10 @@ struct EditorTabView: View {
         externalAbsolutePath == nil || externalEditable
     }
 
+    static func isBinary(loadKind: EditorBuffer.LoadKind?) -> Bool {
+        loadKind == .notUTF8
+    }
+
     private var conflictBannerBuffer: EditorBuffer {
         if let externalAbsolutePath {
             return appState.tabs.externalBuffer(
@@ -498,9 +502,9 @@ struct EditorTabView: View {
 
     private var isBinary: Bool {
         if externalAbsolutePath != nil {
-            return appState.tabs.peekExternalBuffer(tabId: tabId)?.loadKind == .notUTF8
+            return Self.isBinary(loadKind: appState.tabs.peekExternalBuffer(tabId: tabId)?.loadKind)
         }
-        return appState.tabs.peekBuffer(tabId: tabId)?.loadKind == .notUTF8
+        return Self.isBinary(loadKind: appState.tabs.peekBuffer(tabId: tabId)?.loadKind)
     }
 
     private var binaryPlaceholder: some View {
@@ -524,6 +528,9 @@ struct EditorTabView: View {
         }
         .padding(24)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear {
+            onStartupRecoveryReady()
+        }
     }
 
     private var statusBadge: some View {

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -163,6 +163,9 @@ struct EditorTabView: View {
             }
         }
         .background(theme.color("bg-1"))
+        .onAppear {
+            appState.completeStartupRecovery()
+        }
         .onDisappear {
             clearFindHighlights()
             activeTextView?.escapeHandler = nil

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -51,6 +51,7 @@ struct EditorTabView: View {
     var externalEditable: Bool = false
     let originatingRelativePath: String?
     let onRevealInFiles: (String) -> Void
+    var onStartupRecoveryReady: () -> Void = {}
     @Environment(\.theme) var theme
     @Environment(\.openWindow) private var openWindow
 
@@ -159,7 +160,7 @@ struct EditorTabView: View {
                     textRendering: CodeEditorTextRenderingConfiguration(code: appState.config.code),
                     onTextViewAttached: { attachFindController(to: $0) },
                     onTextViewDetached: { detachFindController(from: $0) },
-                    onInitialHighlightReady: { appState.completeStartupRecovery() }
+                    onInitialHighlightReady: onStartupRecoveryReady
                 )
             }
         }

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -158,14 +158,12 @@ struct EditorTabView: View {
                     showLineNumbers: appState.config.code.showLineNumbers,
                     textRendering: CodeEditorTextRenderingConfiguration(code: appState.config.code),
                     onTextViewAttached: { attachFindController(to: $0) },
-                    onTextViewDetached: { detachFindController(from: $0) }
+                    onTextViewDetached: { detachFindController(from: $0) },
+                    onInitialHighlightReady: { appState.completeStartupRecovery() }
                 )
             }
         }
         .background(theme.color("bg-1"))
-        .onAppear {
-            appState.completeStartupRecovery()
-        }
         .onDisappear {
             clearFindHighlights()
             activeTextView?.escapeHandler = nil

--- a/Alas/Sources/Center/FileHistoryTabView.swift
+++ b/Alas/Sources/Center/FileHistoryTabView.swift
@@ -5,6 +5,7 @@ struct FileHistoryTabView: View {
     let state: FileHistoryTabState
     let onSelectCommit: (CommitInfo) -> Void
     let onCopySHA: (CommitInfo) -> Void
+    var onStartupRecoveryReady: () -> Void = {}
 
     @Environment(\.theme) private var theme
     @State private var commits: [CommitInfo] = []
@@ -19,7 +20,10 @@ struct FileHistoryTabView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(theme.color("bg-1"))
-        .task(id: loadKey) { await load() }
+        .task(id: loadKey) {
+            await load()
+            onStartupRecoveryReady()
+        }
     }
 
     private var loadKey: String {

--- a/Alas/Sources/Center/FileSnapshotTabView.swift
+++ b/Alas/Sources/Center/FileSnapshotTabView.swift
@@ -6,6 +6,7 @@ struct FileSnapshotTabView: View {
     let state: FileSnapshotTabState
     var codeFontFamily: String = ""
     var codeFontSize: CGFloat = 13
+    var onStartupRecoveryReady: () -> Void = {}
 
     @Environment(\.theme) private var theme
     @State private var result: HeadBlobTextResult?
@@ -19,7 +20,10 @@ struct FileSnapshotTabView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(theme.color("bg-1"))
-        .task(id: loadKey) { await load() }
+        .task(id: loadKey) {
+            await load()
+            onStartupRecoveryReady()
+        }
     }
 
     private var loadKey: String { "\(worktreePath.path)\u{0}\(state.ref)\u{0}\(state.relativePath)" }

--- a/Alas/Sources/Center/ImagePreviewTabView.swift
+++ b/Alas/Sources/Center/ImagePreviewTabView.swift
@@ -5,6 +5,7 @@ struct ImagePreviewTabView: View {
     let worktreePath: URL
     let relativePath: String
     let onRevealInFiles: (String) -> Void
+    var onStartupRecoveryReady: () -> Void = {}
     @Environment(\.theme) private var theme
     @State private var loadState: LoadState = .idle
 
@@ -36,6 +37,7 @@ struct ImagePreviewTabView: View {
         .background(theme.color("bg-1"))
         .task(id: absoluteURL) {
             await loadImage()
+            onStartupRecoveryReady()
         }
     }
 

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -130,6 +130,7 @@ struct MergeConflictTabView: View {
             // (where currentConflictIndex stays at 0 forever) would never
             // get auto-explained.
             triggerExplainIfNeeded()
+            state.completeStartupRecovery()
         }
     }
 

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -4,6 +4,7 @@ struct MergeConflictTabView: View {
     @Bindable var state: AppState
     let worktree: Worktree
     let tabState: MergeConflictTabState
+    let onStartupRecoveryReady: () -> Void
 
     @State private var model: MergeConflictTabModel
     /// Conflict keys dismissed from the annotation strip. Lifted out of
@@ -13,10 +14,16 @@ struct MergeConflictTabView: View {
     @State private var dismissedAnnotationKeys: Set<String> = []
     @Environment(\.theme) var theme
 
-    init(state: AppState, worktree: Worktree, tabState: MergeConflictTabState) {
+    init(
+        state: AppState,
+        worktree: Worktree,
+        tabState: MergeConflictTabState,
+        onStartupRecoveryReady: @escaping () -> Void = {}
+    ) {
         self.state = state
         self.worktree = worktree
         self.tabState = tabState
+        self.onStartupRecoveryReady = onStartupRecoveryReady
         self._model = State(
             initialValue: MergeConflictTabModel(
                 worktreePath: worktree.path,
@@ -130,7 +137,7 @@ struct MergeConflictTabView: View {
             // (where currentConflictIndex stays at 0 forever) would never
             // get auto-explained.
             triggerExplainIfNeeded()
-            state.completeStartupRecovery()
+            onStartupRecoveryReady()
         }
     }
 

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -25,6 +25,7 @@ struct ReviewTabView: View {
     let worktree: Worktree
     let tabState: ReviewPRTabState
     let appState: AppState
+    var onStartupRecoveryReady: () -> Void = {}
     // Loads the working-tree diff (same as ReviewChangesTabView). To show PR base..head diff
     // instead, inject a PR-diff loader here when that loader exists.
     var loader: ReviewChangesLoader = ReviewChangesLoader()
@@ -115,7 +116,7 @@ struct ReviewTabView: View {
         await loadSession()
         localThreads = reviewRequest?.threads ?? []
         if completingStartupRecovery {
-            appState.completeStartupRecovery()
+            onStartupRecoveryReady()
         }
     }
 

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -95,6 +95,7 @@ struct ReviewTabView: View {
             pendingReview = PendingReview(worktreePath: worktree.path, prNumber: reviewRequest?.number)
             await loadSession()
             localThreads = reviewRequest?.threads ?? []
+            appState.completeStartupRecovery()
         }
         .task(id: reviewRequest?.number) {
             // Re-scope PendingReview and reload when the PR number first arrives (snapshot
@@ -102,6 +103,7 @@ struct ReviewTabView: View {
             pendingReview = PendingReview(worktreePath: worktree.path, prNumber: reviewRequest?.number)
             await loadSession()
             localThreads = reviewRequest?.threads ?? []
+            appState.completeStartupRecovery()
         }
         .onChange(of: reviewRequest) { _, newValue in
             guard !isWriting else { return }

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -92,24 +92,30 @@ struct ReviewTabView: View {
             )
         }
         .task(id: loadKey) {
-            pendingReview = PendingReview(worktreePath: worktree.path, prNumber: reviewRequest?.number)
-            await loadSession()
-            localThreads = reviewRequest?.threads ?? []
-            appState.completeStartupRecovery()
+            let completesStartupRecovery = reviewRequest != nil
+            await reload(completingStartupRecovery: completesStartupRecovery)
         }
         .task(id: reviewRequest?.number) {
             // Re-scope PendingReview and reload when the PR number first arrives (snapshot
             // may populate after the loadKey task has already run with prNumber: nil).
-            pendingReview = PendingReview(worktreePath: worktree.path, prNumber: reviewRequest?.number)
-            await loadSession()
-            localThreads = reviewRequest?.threads ?? []
-            appState.completeStartupRecovery()
+            guard reviewRequest != nil else { return }
+            await reload(completingStartupRecovery: true)
         }
         .onChange(of: reviewRequest) { _, newValue in
             guard !isWriting else { return }
             localThreads = newValue?.threads ?? []
             let currentCheckIDs = Set(newValue?.checks.map { $0.id } ?? [])
             annotations = annotations.filter { currentCheckIDs.contains($0.checkRunID) }
+        }
+    }
+
+    @MainActor
+    private func reload(completingStartupRecovery: Bool) async {
+        pendingReview = PendingReview(worktreePath: worktree.path, prNumber: reviewRequest?.number)
+        await loadSession()
+        localThreads = reviewRequest?.threads ?? []
+        if completingStartupRecovery {
+            appState.completeStartupRecovery()
         }
     }
 

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -22,8 +22,8 @@ enum ReviewTabPendingReviewPresentation {
 }
 
 enum ReviewTabStartupRecoveryReadiness {
-    static func shouldComplete(hasReviewRequest: Bool, hasLoadedSnapshot: Bool) -> Bool {
-        hasReviewRequest || hasLoadedSnapshot
+    static func shouldComplete(hasReviewRequest: Bool, reviewRefreshSettled: Bool) -> Bool {
+        hasReviewRequest || reviewRefreshSettled
     }
 }
 
@@ -101,7 +101,7 @@ struct ReviewTabView: View {
         .task(id: loadKey) {
             let completesStartupRecovery = ReviewTabStartupRecoveryReadiness.shouldComplete(
                 hasReviewRequest: reviewRequest != nil,
-                hasLoadedSnapshot: hasLoadedSnapshot
+                reviewRefreshSettled: reviewRefreshSettled
             )
             await reload(completingStartupRecovery: completesStartupRecovery)
         }
@@ -135,8 +135,12 @@ struct ReviewTabView: View {
         appState.rightPaneStore.activeState(worktreeId: tabState.worktreeId)?.reviewLoop.snapshot
     }
 
-    private var hasLoadedSnapshot: Bool {
-        appState.rightPaneStore.activeState(worktreeId: tabState.worktreeId)?.hasLoadedSnapshot == true
+    private var reviewRefreshSettled: Bool {
+        guard let reviewLoop = appState.rightPaneStore
+            .activeState(worktreeId: tabState.worktreeId)?
+            .reviewLoop
+        else { return false }
+        return reviewLoop.snapshot != nil && !reviewLoop.isRefreshing
     }
 
     private var matchedSnapshot: ReviewLoopSnapshot? {
@@ -169,11 +173,14 @@ struct ReviewTabView: View {
     // MARK: - Load key (mirrors ReviewChangesTabView)
 
     private var loadKey: String {
-        ReviewChangesLoadKey.build(
-            tabID: tabState.id,
-            worktreePath: worktree.path,
-            rightPaneState: appState.rightPaneStore.activeState(worktreeId: worktree.id)
-        )
+        [
+            ReviewChangesLoadKey.build(
+                tabID: tabState.id,
+                worktreePath: worktree.path,
+                rightPaneState: appState.rightPaneStore.activeState(worktreeId: worktree.id)
+            ),
+            "reviewRefreshSettled:\(reviewRefreshSettled)"
+        ].joined(separator: "\u{0}")
     }
 
     // MARK: - Content

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -21,6 +21,12 @@ enum ReviewTabPendingReviewPresentation {
     }
 }
 
+enum ReviewTabStartupRecoveryReadiness {
+    static func shouldComplete(hasReviewRequest: Bool, hasLoadedSnapshot: Bool) -> Bool {
+        hasReviewRequest || hasLoadedSnapshot
+    }
+}
+
 struct ReviewTabView: View {
     let worktree: Worktree
     let tabState: ReviewPRTabState
@@ -93,7 +99,10 @@ struct ReviewTabView: View {
             )
         }
         .task(id: loadKey) {
-            let completesStartupRecovery = reviewRequest != nil
+            let completesStartupRecovery = ReviewTabStartupRecoveryReadiness.shouldComplete(
+                hasReviewRequest: reviewRequest != nil,
+                hasLoadedSnapshot: hasLoadedSnapshot
+            )
             await reload(completingStartupRecovery: completesStartupRecovery)
         }
         .task(id: reviewRequest?.number) {
@@ -124,6 +133,10 @@ struct ReviewTabView: View {
 
     private var activeSnapshot: ReviewLoopSnapshot? {
         appState.rightPaneStore.activeState(worktreeId: tabState.worktreeId)?.reviewLoop.snapshot
+    }
+
+    private var hasLoadedSnapshot: Bool {
+        appState.rightPaneStore.activeState(worktreeId: tabState.worktreeId)?.hasLoadedSnapshot == true
     }
 
     private var matchedSnapshot: ReviewLoopSnapshot? {

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -35,6 +35,16 @@ enum ReviewTabStartupRecoveryReadiness {
     }
 }
 
+enum ReviewTabLoadKey {
+    static func build(baseLoadKey: String, reviewRequestNumber: Int?, reviewRefreshSettled: Bool) -> String {
+        [
+            baseLoadKey,
+            "prNumber:\(reviewRequestNumber.map(String.init) ?? "none")",
+            "reviewRefreshSettled:\(reviewRefreshSettled)"
+        ].joined(separator: "\u{0}")
+    }
+}
+
 struct ReviewTabView: View {
     let worktree: Worktree
     let tabState: ReviewPRTabState
@@ -111,13 +121,9 @@ struct ReviewTabView: View {
                 hasReviewRequest: reviewRequest != nil,
                 reviewRefreshSettled: reviewRefreshSettled
             )
-            await reload(completingStartupRecovery: completesStartupRecovery)
-        }
-        .task(id: reviewRequest?.number) {
-            // Re-scope PendingReview and reload when the PR number first arrives (snapshot
-            // may populate after the loadKey task has already run with prNumber: nil).
-            guard reviewRequest != nil else { return }
-            await reload(completingStartupRecovery: true)
+            if await reload(completingStartupRecovery: completesStartupRecovery) {
+                onStartupRecoveryReady()
+            }
         }
         .onChange(of: reviewRequest) { _, newValue in
             guard !isWriting else { return }
@@ -128,13 +134,11 @@ struct ReviewTabView: View {
     }
 
     @MainActor
-    private func reload(completingStartupRecovery: Bool) async {
+    private func reload(completingStartupRecovery: Bool) async -> Bool {
         pendingReview = PendingReview(worktreePath: worktree.path, prNumber: reviewRequest?.number)
-        await loadSession()
+        guard await loadSession() else { return false }
         localThreads = reviewRequest?.threads ?? []
-        if completingStartupRecovery {
-            onStartupRecoveryReady()
-        }
+        return completingStartupRecovery
     }
 
     // MARK: - Derived state from snapshot
@@ -185,14 +189,15 @@ struct ReviewTabView: View {
     // MARK: - Load key (mirrors ReviewChangesTabView)
 
     private var loadKey: String {
-        [
-            ReviewChangesLoadKey.build(
+        ReviewTabLoadKey.build(
+            baseLoadKey: ReviewChangesLoadKey.build(
                 tabID: tabState.id,
                 worktreePath: worktree.path,
                 rightPaneState: appState.rightPaneStore.activeState(worktreeId: worktree.id)
             ),
-            "reviewRefreshSettled:\(reviewRefreshSettled)"
-        ].joined(separator: "\u{0}")
+            reviewRequestNumber: reviewRequest?.number,
+            reviewRefreshSettled: reviewRefreshSettled
+        )
     }
 
     // MARK: - Content
@@ -641,7 +646,7 @@ struct ReviewTabView: View {
     // MARK: - Loading
 
     @MainActor
-    private func loadSession() async {
+    private func loadSession() async -> Bool {
         let requestedLoadToken = ReviewChangesLoadToken.next(key: loadKey)
         activeLoadKey = requestedLoadToken.key
         activeLoadID = requestedLoadToken.id
@@ -662,27 +667,30 @@ struct ReviewTabView: View {
                 guard
                     requestedLoadToken.isActive(activeKey: activeLoadKey, activeID: activeLoadID),
                     !Task.isCancelled
-                else { return }
+                else { return false }
                 loaded = prSession
             } else {
                 loaded = try await loader.load(worktreePath: worktree.path)
                 guard
                     requestedLoadToken.isActive(activeKey: activeLoadKey, activeID: activeLoadID),
                     !Task.isCancelled
-                else { return }
+                else { return false }
             }
 
             session = loaded
             selectedFileID = selectedFileID.flatMap { selected in
                 loaded.summary.files.contains { $0.id == selected } ? selected : loaded.summary.files.first?.id
             } ?? loaded.summary.files.first?.id
+            return true
         } catch is CancellationError {
+            return false
         } catch {
             guard
                 requestedLoadToken.isActive(activeKey: activeLoadKey, activeID: activeLoadID),
                 !Task.isCancelled
-            else { return }
+            else { return false }
             loadError = error.localizedDescription
+            return true
         }
     }
 

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -22,6 +22,14 @@ enum ReviewTabPendingReviewPresentation {
 }
 
 enum ReviewTabStartupRecoveryReadiness {
+    static func reviewRefreshSettled(
+        hasSnapshot: Bool,
+        isRefreshing: Bool,
+        hasError: Bool
+    ) -> Bool {
+        !isRefreshing && (hasSnapshot || hasError)
+    }
+
     static func shouldComplete(hasReviewRequest: Bool, reviewRefreshSettled: Bool) -> Bool {
         hasReviewRequest || reviewRefreshSettled
     }
@@ -140,7 +148,11 @@ struct ReviewTabView: View {
             .activeState(worktreeId: tabState.worktreeId)?
             .reviewLoop
         else { return false }
-        return reviewLoop.snapshot != nil && !reviewLoop.isRefreshing
+        return ReviewTabStartupRecoveryReadiness.reviewRefreshSettled(
+            hasSnapshot: reviewLoop.snapshot != nil,
+            isRefreshing: reviewLoop.isRefreshing,
+            hasError: reviewLoop.lastError != nil
+        )
     }
 
     private var matchedSnapshot: ReviewLoopSnapshot? {

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -74,6 +74,7 @@ struct ReviewChangesTabView: View {
     let worktree: Worktree
     let tabState: ReviewChangesTabState
     let appState: AppState
+    var onStartupRecoveryReady: () -> Void = {}
     var loader: ReviewChangesLoader = ReviewChangesLoader()
 
     @Environment(\.theme) private var theme
@@ -104,7 +105,7 @@ struct ReviewChangesTabView: View {
         .background(theme.color("bg-1"))
         .task(id: loadKey) {
             await loadSession()
-            appState.completeStartupRecovery()
+            onStartupRecoveryReady()
         }
         .task(id: reviewDraftSessionID.rawValue) {
             loadDraftCommentController()

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -104,8 +104,9 @@ struct ReviewChangesTabView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(theme.color("bg-1"))
         .task(id: loadKey) {
-            await loadSession()
-            onStartupRecoveryReady()
+            if await loadSession() {
+                onStartupRecoveryReady()
+            }
         }
         .task(id: reviewDraftSessionID.rawValue) {
             loadDraftCommentController()
@@ -426,7 +427,8 @@ struct ReviewChangesTabView: View {
     }
 
     @MainActor
-    private func loadSession() async {
+    @discardableResult
+    private func loadSession() async -> Bool {
         let requestedLoadToken = ReviewChangesLoadToken.next(key: loadKey)
         activeLoadKey = requestedLoadToken.key
         activeLoadID = requestedLoadToken.id
@@ -444,19 +446,22 @@ struct ReviewChangesTabView: View {
             guard
                 requestedLoadToken.isActive(activeKey: activeLoadKey, activeID: activeLoadID),
                 !Task.isCancelled
-            else { return }
+            else { return false }
             session = loaded
             selectedFileID = selectedFileID.flatMap { selected in
                 loaded.summary.files.contains { $0.id == selected } ? selected : loaded.summary.files.first?.id
             } ?? loaded.summary.files.first?.id
             loadDraftCommentController()
+            return true
         } catch is CancellationError {
+            return false
         } catch {
             guard
                 requestedLoadToken.isActive(activeKey: activeLoadKey, activeID: activeLoadID),
                 !Task.isCancelled
-            else { return }
+            else { return false }
             loadError = error.localizedDescription
+            return true
         }
     }
 

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -104,6 +104,7 @@ struct ReviewChangesTabView: View {
         .background(theme.color("bg-1"))
         .task(id: loadKey) {
             await loadSession()
+            appState.completeStartupRecovery()
         }
         .task(id: reviewDraftSessionID.rawValue) {
             loadDraftCommentController()

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -101,7 +101,13 @@ struct DraftReviewRequestTabView: View {
             selectedPath = path
         }
         .task(id: contextKey) {
+            let requestedContextKey = contextKey
             await loadContext()
+            guard Self.shouldReportStartupRecoveryReady(
+                requestedContextKey: requestedContextKey,
+                currentContextKey: contextKey,
+                isCancelled: Task.isCancelled
+            ) else { return }
             onStartupRecoveryReady()
         }
         .task(id: reviewDraftSessionID.rawValue) {
@@ -144,6 +150,14 @@ struct DraftReviewRequestTabView: View {
 
     static func canLaunchReviewSession(targetMismatchMessage: String?) -> Bool {
         targetMismatchMessage == nil
+    }
+
+    static func shouldReportStartupRecoveryReady(
+        requestedContextKey: String,
+        currentContextKey: String,
+        isCancelled: Bool
+    ) -> Bool {
+        !isCancelled && requestedContextKey == currentContextKey
     }
 
     private var reviewDraftSessionID: ReviewDraftSessionID {

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -99,7 +99,10 @@ struct DraftReviewRequestTabView: View {
             guard selectedPath != path else { return }
             selectedPath = path
         }
-        .task(id: contextKey) { await loadContext() }
+        .task(id: contextKey) {
+            await loadContext()
+            appState.completeStartupRecovery()
+        }
         .task(id: reviewDraftSessionID.rawValue) {
             loadDraftCommentController()
         }

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -6,6 +6,7 @@ struct DraftReviewRequestTabView: View {
     let worktreeId: String
     let tabState: DraftReviewRequestTabState
     @Bindable var appState: AppState
+    var onStartupRecoveryReady: () -> Void = {}
 
     @State private var title: String = ""
     @State private var bodyText: String = ""
@@ -101,7 +102,7 @@ struct DraftReviewRequestTabView: View {
         }
         .task(id: contextKey) {
             await loadContext()
-            appState.completeStartupRecovery()
+            onStartupRecoveryReady()
         }
         .task(id: reviewDraftSessionID.rawValue) {
             loadDraftCommentController()

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -204,8 +204,9 @@ struct ReviewSessionTabView: View {
         .task(id: loadTaskID) {
             guard loadsOnAppear else { return }
             let token = beginLoadReviewSession()
-            await loadReviewSession(token: token)
-            onStartupRecoveryReady()
+            if await loadReviewSession(token: token) {
+                onStartupRecoveryReady()
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .alasReviewDraftCommentsDidChangeExternally)) { _ in
             try? draftCommentController?.load()
@@ -554,7 +555,7 @@ struct ReviewSessionTabView: View {
         return token
     }
 
-    private func loadReviewSession(token: ReviewSessionTabLoadToken) async {
+    private func loadReviewSession(token: ReviewSessionTabLoadToken) async -> Bool {
         do {
             guard let storedRecord = try sessionStore.load(id: tabState.sessionID) else {
                 throw ReviewSessionTabError.missingSession(tabState.sessionID)
@@ -570,7 +571,7 @@ struct ReviewSessionTabView: View {
                 resolvedRecord = (storedRecord, false)
                 refreshError = error.localizedDescription
             }
-            guard loadCoordinator.canPublish(token) else { return }
+            guard loadCoordinator.canPublish(token) else { return false }
             var refreshedRecord = mergeLatestMutableFields(into: resolvedRecord.record, fallback: storedRecord)
             if let loaded,
                Self.canReuseLoadedTrackedDiff(
@@ -587,14 +588,14 @@ struct ReviewSessionTabView: View {
                 loadDraftCommentController(for: refreshedRecord)
                 isLoading = false
                 loadCoordinator.finish(token)
-                return
+                return true
             }
             if resolvedRecord.paused, refreshedRecord.target != storedRecord.target {
                 try sessionStore.save(refreshedRecord)
             }
 
             let loadedContext = try await loader.load(target: refreshedRecord.target)
-            guard loadCoordinator.canPublish(token) else { return }
+            guard loadCoordinator.canPublish(token) else { return false }
             refreshedRecord = mergeLatestMutableFields(into: refreshedRecord, fallback: storedRecord)
             if !resolvedRecord.paused, refreshedRecord.target != storedRecord.target {
                 try sessionStore.save(refreshedRecord)
@@ -610,15 +611,18 @@ struct ReviewSessionTabView: View {
             loadDraftCommentController(for: refreshedRecord)
             isLoading = false
             loadCoordinator.finish(token)
+            return true
         } catch is CancellationError {
-            guard loadCoordinator.canPublish(token) else { return }
+            guard loadCoordinator.canPublish(token) else { return false }
             isLoading = false
             loadCoordinator.finish(token)
+            return false
         } catch {
-            guard loadCoordinator.canPublish(token) else { return }
+            guard loadCoordinator.canPublish(token) else { return false }
             loadError = error.localizedDescription
             isLoading = false
             loadCoordinator.finish(token)
+            return true
         }
     }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -198,6 +198,7 @@ struct ReviewSessionTabView: View {
             guard loadsOnAppear else { return }
             let token = beginLoadReviewSession()
             await loadReviewSession(token: token)
+            appState?.completeStartupRecovery()
         }
         .onReceive(NotificationCenter.default.publisher(for: .alasReviewDraftCommentsDidChangeExternally)) { _ in
             try? draftCommentController?.load()

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -61,6 +61,7 @@ struct ReviewSessionTabView: View {
     let worktree: Worktree?
     let tabState: ReviewSessionTabState
     let appState: AppState?
+    var onStartupRecoveryReady: () -> Void = {}
     var sessionStore: ReviewSessionStore
     var draftCommentStore: ReviewDraftCommentStore
     var loader: ReviewSessionLoader
@@ -98,10 +99,16 @@ struct ReviewSessionTabView: View {
     @State private var isProviderPublishing = false
     @State private var providerPublishError: String?
 
-    init(worktree: Worktree, tabState: ReviewSessionTabState, appState: AppState) {
+    init(
+        worktree: Worktree,
+        tabState: ReviewSessionTabState,
+        appState: AppState,
+        onStartupRecoveryReady: @escaping () -> Void = {}
+    ) {
         self.worktree = worktree
         self.tabState = tabState
         self.appState = appState
+        self.onStartupRecoveryReady = onStartupRecoveryReady
         self.sessionStore = ReviewSessionStore()
         self.draftCommentStore = ReviewDraftCommentStore()
         self.loader = ReviewSessionLoader.production(appState: appState, worktree: worktree)
@@ -198,7 +205,7 @@ struct ReviewSessionTabView: View {
             guard loadsOnAppear else { return }
             let token = beginLoadReviewSession()
             await loadReviewSession(token: token)
-            appState?.completeStartupRecovery()
+            onStartupRecoveryReady()
         }
         .onReceive(NotificationCenter.default.publisher(for: .alasReviewDraftCommentsDidChangeExternally)) { _ in
             try? draftCommentController?.load()

--- a/Alas/Sources/Center/StashDiffTabView.swift
+++ b/Alas/Sources/Center/StashDiffTabView.swift
@@ -5,6 +5,7 @@ struct StashDiffTabView: View {
     let state: StashDiffTabState
     var codeFontFamily: String = ""
     var codeFontSize: CGFloat = 13
+    var onStartupRecoveryReady: () -> Void = {}
 
     @Environment(\.theme) private var theme
     @State private var loaded = false
@@ -51,7 +52,10 @@ struct StashDiffTabView: View {
             }
         }
         .background(theme.color("bg-1"))
-        .task(id: imageLoadKey) { await loadImagePair() }
+        .task(id: imageLoadKey) {
+            await loadImagePair()
+            onStartupRecoveryReady()
+        }
     }
 
     private var imageLoadKey: String {
@@ -114,7 +118,10 @@ struct StashDiffTabView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(theme.color("bg-1"))
-        .task(id: "\(state.stash.ref)\u{0}\(state.file.path)") { await load() }
+        .task(id: "\(state.stash.ref)\u{0}\(state.file.path)") {
+            await load()
+            onStartupRecoveryReady()
+        }
     }
 
     private var header: some View {

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -151,10 +151,16 @@ final class TabsManager {
         return tabId
     }
 
-    func loadAll(worktreeIds: [String]) {
+    func loadAll(worktreeIds: [String], restoringActiveTabs: Bool = true) {
         for id in worktreeIds {
-            if let file = try? store.readIfExists(TabsFile.self, from: tabsFile(forWorktreeId: id)) {
+            if var file = try? store.readIfExists(TabsFile.self, from: tabsFile(forWorktreeId: id)) {
+                if !restoringActiveTabs {
+                    file.activeTabId = nil
+                }
                 byWorktree[id] = file
+                if !restoringActiveTabs {
+                    persist(id)
+                }
             }
         }
         hasLoaded = true

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -171,7 +171,10 @@ final class TabsManager {
     func loadAllPersisted(restoringActiveTabs: Bool = true) {
         guard let relativeFiles = try? FileManager.default.subpathsOfDirectory(
             atPath: tabsDirectory.path
-        ) else { return }
+        ) else {
+            loadAll(worktreeIds: [], restoringActiveTabs: restoringActiveTabs)
+            return
+        }
         let worktreeIDs = relativeFiles.compactMap { relativeFile -> String? in
             guard relativeFile.hasSuffix(".json") else { return nil }
             let file = tabsDirectory.appendingPathComponent(relativeFile)

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -168,7 +168,7 @@ final class TabsManager {
 
     /// Loads every persisted tab file, including files whose worktree is not
     /// currently discoverable. `TabsFile` skips unsupported tab cases.
-    func loadAllPersisted() {
+    func loadAllPersisted(restoringActiveTabs: Bool = true) {
         guard let relativeFiles = try? FileManager.default.subpathsOfDirectory(
             atPath: tabsDirectory.path
         ) else { return }
@@ -181,7 +181,7 @@ final class TabsManager {
             guard !relativePath.isEmpty else { return nil }
             return relativePath.contains("/") ? "/\(relativePath)" : relativePath
         }
-        loadAll(worktreeIds: worktreeIDs)
+        loadAll(worktreeIds: worktreeIDs, restoringActiveTabs: restoringActiveTabs)
     }
 
     @discardableResult

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -32,6 +32,7 @@ struct TerminalTabView: View {
         }
         .task(id: tabId) {
             _ = try? await state.restoreTerminalTabIfNeededAsync(worktreeId: worktreeId, tabId: tabId)
+            state.completeStartupRecovery()
         }
         .background(theme.color("bg-0"))
     }

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -6,6 +6,7 @@ struct TerminalTabView: View {
     let worktreeId: String
     let tabId: TabID
     var allowsPaneFocus: Bool = true
+    var onStartupRecoveryReady: () -> Void = {}
 
     @Environment(\.theme) var theme
 
@@ -32,7 +33,7 @@ struct TerminalTabView: View {
         }
         .task(id: tabId) {
             _ = try? await state.restoreTerminalTabIfNeededAsync(worktreeId: worktreeId, tabId: tabId)
-            state.completeStartupRecovery()
+            onStartupRecoveryReady()
         }
         .background(theme.color("bg-0"))
     }

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -691,6 +691,7 @@ final class CodeEditorCoordinator {
 
     private func makeLSPDidChangePayload(edits: [EditorTextEdit]? = nil) -> LSPDidChangePayload? {
         guard let buffer, let language = currentLanguage else { return nil }
+        guard !buffer.isExternal else { return nil }
         let url = buffer.worktreeRoot.appendingPathComponent(buffer.relativePath)
         return LSPDidChangePayload(
             worktreeRoot: buffer.worktreeRoot,

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -691,7 +691,7 @@ final class CodeEditorCoordinator {
 
     private func makeLSPDidChangePayload(edits: [EditorTextEdit]? = nil) -> LSPDidChangePayload? {
         guard let buffer, let language = currentLanguage else { return nil }
-        guard !buffer.isExternal else { return nil }
+        guard !buffer.isExternal || buffer.externalEditable else { return nil }
         let url = buffer.worktreeRoot.appendingPathComponent(buffer.relativePath)
         return LSPDidChangePayload(
             worktreeRoot: buffer.worktreeRoot,

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -13,6 +13,7 @@ final class CodeEditorCoordinator {
     let appState: AppState
     var onTextViewAttached: ((CodeTextView, TabID) -> Void)?
     var onTextViewDetached: ((CodeTextView?, TabID?) -> Void)?
+    var onInitialHighlightReady: ((TabID) -> Void)?
 
     private weak var textView: CodeTextView?
     private weak var buffer: EditorBuffer?
@@ -54,6 +55,7 @@ final class CodeEditorCoordinator {
     private var definition: DefinitionFeature?
     private var hoverHighlight: HoverHighlightFeature?
     private var completion: CompletionFeature?
+    private var reportedInitialHighlightReady = false
 
     private var editObserverToken: EditorBuffer.EditObserverToken?
     private var didChangeTask: Task<Void, Never>?
@@ -339,6 +341,7 @@ final class CodeEditorCoordinator {
             clearRevealHighlight()
             hoverHighlight?.cancelAndClear()
             completion?.cancelAndDismiss()
+            reportedInitialHighlightReady = false
             didChangeTask?.cancel()
             hasPendingDidChange = false
             pendingTextEdits.removeAll()
@@ -787,6 +790,10 @@ final class CodeEditorCoordinator {
             storage.endEditing()
             if !cachedDiagnostics.isEmpty {
                 self.diagnosticsFeature.apply(cachedDiagnostics, to: storage, theme: theme)
+            }
+            if b.initialLoadFinished, !self.reportedInitialHighlightReady, let tabId = stableTabId {
+                self.reportedInitialHighlightReady = true
+                self.onInitialHighlightReady?(tabId)
             }
         }
     }

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -130,6 +130,7 @@ struct CodeEditorView: NSViewRepresentable {
     let textRendering: CodeEditorTextRenderingConfiguration
     var onTextViewAttached: (CodeTextView) -> Void = { _ in }
     var onTextViewDetached: (CodeTextView?) -> Void = { _ in }
+    var onInitialHighlightReady: () -> Void = {}
     @Environment(\.theme) var theme
 
     func makeCoordinator() -> CodeEditorCoordinator {
@@ -277,6 +278,12 @@ struct CodeEditorView: NSViewRepresentable {
             guard detachedTabId == nil || detachedTabId == expectedTabId else { return }
             DispatchQueue.main.async {
                 onTextViewDetached(textView)
+            }
+        }
+        coordinator.onInitialHighlightReady = { readyTabId in
+            guard readyTabId == expectedTabId else { return }
+            DispatchQueue.main.async {
+                onInitialHighlightReady()
             }
         }
     }

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -466,13 +466,13 @@ final class EditorBuffer {
             checkForConflictOnRestore()
         }
         onEdit { [weak self] in self?.scheduleSnapshot() }
+        initialLoadFinished = true
         // Notify any already-attached coordinator that content has arrived
         // so it can re-apply base style (font/color) to the freshly loaded
         // storage. Without this, bindBuffer's applyBaseStyle ran against
         // empty storage and the loadFromDisk setAttributedString wiped
         // everything, leaving the text view unstyled.
         handleEdit(edit: nil)
-        initialLoadFinished = true
         openLSPDocumentIfReady()
         onInitialLoadFinished?()
     }
@@ -651,11 +651,11 @@ final class EditorBuffer {
         if let edit, markUserEditDuringLoadIfNeeded(edit) {
             return
         }
-        // Read-only external buffers suppress all observer notifications so
-        // didChange is never propagated to LSP or snapshot scheduling. The
-        // explicitly editable external buffers used by run scripts still need
-        // this invalidation path for their dirty indicator and Save All state.
-        guard !isExternal || externalEditable else { return }
+        // Read-only external buffers suppress real edit notifications so
+        // didChange is never propagated to LSP or snapshot scheduling. Nil
+        // notifications are load/reload signals; views still need those to
+        // render and mark startup recovery complete after disk content arrives.
+        guard !isExternal || externalEditable || edit == nil else { return }
         editGeneration &+= 1
         let snapshot = Array(editObservers.values)
         for block in snapshot { block(edit) }

--- a/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
@@ -87,7 +87,7 @@ final class MarkdownPreviewController: NSObject {
     }
 
     /// Replace the rendered content. Must be called on the main thread.
-    func apply(result: MarkdownRenderResult) {
+    func apply(result: MarkdownRenderResult, onReady: (() -> Void)? = nil) {
         guard result.revision != lastAppliedRevision else { return }
         let sourceDisclosureSnapshot = mermaidCoordinator
             .explicitSourceDisclosureSnapshot(in: textView)
@@ -112,7 +112,8 @@ final class MarkdownPreviewController: NSObject {
             to: textView,
             onTextStorageDelta: { [weak self] location, delta in
                 self?.shiftAnchors(startingAt: location, by: delta)
-            }
+            },
+            onReady: onReady
         )
         mermaidCoordinator.restoreExplicitSourceDisclosures(
             sourceDisclosureSnapshot,

--- a/Alas/Sources/Code/Markdown/MarkdownPreviewView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownPreviewView.swift
@@ -4,6 +4,7 @@ import AppKit
 struct MarkdownPreviewView: NSViewRepresentable {
     let result: MarkdownRenderResult
     let onLinkClick: (URL) -> Void
+    var onReady: () -> Void = {}
     @Environment(\.theme) var theme
 
     func makeCoordinator() -> MarkdownPreviewController {
@@ -13,7 +14,7 @@ struct MarkdownPreviewView: NSViewRepresentable {
     func makeNSView(context: Context) -> NSScrollView {
         context.coordinator.onLinkClick = onLinkClick
         context.coordinator.reapplyTheme(theme)
-        context.coordinator.apply(result: result)
+        context.coordinator.apply(result: result, onReady: onReady)
         return context.coordinator.scrollView
     }
 
@@ -26,7 +27,7 @@ struct MarkdownPreviewView: NSViewRepresentable {
         // SwiftUI may call this repeatedly with the same value. The result's
         // revision lets the controller preserve attachment tasks and source
         // disclosure across those duplicate updates.
-        context.coordinator.apply(result: result)
+        context.coordinator.apply(result: result, onReady: onReady)
     }
 
     static func dismantleNSView(

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -15,11 +15,13 @@ struct MarkdownTabView: View {
     let revealRevision: Int?
     @Bindable var appState: AppState
     let onRevealInFiles: (String) -> Void
+    var onStartupRecoveryReady: () -> Void = {}
     @Environment(\.theme) var theme
 
     @State private var renderCache = MarkdownPreviewCache<MarkdownRenderResult>()
     @State private var debounceTask: Task<Void, Never>?
     @State private var mermaidPreviewSource = ""
+    @State private var hasMermaidPreviewSource = false
 
     // Editor/preview divider drag: transient during the drag, committed to
     // the tab store (and disk) once on drag end.
@@ -192,7 +194,7 @@ struct MarkdownTabView: View {
             textRendering: CodeEditorTextRenderingConfiguration(code: appState.config.code),
             onInitialHighlightReady: {
                 if resolvedMode == .editor {
-                    appState.completeStartupRecovery()
+                    onStartupRecoveryReady()
                 }
             }
         )
@@ -201,7 +203,14 @@ struct MarkdownTabView: View {
     @ViewBuilder
     private var preview: some View {
         if isStandaloneMermaid {
-            StandaloneMermaidPreviewView(source: mermaidPreviewSource)
+            if hasMermaidPreviewSource {
+                StandaloneMermaidPreviewView(
+                    source: mermaidPreviewSource,
+                    onRenderComplete: onStartupRecoveryReady
+                )
+            } else {
+                Color.clear.onAppear { scheduleRender(immediate: true) }
+            }
         } else if let renderResult = renderCache.value(for: renderIdentity) {
             MarkdownPreviewView(result: renderResult, onLinkClick: handleLinkClick)
         } else {
@@ -286,7 +295,7 @@ struct MarkdownTabView: View {
             let source = buffer.storage.string
             if isStandaloneMermaid {
                 mermaidPreviewSource = source
-                appState.completeStartupRecovery()
+                hasMermaidPreviewSource = true
                 return
             }
             let parsed = MarkdownParser.parse(source)
@@ -301,12 +310,13 @@ struct MarkdownTabView: View {
             )
             if Task.isCancelled { return }
             renderCache.storeCompletedRender(result, for: renderIdentity)
-            appState.completeStartupRecovery()
+            onStartupRecoveryReady()
         }
     }
 
     private func invalidateRender() {
         debounceTask?.cancel()
+        hasMermaidPreviewSource = false
         renderCache.invalidate()
     }
 
@@ -372,12 +382,17 @@ struct MarkdownTabView: View {
 
 private struct StandaloneMermaidPreviewView: View {
     let source: String
+    var onRenderComplete: () -> Void = {}
 
     @Environment(\.theme) private var theme
 
     var body: some View {
         ScrollView(.vertical) {
-            MermaidDiagramBlockView(source: source, profile: .full)
+            MermaidDiagramBlockView(
+                source: source,
+                profile: .full,
+                onRenderComplete: onRenderComplete
+            )
                 .padding(16)
                 .frame(maxWidth: .infinity, alignment: .topLeading)
         }

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -189,7 +189,12 @@ struct MarkdownTabView: View {
             fontFamily: appState.config.code.fontFamily,
             fontSize: appState.config.code.fontSize,
             showLineNumbers: appState.config.code.showLineNumbers,
-            textRendering: CodeEditorTextRenderingConfiguration(code: appState.config.code)
+            textRendering: CodeEditorTextRenderingConfiguration(code: appState.config.code),
+            onInitialHighlightReady: {
+                if resolvedMode == .editor {
+                    appState.completeStartupRecovery()
+                }
+            }
         )
     }
 
@@ -250,12 +255,14 @@ struct MarkdownTabView: View {
     }
 
     private func scheduleRender(immediate: Bool) {
+        let buffer = self.buffer
+        guard buffer.initialLoadFinished else { return }
+
         // No preview is visible in editor-only mode, so skip parsing and
         // rendering entirely. Switching out of editor mode triggers
         // scheduleRender via .onChange(of: resolvedMode).
         guard resolvedMode != .editor else {
             debounceTask?.cancel()
-            appState.completeStartupRecovery()
             return
         }
         debounceTask?.cancel()
@@ -264,7 +271,6 @@ struct MarkdownTabView: View {
         if !isStandaloneMermaid {
             renderCache.beginRender(for: renderIdentity)
         }
-        let buffer = self.buffer
         let theme = self.theme
         let fontFamily = appState.config.code.fontFamily
         let fontSize = appState.config.code.fontSize

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -212,7 +212,11 @@ struct MarkdownTabView: View {
                 Color.clear.onAppear { scheduleRender(immediate: true) }
             }
         } else if let renderResult = renderCache.value(for: renderIdentity) {
-            MarkdownPreviewView(result: renderResult, onLinkClick: handleLinkClick)
+            MarkdownPreviewView(
+                result: renderResult,
+                onLinkClick: handleLinkClick,
+                onReady: onStartupRecoveryReady
+            )
         } else {
             Color.clear.onAppear { scheduleRender(immediate: true) }
         }
@@ -310,7 +314,6 @@ struct MarkdownTabView: View {
             )
             if Task.isCancelled { return }
             renderCache.storeCompletedRender(result, for: renderIdentity)
-            onStartupRecoveryReady()
         }
     }
 

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -255,6 +255,7 @@ struct MarkdownTabView: View {
         // scheduleRender via .onChange(of: resolvedMode).
         guard resolvedMode != .editor else {
             debounceTask?.cancel()
+            appState.completeStartupRecovery()
             return
         }
         debounceTask?.cancel()
@@ -279,6 +280,7 @@ struct MarkdownTabView: View {
             let source = buffer.storage.string
             if isStandaloneMermaid {
                 mermaidPreviewSource = source
+                appState.completeStartupRecovery()
                 return
             }
             let parsed = MarkdownParser.parse(source)
@@ -293,6 +295,7 @@ struct MarkdownTabView: View {
             )
             if Task.isCancelled { return }
             renderCache.storeCompletedRender(result, for: renderIdentity)
+            appState.completeStartupRecovery()
         }
     }
 

--- a/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
@@ -40,6 +40,7 @@ final class MermaidAttachmentCoordinator {
     private var failureDisclosedSourceIDs: Set<String> = []
     private var viewerTheme: Theme?
     private let onWillPresentViewer: (() -> Void)?
+    private var onReady: (() -> Void)?
 
     init(
         mode: MermaidPresentationProfile = .full,
@@ -150,7 +151,8 @@ final class MermaidAttachmentCoordinator {
         _ references: [MermaidAttachmentReference],
         revision: UUID,
         to textView: NSTextView,
-        onTextStorageDelta: ((_ location: Int, _ delta: Int) -> Void)?
+        onTextStorageDelta: ((_ location: Int, _ delta: Int) -> Void)?,
+        onReady: (() -> Void)? = nil
     ) {
         let scale = textView.window?.backingScaleFactor
             ?? NSScreen.main?.backingScaleFactor
@@ -167,8 +169,13 @@ final class MermaidAttachmentCoordinator {
         self.textView = textView
         self.references = Dictionary(uniqueKeysWithValues: references.map { ($0.id, $0) })
         self.onTextStorageDelta = onTextStorageDelta
+        self.onReady = onReady
         self.backingScale = scale
         observeBackingPropertiesIfNeeded(of: textView.window)
+        if references.isEmpty {
+            finishIfReady()
+            return
+        }
         for reference in references {
             let cell = reference.attachment.mermaidCell
             cell.delegate = self
@@ -213,6 +220,7 @@ final class MermaidAttachmentCoordinator {
         revision = nil
         textView = nil
         onTextStorageDelta = nil
+        onReady = nil
         backingScale = nil
         if let backingPropertiesObserver {
             NotificationCenter.default.removeObserver(backingPropertiesObserver)
@@ -249,7 +257,8 @@ final class MermaidAttachmentCoordinator {
                     Array(self.references.values),
                     revision: revision,
                     to: textView,
-                    onTextStorageDelta: self.onTextStorageDelta
+                    onTextStorageDelta: self.onTextStorageDelta,
+                    onReady: self.onReady
                 )
             }
         }
@@ -361,6 +370,14 @@ final class MermaidAttachmentCoordinator {
             hideSource(id: id, in: textView)
         }
         invalidate(reference.attachment, in: textView)
+        finishIfReady()
+    }
+
+    private func finishIfReady() {
+        guard tasks.isEmpty else { return }
+        let callback = onReady
+        onReady = nil
+        callback?()
     }
 
     private func sourceRange(

--- a/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
@@ -173,7 +173,12 @@ final class MermaidAttachmentCoordinator {
         self.backingScale = scale
         observeBackingPropertiesIfNeeded(of: textView.window)
         if references.isEmpty {
-            finishIfReady(deferCallback: true)
+            finishIfReady { [weak self, weak textView] in
+                guard let self, self.revision == revision, self.textView === textView else {
+                    return false
+                }
+                return true
+            }
             return
         }
         for reference in references {
@@ -370,15 +375,16 @@ final class MermaidAttachmentCoordinator {
             hideSource(id: id, in: textView)
         }
         invalidate(reference.attachment, in: textView)
-        finishIfReady(deferCallback: false)
+        finishIfReady()
     }
 
-    private func finishIfReady(deferCallback: Bool) {
+    private func finishIfReady(afterDeferralShouldRun: (() -> Bool)? = nil) {
         guard tasks.isEmpty else { return }
         let callback = onReady
         onReady = nil
-        if deferCallback {
+        if let afterDeferralShouldRun {
             Task { @MainActor in
+                guard afterDeferralShouldRun() else { return }
                 callback?()
             }
         } else {

--- a/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidAttachmentCoordinator.swift
@@ -173,7 +173,7 @@ final class MermaidAttachmentCoordinator {
         self.backingScale = scale
         observeBackingPropertiesIfNeeded(of: textView.window)
         if references.isEmpty {
-            finishIfReady()
+            finishIfReady(deferCallback: true)
             return
         }
         for reference in references {
@@ -370,14 +370,20 @@ final class MermaidAttachmentCoordinator {
             hideSource(id: id, in: textView)
         }
         invalidate(reference.attachment, in: textView)
-        finishIfReady()
+        finishIfReady(deferCallback: false)
     }
 
-    private func finishIfReady() {
+    private func finishIfReady(deferCallback: Bool) {
         guard tasks.isEmpty else { return }
         let callback = onReady
         onReady = nil
-        callback?()
+        if deferCallback {
+            Task { @MainActor in
+                callback?()
+            }
+        } else {
+            callback?()
+        }
     }
 
     private func sourceRange(

--- a/Alas/Sources/Code/Mermaid/MermaidDiagramBlockView.swift
+++ b/Alas/Sources/Code/Mermaid/MermaidDiagramBlockView.swift
@@ -31,6 +31,7 @@ struct MermaidDiagramBlockView: View {
     let source: String
     let profile: MermaidPresentationProfile
     var service: MermaidRenderService = .shared
+    var onRenderComplete: () -> Void = {}
 
     @Environment(\.displayScale) private var displayScale
     @Environment(\.theme) private var theme
@@ -81,6 +82,7 @@ struct MermaidDiagramBlockView: View {
             guard renderState.currentKey == requestedKey else { return }
             renderState.apply(rendered, for: requestedKey)
             sourceDisclosure.apply(rendered)
+            onRenderComplete()
         }
     }
 

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -165,6 +165,16 @@ struct WorktreeService {
         return normalizedLineageID(stored)
     }
 
+    static func localBranchName(forWorktreeAt path: URL) -> String? {
+        guard let gitDirectory = localGitDirectory(forWorktreeAt: path),
+              let head = HeadReader.read(headFile: gitDirectory.appendingPathComponent("HEAD"))
+        else { return nil }
+        switch head {
+        case .branch(let name): return name
+        case .detached: return "(detached)"
+        }
+    }
+
     private static func localGitDirectory(forWorktreeAt path: URL) -> URL? {
         let dotGit = path.appendingPathComponent(".git")
         var isDirectory = ObjCBool(false)

--- a/Alas/Sources/Integrations/GG/GGInboxStore.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxStore.swift
@@ -32,13 +32,14 @@ final class GGInboxStore {
         return now.timeIntervalSince(fetchedAt) >= threshold
     }
 
+    @discardableResult
     func refresh(
         projectId: String,
         repoPath: String,
         service: GGService,
         now: () -> Date = Date.init
-    ) async {
-        if states[projectId]?.isRefreshing == true { return }
+    ) async -> Bool {
+        if states[projectId]?.isRefreshing == true { return false }
         let generation = invalidationGenerations[projectId, default: 0]
         var state = states[projectId] ?? State()
         let rollbackSnapshot = state.snapshot
@@ -96,7 +97,7 @@ final class GGInboxStore {
         } catch let error as GGServiceError {
             guard invalidationGenerations[projectId, default: 0] == generation else {
                 finishInvalidatedRefresh(projectId: projectId, rollbackSnapshot: rollbackSnapshot)
-                return
+                return true
             }
             state.snapshot = rollbackSnapshot
             state.fetchedAt = rollbackFetchedAt
@@ -105,7 +106,7 @@ final class GGInboxStore {
         } catch {
             guard invalidationGenerations[projectId, default: 0] == generation else {
                 finishInvalidatedRefresh(projectId: projectId, rollbackSnapshot: rollbackSnapshot)
-                return
+                return true
             }
             state.snapshot = rollbackSnapshot
             state.fetchedAt = rollbackFetchedAt
@@ -114,7 +115,7 @@ final class GGInboxStore {
         }
         guard invalidationGenerations[projectId, default: 0] == generation else {
             finishInvalidatedRefresh(projectId: projectId, rollbackSnapshot: rollbackSnapshot)
-            return
+            return true
         }
         if !sawSummary && state.lastError == nil {
             state.snapshot = rollbackSnapshot
@@ -124,6 +125,7 @@ final class GGInboxStore {
         }
         state.isRefreshing = false
         write(projectId, state)
+        return true
     }
 
     /// Expires cached freshness while retaining the last visible result.

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -63,6 +63,7 @@ enum GGInboxWorktreeResolver {
 struct GGInboxTabView: View {
     let state: AppState
     let tabState: GGInboxTabState
+    var onStartupRecoveryReady: () -> Void = {}
 
     @Environment(\.theme) private var theme
     @State private var ggUpgrade = GGInstallController()
@@ -160,7 +161,7 @@ struct GGInboxTabView: View {
             content
         }
         .background(theme.color("bg-1"))
-        .onAppear { refreshIfStale() }
+        .onAppear { refreshIfStale(onComplete: onStartupRecoveryReady) }
         .onChange(of: ggUpgrade.phase) { _, phase in
             guard phase == .succeeded, supportsStreamingInbox else { return }
             refresh()
@@ -495,17 +496,27 @@ struct GGInboxTabView: View {
         )
     }
 
-    private func refreshIfStale() {
-        guard supportsStreamingInbox else { return }
+    private func refreshIfStale(onComplete: (() -> Void)? = nil) {
+        guard supportsStreamingInbox else {
+            onComplete?()
+            return
+        }
         guard inboxState.snapshot == nil
-            || GGInboxStore.isStale(fetchedAt: inboxState.fetchedAt, now: Date()) else { return }
-        refresh()
+            || GGInboxStore.isStale(fetchedAt: inboxState.fetchedAt, now: Date()) else {
+            onComplete?()
+            return
+        }
+        refresh(onComplete: onComplete)
     }
 
-    private func refresh() {
-        guard supportsStreamingInbox, let project, state.ggInboxAvailable(projectId: project.id) else { return }
+    private func refresh(onComplete: (() -> Void)? = nil) {
+        guard supportsStreamingInbox, let project, state.ggInboxAvailable(projectId: project.id) else {
+            onComplete?()
+            return
+        }
         Task { @MainActor in
             await store.refresh(projectId: project.id, repoPath: project.path, service: service)
+            onComplete?()
         }
     }
 }

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -182,7 +182,7 @@ struct GGInboxTabView: View {
         }
         .onChange(of: inboxState.isRefreshing) { wasRefreshing, isRefreshing in
             guard wasRefreshing, !isRefreshing else { return }
-            refreshIfStale(onComplete: onStartupRecoveryReady)
+            onStartupRecoveryReady()
         }
     }
 

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -166,6 +166,10 @@ struct GGInboxTabView: View {
             guard phase == .succeeded, supportsStreamingInbox else { return }
             refresh()
         }
+        .onChange(of: GGAvailability.shared.hasProbed) { _, hasProbed in
+            guard hasProbed else { return }
+            refreshIfStale(onComplete: onStartupRecoveryReady)
+        }
         .onChange(of: supportsStreamingInbox) { wasSupported, isSupported in
             guard Self.shouldRefreshAfterSupportTransition(
                 wasSupported: wasSupported,
@@ -174,7 +178,11 @@ struct GGInboxTabView: View {
                 fetchedAt: inboxState.fetchedAt,
                 now: Date()
             ) else { return }
-            refresh()
+            refreshIfStale(onComplete: onStartupRecoveryReady)
+        }
+        .onChange(of: inboxState.isRefreshing) { wasRefreshing, isRefreshing in
+            guard wasRefreshing, !isRefreshing else { return }
+            refreshIfStale(onComplete: onStartupRecoveryReady)
         }
     }
 
@@ -497,6 +505,7 @@ struct GGInboxTabView: View {
     }
 
     private func refreshIfStale(onComplete: (() -> Void)? = nil) {
+        guard GGAvailability.shared.hasProbed else { return }
         guard supportsStreamingInbox else {
             onComplete?()
             return
@@ -506,6 +515,7 @@ struct GGInboxTabView: View {
             onComplete?()
             return
         }
+        guard !inboxState.isRefreshing else { return }
         refresh(onComplete: onComplete)
     }
 

--- a/Alas/Sources/Integrations/GG/GGInboxTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGInboxTabView.swift
@@ -525,8 +525,9 @@ struct GGInboxTabView: View {
             return
         }
         Task { @MainActor in
-            await store.refresh(projectId: project.id, repoPath: project.path, service: service)
-            onComplete?()
+            if await store.refresh(projectId: project.id, repoPath: project.path, service: service) {
+                onComplete?()
+            }
         }
     }
 }

--- a/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
@@ -7,6 +7,7 @@ struct GGSplitCommitTabView: View {
     let capabilities: GGCapabilities
     let workflowAvailable: Bool
     let hasBlockingGitOperation: Bool
+    let completesStartupRecoveryWhenUnavailable: Bool
     let codeFontFamily: String
     let codeFontSize: CGFloat
     let onCancel: () -> Void
@@ -38,6 +39,7 @@ struct GGSplitCommitTabView: View {
         capabilities: GGCapabilities,
         workflowAvailable: Bool,
         hasBlockingGitOperation: Bool,
+        completesStartupRecoveryWhenUnavailable: Bool = false,
         initialDraft: GGSplitCommitDraft?,
         codeFontFamily: String,
         codeFontSize: CGFloat,
@@ -50,6 +52,7 @@ struct GGSplitCommitTabView: View {
         self.capabilities = capabilities
         self.workflowAvailable = workflowAvailable
         self.hasBlockingGitOperation = hasBlockingGitOperation
+        self.completesStartupRecoveryWhenUnavailable = completesStartupRecoveryWhenUnavailable
         self.codeFontFamily = codeFontFamily
         self.codeFontSize = codeFontSize
         self.onCancel = onCancel
@@ -75,6 +78,7 @@ struct GGSplitCommitTabView: View {
         capabilities: GGCapabilities,
         workflowAvailable: Bool,
         hasBlockingGitOperation: Bool,
+        completesStartupRecoveryWhenUnavailable: Bool = false,
         model: GGSplitCommitModel,
         codeFontFamily: String,
         codeFontSize: CGFloat,
@@ -87,6 +91,7 @@ struct GGSplitCommitTabView: View {
         self.capabilities = capabilities
         self.workflowAvailable = workflowAvailable
         self.hasBlockingGitOperation = hasBlockingGitOperation
+        self.completesStartupRecoveryWhenUnavailable = completesStartupRecoveryWhenUnavailable
         self.codeFontFamily = codeFontFamily
         self.codeFontSize = codeFontSize
         self.onCancel = onCancel
@@ -112,10 +117,13 @@ struct GGSplitCommitTabView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(theme.color("bg-1"))
-        .task(id: tabState.id) {
+        .task(id: "\(tabState.id):\(completesStartupRecoveryWhenUnavailable)") {
             if loadsOnAppear {
-                await load()
-                onStartupRecoveryReady()
+                if await load() {
+                    onStartupRecoveryReady()
+                } else if completesStartupRecoveryWhenUnavailable {
+                    onStartupRecoveryReady()
+                }
             }
         }
     }
@@ -583,10 +591,10 @@ struct GGSplitCommitTabView: View {
         .padding(24)
     }
 
-    private func load() async {
+    private func load() async -> Bool {
         guard model.isAvailable else {
             isLoading = false
-            return
+            return false
         }
         isLoading = true
         errorMessage = nil
@@ -597,6 +605,7 @@ struct GGSplitCommitTabView: View {
             errorMessage = GGErrorPresentation.message(for: error)
         }
         isLoading = false
+        return true
     }
 
     private func apply() {

--- a/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGSplitCommitTabView.swift
@@ -11,6 +11,7 @@ struct GGSplitCommitTabView: View {
     let codeFontSize: CGFloat
     let onCancel: () -> Void
     let onDraftChange: (GGSplitCommitDraft) -> Void
+    let onStartupRecoveryReady: () -> Void
     let loadsOnAppear: Bool
 
     @Environment(\.theme) private var theme
@@ -41,7 +42,8 @@ struct GGSplitCommitTabView: View {
         codeFontFamily: String,
         codeFontSize: CGFloat,
         onCancel: @escaping () -> Void,
-        onDraftChange: @escaping (GGSplitCommitDraft) -> Void
+        onDraftChange: @escaping (GGSplitCommitDraft) -> Void,
+        onStartupRecoveryReady: @escaping () -> Void = {}
     ) {
         self.tabState = tabState
         self.worktreePath = worktreePath
@@ -52,6 +54,7 @@ struct GGSplitCommitTabView: View {
         self.codeFontSize = codeFontSize
         self.onCancel = onCancel
         self.onDraftChange = onDraftChange
+        self.onStartupRecoveryReady = onStartupRecoveryReady
         self.loadsOnAppear = true
         _model = State(initialValue: GGSplitCommitModel(
             service: rightPaneState,
@@ -76,7 +79,8 @@ struct GGSplitCommitTabView: View {
         codeFontFamily: String,
         codeFontSize: CGFloat,
         onCancel: @escaping () -> Void,
-        onDraftChange: @escaping (GGSplitCommitDraft) -> Void
+        onDraftChange: @escaping (GGSplitCommitDraft) -> Void,
+        onStartupRecoveryReady: @escaping () -> Void = {}
     ) {
         self.tabState = tabState
         self.worktreePath = worktreePath
@@ -87,6 +91,7 @@ struct GGSplitCommitTabView: View {
         self.codeFontSize = codeFontSize
         self.onCancel = onCancel
         self.onDraftChange = onDraftChange
+        self.onStartupRecoveryReady = onStartupRecoveryReady
         self.loadsOnAppear = false
         _model = State(initialValue: model)
         _isLoading = State(initialValue: false)
@@ -110,6 +115,7 @@ struct GGSplitCommitTabView: View {
         .task(id: tabState.id) {
             if loadsOnAppear {
                 await load()
+                onStartupRecoveryReady()
             }
         }
     }

--- a/Alas/Sources/Layout/ThreePaneLayout.swift
+++ b/Alas/Sources/Layout/ThreePaneLayout.swift
@@ -7,7 +7,7 @@ struct ThreePaneLayout<Sidebar: View, Center: View, Right: View>: View {
     let rightVisible: Bool
     let onWidthsChanged: () -> Void
     @ViewBuilder let sidebar: () -> Sidebar
-    @ViewBuilder let center: () -> Center
+    @ViewBuilder let center: (_ rightVisible: Bool) -> Center
     @ViewBuilder let right: () -> Right
 
     // Gutter drags mutate only this transient state, so the drag invalidates
@@ -89,7 +89,7 @@ struct ThreePaneLayout<Sidebar: View, Center: View, Right: View>: View {
                         }
                     )
                 }
-                center()
+                center(sizing.rightVisible)
                     .frame(width: CGFloat(alignedCenterWidth))
                     .frame(maxHeight: .infinity)
                 if sizing.rightVisible {

--- a/Alas/Sources/Persistence/ProjectConfig.swift
+++ b/Alas/Sources/Persistence/ProjectConfig.swift
@@ -85,6 +85,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
     var addedAt: Date
     var hiddenWorktreePaths: [String] = []
     var worktreeOrder: [String] = []
+    var cachedWorktrees: [Worktree] = []
     /// Explicit signal that the user dragged worktrees into a custom order.
     /// When `false`, the global default sort mode applies regardless of any
     /// legacy `worktreeOrder` left on disk. Set to `true` by drag reorders;
@@ -107,7 +108,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
 
     enum CodingKeys: String, CodingKey {
         case id, name, path, color, icon, addedAt, hiddenWorktreePaths, worktreeOrder,
-             worktreeOrderIsManual, startupScripts,
+             cachedWorktrees, worktreeOrderIsManual, startupScripts,
              mcpServers, worktreeOpenAfterCreate, worktreeDefaultLauncherMode, host, ggMode,
              ggWorktreeModes, issueAttachments
     }
@@ -121,6 +122,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         icon: ProjectIcon? = nil,
         hiddenWorktreePaths: [String] = [],
         worktreeOrder: [String] = [],
+        cachedWorktrees: [Worktree] = [],
         worktreeOrderIsManual: Bool = false,
         startupScripts: ProjectStartupScripts = .defaults,
         mcpServers: [ProjectMCPServer] = [],
@@ -138,6 +140,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         self.addedAt = addedAt
         self.hiddenWorktreePaths = hiddenWorktreePaths
         self.worktreeOrder = worktreeOrder
+        self.cachedWorktrees = cachedWorktrees
         self.worktreeOrderIsManual = worktreeOrderIsManual
         self.startupScripts = startupScripts
         self.mcpServers = mcpServers
@@ -166,6 +169,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         addedAt = try c.decode(Date.self, forKey: .addedAt)
         hiddenWorktreePaths = (try? c.decode([String].self, forKey: .hiddenWorktreePaths)) ?? []
         worktreeOrder = (try? c.decode([String].self, forKey: .worktreeOrder)) ?? []
+        cachedWorktrees = (try? c.decode([Worktree].self, forKey: .cachedWorktrees)) ?? []
         worktreeOrderIsManual = (try? c.decode(Bool.self, forKey: .worktreeOrderIsManual)) ?? false
         startupScripts = (try? c.decode(ProjectStartupScripts.self, forKey: .startupScripts))
             ?? .defaults
@@ -188,6 +192,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         try c.encode(addedAt, forKey: .addedAt)
         try c.encode(hiddenWorktreePaths, forKey: .hiddenWorktreePaths)
         try c.encode(worktreeOrder, forKey: .worktreeOrder)
+        try c.encode(cachedWorktrees, forKey: .cachedWorktrees)
         try c.encode(worktreeOrderIsManual, forKey: .worktreeOrderIsManual)
         try c.encode(startupScripts, forKey: .startupScripts)
         try c.encode(mcpServers, forKey: .mcpServers)

--- a/AlasTests/Center/Review/ReviewTabViewTests.swift
+++ b/AlasTests/Center/Review/ReviewTabViewTests.swift
@@ -73,6 +73,18 @@ struct ReviewTabViewTests {
         ))
     }
 
+    @Test func reviewTabLoadKeyChangesWhenReviewRequestArrives() {
+        #expect(ReviewTabLoadKey.build(
+            baseLoadKey: "base",
+            reviewRequestNumber: nil,
+            reviewRefreshSettled: false
+        ) != ReviewTabLoadKey.build(
+            baseLoadKey: "base",
+            reviewRequestNumber: 1042,
+            reviewRefreshSettled: false
+        ))
+    }
+
     @Test func outdatedDrawerCapsExpandedListHeightToProtectReviewContent() {
         #expect(OutdatedThreadsDrawerPresentation.expandedListMaxHeight(availableHeight: 1_200) == 280)
         #expect(OutdatedThreadsDrawerPresentation.expandedListMaxHeight(availableHeight: 600) == 210)

--- a/AlasTests/Center/Review/ReviewTabViewTests.swift
+++ b/AlasTests/Center/Review/ReviewTabViewTests.swift
@@ -51,15 +51,15 @@ struct ReviewTabViewTests {
     @Test func startupRecoveryCompletesAfterMatchedOrSettledReviewLoad() {
         #expect(ReviewTabStartupRecoveryReadiness.shouldComplete(
             hasReviewRequest: true,
-            hasLoadedSnapshot: false
+            reviewRefreshSettled: false
         ))
         #expect(ReviewTabStartupRecoveryReadiness.shouldComplete(
             hasReviewRequest: false,
-            hasLoadedSnapshot: true
+            reviewRefreshSettled: true
         ))
         #expect(!ReviewTabStartupRecoveryReadiness.shouldComplete(
             hasReviewRequest: false,
-            hasLoadedSnapshot: false
+            reviewRefreshSettled: false
         ))
     }
 

--- a/AlasTests/Center/Review/ReviewTabViewTests.swift
+++ b/AlasTests/Center/Review/ReviewTabViewTests.swift
@@ -61,6 +61,16 @@ struct ReviewTabViewTests {
             hasReviewRequest: false,
             reviewRefreshSettled: false
         ))
+        #expect(ReviewTabStartupRecoveryReadiness.reviewRefreshSettled(
+            hasSnapshot: false,
+            isRefreshing: false,
+            hasError: true
+        ))
+        #expect(!ReviewTabStartupRecoveryReadiness.reviewRefreshSettled(
+            hasSnapshot: true,
+            isRefreshing: true,
+            hasError: false
+        ))
     }
 
     @Test func outdatedDrawerCapsExpandedListHeightToProtectReviewContent() {

--- a/AlasTests/Center/Review/ReviewTabViewTests.swift
+++ b/AlasTests/Center/Review/ReviewTabViewTests.swift
@@ -48,6 +48,21 @@ struct ReviewTabViewTests {
         ))
     }
 
+    @Test func startupRecoveryCompletesAfterMatchedOrSettledReviewLoad() {
+        #expect(ReviewTabStartupRecoveryReadiness.shouldComplete(
+            hasReviewRequest: true,
+            hasLoadedSnapshot: false
+        ))
+        #expect(ReviewTabStartupRecoveryReadiness.shouldComplete(
+            hasReviewRequest: false,
+            hasLoadedSnapshot: true
+        ))
+        #expect(!ReviewTabStartupRecoveryReadiness.shouldComplete(
+            hasReviewRequest: false,
+            hasLoadedSnapshot: false
+        ))
+    }
+
     @Test func outdatedDrawerCapsExpandedListHeightToProtectReviewContent() {
         #expect(OutdatedThreadsDrawerPresentation.expandedListMaxHeight(availableHeight: 1_200) == 280)
         #expect(OutdatedThreadsDrawerPresentation.expandedListMaxHeight(availableHeight: 600) == 210)

--- a/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
@@ -376,6 +376,41 @@ struct MermaidAttachmentCoordinatorTests {
         #expect(await backend.waitForCancellation(source: reference.source))
     }
 
+    @Test("preview readiness waits for embedded Mermaid outcomes")
+    func previewReadinessWaitsForEmbeddedMermaidOutcomes() async throws {
+        let backend = ControlledMermaidBackend()
+        let service = MermaidRenderService(backend: backend)
+        let attachment = MermaidTextAttachment(
+            id: "mermaid-0",
+            source: "graph TD; A-->B",
+            profile: .full
+        )
+        let reference = try makeReference(attachment: attachment)
+        let controller = MarkdownPreviewController(
+            theme: try Theme.loadBundled(id: "cool-slate"),
+            mermaidService: service
+        )
+        defer { controller.dismantle() }
+        var readyCount = 0
+
+        controller.apply(result: MarkdownRenderResult(
+            revision: UUID(),
+            attributedString: makeContents(attachment: attachment),
+            anchorRanges: [:],
+            remoteImages: [],
+            mermaidAttachments: [reference]
+        ), onReady: {
+            readyCount += 1
+        })
+
+        #expect(await backend.waitForRequest(source: reference.source))
+        #expect(readyCount == 0)
+
+        await backend.resume(source: reference.source, outcome: renderedOutcome())
+        #expect(await waitForOutcome(in: attachment))
+        #expect(readyCount == 1)
+    }
+
     @Test("failure-disclosed source clears after a successful rerender")
     func failureDisclosedSourceClearsAfterSuccess() async throws {
         let backend = ControlledMermaidBackend()

--- a/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
@@ -411,6 +411,28 @@ struct MermaidAttachmentCoordinatorTests {
         #expect(readyCount == 1)
     }
 
+    @Test("empty Mermaid readiness is deferred")
+    func emptyMermaidReadinessIsDeferred() async {
+        let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
+        let coordinator = MermaidAttachmentCoordinator()
+        defer { coordinator.cancelAll() }
+        var readyCount = 0
+
+        coordinator.apply(
+            [],
+            revision: UUID(),
+            to: textView,
+            onTextStorageDelta: nil,
+            onReady: {
+                readyCount += 1
+            }
+        )
+
+        #expect(readyCount == 0)
+        await Task.yield()
+        #expect(readyCount == 1)
+    }
+
     @Test("failure-disclosed source clears after a successful rerender")
     func failureDisclosedSourceClearsAfterSuccess() async throws {
         let backend = ControlledMermaidBackend()

--- a/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
+++ b/AlasTests/Code/Mermaid/MermaidAttachmentCoordinatorTests.swift
@@ -433,6 +433,27 @@ struct MermaidAttachmentCoordinatorTests {
         #expect(readyCount == 1)
     }
 
+    @Test("cancelled empty Mermaid readiness is skipped")
+    func cancelledEmptyMermaidReadinessIsSkipped() async {
+        let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
+        let coordinator = MermaidAttachmentCoordinator()
+        var readyCount = 0
+
+        coordinator.apply(
+            [],
+            revision: UUID(),
+            to: textView,
+            onTextStorageDelta: nil,
+            onReady: {
+                readyCount += 1
+            }
+        )
+        coordinator.cancelAll()
+
+        await Task.yield()
+        #expect(readyCount == 0)
+    }
+
     @Test("failure-disclosed source clears after a successful rerender")
     func failureDisclosedSourceClearsAfterSuccess() async throws {
         let backend = ControlledMermaidBackend()

--- a/AlasTests/EditorBufferExternalEditableTests.swift
+++ b/AlasTests/EditorBufferExternalEditableTests.swift
@@ -66,6 +66,12 @@ struct EditorBufferExternalEditableTests {
         ))
     }
 
+    @Test func editorBinaryPlaceholderCoversStartupRecoveryReadiness() {
+        #expect(EditorTabView.isBinary(loadKind: .notUTF8))
+        #expect(!EditorTabView.isBinary(loadKind: .loaded))
+        #expect(!EditorTabView.isBinary(loadKind: nil))
+    }
+
     /// Regression test for the Task-9 critical fix: `CodeEditorCoordinator`
     /// computes `textView.isEditable` as `!buffer.isExternal || !buffer.readOnly`
     /// so that non-external buffers (e.g. remote in-worktree files whose

--- a/AlasTests/Integrations/GGInboxStoreTests.swift
+++ b/AlasTests/Integrations/GGInboxStoreTests.swift
@@ -98,7 +98,8 @@ struct GGInboxStoreTests {
         }
         try await waitUntil { runner.lastArgs == ["inbox", "--jsonl"] }
 
-        await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner))
+        let didStartDuplicate = await store.refresh(projectId: "p1", repoPath: "/repo", service: GGService(runner: runner))
+        #expect(!didStartDuplicate)
         #expect(store.states["p1"]?.isRefreshing == true)
         #expect(store.states["p1"]?.snapshot == nil)
 
@@ -106,7 +107,7 @@ struct GGInboxStoreTests {
         try await waitUntil { store.states["p1"]?.refreshProgress?.total == 0 }
         runner.yield(Self.emptySummary)
         runner.finish()
-        await task.value
+        _ = await task.value
     }
 
     @Test func staleness() {
@@ -147,7 +148,7 @@ struct GGInboxStoreTests {
         runner.yield(#"{"event":"start","total_candidates":0,"total_stack_errors":0,"version":1,"command":"inbox"}"#)
         runner.yield(Self.emptySummary)
         runner.finish()
-        await refresh.value
+        _ = await refresh.value
 
         let state = try #require(store.states["p1"])
         #expect(state.snapshot == nil)
@@ -182,7 +183,7 @@ struct GGInboxStoreTests {
         runner.yield(#"{"event":"start","total_candidates":0,"total_stack_errors":0,"version":1,"command":"inbox"}"#)
         runner.yield(replacementSummary)
         runner.finish()
-        await refresh.value
+        _ = await refresh.value
 
         let state = try #require(store.states["p1"])
         #expect(state.snapshot == previousSnapshot)
@@ -211,7 +212,7 @@ struct GGInboxStoreTests {
 
         runner.yield(Self.emptySummary)
         runner.finish()
-        await task.value
+        _ = await task.value
         #expect(store.states["p1"]?.snapshot?.totalItems == 0)
         #expect(store.states["p1"]?.fetchedAt == Date(timeIntervalSince1970: 200))
         #expect(store.states["p1"]?.refreshProgress == nil)
@@ -235,7 +236,7 @@ struct GGInboxStoreTests {
 
         runner.yield(Self.emptySummary)
         runner.finish()
-        await task.value
+        _ = await task.value
     }
 
     @Test func excludedEntryPublishesEmptyPartialStateAndAdvancesProgress() async throws {
@@ -257,7 +258,7 @@ struct GGInboxStoreTests {
 
         runner.yield(Self.emptySummary)
         runner.finish()
-        await task.value
+        _ = await task.value
     }
 
     @Test func partialEntriesRemainInStableDisplayOrderWhenCompletionOrderDiffers() async throws {
@@ -278,7 +279,7 @@ struct GGInboxStoreTests {
 
         runner.yield(Self.emptySummary)
         runner.finish()
-        await task.value
+        _ = await task.value
     }
 
     @Test func stackErrorsPublishWithFirstPartialSnapshot() async throws {
@@ -298,7 +299,7 @@ struct GGInboxStoreTests {
 
         runner.yield(Self.emptySummary)
         runner.finish()
-        await task.value
+        _ = await task.value
     }
 
     @Test func fatalEOFBeforeSummaryRestoresOldSnapshotAndFetchedAt() async throws {
@@ -317,7 +318,7 @@ struct GGInboxStoreTests {
         runner.yield(Self.readyEntryEvent(completed: 1, total: 1))
         try await waitUntil { store.states["p1"]?.snapshot?.totalItems == 1 }
         runner.finish()
-        await task.value
+        _ = await task.value
 
         let state = try #require(store.states["p1"])
         #expect(state.snapshot == old)
@@ -343,7 +344,7 @@ struct GGInboxStoreTests {
         store.invalidate(projectId: "p1")
         runner.yield(Self.emptySummary)
         runner.finish()
-        await task.value
+        _ = await task.value
 
         let state = try #require(store.states["p1"])
         #expect(state.snapshot == old)

--- a/AlasTests/Integrations/ReviewRequestDraftTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDraftTests.swift
@@ -77,6 +77,24 @@ struct ReviewRequestDraftTests {
         ))
     }
 
+    @Test func draftReviewRequestReportsReadinessOnlyForCurrentContext() {
+        #expect(DraftReviewRequestTabView.shouldReportStartupRecoveryReady(
+            requestedContextKey: "head:base",
+            currentContextKey: "head:base",
+            isCancelled: false
+        ))
+        #expect(!DraftReviewRequestTabView.shouldReportStartupRecoveryReady(
+            requestedContextKey: "head:base",
+            currentContextKey: "next:base",
+            isCancelled: false
+        ))
+        #expect(!DraftReviewRequestTabView.shouldReportStartupRecoveryReady(
+            requestedContextKey: "head:base",
+            currentContextKey: "head:base",
+            isCancelled: true
+        ))
+    }
+
     @Test @MainActor func selectingDraftSummaryCommentFocusesAndSelectsFile() async throws {
         let path = "Sources/A.swift"
         let context = ReviewRequestDraftContext(

--- a/AlasTests/ProjectConfigTests.swift
+++ b/AlasTests/ProjectConfigTests.swift
@@ -27,10 +27,20 @@ struct ProjectConfigTests {
     }
 
     @Test func roundTripPreservesHiddenPaths() throws {
+        let cachedWorktree = Worktree(
+            id: "/tmp/alpha/wt-a",
+            projectId: "abc",
+            name: "wt-a",
+            branch: "wt-a",
+            path: URL(fileURLWithPath: "/tmp/alpha/wt-a"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 1)
+        )
         let project = ProjectConfig(
             id: "abc", name: "alpha", path: "/tmp/alpha",
             color: "#5fb7c4", addedAt: Date(timeIntervalSince1970: 0),
-            hiddenWorktreePaths: ["/tmp/alpha/wt-a", "/tmp/alpha/wt-b"]
+            hiddenWorktreePaths: ["/tmp/alpha/wt-a", "/tmp/alpha/wt-b"],
+            cachedWorktrees: [cachedWorktree]
         )
         let file = ProjectsFile(projects: [project])
         let encoder = JSONEncoder()
@@ -40,6 +50,7 @@ struct ProjectConfigTests {
         decoder.dateDecodingStrategy = .secondsSince1970
         let decoded = try decoder.decode(ProjectsFile.self, from: data)
         #expect(decoded.projects[0].hiddenWorktreePaths == ["/tmp/alpha/wt-a", "/tmp/alpha/wt-b"])
+        #expect(decoded.projects[0].cachedWorktrees == [cachedWorktree])
     }
 
     @Test func roundTripPreservesStartupScripts() throws {

--- a/AlasTests/ProjectsManagerHeadUpdatesTests.swift
+++ b/AlasTests/ProjectsManagerHeadUpdatesTests.swift
@@ -68,6 +68,28 @@ struct ProjectsManagerHeadUpdatesTests {
         #expect(trees.first { $0.path.path == "/wts/feat" }?.name == "feat/bar")
     }
 
+    @Test func updatesCachedBranchForMatchingPath() {
+        let cached = wt(path: "/repo", branch: "old")
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: "/repo",
+            color: "blue",
+            addedAt: Date(),
+            cachedWorktrees: [cached]
+        )
+        let mgr = ProjectsManager(persistedProjects: [project])
+        seed(mgr, projectId: project.id, [cached])
+
+        mgr.applyHeadUpdates(
+            projectId: project.id,
+            branchByWorktreePath: [URL(fileURLWithPath: "/repo"): "main"]
+        )
+
+        #expect(mgr.projects[0].cachedWorktrees.first?.branch == "main")
+        #expect(mgr.projects[0].cachedWorktrees.first?.name == "main")
+    }
+
     @Test func ignoresUnknownPaths() {
         let (mgr, project) = makeManager()
         seed(mgr, projectId: project.id, [wt(path: "/repo", branch: "main")])

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -126,6 +126,7 @@ struct StartupRecoveryTests {
         )
 
         #expect(composition.activeId == tab.id)
+        #expect(composition.activeTab == tab)
     }
 
     @Test func recoveryCompletesOnlyAfterTheCenterPaneAppears() {

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -167,6 +167,33 @@ struct StartupRecoveryTests {
         #expect(state.suppressesRestoredRightPaneAfterAbandonedStartup)
     }
 
+    @Test func recoveryLaunchSkipsProjectTopologyRefresh() {
+        #expect(!RootView.shouldRefreshProjectTopologiesOnStartup(
+            isRecoveringFromAbandonedStartup: true
+        ))
+        #expect(RootView.shouldRefreshProjectTopologiesOnStartup(
+            isRecoveringFromAbandonedStartup: false
+        ))
+    }
+
+    @Test func gracefulTerminationCompletesStartupRecovery() {
+        let coordinator = AlasTerminationCoordinator.shared
+        let originalFinish = coordinator.finish
+        let originalFlush = coordinator.flush
+        defer {
+            coordinator.finish = originalFinish
+            coordinator.flush = originalFlush
+        }
+        coordinator.flush = nil
+        var finishCount = 0
+        coordinator.finish = { finishCount += 1 }
+
+        let reply = AlasApplicationDelegate().applicationShouldTerminate(.shared)
+
+        #expect(reply == .terminateNow)
+        #expect(finishCount == 1)
+    }
+
     @Test func asyncRestoredTabsDoNotCompleteRecoveryFromCenterPane() {
         let terminal = Tab.terminal(.init(id: "terminal", title: "Terminal", sessionId: "terminal"))
         let acp = Tab.acpSession(.init(sessionId: "acp", title: "ACP"))

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -171,4 +171,22 @@ struct StartupRecoveryTests {
         #expect(!StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: ggInbox))
         #expect(StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: nil))
     }
+
+    @Test func ggSplitUnavailableRecoveryWaitsForAvailabilityProbe() {
+        #expect(!CenterPaneView.shouldCompleteGGSplitStartupRecoveryWhenUnavailable(
+            hasLoadedSnapshot: true,
+            ggStackLoadState: .inactive,
+            ggAvailabilityHasProbed: false
+        ))
+        #expect(CenterPaneView.shouldCompleteGGSplitStartupRecoveryWhenUnavailable(
+            hasLoadedSnapshot: true,
+            ggStackLoadState: .inactive,
+            ggAvailabilityHasProbed: true
+        ))
+        #expect(!CenterPaneView.shouldCompleteGGSplitStartupRecoveryWhenUnavailable(
+            hasLoadedSnapshot: true,
+            ggStackLoadState: .loading,
+            ggAvailabilityHasProbed: true
+        ))
+    }
 }

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -135,4 +135,15 @@ struct StartupRecoveryTests {
 
         #expect(didFinish)
     }
+
+    @Test func asyncRestoredTabsDoNotCompleteRecoveryFromCenterPane() {
+        let terminal = Tab.terminal(.init(id: "terminal", title: "Terminal", sessionId: "terminal"))
+        let acp = Tab.acpSession(.init(sessionId: "acp", title: "ACP"))
+        let editor = Tab.editor(.init(id: "editor", title: "README.md", relativePath: "README.md"))
+
+        #expect(!StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: terminal))
+        #expect(!StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: acp))
+        #expect(StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: editor))
+        #expect(StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: nil))
+    }
 }

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -157,6 +157,16 @@ struct StartupRecoveryTests {
         #expect(didFinish)
     }
 
+    @Test func recoverySuppressesRestoredSurfacesUntilStartupCompletes() {
+        let state = AppState(restoreActiveTabsOnStartup: false)
+
+        #expect(state.isRecoveringFromAbandonedStartup)
+
+        state.completeStartupRecovery()
+
+        #expect(!state.isRecoveringFromAbandonedStartup)
+    }
+
     @Test func asyncRestoredTabsDoNotCompleteRecoveryFromCenterPane() {
         let terminal = Tab.terminal(.init(id: "terminal", title: "Terminal", sessionId: "terminal"))
         let acp = Tab.acpSession(.init(sessionId: "acp", title: "ACP"))

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -157,14 +157,14 @@ struct StartupRecoveryTests {
         #expect(didFinish)
     }
 
-    @Test func recoverySuppressesRestoredSurfacesUntilStartupCompletes() {
+    @Test func recoverySuppressesRestoredRightPaneForTheLaunch() {
         let state = AppState(restoreActiveTabsOnStartup: false)
 
-        #expect(state.isRecoveringFromAbandonedStartup)
+        #expect(state.suppressesRestoredRightPaneAfterAbandonedStartup)
 
         state.completeStartupRecovery()
 
-        #expect(!state.isRecoveringFromAbandonedStartup)
+        #expect(state.suppressesRestoredRightPaneAfterAbandonedStartup)
     }
 
     @Test func asyncRestoredTabsDoNotCompleteRecoveryFromCenterPane() {

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -189,4 +189,16 @@ struct StartupRecoveryTests {
             ggAvailabilityHasProbed: true
         ))
     }
+
+    @Test func commitEditorDiffTaskRerunsAfterDetailsSettle() {
+        #expect(CommitEditorTabView.diffTaskKey(
+            currentSha: "abc",
+            selectedPath: "file.swift",
+            loadingDetails: true
+        ) != CommitEditorTabView.diffTaskKey(
+            currentSha: "abc",
+            selectedPath: "file.swift",
+            loadingDetails: false
+        ))
+    }
 }

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -96,4 +96,16 @@ struct StartupRecoveryTests {
 
         #expect(composition.activeId == tab.id)
     }
+
+    @Test func reloadTabsMarksStartupRecoveryComplete() {
+        let coordinator = AlasTerminationCoordinator.shared
+        let originalFinish = coordinator.finish
+        defer { coordinator.finish = originalFinish }
+        var didFinish = false
+        coordinator.finish = { didFinish = true }
+
+        AppState().reloadTabs()
+
+        #expect(didFinish)
+    }
 }

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -218,15 +218,18 @@ struct StartupRecoveryTests {
 
         #expect(!CenterPaneView.shouldCompleteStartupRecoveryForCenterPane(
             activeTab: terminal,
-            readyTabID: nil
+            readyKey: nil,
+            currentKey: "terminal\u{0}snapshot-1"
         ))
         #expect(CenterPaneView.shouldCompleteStartupRecoveryForCenterPane(
             activeTab: terminal,
-            readyTabID: "terminal"
+            readyKey: "terminal\u{0}snapshot-1",
+            currentKey: "terminal\u{0}snapshot-1"
         ))
         #expect(!CenterPaneView.shouldCompleteStartupRecoveryForCenterPane(
             activeTab: terminal,
-            readyTabID: "other"
+            readyKey: "terminal\u{0}snapshot-1",
+            currentKey: "terminal\u{0}snapshot-2"
         ))
     }
 

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -165,7 +165,7 @@ struct StartupRecoveryTests {
         #expect(!StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: terminal))
         #expect(!StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: acp))
         #expect(!StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: history))
-        #expect(StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: editor))
+        #expect(!StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: editor))
         #expect(StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: nil))
     }
 }

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct StartupRecoveryTests {
+    @Test func detectsAnUnfinishedPreviousLaunch() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-startup-recovery-\(UUID().uuidString)")
+        let marker = directory.appendingPathComponent("launching")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let recovery = StartupRecovery(markerURL: marker)
+
+        #expect(recovery.begin() == false)
+        #expect(recovery.begin() == true)
+
+        recovery.finish()
+
+        #expect(recovery.begin() == false)
+    }
+
+    @Test func recoveryLoadKeepsTabsWithoutActivatingOne() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-tabs-recovery-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let worktreeID = "worktree"
+        let original = TabsManager(store: PersistenceStore(), tabsDirectory: directory)
+        let first = original.appendTerminal(worktreeId: worktreeID, title: "First", sessionId: "first")
+        let second = original.appendTerminal(worktreeId: worktreeID, title: "Second", sessionId: "second")
+
+        let recovered = TabsManager(store: PersistenceStore(), tabsDirectory: directory)
+        recovered.loadAll(worktreeIds: [worktreeID], restoringActiveTabs: false)
+
+        #expect(recovered.tabs(forWorktree: worktreeID).map(\.id) == [first.id, second.id])
+        #expect(recovered.activeTabId(forWorktree: worktreeID) == nil)
+
+        let reloaded = TabsManager(store: PersistenceStore(), tabsDirectory: directory)
+        reloaded.loadAll(worktreeIds: [worktreeID])
+        #expect(reloaded.activeTabId(forWorktree: worktreeID) == nil)
+    }
+
+    @Test func missingSelectionDoesNotFallBackToRenderingTheFirstTab() {
+        let tab = Tab.terminal(.init(id: "first", title: "First", sessionId: "first"))
+
+        let composition = CenterTabComposition(
+            worktreeTabs: [tab],
+            activeWorktreeTabId: nil
+        )
+
+        #expect(composition.activeId == nil)
+    }
+}

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -97,7 +97,7 @@ struct StartupRecoveryTests {
         #expect(composition.activeId == tab.id)
     }
 
-    @Test func reloadTabsMarksStartupRecoveryComplete() {
+    @Test func recoveryCompletesOnlyAfterTheCenterPaneAppears() {
         let coordinator = AlasTerminationCoordinator.shared
         let originalFinish = coordinator.finish
         defer { coordinator.finish = originalFinish }
@@ -105,6 +105,10 @@ struct StartupRecoveryTests {
         coordinator.finish = { didFinish = true }
 
         AppState().reloadTabs()
+
+        #expect(!didFinish)
+
+        AppState().completeStartupRecovery()
 
         #expect(didFinish)
     }

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -8,10 +8,13 @@ struct StartupRecoveryTests {
     @Test func detectsAnUnfinishedPreviousLaunch() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-startup-recovery-\(UUID().uuidString)")
-        let marker = directory.appendingPathComponent("launching")
         defer { try? FileManager.default.removeItem(at: directory) }
 
-        let recovery = StartupRecovery(markerURL: marker)
+        let recovery = StartupRecovery(
+            markerDirectory: directory,
+            processID: 42,
+            isProcessAlive: { _ in false }
+        )
 
         #expect(recovery.begin() == false)
         #expect(recovery.begin() == true)
@@ -19,6 +22,24 @@ struct StartupRecoveryTests {
         recovery.finish()
 
         #expect(recovery.begin() == false)
+    }
+
+    @Test func ignoresMarkersOwnedByLiveInstances() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-startup-recovery-live-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let liveMarker = directory.appendingPathComponent("launching-7-live")
+        _ = FileManager.default.createFile(atPath: liveMarker.path, contents: Data())
+
+        let recovery = StartupRecovery(
+            markerDirectory: directory,
+            processID: 42,
+            isProcessAlive: { $0 == 7 }
+        )
+
+        #expect(recovery.begin() == false)
+        #expect(FileManager.default.fileExists(atPath: liveMarker.path))
     }
 
     @Test func recoveryLoadKeepsTabsWithoutActivatingOne() throws {
@@ -41,6 +62,19 @@ struct StartupRecoveryTests {
         #expect(reloaded.activeTabId(forWorktree: worktreeID) == nil)
     }
 
+    @Test func recoveryLoadAlsoClearsUndiscoveredWorktrees() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-tabs-recovery-all-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let original = TabsManager(store: PersistenceStore(), tabsDirectory: directory)
+        _ = original.appendTerminal(worktreeId: "undiscovered", title: "Terminal", sessionId: "terminal")
+
+        let recovered = TabsManager(store: PersistenceStore(), tabsDirectory: directory)
+        recovered.loadAllPersisted(restoringActiveTabs: false)
+
+        #expect(recovered.activeTabId(forWorktree: "undiscovered") == nil)
+    }
+
     @Test func missingSelectionDoesNotFallBackToRenderingTheFirstTab() {
         let tab = Tab.terminal(.init(id: "first", title: "First", sessionId: "first"))
 
@@ -50,5 +84,16 @@ struct StartupRecoveryTests {
         )
 
         #expect(composition.activeId == nil)
+    }
+
+    @Test func staleSelectionFallsBackToTheFirstAvailableTab() {
+        let tab = Tab.terminal(.init(id: "first", title: "First", sessionId: "first"))
+
+        let composition = CenterTabComposition(
+            worktreeTabs: [tab],
+            activeWorktreeTabId: "removed-tab"
+        )
+
+        #expect(composition.activeId == tab.id)
     }
 }

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -75,6 +75,17 @@ struct StartupRecoveryTests {
         #expect(recovered.activeTabId(forWorktree: "undiscovered") == nil)
     }
 
+    @Test func recoveryLoadMarksMissingTabsDirectoryAsLoaded() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-tabs-recovery-missing-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let recovered = TabsManager(store: PersistenceStore(), tabsDirectory: directory)
+        recovered.loadAllPersisted(restoringActiveTabs: false)
+
+        #expect(recovered.hasLoaded)
+    }
+
     @Test func missingSelectionDoesNotFallBackToRenderingTheFirstTab() {
         let tab = Tab.terminal(.init(id: "first", title: "First", sessionId: "first"))
 
@@ -109,6 +120,18 @@ struct StartupRecoveryTests {
         #expect(!didFinish)
 
         AppState().completeStartupRecovery()
+
+        #expect(didFinish)
+    }
+
+    @Test func recoveryCompletesWhenStartupHasNoCenterPane() {
+        let coordinator = AlasTerminationCoordinator.shared
+        let originalFinish = coordinator.finish
+        defer { coordinator.finish = originalFinish }
+        var didFinish = false
+        coordinator.finish = { didFinish = true }
+
+        AppState().completeStartupRecoveryIfCenterPaneWillNotAppear()
 
         #expect(didFinish)
     }

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -190,6 +190,29 @@ struct StartupRecoveryTests {
         ))
     }
 
+    @Test func startupRecoveryWaitsForVisibleRightPaneSnapshot() {
+        #expect(CenterPaneView.shouldCompleteStartupRecoveryForRightPane(
+            isRightPaneVisible: false,
+            hasLoadedSnapshot: false,
+            isLoading: true
+        ))
+        #expect(!CenterPaneView.shouldCompleteStartupRecoveryForRightPane(
+            isRightPaneVisible: true,
+            hasLoadedSnapshot: false,
+            isLoading: false
+        ))
+        #expect(!CenterPaneView.shouldCompleteStartupRecoveryForRightPane(
+            isRightPaneVisible: true,
+            hasLoadedSnapshot: true,
+            isLoading: true
+        ))
+        #expect(CenterPaneView.shouldCompleteStartupRecoveryForRightPane(
+            isRightPaneVisible: true,
+            hasLoadedSnapshot: true,
+            isLoading: false
+        ))
+    }
+
     @Test func commitEditorDiffTaskRerunsAfterDetailsSettle() {
         #expect(CommitEditorTabView.diffTaskKey(
             currentSha: "abc",

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -29,17 +29,37 @@ struct StartupRecoveryTests {
             .appendingPathComponent("alas-startup-recovery-live-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: directory) }
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let liveMarker = directory.appendingPathComponent("launching-7-live")
+        let liveMarker = directory.appendingPathComponent("launching-7-7000000-live")
         _ = FileManager.default.createFile(atPath: liveMarker.path, contents: Data())
 
         let recovery = StartupRecovery(
             markerDirectory: directory,
             processID: 42,
-            isProcessAlive: { $0 == 7 }
+            isProcessAlive: { $0 == 7 },
+            processStartTime: { $0 == 7 ? 7 : 42 }
         )
 
         #expect(recovery.begin() == false)
         #expect(FileManager.default.fileExists(atPath: liveMarker.path))
+    }
+
+    @Test func treatsReusedPIDMarkerAsAbandoned() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-startup-recovery-reused-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let staleMarker = directory.appendingPathComponent("launching-7-7000000-stale")
+        _ = FileManager.default.createFile(atPath: staleMarker.path, contents: Data())
+
+        let recovery = StartupRecovery(
+            markerDirectory: directory,
+            processID: 42,
+            isProcessAlive: { $0 == 7 },
+            processStartTime: { $0 == 7 ? 8 : 42 }
+        )
+
+        #expect(recovery.begin())
+        #expect(!FileManager.default.fileExists(atPath: staleMarker.path))
     }
 
     @Test func recoveryLoadKeepsTabsWithoutActivatingOne() throws {
@@ -139,10 +159,12 @@ struct StartupRecoveryTests {
     @Test func asyncRestoredTabsDoNotCompleteRecoveryFromCenterPane() {
         let terminal = Tab.terminal(.init(id: "terminal", title: "Terminal", sessionId: "terminal"))
         let acp = Tab.acpSession(.init(sessionId: "acp", title: "ACP"))
+        let history = Tab.fileHistory(.init(worktreeId: "wt", relativePath: "README.md"))
         let editor = Tab.editor(.init(id: "editor", title: "README.md", relativePath: "README.md"))
 
         #expect(!StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: terminal))
         #expect(!StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: acp))
+        #expect(!StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: history))
         #expect(StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: editor))
         #expect(StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: nil))
     }

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -205,31 +205,43 @@ struct StartupRecoveryTests {
             isRightPaneVisible: false,
             hasLoadedSnapshot: false,
             isLoading: true,
-            ggStackLoadState: .loading
+            ggStackLoadState: .loading,
+            ggAvailabilityHasProbed: false
         ))
         #expect(!CenterPaneView.shouldCompleteStartupRecoveryForRightPane(
             isRightPaneVisible: true,
             hasLoadedSnapshot: false,
             isLoading: false,
-            ggStackLoadState: .inactive
+            ggStackLoadState: .inactive,
+            ggAvailabilityHasProbed: true
         ))
         #expect(!CenterPaneView.shouldCompleteStartupRecoveryForRightPane(
             isRightPaneVisible: true,
             hasLoadedSnapshot: true,
             isLoading: true,
-            ggStackLoadState: .inactive
+            ggStackLoadState: .inactive,
+            ggAvailabilityHasProbed: true
         ))
         #expect(!CenterPaneView.shouldCompleteStartupRecoveryForRightPane(
             isRightPaneVisible: true,
             hasLoadedSnapshot: true,
             isLoading: false,
-            ggStackLoadState: .loading
+            ggStackLoadState: .loading,
+            ggAvailabilityHasProbed: true
+        ))
+        #expect(!CenterPaneView.shouldCompleteStartupRecoveryForRightPane(
+            isRightPaneVisible: true,
+            hasLoadedSnapshot: true,
+            isLoading: false,
+            ggStackLoadState: .inactive,
+            ggAvailabilityHasProbed: false
         ))
         #expect(CenterPaneView.shouldCompleteStartupRecoveryForRightPane(
             isRightPaneVisible: true,
             hasLoadedSnapshot: true,
             isLoading: false,
-            ggStackLoadState: .loaded
+            ggStackLoadState: .loaded,
+            ggAvailabilityHasProbed: true
         ))
     }
 

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -233,6 +233,13 @@ struct StartupRecoveryTests {
         ))
     }
 
+    @Test func independentAsyncTabReadinessIgnoresRightPaneFingerprintChanges() {
+        let terminal = Tab.terminal(.init(id: "terminal", title: "Terminal", sessionId: "terminal"))
+
+        #expect(CenterPaneView.startupRecoveryActiveKey(activeTab: terminal, rightPaneState: nil) ==
+            "terminal\u{0}tab")
+    }
+
     @Test func commitEditorDiffTaskRerunsAfterDetailsSettle() {
         #expect(CommitEditorTabView.diffTaskKey(
             currentSha: "abc",

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -161,11 +161,13 @@ struct StartupRecoveryTests {
         let acp = Tab.acpSession(.init(sessionId: "acp", title: "ACP"))
         let history = Tab.fileHistory(.init(worktreeId: "wt", relativePath: "README.md"))
         let editor = Tab.editor(.init(id: "editor", title: "README.md", relativePath: "README.md"))
+        let ggInbox = Tab.ggInbox(.init(projectId: "project", projectName: "Project"))
 
         #expect(!StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: terminal))
         #expect(!StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: acp))
         #expect(!StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: history))
         #expect(!StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: editor))
+        #expect(!StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: ggInbox))
         #expect(StartupRecoveryPaneCompletionPolicy.shouldComplete(activeTab: nil))
     }
 }

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -271,4 +271,22 @@ struct StartupRecoveryTests {
             loadingDetails: false
         ))
     }
+
+    @Test func commitEditorReportsReadinessOnlyForCurrentDiffTask() {
+        #expect(CommitEditorTabView.shouldReportStartupRecoveryReady(
+            requestedDiffTaskKey: "sha:file:false",
+            currentDiffTaskKey: "sha:file:false",
+            isCancelled: false
+        ))
+        #expect(!CommitEditorTabView.shouldReportStartupRecoveryReady(
+            requestedDiffTaskKey: "sha:file:false",
+            currentDiffTaskKey: "next:file:false",
+            isCancelled: false
+        ))
+        #expect(!CommitEditorTabView.shouldReportStartupRecoveryReady(
+            requestedDiffTaskKey: "sha:file:false",
+            currentDiffTaskKey: "sha:file:false",
+            isCancelled: true
+        ))
+    }
 }

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -213,6 +213,23 @@ struct StartupRecoveryTests {
         ))
     }
 
+    @Test func asyncTabReadinessCanCompleteAfterRightPaneSettles() {
+        let terminal = Tab.terminal(.init(id: "terminal", title: "Terminal", sessionId: "terminal"))
+
+        #expect(!CenterPaneView.shouldCompleteStartupRecoveryForCenterPane(
+            activeTab: terminal,
+            readyTabID: nil
+        ))
+        #expect(CenterPaneView.shouldCompleteStartupRecoveryForCenterPane(
+            activeTab: terminal,
+            readyTabID: "terminal"
+        ))
+        #expect(!CenterPaneView.shouldCompleteStartupRecoveryForCenterPane(
+            activeTab: terminal,
+            readyTabID: "other"
+        ))
+    }
+
     @Test func commitEditorDiffTaskRerunsAfterDetailsSettle() {
         #expect(CommitEditorTabView.diffTaskKey(
             currentSha: "abc",

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -204,22 +204,32 @@ struct StartupRecoveryTests {
         #expect(CenterPaneView.shouldCompleteStartupRecoveryForRightPane(
             isRightPaneVisible: false,
             hasLoadedSnapshot: false,
-            isLoading: true
+            isLoading: true,
+            ggStackLoadState: .loading
         ))
         #expect(!CenterPaneView.shouldCompleteStartupRecoveryForRightPane(
             isRightPaneVisible: true,
             hasLoadedSnapshot: false,
-            isLoading: false
+            isLoading: false,
+            ggStackLoadState: .inactive
         ))
         #expect(!CenterPaneView.shouldCompleteStartupRecoveryForRightPane(
             isRightPaneVisible: true,
             hasLoadedSnapshot: true,
-            isLoading: true
+            isLoading: true,
+            ggStackLoadState: .inactive
+        ))
+        #expect(!CenterPaneView.shouldCompleteStartupRecoveryForRightPane(
+            isRightPaneVisible: true,
+            hasLoadedSnapshot: true,
+            isLoading: false,
+            ggStackLoadState: .loading
         ))
         #expect(CenterPaneView.shouldCompleteStartupRecoveryForRightPane(
             isRightPaneVisible: true,
             hasLoadedSnapshot: true,
-            isLoading: false
+            isLoading: false,
+            ggStackLoadState: .loaded
         ))
     }
 

--- a/AlasTests/StartupRecoveryTests.swift
+++ b/AlasTests/StartupRecoveryTests.swift
@@ -5,6 +5,18 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct StartupRecoveryTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        var projectsFile: ProjectsFile
+
+        func write<T: Encodable>(_ value: T, to url: URL) throws {}
+
+        func readIfExists<T: Decodable>(_ type: T.Type, from url: URL) throws -> T? {
+            if type == ProjectsFile.self { return projectsFile as? T }
+            if type == AppConfig.self { return AppConfig.defaults as? T }
+            return nil
+        }
+    }
+
     @Test func detectsAnUnfinishedPreviousLaunch() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-startup-recovery-\(UUID().uuidString)")
@@ -174,6 +186,146 @@ struct StartupRecoveryTests {
         #expect(RootView.shouldRefreshProjectTopologiesOnStartup(
             isRecoveringFromAbandonedStartup: false
         ))
+    }
+
+    @Test func recoveryLaunchSkipsRemoteProjectGitWatchers() {
+        let localProject = ProjectConfig(
+            id: "local",
+            name: "Local",
+            path: "/local",
+            color: "#5fb7c4",
+            addedAt: Date()
+        )
+        let remoteProject = ProjectConfig(
+            id: "remote",
+            name: "Remote",
+            path: "/remote",
+            color: "#5fb7c4",
+            addedAt: Date(),
+            host: "devbox"
+        )
+        var watchedPaths: [String] = []
+        let state = AppState(
+            store: MemoryStore(projectsFile: ProjectsFile(projects: [localProject, remoteProject])),
+            projectGitWatcherFactory: { path in
+                watchedPaths.append(path.path)
+                return ProjectGitWatcher(
+                    repoPath: path,
+                    resolvedGitDir: URL(fileURLWithPath: "/git"),
+                    resolvedWorktreeRoot: path,
+                    headDebounceInterval: 0.01,
+                    headDebounceMaxWait: 0.02,
+                    topologyDebounceInterval: 0.01,
+                    topologyDebounceMaxWait: 0.02,
+                    startStreamOverride: { _, _ in }
+                )
+            }
+        )
+
+        state.startAllProjectGitWatchers(includeRemoteProjects: false)
+
+        #expect(watchedPaths == ["/local"])
+    }
+
+    @Test func recoveryLaunchPopulatesConfiguredProjectWorktrees() {
+        let root = "/srv/alas-recovery-\(UUID().uuidString)"
+        let linked = "/srv/alas-linked-\(UUID().uuidString)"
+        defer {
+            RemoteHostRegistry.shared.unregister(root: root)
+            RemoteHostRegistry.shared.unregister(root: linked)
+        }
+        let cached = Worktree(
+            id: linked,
+            projectId: "project",
+            name: "linked",
+            branch: "linked",
+            path: URL(fileURLWithPath: linked),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 1)
+        )
+        let project = ProjectConfig(
+            id: "project",
+            name: "Project",
+            path: root,
+            color: "#5fb7c4",
+            addedAt: Date(),
+            cachedWorktrees: [cached],
+            host: "devbox"
+        )
+        let manager = ProjectsManager(persistedProjects: [project])
+
+        manager.populateConfiguredProjectWorktreesForRecovery()
+
+        let rows = manager.worktrees(projectId: project.id)
+        #expect(rows.count == 1)
+        #expect(rows.first?.id == cached.id)
+        #expect(RemoteHostRegistry.shared.host(forPath: linked) == "devbox")
+    }
+
+    @Test func recoveryLaunchSkipsMissingLocalCachedWorktrees() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-recovery-\(UUID().uuidString)")
+        let missing = root.appendingPathComponent("missing")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let project = ProjectConfig(
+            id: "project",
+            name: "Project",
+            path: root.path,
+            color: "#5fb7c4",
+            addedAt: Date(),
+            cachedWorktrees: [
+                Worktree(
+                    id: Worktree.makeId(path: missing),
+                    projectId: "project",
+                    name: "missing",
+                    branch: "missing",
+                    path: missing,
+                    status: .clean,
+                    lastActivity: Date(timeIntervalSince1970: 1)
+                ),
+            ]
+        )
+        let manager = ProjectsManager(persistedProjects: [project])
+
+        manager.populateConfiguredProjectWorktreesForRecovery()
+
+        let rows = manager.worktrees(projectId: project.id)
+        #expect(rows.count == 1)
+        #expect(rows.first?.id == Worktree.makeId(path: root))
+        #expect(rows.first?.branch == "")
+        #expect(rows.first?.name == project.name)
+    }
+
+    @Test func recoveryLaunchReadsSyntheticLocalBranchFromHead() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-recovery-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        try "ref: refs/heads/main\n".write(
+            to: root.appendingPathComponent(".git/HEAD"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let project = ProjectConfig(
+            id: "project",
+            name: "Display Name",
+            path: root.path,
+            color: "#5fb7c4",
+            addedAt: Date()
+        )
+        let manager = ProjectsManager(persistedProjects: [project])
+
+        manager.populateConfiguredProjectWorktreesForRecovery()
+
+        let row = try #require(manager.worktrees(projectId: project.id).first)
+        #expect(row.branch == "main")
+        #expect(row.name == "main")
     }
 
     @Test func gracefulTerminationCompletesStartupRecovery() {


### PR DESCRIPTION
## What changed

Adds an unclean-launch marker. If Alas is killed or crashes during startup, the next launch restores the tab list but deliberately leaves every tab inactive, avoiding an automatic return to the pane that blocked startup.

## Root cause

The persisted active tab was eagerly rendered on launch, so a failing pane could create a deterministic relaunch loop.

The full test suite was also attempted; unrelated failures occurred and Xcode then stalled in test-runner cleanup.