### PR TITLE
fix(gg): prevent changes sidebar flashing

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -2095,7 +2095,8 @@ final class AppState {
         let watcher = projectGitWatcherFactory(URL(fileURLWithPath: project.path))
         let projectId = project.id
         watcher.onHeadChanged = { [weak self] map in self?.handleProjectHeadUpdates(projectId: projectId, branchByWorktreePath: map) }
-        watcher.onRevisionChanged = { [weak self] in self?.handleProjectRevisionChange(projectId: projectId) }
+        watcher.onRevisionChanged = { [weak self] in self?.bumpRevisionGenerationForProject(projectId: projectId) }
+        watcher.onStackRevisionChanged = { [weak self] in self?.handleProjectStackRevisionChange(projectId: projectId) }
         watcher.onTopologyChanged = { [weak self] in
             self?.handleProjectRevisionChange(projectId: projectId)
             self?.handleProjectTopologyChange(projectId: projectId)
@@ -2145,6 +2146,10 @@ final class AppState {
 
     private func handleProjectRevisionChange(projectId: String) {
         bumpRevisionGenerationForProject(projectId: projectId)
+        handleProjectStackRevisionChange(projectId: projectId)
+    }
+
+    private func handleProjectStackRevisionChange(projectId: String) {
         invalidateGGStackCacheAndRebumpGeneration(projectId: projectId)
         rightPaneStore.refreshActiveGGPresentationForProjectRevision(projectId: projectId)
     }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1024,11 +1024,13 @@ final class RightPaneState: GGSplitCommitServicing {
         let previousKey = ggStackCommitsKey
         let previousLoadState = ggStackLoadState
         let previousSummary = GGStackSummaryStore.shared.summaries[worktree.path.path]
+        let keepsPreviousPresentation = previousKey == key
+            && previousLoadState == .loaded
         defer {
             if Task.isCancelled,
                snapshotGeneration == snapshotInvalidationGeneration,
                refreshGeneration == ggStackRefreshGeneration,
-               ggStackLoadState == .loading {
+               !((ggStackLoadState == .loaded || ggStackLoadState == .empty) && ggStackCommitsKey == key) {
                 let canRestorePreviousSnapshot = previousKey == key
                     && key == currentGGStackCommitsKey
                     && (previousLoadState == .loaded || previousLoadState == .empty)
@@ -1050,17 +1052,19 @@ final class RightPaneState: GGSplitCommitServicing {
                 }
             }
         }
-        invalidateOlderHistoryForDisplaySourceChange()
-        ggStackLoadState = .loading
-        ggStackRemoteError = nil
-        ggStackRemoteEnrichmentPending = false
-        ggStackCommitsKey = nil
-        if ggStack != nil { ggStack = nil }
-        if !ggStackDisplayCommits.isEmpty { ggStackDisplayCommits = [] }
-        if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
-            GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
+        if !keepsPreviousPresentation {
+            invalidateOlderHistoryForDisplaySourceChange()
+            ggStackLoadState = .loading
+            ggStackRemoteError = nil
+            ggStackRemoteEnrichmentPending = false
+            ggStackCommitsKey = nil
+            if ggStack != nil { ggStack = nil }
+            if !ggStackDisplayCommits.isEmpty { ggStackDisplayCommits = [] }
+            if GGStackSummaryStore.shared.summaries[worktree.path.path] != nil {
+                GGStackSummaryStore.shared.summaries[worktree.path.path] = nil
+            }
+            ggMutationCoordinator.suspendUndoCandidate()
         }
-        ggMutationCoordinator.suspendUndoCandidate()
         do {
             let usesLocalSnapshot = ggCapabilities().localStackSnapshot
             var stack = try await ggService.currentStack(
@@ -1096,6 +1100,7 @@ final class RightPaneState: GGSplitCommitServicing {
                 resolvedContext = branchContext
             }
             if ggContext != resolvedContext { ggContext = resolvedContext }
+            ggStackRemoteError = nil
             ggStackCommitsKey = currentGGStackCommitsKey
             if ggStack != stack { ggStack = stack }
             ggStackDisplayCommits = displayCommits
@@ -1117,26 +1122,17 @@ final class RightPaneState: GGSplitCommitServicing {
                 refreshGeneration: refreshGeneration
             )
         } catch {
-            // A transient gg/provider failure (gh/glab auth hiccup, network
-            // blip, etc.) must not cache the *failed* key `key` — it stays
-            // unset so the next refresh for it retries instead of being
-            // skipped by the unchanged-key guard above. But whatever
-            // `ggStack` currently holds was loaded for the *previous*
-            // cached key (the guard above only lets us reach this point
-            // when `key` differs from it) — e.g. the previous branch's
-            // stack, if the user just checked out a different stack-shaped
-            // branch and this fetch for it failed. Rendering it against the
-            // now-different `commits` would misattribute its header, PR
-            // chips, and sidebar badge to the wrong branch, so clear it and
-            // degrade to plain commits. Clearing `ggStackCommitsKey` too
-            // (not just leaving it at the previous key) matters just as
-            // much: leaving it would make the guard above wrongly treat a
-            // later return to that same branch/commit set as "already
-            // cached" and skip re-fetching the now-cleared stack.
+            // Keep a same-key stack visible on a transient remote failure.
+            // A failed refresh for a different key cannot be rendered safely,
+            // so drop it and retry on the next refresh.
             if Task.isCancelled { return }
             guard snapshotGeneration == snapshotInvalidationGeneration,
                   refreshGeneration == ggStackRefreshGeneration
             else { return }
+            if keepsPreviousPresentation, key == currentGGStackCommitsKey {
+                ggStackRemoteError = (error as? GGServiceError)?.userMessage ?? error.localizedDescription
+                return
+            }
             if ggContext != branchContext { ggContext = branchContext }
             ggStackCommitsKey = nil
             if ggStack != nil { ggStack = nil }

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -8,6 +8,7 @@ enum GitEventCategory: Equatable {
     case ignored                  // *.lock under .git/ — mid-write, never react
     case headChange(URL)          // worktree root whose HEAD just changed
     case revisionChange           // shared refs moved; tracked revisions may resolve differently
+    case transientRevisionChange  // FETCH_HEAD changed; refs did not move
     case revisionAndTopologyChange
     case topologyChange           // .git/worktrees/ contents changed
     case other                    // unrelated event, caller decides
@@ -61,6 +62,9 @@ enum GitEventFilter {
                 let worktreeRoot = URL(fileURLWithPath: gitlink).deletingLastPathComponent()
                 return .headChange(worktreeRoot.standardizedFileURL)
             }
+            if parts.count == 3 && parts[2] == "FETCH_HEAD" {
+                return .transientRevisionChange
+            }
             if parts.count == 3 && Self.revisionPseudoRefs.contains(parts[2]) {
                 return .revisionChange
             }
@@ -96,6 +100,9 @@ enum GitEventFilter {
         if rel == "logs/HEAD" || rel.hasPrefix("logs/refs/") {
             return .revisionChange
         }
+        if rel == "FETCH_HEAD" {
+            return .transientRevisionChange
+        }
         if Self.revisionPseudoRefs.contains(rel) {
             return .revisionChange
         }
@@ -115,7 +122,6 @@ enum GitEventFilter {
     private static let revisionPseudoRefs: Set<String> = [
         "AUTO_MERGE",
         "CHERRY_PICK_HEAD",
-        "FETCH_HEAD",
         "MERGE_HEAD",
         "ORIG_HEAD",
         "REBASE_HEAD",

--- a/Alas/Sources/Watch/ProjectGitWatcher.swift
+++ b/Alas/Sources/Watch/ProjectGitWatcher.swift
@@ -17,10 +17,11 @@ private final class ProjectGitWatcherStreamContext {
 private struct ProjectGitWatcherStreamBatch {
     var headFiles: Set<URL> = []
     var sawRevision = false
+    var sawTransientRevision = false
     var sawTopology = false
 
     var hasChanges: Bool {
-        !headFiles.isEmpty || sawRevision || sawTopology
+        !headFiles.isEmpty || sawRevision || sawTransientRevision || sawTopology
     }
 }
 
@@ -43,6 +44,7 @@ final class ProjectGitWatcher {
 
     var onHeadChanged: (([URL: String]) -> Void)?
     var onRevisionChanged: (() -> Void)?
+    var onStackRevisionChanged: (() -> Void)?
     var onTopologyChanged: (() -> Void)?
 
     private let repoPath: URL
@@ -286,6 +288,8 @@ final class ProjectGitWatcher {
                 batch.headFiles.insert(URL(fileURLWithPath: path).standardizedFileURL)
             case .revisionChange:
                 batch.sawRevision = true
+            case .transientRevisionChange:
+                batch.sawTransientRevision = true
             case .revisionAndTopologyChange:
                 batch.sawRevision = true
                 batch.sawTopology = true
@@ -302,8 +306,11 @@ final class ProjectGitWatcher {
             pendingHeadFiles.formUnion(batch.headFiles)
             headDebouncer.poke()
         }
-        if batch.sawRevision {
+        if batch.sawRevision || batch.sawTransientRevision {
             onRevisionChanged?()
+        }
+        if batch.sawRevision {
+            onStackRevisionChanged?()
         }
         if batch.sawTopology {
             topologyDebouncer.poke()

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -148,7 +148,6 @@ struct GitEventFilterTests {
 
     @Test func pseudoRefsAcceptedByRevisionResolverAreRevisionChanges() {
         let cases = [
-            "FETCH_HEAD",
             "REBASE_HEAD",
             "MERGE_HEAD",
             "CHERRY_PICK_HEAD",
@@ -163,6 +162,16 @@ struct GitEventFilterTests {
                 worktreeRoot: worktreeRoot
             ) == .revisionChange)
         }
+    }
+
+    @Test func fetchHeadIsATransientRevisionChange() {
+        let gitDir = URL(fileURLWithPath: "/repo/.git")
+        let worktreeRoot = URL(fileURLWithPath: "/repo")
+        #expect(GitEventFilter.classify(
+            eventPath: gitDir.appendingPathComponent("FETCH_HEAD").path,
+            gitDir: gitDir,
+            worktreeRoot: worktreeRoot
+        ) == .transientRevisionChange)
     }
 
     @Test func topLevelSymbolicRevisionIsRevisionChange() throws {
@@ -216,7 +225,7 @@ struct GitEventFilterTests {
             eventPath: "/repo/.git/worktrees/feat/FETCH_HEAD",
             gitDir: gitDir,
             worktreeRoot: worktreeRoot
-        ) == .revisionChange)
+        ) == .transientRevisionChange)
     }
 
     @Test func linkedWorktreeConfigAndReflogsAreRevisionChanges() {

--- a/AlasTests/ProjectsManagerHeadUpdatesTests.swift
+++ b/AlasTests/ProjectsManagerHeadUpdatesTests.swift
@@ -261,4 +261,70 @@ struct ProjectsManagerHeadUpdatesTests {
         #expect(await loads.count == 2)
         state.stopProjectGitWatcher(projectId: project.id)
     }
+
+    @Test func fetchHeadRevisionDoesNotInvalidateGGStackCache() async throws {
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: "/repo",
+            color: "blue",
+            addedAt: Date()
+        )
+        let main = wt(path: "/repo", branch: "main")
+        let gitDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-app-state-fetch-head-\(UUID().uuidString)/.git")
+        try FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: gitDir.deletingLastPathComponent()) }
+
+        let watcher = ProjectGitWatcher(
+            repoPath: URL(fileURLWithPath: project.path),
+            resolvedGitDir: gitDir,
+            resolvedWorktreeRoot: main.path,
+            headDebounceInterval: 0.05,
+            headDebounceMaxWait: 0.2,
+            topologyDebounceInterval: 0.05,
+            topologyDebounceMaxWait: 0.2,
+            startStreamOverride: { _, _ in }
+        )
+        let state = AppState(
+            store: MemoryStore(projectsFile: ProjectsFile(projects: [project])),
+            projectGitWatcherFactory: { _ in watcher }
+        )
+        seed(state.projectsManager, projectId: project.id, [main])
+
+        actor LoadCounter {
+            var count = 0
+            func increment() { count += 1 }
+        }
+        let loads = LoadCounter()
+        let cachePath = gitDir.appendingPathComponent("worktree")
+        let stack = GGStack(
+            name: "stack",
+            base: "main",
+            totalCommits: 1,
+            syncedCommits: 0,
+            currentPosition: 1,
+            behindBase: 0,
+            entries: []
+        )
+
+        await GGStackCache.shared.invalidate()
+        defer { Task { await GGStackCache.shared.invalidate() } }
+        _ = try await GGStackCache.shared.stack(at: cachePath) {
+            await loads.increment()
+            return stack
+        }
+
+        state.startProjectGitWatcher(for: project)
+        watcher.processEvents([gitDir.appendingPathComponent("FETCH_HEAD").path])
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        _ = try await GGStackCache.shared.stack(at: cachePath) {
+            await loads.increment()
+            return stack
+        }
+        #expect(state.revisionChangeGeneration(worktreeID: main.id) == 1)
+        #expect(await loads.count == 1)
+        state.stopProjectGitWatcher(projectId: project.id)
+    }
 }

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -777,6 +777,10 @@ struct RightPaneGGStackTests {
         first.cancel()
         await first.value
 
+        #expect(state.ggStackLoadState == .loaded)
+        #expect(state.ggStackDisplayCommits.count == 3)
+        #expect(state.ggStackRemoteEnrichmentPending)
+
         await state.refreshGGStack()
 
         #expect(runner.calls == [
@@ -788,6 +792,34 @@ struct RightPaneGGStackTests {
         #expect(state.ggStackDisplayCommits.count == 3)
         #expect(state.ggStackRemoteError == "remote unavailable")
         #expect(!state.ggStackRemoteEnrichmentPending)
+    }
+
+    @Test func cancelledRemoteEnrichmentKeepsPublishedEmptyStack() async throws {
+        let runner = LocalFirstGGRunner()
+        runner.delaysRemote = true
+        runner.localJSON = GGStackClassificationFixture.nilStack.json
+        let state = makeState()
+        state.ggService = GGService(runner: runner)
+        state.ggCapabilities = {
+            GGCapabilities(
+                structuredSplit: false,
+                keepCurrentUnstack: false,
+                localStackSnapshot: true
+            )
+        }
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
+
+        let refresh = Task { @MainActor in await state.refreshGGStack() }
+        for _ in 0..<500 where runner.calls.count < 2 {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        refresh.cancel()
+        await refresh.value
+
+        #expect(state.ggStackLoadState == .empty)
+        #expect(state.ggStackDisplayCommits.isEmpty)
+        #expect(state.ggStackRemoteEnrichmentPending)
     }
 
     @Test func manualRetryPreservesCachedMetadataWhenRemoteFailsAgain() async {
@@ -2146,7 +2178,9 @@ struct RightPaneGGStackTests {
             await state.refreshGGStack(forceRemote: true)
         }
         await runner.waitUntilCall(2)
-        #expect(state.ggStackLoadState == .loading)
+        #expect(state.ggStackLoadState == .loaded)
+        #expect(state.ggStack?.name == "agent-inbox")
+        #expect(state.ggStackDisplayCommits == stableDisplayCommits)
 
         refresh.cancel()
         await runner.complete(call: 2)
@@ -2160,6 +2194,53 @@ struct RightPaneGGStackTests {
         #expect(state.ggStackDisplayCommits.allSatisfy { $0.subject == "stable hydration" })
         #expect(hydrationInvocation == 2)
         #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] == stableSummary)
+    }
+
+    @Test func successfulSameKeyRetryClearsRemoteError() async {
+        let worktree = makeWorktree()
+        let result = ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        let runner = ControlledStackGGRunner(
+            stackResults: [
+                ("agent-inbox", result),
+                ("agent-inbox", ProcessResult(exitCode: 1, stdout: "", stderr: "remote unavailable")),
+                ("agent-inbox", result),
+            ],
+            suspendedCalls: []
+        )
+        let state = makeState(worktree: worktree)
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "q", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+        await state.refreshGGStack(forceRemote: true)
+        #expect(state.ggStackRemoteError == "remote unavailable")
+
+        await state.refreshGGStack(forceRemote: true)
+        #expect(state.ggStackRemoteError == nil)
+    }
+
+    @Test func sameKeyEmptyRefreshFailureBecomesRetryableFailure() async {
+        let worktree = makeWorktree()
+        let emptyResult = ProcessResult(exitCode: 0, stdout: GGStackClassificationFixture.nilStack.json, stderr: "")
+        let runner = ControlledStackGGRunner(
+            stackResults: [
+                ("agent-inbox", emptyResult),
+                ("agent-inbox", ProcessResult(exitCode: 1, stdout: "", stderr: "remote unavailable")),
+            ],
+            suspendedCalls: []
+        )
+        let state = makeState(worktree: worktree)
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "q", count: 40), stackShaped: true)]
+
+        await state.refreshGGStack()
+        #expect(state.ggStackLoadState == .empty)
+
+        await state.refreshGGStack(forceRemote: true)
+        #expect(state.ggStackLoadState == .failed("remote unavailable"))
+        #expect(state.ggStackRemoteError == nil)
     }
 
     @Test func cancelledRefreshWithChangedLiveKeyDoesNotRestorePreviousStack() async {


### PR DESCRIPTION
## Summary
- keep GG stack state visible during same-key remote refreshes
- avoid invalidating GG presentation for FETCH_HEAD-only updates
- add regression coverage for both paths

## Verification
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-blink-tests -quiet build
- full local test launch stalled before xctest started; CI will run the suite