### PR TITLE
feat(changes): virtualize Changes tab scrolling

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		1B9CC3C13E96290B391E7C26 /* ImagePreviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */; };
 		1BA6A97406CD857F02D81AE0 /* BuiltInAlasMCPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7A4A7B920C0E748973F282 /* BuiltInAlasMCPTests.swift */; };
 		1BC03FAEA1E89F3A74A98DE4 /* AppConfigShortcutsCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */; };
+		1C2015ABCBACE0F6B475AE9A /* WorkingTreeFlatRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318E4E3130F42671D888DC5C /* WorkingTreeFlatRowTests.swift */; };
 		1C2C949642E10060172AB1BA /* ACPToolCallPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77D7A400059AFD189D1CA5A /* ACPToolCallPresentationTests.swift */; };
 		1C5D64F032EAD5EA28B2482B /* ACPComposerActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0206F856D9639147D0A4BF /* ACPComposerActions.swift */; };
 		1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */; };
@@ -494,6 +495,7 @@
 		4F2BB7482C39B07F5E35E9D1 /* RemoteMessageWireJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD68C6A69930BE0F9437AAE /* RemoteMessageWireJSON.swift */; };
 		4F6177806CEB8E50F0D70F7B /* MermaidViewerStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A09AB192DD6181CD974283 /* MermaidViewerStateTests.swift */; };
 		4F6DAC87A8E1730770319BBB /* RightPaneGGStackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5820BB012E55F3A0C1272B /* RightPaneGGStackTests.swift */; };
+		4F762FC22287E279018BBD0B /* AppKitChangesScrollerFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0EF035A794FACA5F504F52 /* AppKitChangesScrollerFlag.swift */; };
 		4FD9E5FFB4C75850CF7B2FE7 /* StagedDiffLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CD99C81057F377C5E249B7 /* StagedDiffLoaderTests.swift */; };
 		4FE322C88A2B06C317DDA9B5 /* ReviewSessionTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C593F9F14DD962C9822C64 /* ReviewSessionTabView.swift */; };
 		5015F89D084573BFC8A9E2C3 /* AttachedIssueDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7A1961A7FEA8DC28BD6C87A /* AttachedIssueDraft.swift */; };
@@ -536,6 +538,7 @@
 		5685074AFE30889AAC69EB8D /* ThreePaneLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */; };
 		568F6E986ED37A79D21CF09B /* SSHHostPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FA3C5D49DC1B6AB83479412 /* SSHHostPicker.swift */; };
 		56B6EF95B863B557992AE9DA /* ACPAutoRunToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EDEEB00185F9C717205540 /* ACPAutoRunToggle.swift */; };
+		56E8E0DE689D2107521DFD75 /* AppKitChangesScrollerFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B75422E0FA09B32F72F311D /* AppKitChangesScrollerFlagTests.swift */; };
 		5711B2BE2D70220A4BED5B2B /* DefinitionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12340A649892955245BECB7 /* DefinitionFeature.swift */; };
 		57138814D45D03AE10BE9D67 /* ACPPermissionFSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B932ED9D5A485AE1545223C /* ACPPermissionFSTests.swift */; };
 		5723C73E91B9143B73554042 /* ReviewSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0704EBDA62931ADE79B04F30 /* ReviewSessionStore.swift */; };
@@ -1857,6 +1860,7 @@
 		3111744632DAC342A40DB62A /* ACPAdapterUpdateBannerDecider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterUpdateBannerDecider.swift; sourceTree = "<group>"; };
 		311B7CA55176621C35DE3E92 /* AlasCLIWorktreeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIWorktreeResolverTests.swift; sourceTree = "<group>"; };
 		312DC027D433B496FD010F85 /* DiffReviewSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewSurfaceTests.swift; sourceTree = "<group>"; };
+		318E4E3130F42671D888DC5C /* WorkingTreeFlatRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeFlatRowTests.swift; sourceTree = "<group>"; };
 		31CE012ED93AA22C257FEB8A /* MergeConflictBinaryDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictBinaryDetectionTests.swift; sourceTree = "<group>"; };
 		31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowController.swift; sourceTree = "<group>"; };
 		321866B3EB8CCE337B1D3A58 /* ACPMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessage.swift; sourceTree = "<group>"; };
@@ -2301,6 +2305,7 @@
 		7A240CD3EF074300828A1214 /* CommitReviewLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitReviewLoader.swift; sourceTree = "<group>"; };
 		7A2B4B719D9F4EAAE84B14D1 /* ProjectAvatarPresetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectAvatarPresetProvider.swift; sourceTree = "<group>"; };
 		7B22D5EBE7EDAC07C943C91D /* WebSocketFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketFrame.swift; sourceTree = "<group>"; };
+		7B75422E0FA09B32F72F311D /* AppKitChangesScrollerFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitChangesScrollerFlagTests.swift; sourceTree = "<group>"; };
 		7BA6DF8E37E9B38C627B030A /* ACPTranscriptRowHostingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptRowHostingView.swift; sourceTree = "<group>"; };
 		7BEC4E033DB3BA44C825D453 /* EmojiPickerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerButton.swift; sourceTree = "<group>"; };
 		7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnvironment.swift; sourceTree = "<group>"; };
@@ -3002,6 +3007,7 @@
 		ECFB48AF581F74C564ACBCF5 /* CompletionDocumentationRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDocumentationRenderer.swift; sourceTree = "<group>"; };
 		EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerActionTests.swift; sourceTree = "<group>"; };
 		EE0C0029F439C282D474ED77 /* ACPFileWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileWriter.swift; sourceTree = "<group>"; };
+		EE0EF035A794FACA5F504F52 /* AppKitChangesScrollerFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitChangesScrollerFlag.swift; sourceTree = "<group>"; };
 		EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParserTests.swift; sourceTree = "<group>"; };
 		EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRow.swift; sourceTree = "<group>"; };
 		EE6F36C31DB1C13D86416B4B /* PiACPInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiACPInstaller.swift; sourceTree = "<group>"; };
@@ -3365,6 +3371,7 @@
 				B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */,
 				C0458AFA9BCBC4484B084085 /* AppConfigWorktreeOrderingDecodeTests.swift */,
 				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
+				7B75422E0FA09B32F72F311D /* AppKitChangesScrollerFlagTests.swift */,
 				EBEC713703928ABF1942645D /* AppKitDiffReviewPresentationStateTests.swift */,
 				FD2672B5B84D96BDDE9D80A0 /* AppQuitActionTests.swift */,
 				447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */,
@@ -3680,6 +3687,7 @@
 				708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */,
 				CF0005D9107053886C37A3AC /* WarningCharacterTests.swift */,
 				2F5959FF98A5105FF7B17894 /* WorkingTreeChangeGroupTests.swift */,
+				318E4E3130F42671D888DC5C /* WorkingTreeFlatRowTests.swift */,
 				5F931B1EEA7F04855BAE5A43 /* WorkingTreeStageAllActionTests.swift */,
 				AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */,
 				8B94010802299E6AC5597E85 /* WorktreeCodableTests.swift */,
@@ -4056,6 +4064,7 @@
 		413E432DDAAAE618029482C3 /* Right */ = {
 			isa = PBXGroup;
 			children = (
+				EE0EF035A794FACA5F504F52 /* AppKitChangesScrollerFlag.swift */,
 				002C8D5C52466955E0A90606 /* BaseBranchSelector.swift */,
 				FF68BCA1222E7C06DA4AC595 /* BaseResolutionMapping.swift */,
 				6BAD20759A17B6EFE3AC0C81 /* BranchOpsMenu.swift */,
@@ -6157,6 +6166,7 @@
 				214A48509F96D0B6613A1D1D /* AlasSlider.swift in Sources */,
 				F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */,
 				5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */,
+				4F762FC22287E279018BBD0B /* AppKitChangesScrollerFlag.swift in Sources */,
 				534E1DFA40F7F467F82D900E /* AppKitDiffReviewPresentationState.swift in Sources */,
 				5B2E19E0AE25DC4FA27332A3 /* AppKitDiffReviewRowPlan.swift in Sources */,
 				308CDBB267D8A16BF7AA8008 /* AppKitDiffReviewScroller.swift in Sources */,
@@ -6974,6 +6984,7 @@
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				FCB5091692C10A45B4E5D6BB /* AppConfigWorktreeOrderingDecodeTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
+				56E8E0DE689D2107521DFD75 /* AppKitChangesScrollerFlagTests.swift in Sources */,
 				F916235528BF9A5E4773804E /* AppKitDiffReviewFlingPerfTests.swift in Sources */,
 				3B925198F948BE8054662C43 /* AppKitDiffReviewPresentationStateTests.swift in Sources */,
 				BBCC834135D0915CAEED5A4C /* AppKitDiffReviewRowPlanTests.swift in Sources */,
@@ -7453,6 +7464,7 @@
 				61E502981D902F018F464831 /* WebPageMetadataFetcherTests.swift in Sources */,
 				2DDF8175D7490F505AED7DF4 /* WebSocketFrameTests.swift in Sources */,
 				175AA2192F1DBD9836E08E77 /* WorkingTreeChangeGroupTests.swift in Sources */,
+				1C2015ABCBACE0F6B475AE9A /* WorkingTreeFlatRowTests.swift in Sources */,
 				9BA16B0D5FC26501D54B5192 /* WorkingTreeStageAllActionTests.swift in Sources */,
 				BE70DBB10DB7106860886AD7 /* WorkspaceLSPManagerStatusTests.swift in Sources */,
 				B34227BF866AFDACB3194333 /* WorktreeCodableTests.swift in Sources */,

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowSpec.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowSpec.swift
@@ -25,6 +25,7 @@ extension AppKitDiffRowEqualityToken: Equatable {
 enum AppKitDiffRowRetention: Equatable {
     case recyclable
     case pinned
+    case sticky
 }
 
 struct AppKitDiffRowSpec {

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
@@ -12,6 +12,7 @@ final class AppKitDiffScrollerReconciler {
     private var specsByID: [String: AppKitDiffRowSpec] = [:]
     private var orderedIDs: [String] = []
     private var pinnedRowIDs: Set<String> = []
+    private var stickyRowIDs: [String] = []
     private var measuredHeights: [String: CGFloat] = [:]
     private var contentWidth: CGFloat = 0
     private var contentInsets: AppKitDiffContentInsets = .zero
@@ -69,14 +70,18 @@ final class AppKitDiffScrollerReconciler {
         let previousMeasuredHeights = measuredHeights
         var nextSpecs: [String: AppKitDiffRowSpec] = [:]
         var nextPinnedRowIDs: Set<String> = []
+        var nextStickyRowIDs: [String] = []
         var nextMeasuredHeights: [String: CGFloat] = [:]
         for spec in plan.rows {
             #if DEBUG
             retentionInspectionCountForTests += 1
             #endif
             nextSpecs[spec.id] = spec
-            if spec.retention == .pinned {
+            if spec.retention == .pinned || spec.retention == .sticky {
                 nextPinnedRowIDs.insert(spec.id)
+            }
+            if spec.retention == .sticky {
+                nextStickyRowIDs.append(spec.id)
             }
             if !widthChanged,
                previousSpecs[spec.id]?.equalityToken.isEqual(to: spec.equalityToken) == true,
@@ -108,6 +113,7 @@ final class AppKitDiffScrollerReconciler {
         specsByID = nextSpecs
         orderedIDs = ids
         pinnedRowIDs = nextPinnedRowIDs
+        stickyRowIDs = nextStickyRowIDs
         measuredHeights = nextMeasuredHeights
         contentWidth = rowContentWidth
         contentInsets = plan.contentInsets
@@ -295,6 +301,21 @@ final class AppKitDiffScrollerReconciler {
             scrollView.setDocumentHeight(tiling.documentHeight)
             guard geometryChanged else { break }
         }
+        layoutStickyRow()
+    }
+
+    private func layoutStickyRow() {
+        guard let layout = tiling.stickyRowLayout(ids: stickyRowIDs, viewportMinY: scrollView.scrollY),
+              let row = tiling.row(withID: layout.id),
+              let view = pool.mountedView(id: layout.id)
+        else { return }
+        view.frame = NSRect(
+            x: contentInsets.left,
+            y: layout.minY,
+            width: contentWidth,
+            height: row.height
+        )
+        scrollView.flippedDocumentView.addSubview(view, positioned: .above, relativeTo: nil)
     }
 
     private func intrinsicSizeInvalidated(for id: String) {

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffTilingController.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffTilingController.swift
@@ -24,6 +24,11 @@ final class AppKitDiffTilingController {
         var maxY: CGFloat { minY + height }
     }
 
+    struct StickyRowLayout: Equatable {
+        let id: String
+        let minY: CGFloat
+    }
+
     private var metrics: Metrics
     private var rows: [RowLayout] = []
     private var indexByID: [String: Int] = [:]
@@ -105,6 +110,14 @@ final class AppKitDiffTilingController {
             desired = row.minY - (viewportHeight - row.height) / 2
         }
         return min(max(0, desired), max(0, documentHeight - viewportHeight))
+    }
+
+    func stickyRowLayout(ids: [String], viewportMinY: CGFloat) -> StickyRowLayout? {
+        let stickyRows: [RowLayout] = ids.compactMap { id in self.row(withID: id) }
+        guard let index = stickyRows.lastIndex(where: { $0.minY <= viewportMinY }) else { return nil }
+        let currentRow = stickyRows[index]
+        let nextMinY = stickyRows.indices.contains(index + 1) ? stickyRows[index + 1].minY : .greatestFiniteMagnitude
+        return .init(id: currentRow.id, minY: min(viewportMinY, nextMinY - currentRow.height))
     }
 
     /// Returns the row containing `y` under the half-open interval convention.

--- a/Alas/Sources/Right/AppKitChangesScrollerFlag.swift
+++ b/Alas/Sources/Right/AppKitChangesScrollerFlag.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+enum AppKitChangesScrollerFlag {
+    static let defaultsKey = "alas.changes.appKitScroller"
+    static let overrideDidChangeNotification = Notification.Name(
+        "io.nlopez.alas.AppKitChangesScrollerFlag.overrideDidChange"
+    )
+
+    static var isEnabled: Bool {
+        isEnabledWithDefaults(.standard)
+    }
+
+    nonisolated static func readOverride(from defaults: UserDefaults) -> Bool? {
+        defaults.object(forKey: defaultsKey) as? Bool
+    }
+
+    nonisolated static func isEnabledWithDefaults(_ defaults: UserDefaults) -> Bool {
+        #if DEBUG
+        resolve(override: readOverride(from: defaults), isDebugBuild: true)
+        #else
+        resolve(override: readOverride(from: defaults), isDebugBuild: false)
+        #endif
+    }
+
+    nonisolated static func resolve(override: Bool?, isDebugBuild: Bool) -> Bool {
+        override ?? isDebugBuild
+    }
+
+    nonisolated static func setOverride(
+        _ enabled: Bool,
+        in defaults: UserDefaults = .standard,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        defaults.set(enabled, forKey: defaultsKey)
+        notificationCenter.post(name: overrideDidChangeNotification, object: nil)
+    }
+}

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -566,6 +566,7 @@ struct ChangesTabView: View {
         Self.commitRowsStateToken(
             ggStack: rps.ggStack,
             ggModeActive: rps.ggContext.isActive,
+            comparisonRef: rps.comparisonRef,
             ggCapabilities: GGAvailability.shared.capabilities,
             inFlightAction: rps.ggActionState.inFlightAction,
             pausedOperation: rps.ggActionState.pausedOperation,
@@ -580,6 +581,7 @@ struct ChangesTabView: View {
     static func commitRowsStateToken(
         ggStack: GGStack?,
         ggModeActive: Bool,
+        comparisonRef: String? = nil,
         ggCapabilities: GGCapabilities = GGCapabilities(structuredSplit: false, keepCurrentUnstack: false),
         inFlightAction: GGStackActionKind?,
         pausedOperation: GGPausedOperation?,
@@ -591,6 +593,7 @@ struct ChangesTabView: View {
     ) -> String {
         String(reflecting: ggStack)
             + String(ggModeActive)
+            + String(reflecting: comparisonRef)
             + String(reflecting: ggCapabilities)
             + String(reflecting: inFlightAction)
             + String(reflecting: pausedOperation)

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -8,6 +8,11 @@ struct ChangesTabView: View {
     let onEditCommit: (CommitInfo, String) -> Void
     let onReviewCommit: (CommitInfo) -> Void
 
+    @State private var appKitScrollerEnabled = AppKitChangesScrollerFlag.isEnabled
+    @State private var collapsedChangePaths: Set<String> = []
+    @State private var appKitActionRelay = ChangesAppKitActionRelay()
+    @Environment(\.theme) private var theme
+
     private var conflicts: [ChangedFile] {
         rps.changes.filter { $0.conflict != nil }
     }
@@ -50,9 +55,24 @@ struct ChangesTabView: View {
     }
 
     var body: some View {
+        let _ = appKitActionRelay.update(
+            onSelectFile: onSelect,
+            onSelectCommit: onSelectCommit,
+            onEditCommit: onEditCommit,
+            onReviewCommit: onReviewCommit
+        )
         VStack(spacing: 0) {
-            ScrollView {
-                scrollContent
+            if appKitScrollerEnabled {
+                AppKitDiffScroller(
+                    plan: appKitScrollPlan,
+                    scrollRequest: nil,
+                    onActiveOwnerChange: { _ in },
+                    onScrollRequestCompletion: { _ in }
+                )
+            } else {
+                ScrollView {
+                    scrollContent
+                }
             }
             if isGGDrawerActive {
                 GGStackDrawer(rps: rps, appState: appState)
@@ -63,6 +83,9 @@ struct ChangesTabView: View {
                     onAction: { action in rps.handleReviewReadinessAction(action, appState: appState) }
                 )
             }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: AppKitChangesScrollerFlag.overrideDidChangeNotification)) { _ in
+            appKitScrollerEnabled = AppKitChangesScrollerFlag.isEnabled
         }
     }
 
@@ -229,70 +252,7 @@ struct ChangesTabView: View {
                     }
                 )
             }
-            WorkingTreeSectionView(
-                changes: nonConflictChanges,
-                expanded: $rps.workingTreeExpanded,
-                onSelect: onSelect,
-                fileContextTarget: { file in
-                    FileContextMenuTarget.resolve(
-                        kind: .file,
-                        worktreePath: rps.worktree.path,
-                        relativePath: file.path
-                    )
-                },
-                onStageAll: { rps.stageAll($0) },
-                onUnstageAll: { rps.unstageAll($0) },
-                onIgnore: { path, isDir, dest in
-                    rps.ignore(path: path, isDirectory: isDir, destination: dest)
-                },
-                onDiscardAll: { rps.requestDiscardAll() },
-                onDiscardFolder: { path in rps.requestDiscardFolder(path: path) },
-                onOpenFile: { file in
-                    appState.openFile(relativePath: file.path, worktreeId: rps.worktree.id)
-                },
-                onCopyRelative: { file in
-                    Clipboard.copy(file.path)
-                },
-                onCopyFull: { file in
-                    let absolute = rps.worktree.path.appendingPathComponent(file.path).path
-                    Clipboard.copy(absolute)
-                },
-                onCopyDiff: { file in
-                    rps.copyDiff(for: file.path, renameFrom: file.renameFrom)
-                },
-                onViewAtHEAD: { file in
-                    appState.openFileSnapshotAtHEAD(
-                        relativePath: file.renameFrom ?? file.path,
-                        worktreeId: rps.worktree.id
-                    )
-                },
-                onCompareWithHEAD: { file in
-                    appState.openDiffTab(
-                        forFileInWorktree: rps.worktree,
-                        relativePath: file.path,
-                        originalPath: file.renameFrom,
-                        compareWithHEAD: true
-                    )
-                },
-                onFileHistory: { file in
-                    appState.openFileHistory(
-                        relativePath: file.renameFrom ?? file.path,
-                        worktreeId: rps.worktree.id
-                    )
-                },
-                onDiscardFile: { file in rps.requestDiscardFile(path: file.path) },
-                onStashChanges: { rps.requestStashChanges() },
-                stashChangesDisabled: rps.mergeOp.current != nil || rps.stashOperationInFlight,
-                isOpenFileEnabled: { file in
-                    DiffOpenFileAvailability.isAvailable(
-                        worktreePath: rps.worktree.path,
-                        relativePath: file.path
-                    )
-                },
-                dragPayload: { file in
-                    .workingTreeFile(worktreePath: rps.worktree.path, relativePath: file.path)
-                }
-            )
+            workingTreeSection
             StashesSectionView(
                 stashes: rps.stashes,
                 filesByRef: rps.stashFilesByRef,
@@ -312,45 +272,411 @@ struct ChangesTabView: View {
                 }
             )
             Divider().opacity(0.4)
-            CommitsSectionView(
-                commits: rps.commitsForDisplay,
-                olderCommits: rps.olderCommits,
-                comparisonRef: rps.comparisonRef,
-                hasMoreOlder: rps.hasMoreOlder && rps.ggStackLoadState != .loading,
-                isLoadingOlder: rps.isLoadingOlder,
-                behindBase: rps.showBehindBaseChip ? rps.behindBase : nil,
-                behindUpstream: rps.showBehindUpstreamChip ? rps.behindUpstream : nil,
-                expanded: $rps.commitsExpanded,
-                baseBranch: $rps.baseBranch,
-                branches: BaseBranchSelector.smartList(
-                    branches: rps.availableBranches,
-                    currentRef: rps.comparisonRef,
-                    upstream: rps.upstreamRef,
-                    recent: rps.recentBaseBranches
-                ),
-                isLoadingBranches: rps.isFetchingBranches,
-                hasLoadedBranches: rps.hasFetchedBranches,
-                onSelect: onSelectCommit,
-                onCopySHA: copyCommitSHA,
-                onEdit: { commit in
-                    if let ref = rps.comparisonRef {
-                        onEditCommit(commit, ref)
-                    }
-                },
-                onReview: onReviewCommit,
-                onLoadOlder: { Task { @MainActor in await rps.loadOlder() } },
-                onSelectBaseBranch: { branch in
-                    rps.selectBaseBranch(branch)
-                },
-                onOpenBaseBranchSelector: { Task { @MainActor in await rps.fetchBranches() } },
-                rps: rps,
-                ggStack: rps.ggStack,
-                stackCodeHostKind: rps.commitRemote?.kind,
-                onGGAction: { action, commit in
-                    rps.handleGGCommitAction(action, commit: commit, appState: appState)
-                }
-            )
+            commitsSection
         }
+    }
+
+    private var appKitScrollPlan: AppKitDiffRowPlan {
+        let preparation = preparationModel
+        let workingTree = workingTreeSection
+        let workingGroups = WorkingTreeChangeGroup.group(files: nonConflictChanges)
+        let workingGroupsSignature = String(reflecting: workingGroups).hashValue
+        let groupsByPath = Dictionary(uniqueKeysWithValues: workingGroups.map { ($0.path, $0) })
+        let commits = commitsSection
+        var rows: [AppKitDiffRowSpec] = []
+
+        if let error = rps.sidebarError {
+            rows.append(appKitRow(id: "changes-error", token: error, estimatedHeight: 38) {
+                InlineErrorStrip(message: error, onDismiss: { rps.sidebarError = nil })
+                    .padding(.horizontal, 12)
+                    .padding(.top, 6)
+            })
+        }
+
+        if let operation = rps.mergeOp.current,
+           Self.shouldShowGenericOperationCard(
+            mergeOperation: operation,
+            pausedGGOperation: rps.ggActionState.pausedOperation
+           ) {
+            rows.append(appKitRow(
+                id: "changes-operation",
+                token: String(reflecting: operation) + String(!conflicts.isEmpty),
+                estimatedHeight: 110
+            ) {
+                OperationCard(
+                    operation: operation,
+                    hasUnresolvedConflicts: !conflicts.isEmpty,
+                    onContinue: { rps.continueOperation() },
+                    onSkip: { rps.skipOperation() },
+                    onAbort: { rps.abortOperation() }
+                )
+            })
+        }
+
+        if !conflicts.isEmpty || rps.bulkResolveInFlight || rps.bulkResolveReport != nil {
+            let token = String(reflecting: conflicts)
+                + String(reflecting: rps.bulkResolveInFlight)
+                + String(reflecting: rps.bulkResolveReport)
+                + String(reflecting: resolvedBulkAgent)
+                + appState.config.changes.mergeBulkResolvePrompt
+            rows.append(appKitRow(id: "changes-conflicts", token: token, estimatedHeight: 120) {
+                ConflictsSection(
+                    conflicts: conflicts,
+                    bulkInFlight: rps.bulkResolveInFlight,
+                    bulkReport: rps.bulkResolveReport,
+                    hasAgent: resolvedBulkAgent != nil,
+                    onSelect: { file in rps.openConflict?(file.path) },
+                    onUseOurs: { rps.useOurs(file: $0) },
+                    onUseTheirs: { rps.useTheirs(file: $0) },
+                    onKeepDeleted: { rps.keepDeleted(file: $0) },
+                    onMarkResolved: { rps.markResolved(file: $0) },
+                    onResolveAllWithAgent: {
+                        guard let agent = resolvedBulkAgent else { return }
+                        rps.resolveAllConflicts(
+                            using: agent,
+                            prompt: appState.config.changes.mergeBulkResolvePrompt
+                        )
+                    },
+                    onCancelBulkResolve: { rps.cancelBulkResolve() },
+                    onDismissBulkReport: { rps.dismissBulkResolveReport() },
+                    dragPayload: { file in
+                        .workingTreeFile(worktreePath: rps.worktree.path, relativePath: file.path)
+                    }
+                )
+            })
+        }
+
+        if Self.shouldShowChangesPreparationCard(preparationIsVisible: preparation.isVisible) {
+            rows.append(appKitRow(
+                id: "changes-preparation",
+                token: String(reflecting: preparation),
+                estimatedHeight: 92
+            ) {
+                ChangesPreparationCard(
+                    model: preparation,
+                    onReviewChanges: openReviewChangesTab,
+                    onDraftCommit: openDraftTab,
+                    onGGAction: handleGGPreparationAction,
+                    onGGStackAction: { rps.onGGStackAction($0, appState: appState) },
+                    onReviewRequestAction: { rps.handleReviewReadinessAction($0, appState: appState) }
+                )
+            })
+        }
+
+        rows.append(appKitRow(
+            id: "working-tree-header",
+            token: "\(workingGroupsSignature)-\(rps.workingTreeExpanded)-\(rps.mergeOp.current != nil)-\(rps.stashOperationInFlight)",
+            estimatedHeight: 32,
+            retention: .sticky
+        ) { workingTree.headerRow })
+
+        if rps.workingTreeExpanded {
+            if workingGroups.isEmpty {
+                rows.append(appKitRow(id: "working-tree-empty", token: 0, estimatedHeight: 32) {
+                    ChangesEmptyRow(text: "no changes")
+                })
+            } else {
+                for row in WorkingTreeFlatRow.make(
+                    groups: workingGroups,
+                    collapsedPaths: collapsedChangePaths
+                ) {
+                    rows.append(appKitRow(
+                        id: "working-tree-\(row.id)",
+                        token: String(reflecting: row)
+                            + (row.node.kind == .dir
+                                ? String(workingGroupsSignature)
+                                : String(reflecting: groupsByPath[row.node.path])),
+                        estimatedHeight: 28
+                    ) {
+                        WorkingTreeFlatRowView(
+                            row: row,
+                            groups: workingGroups,
+                            groupsByPath: groupsByPath,
+                            collapsedPaths: $collapsedChangePaths,
+                            actions: workingTree.rowActions
+                        )
+                    })
+                }
+            }
+        }
+
+        appendStashRows(to: &rows)
+        rows.append(appKitRow(id: "changes-commit-divider", token: 0, estimatedHeight: 1) {
+            Divider().opacity(0.4)
+        })
+        appendCommitRows(commits, to: &rows)
+        return AppKitDiffRowPlan(rows: rows)
+    }
+
+    private func appendStashRows(to rows: inout [AppKitDiffRowSpec]) {
+        guard !rps.stashes.isEmpty else { return }
+        rows.append(appKitRow(
+            id: "stashes-header",
+            token: String(reflecting: rps.stashes) + String(rps.stashesExpanded),
+            estimatedHeight: 32,
+            retention: .sticky
+        ) {
+            SectionHeader(
+                role: .stashes,
+                title: "Stashes",
+                count: rps.stashes.count,
+                expanded: rps.stashesExpanded,
+                onToggle: { rps.stashesExpanded.toggle() }
+            )
+        })
+        guard rps.stashesExpanded else { return }
+
+        for stash in rps.stashes {
+            let isOpen = rps.expandedStashRefs.contains(stash.ref)
+            let isLoading = rps.loadingStashRefs.contains(stash.ref)
+            rows.append(appKitRow(
+                id: "stash-\(stash.ref)",
+                token: String(reflecting: stash) + String(isOpen) + String(isLoading),
+                estimatedHeight: 32
+            ) {
+                StashSummaryRow(
+                    stash: stash,
+                    open: isOpen,
+                    loading: isLoading,
+                    onToggle: { rps.toggleStashExpanded(stash) },
+                    onApply: { rps.applyStash(stash) },
+                    onPop: { rps.popStash(stash) },
+                    onDrop: { rps.requestDropStash(stash) }
+                )
+            })
+            guard isOpen else { continue }
+            let files = rps.stashFilesByRef[stash.ref] ?? []
+            if files.isEmpty {
+                rows.append(appKitRow(
+                    id: "stash-\(stash.ref)-empty",
+                    token: isLoading,
+                    estimatedHeight: 32
+                ) { StashEmptyRow(loading: isLoading) })
+            } else {
+                for file in files {
+                    rows.append(appKitRow(
+                        id: "stash-\(stash.ref)-file-\(file.id)",
+                        token: file,
+                        estimatedHeight: 30
+                    ) {
+                        StashFileRow(
+                            file: file,
+                            onSelect: {
+                                appState.openStashDiffTab(worktree: rps.worktree, stash: stash, file: file)
+                            },
+                            dragPayload: {
+                                .stashFile(worktreePath: rps.worktree.path, stash: stash, file: file)
+                            }
+                        )
+                    })
+                }
+            }
+        }
+    }
+
+    private func appendCommitRows(
+        _ section: CommitsSectionView,
+        to rows: inout [AppKitDiffRowSpec]
+    ) {
+        let commits = rps.commitsForDisplay
+        let older = rps.olderCommits
+        let rowStateToken = commitRowsStateToken
+        rows.append(appKitRow(
+            id: "commits-header",
+            token: commitHeaderToken,
+            estimatedHeight: 32,
+            retention: .sticky
+        ) { section.headerRow })
+        guard rps.commitsExpanded else { return }
+
+        for commit in commits {
+            rows.append(appKitRow(
+                id: "commit-primary-\(commit.sha)",
+                token: String(reflecting: commit) + rowStateToken,
+                estimatedHeight: 64
+            ) { section.primaryCommitRow(commit) })
+        }
+        if commits.isEmpty && older.isEmpty {
+            let text = rps.comparisonRef.map { "up to date with \($0)" } ?? "no comparison branch"
+            rows.append(appKitRow(id: "commits-empty", token: text, estimatedHeight: 32) {
+                CommitHistoryEmptyRow(text: text)
+            })
+        }
+        if !older.isEmpty, let comparisonRef = rps.comparisonRef {
+            rows.append(appKitRow(id: "commits-boundary", token: comparisonRef, estimatedHeight: 32) {
+                CommitHistoryDividerRow(label: comparisonRef)
+            })
+        }
+        for commit in older {
+            rows.append(appKitRow(
+                id: "commit-older-\(commit.sha)",
+                token: String(reflecting: commit) + rowStateToken,
+                estimatedHeight: 64
+            ) { section.historicalCommitRow(commit) })
+        }
+        if rps.isLoadingOlder || (rps.hasMoreOlder && rps.ggStackLoadState != .loading) || !older.isEmpty {
+            rows.append(appKitRow(
+                id: "commits-footer",
+                token: "\(rps.isLoadingOlder)-\(rps.hasMoreOlder)-\(rps.ggStackLoadState)-\(older.isEmpty)",
+                estimatedHeight: 32
+            ) {
+                CommitHistoryFooterRow(
+                    isLoading: rps.isLoadingOlder,
+                    canLoadMore: rps.hasMoreOlder && rps.ggStackLoadState != .loading,
+                    hasOlderCommits: !older.isEmpty,
+                    onLoadOlder: { Task { @MainActor in await rps.loadOlder() } }
+                )
+            })
+        }
+    }
+
+    private var commitHeaderToken: String {
+        String(rps.commitsExpanded)
+            + String(reflecting: rps.ggStack)
+            + String(rps.showBehindBaseChip)
+            + String(rps.showBehindUpstreamChip)
+            + String(reflecting: rps.behindBase)
+            + String(reflecting: rps.behindUpstream)
+            + rps.baseBranch
+            + String(reflecting: rps.availableBranches)
+            + String(reflecting: rps.comparisonRef)
+            + String(reflecting: rps.upstreamRef)
+            + String(reflecting: rps.recentBaseBranches)
+            + String(rps.isFetchingBranches)
+            + String(rps.hasFetchedBranches)
+            + String(rps.pullInFlight)
+            + String(reflecting: rps.mergeOp.current)
+    }
+
+    private var commitRowsStateToken: String {
+        String(reflecting: rps.ggStack)
+            + String(reflecting: rps.ggActionState.inFlightAction)
+            + String(reflecting: rps.ggActionState.pausedOperation)
+            + String(reflecting: rps.mergeOp.current)
+            + String(rps.ggCommitSelectionIsStale)
+            + String(rps.commitsNeedPush)
+            + String(reflecting: rps.commitRemote)
+    }
+
+    private func appKitRow<Token: Equatable, Content: View>(
+        id: String,
+        token: Token,
+        estimatedHeight: CGFloat,
+        retention: AppKitDiffRowRetention = .recyclable,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> AppKitDiffRowSpec {
+        AppKitDiffRowSpec(
+            id: id,
+            ownerID: nil,
+            equalityToken: .init(ChangesAppKitRowToken(value: token, theme: theme)),
+            contentSignature: id.hashValue,
+            estimatedHeight: estimatedHeight,
+            retention: retention
+        ) {
+            AnyView(content().environment(\.theme, theme))
+        }
+    }
+
+    private var workingTreeSection: WorkingTreeSectionView {
+        WorkingTreeSectionView(
+            changes: nonConflictChanges,
+            expanded: $rps.workingTreeExpanded,
+            collapsedChangePaths: $collapsedChangePaths,
+            onSelect: { appKitActionRelay.onSelectFile($0) },
+            fileContextTarget: { file in
+                FileContextMenuTarget.resolve(
+                    kind: .file,
+                    worktreePath: rps.worktree.path,
+                    relativePath: file.path
+                )
+            },
+            onStageAll: { rps.stageAll($0) },
+            onUnstageAll: { rps.unstageAll($0) },
+            onIgnore: { path, isDir, destination in
+                rps.ignore(path: path, isDirectory: isDir, destination: destination)
+            },
+            onDiscardAll: { rps.requestDiscardAll() },
+            onDiscardFolder: { rps.requestDiscardFolder(path: $0) },
+            onOpenFile: { file in
+                appState.openFile(relativePath: file.path, worktreeId: rps.worktree.id)
+            },
+            onCopyRelative: { Clipboard.copy($0.path) },
+            onCopyFull: { file in
+                Clipboard.copy(rps.worktree.path.appendingPathComponent(file.path).path)
+            },
+            onCopyDiff: { rps.copyDiff(for: $0.path, renameFrom: $0.renameFrom) },
+            onViewAtHEAD: { file in
+                appState.openFileSnapshotAtHEAD(
+                    relativePath: file.renameFrom ?? file.path,
+                    worktreeId: rps.worktree.id
+                )
+            },
+            onCompareWithHEAD: { file in
+                appState.openDiffTab(
+                    forFileInWorktree: rps.worktree,
+                    relativePath: file.path,
+                    originalPath: file.renameFrom,
+                    compareWithHEAD: true
+                )
+            },
+            onFileHistory: { file in
+                appState.openFileHistory(
+                    relativePath: file.renameFrom ?? file.path,
+                    worktreeId: rps.worktree.id
+                )
+            },
+            onDiscardFile: { rps.requestDiscardFile(path: $0.path) },
+            onStashChanges: { rps.requestStashChanges() },
+            stashChangesDisabled: rps.mergeOp.current != nil || rps.stashOperationInFlight,
+            isOpenFileEnabled: { file in
+                DiffOpenFileAvailability.isAvailable(
+                    worktreePath: rps.worktree.path,
+                    relativePath: file.path
+                )
+            },
+            dragPayload: { file in
+                .workingTreeFile(worktreePath: rps.worktree.path, relativePath: file.path)
+            }
+        )
+    }
+
+    private var commitsSection: CommitsSectionView {
+        CommitsSectionView(
+            commits: rps.commitsForDisplay,
+            olderCommits: rps.olderCommits,
+            comparisonRef: rps.comparisonRef,
+            hasMoreOlder: rps.hasMoreOlder && rps.ggStackLoadState != .loading,
+            isLoadingOlder: rps.isLoadingOlder,
+            behindBase: rps.showBehindBaseChip ? rps.behindBase : nil,
+            behindUpstream: rps.showBehindUpstreamChip ? rps.behindUpstream : nil,
+            expanded: $rps.commitsExpanded,
+            baseBranch: $rps.baseBranch,
+            branches: BaseBranchSelector.smartList(
+                branches: rps.availableBranches,
+                currentRef: rps.comparisonRef,
+                upstream: rps.upstreamRef,
+                recent: rps.recentBaseBranches
+            ),
+            isLoadingBranches: rps.isFetchingBranches,
+            hasLoadedBranches: rps.hasFetchedBranches,
+            onSelect: { appKitActionRelay.onSelectCommit($0) },
+            onCopySHA: copyCommitSHA,
+            onEdit: { commit in
+                if let comparisonRef = rps.comparisonRef {
+                    appKitActionRelay.onEditCommit(commit, comparisonRef)
+                }
+            },
+            onReview: { appKitActionRelay.onReviewCommit($0) },
+            onLoadOlder: { Task { @MainActor in await rps.loadOlder() } },
+            onSelectBaseBranch: { rps.selectBaseBranch($0) },
+            onOpenBaseBranchSelector: { Task { @MainActor in await rps.fetchBranches() } },
+            rps: rps,
+            ggStack: rps.ggStack,
+            stackCodeHostKind: rps.commitRemote?.kind,
+            onGGAction: { action, commit in
+                rps.handleGGCommitAction(action, commit: commit, appState: appState)
+            }
+        )
     }
 
     static func shouldShowGenericOperationCard(
@@ -453,6 +779,45 @@ struct ChangesTabView: View {
         // available.
         return appState.agentRegistry.enabled()
             .first(where: { $0.bypassPermissionsFlag != nil })
+    }
+}
+
+@MainActor
+final class ChangesAppKitActionRelay {
+    var onSelectFile: (ChangedFile) -> Void = { _ in }
+    var onSelectCommit: (CommitInfo) -> Void = { _ in }
+    var onEditCommit: (CommitInfo, String) -> Void = { _, _ in }
+    var onReviewCommit: (CommitInfo) -> Void = { _ in }
+
+    func update(
+        onSelectFile: @escaping (ChangedFile) -> Void,
+        onSelectCommit: @escaping (CommitInfo) -> Void,
+        onEditCommit: @escaping (CommitInfo, String) -> Void,
+        onReviewCommit: @escaping (CommitInfo) -> Void
+    ) {
+        self.onSelectFile = onSelectFile
+        self.onSelectCommit = onSelectCommit
+        self.onEditCommit = onEditCommit
+        self.onReviewCommit = onReviewCommit
+    }
+}
+
+private struct ChangesAppKitRowToken<Value: Equatable>: Equatable {
+    let value: Value
+    let theme: Theme
+}
+
+private struct ChangesEmptyRow: View {
+    let text: String
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11))
+            .foregroundColor(theme.color("fg-faint"))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -565,6 +565,7 @@ struct ChangesTabView: View {
     private var commitRowsStateToken: String {
         Self.commitRowsStateToken(
             ggStack: rps.ggStack,
+            ggModeActive: rps.ggContext.isActive,
             inFlightAction: rps.ggActionState.inFlightAction,
             pausedOperation: rps.ggActionState.pausedOperation,
             mergeOperation: rps.mergeOp.current,
@@ -577,6 +578,7 @@ struct ChangesTabView: View {
 
     static func commitRowsStateToken(
         ggStack: GGStack?,
+        ggModeActive: Bool,
         inFlightAction: GGStackActionKind?,
         pausedOperation: GGPausedOperation?,
         mergeOperation: MergeOperation?,
@@ -586,6 +588,7 @@ struct ChangesTabView: View {
         primaryCommitRemote: CodeHostRemote?
     ) -> String {
         String(reflecting: ggStack)
+            + String(ggModeActive)
             + String(reflecting: inFlightAction)
             + String(reflecting: pausedOperation)
             + String(reflecting: mergeOperation)

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -549,13 +549,36 @@ struct ChangesTabView: View {
     }
 
     private var commitRowsStateToken: String {
-        String(reflecting: rps.ggStack)
-            + String(reflecting: rps.ggActionState.inFlightAction)
-            + String(reflecting: rps.ggActionState.pausedOperation)
-            + String(reflecting: rps.mergeOp.current)
-            + String(rps.ggCommitSelectionIsStale)
-            + String(rps.commitsNeedPush)
-            + String(reflecting: rps.commitRemote)
+        Self.commitRowsStateToken(
+            ggStack: rps.ggStack,
+            inFlightAction: rps.ggActionState.inFlightAction,
+            pausedOperation: rps.ggActionState.pausedOperation,
+            mergeOperation: rps.mergeOp.current,
+            selectionIsStale: rps.ggCommitSelectionIsStale,
+            commitsNeedPush: rps.commitsNeedPush,
+            commitRemote: rps.commitRemote,
+            primaryCommitRemote: rps.primaryCommitRemote
+        )
+    }
+
+    static func commitRowsStateToken(
+        ggStack: GGStack?,
+        inFlightAction: GGStackActionKind?,
+        pausedOperation: GGPausedOperation?,
+        mergeOperation: MergeOperation?,
+        selectionIsStale: Bool,
+        commitsNeedPush: Bool,
+        commitRemote: CodeHostRemote?,
+        primaryCommitRemote: CodeHostRemote?
+    ) -> String {
+        String(reflecting: ggStack)
+            + String(reflecting: inFlightAction)
+            + String(reflecting: pausedOperation)
+            + String(reflecting: mergeOperation)
+            + String(selectionIsStale)
+            + String(commitsNeedPush)
+            + String(reflecting: commitRemote)
+            + String(reflecting: primaryCommitRemote)
     }
 
     private func appKitRow<Token: Equatable, Content: View>(

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -566,6 +566,7 @@ struct ChangesTabView: View {
         Self.commitRowsStateToken(
             ggStack: rps.ggStack,
             ggModeActive: rps.ggContext.isActive,
+            ggCapabilities: GGAvailability.shared.capabilities,
             inFlightAction: rps.ggActionState.inFlightAction,
             pausedOperation: rps.ggActionState.pausedOperation,
             mergeOperation: rps.mergeOp.current,
@@ -579,6 +580,7 @@ struct ChangesTabView: View {
     static func commitRowsStateToken(
         ggStack: GGStack?,
         ggModeActive: Bool,
+        ggCapabilities: GGCapabilities = GGCapabilities(structuredSplit: false, keepCurrentUnstack: false),
         inFlightAction: GGStackActionKind?,
         pausedOperation: GGPausedOperation?,
         mergeOperation: MergeOperation?,
@@ -589,6 +591,7 @@ struct ChangesTabView: View {
     ) -> String {
         String(reflecting: ggStack)
             + String(ggModeActive)
+            + String(reflecting: ggCapabilities)
             + String(reflecting: inFlightAction)
             + String(reflecting: pausedOperation)
             + String(reflecting: mergeOperation)

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -546,6 +546,14 @@ struct ChangesTabView: View {
             + String(rps.hasFetchedBranches)
             + String(rps.pullInFlight)
             + String(reflecting: rps.mergeOp.current)
+            + Self.commitHeaderCountsToken(
+                primary: rps.commitsForDisplay.count,
+                older: rps.olderCommits.count
+            )
+    }
+
+    static func commitHeaderCountsToken(primary: Int, older: Int) -> String {
+        "\(primary):\(older)"
     }
 
     private var commitRowsStateToken: String {

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -490,9 +490,10 @@ struct ChangesTabView: View {
         guard rps.commitsExpanded else { return }
 
         for commit in commits {
+            let isLast = commit.id == commits.last?.id && older.isEmpty
             rows.append(appKitRow(
                 id: "commit-primary-\(commit.sha)",
-                token: String(reflecting: commit) + rowStateToken,
+                token: String(reflecting: commit) + rowStateToken + Self.commitRowTerminalToken(isLast: isLast),
                 estimatedHeight: 64
             ) { section.primaryCommitRow(commit) })
         }
@@ -508,9 +509,10 @@ struct ChangesTabView: View {
             })
         }
         for commit in older {
+            let isLast = commit.id == older.last?.id
             rows.append(appKitRow(
                 id: "commit-older-\(commit.sha)",
-                token: String(reflecting: commit) + rowStateToken,
+                token: String(reflecting: commit) + rowStateToken + Self.commitRowTerminalToken(isLast: isLast),
                 estimatedHeight: 64
             ) { section.historicalCommitRow(commit) })
         }
@@ -554,6 +556,10 @@ struct ChangesTabView: View {
 
     static func commitHeaderCountsToken(primary: Int, older: Int) -> String {
         "\(primary):\(older)"
+    }
+
+    static func commitRowTerminalToken(isLast: Bool) -> String {
+        String(isLast)
     }
 
     private var commitRowsStateToken: String {

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -112,22 +112,25 @@ struct CommitsSectionView: View {
     let stackCodeHostKind: CodeHostKind?
     let onGGAction: (GGCommitAction, CommitInfo) -> Void
 
-    @Environment(\.theme) private var theme
-
     var body: some View {
         Section {
             if expanded {
                 expandedBody
             }
         } header: {
-            SectionHeader(
+            headerRow
+        }
+    }
+
+    var headerRow: some View {
+        SectionHeader(
                 role: ggStack == nil ? .commits : .stack,
                 title: Self.sectionTitle(ggStack: ggStack),
                 count: Self.sectionCount(primary: commits, older: olderCommits),
                 expanded: expanded,
                 onToggle: { expanded.toggle() }
-            ) {
-                HStack(spacing: 6) {
+        ) {
+            HStack(spacing: 6) {
                     if let s = behindBase {
                         BehindChip(count: s.count, label: baseBranch, role: .base)
                             .help("\(s.count) behind \(s.ref)")
@@ -153,7 +156,6 @@ struct CommitsSectionView: View {
                         onOpen: onOpenBaseBranchSelector
                     )
                     BranchOpsMenu(rps: rps)
-                }
             }
         }
     }
@@ -217,32 +219,7 @@ struct CommitsSectionView: View {
             ForEach(Self.rowBatches(for: commits)) { batch in
                 VStack(alignment: .leading, spacing: 0) {
                     ForEach(commits[batch.range]) { commit in
-                        let entry = ggStack?.entry(matchingCommitSHA: commit.sha)
-                        let allowsGenericGitActions = Self.genericGitActionsAllowed(for: entry, in: ggStack)
-                        let remote = entry == nil
-                            ? (rps.commitsNeedPush ? nil : rps.primaryCommitRemote)
-                            : rps.commitRemote
-                        CommitRow(
-                            commit: commit,
-                            isLast: commit.id == commits.last?.id && olderCommits.isEmpty,
-                            onSelect: { onSelect(commit) },
-                            onCopySHA: { onCopySHA(commit) },
-                            onCopyMessage: { Clipboard.copy(commit.fullMessage) },
-                            ggID: Self.contextMenuGGID(for: commit, ggModeEnabled: rps.ggContext.isActive),
-                            onOpenRemote: openRemoteAction(for: commit, remote: remote),
-                            onEdit: allowsGenericGitActions ? { onEdit(commit) } : nil,
-                            onReview: { onReview(commit) },
-                            onCherryPick: allowsGenericGitActions ? { rps.requestCherryPick(sha: commit.sha) } : nil,
-                            onRevert: allowsGenericGitActions ? { rps.runRevert(sha: commit.sha) } : nil,
-                            ggMenu: ggMenu(for: commit),
-                            onGGAction: { action in onGGAction(action, commit) },
-                            onGGOpenPR: ggOpenReviewRequestAction(for: commit).map { action in
-                                { onGGAction(action, commit) }
-                            },
-                            stackEntry: entry,
-                            currentPositionIndicator: entry.flatMap { ggStack?.currentPositionIndicator(for: $0) },
-                            codeHostKind: stackCodeHostKind
-                        )
+                        primaryCommitRow(commit)
                     }
                 }
             }
@@ -261,19 +238,7 @@ struct CommitsSectionView: View {
             ForEach(Self.rowBatches(for: olderCommits)) { batch in
                 VStack(alignment: .leading, spacing: 0) {
                     ForEach(olderCommits[batch.range]) { commit in
-                        CommitRow(
-                            commit: commit,
-                            isLast: commit.id == olderCommits.last?.id,
-                            isHistorical: comparisonRef != nil,
-                            onSelect: { onSelect(commit) },
-                            onCopySHA: { onCopySHA(commit) },
-                            onCopyMessage: { Clipboard.copy(commit.fullMessage) },
-                            ggID: Self.contextMenuGGID(for: commit, ggModeEnabled: rps.ggContext.isActive),
-                            onOpenRemote: openRemoteAction(for: commit, remote: rps.commitRemote),
-                            onReview: { onReview(commit) },
-                            onCherryPick: { rps.requestCherryPick(sha: commit.sha) },
-                            onRevert: { rps.runRevert(sha: commit.sha) }
-                        )
+                        historicalCommitRow(commit)
                     }
                 }
             }
@@ -283,30 +248,57 @@ struct CommitsSectionView: View {
         footer
     }
 
+    func primaryCommitRow(_ commit: CommitInfo) -> AnyView {
+        let entry = ggStack?.entry(matchingCommitSHA: commit.sha)
+        let allowsGenericGitActions = Self.genericGitActionsAllowed(for: entry, in: ggStack)
+        let remote = entry == nil
+            ? (rps.commitsNeedPush ? nil : rps.primaryCommitRemote)
+            : rps.commitRemote
+        return AnyView(CommitRow(
+            commit: commit,
+            isLast: commit.id == commits.last?.id && olderCommits.isEmpty,
+            onSelect: { onSelect(commit) },
+            onCopySHA: { onCopySHA(commit) },
+            onCopyMessage: { Clipboard.copy(commit.fullMessage) },
+            ggID: Self.contextMenuGGID(for: commit, ggModeEnabled: rps.ggContext.isActive),
+            onOpenRemote: openRemoteAction(for: commit, remote: remote),
+            onEdit: allowsGenericGitActions ? { onEdit(commit) } : nil,
+            onReview: { onReview(commit) },
+            onCherryPick: allowsGenericGitActions ? { rps.requestCherryPick(sha: commit.sha) } : nil,
+            onRevert: allowsGenericGitActions ? { rps.runRevert(sha: commit.sha) } : nil,
+            ggMenu: ggMenu(for: commit),
+            onGGAction: { action in onGGAction(action, commit) },
+            onGGOpenPR: ggOpenReviewRequestAction(for: commit).map { action in
+                { onGGAction(action, commit) }
+            },
+            stackEntry: entry,
+            currentPositionIndicator: entry.flatMap { ggStack?.currentPositionIndicator(for: $0) },
+            codeHostKind: stackCodeHostKind
+        ))
+    }
+
+    func historicalCommitRow(_ commit: CommitInfo) -> AnyView {
+        AnyView(CommitRow(
+            commit: commit,
+            isLast: commit.id == olderCommits.last?.id,
+            isHistorical: comparisonRef != nil,
+            onSelect: { onSelect(commit) },
+            onCopySHA: { onCopySHA(commit) },
+            onCopyMessage: { Clipboard.copy(commit.fullMessage) },
+            ggID: Self.contextMenuGGID(for: commit, ggModeEnabled: rps.ggContext.isActive),
+            onOpenRemote: openRemoteAction(for: commit, remote: rps.commitRemote),
+            onReview: { onReview(commit) },
+            onCherryPick: { rps.requestCherryPick(sha: commit.sha) },
+            onRevert: { rps.runRevert(sha: commit.sha) }
+        ))
+    }
+
     private var emptyPlaceholder: some View {
-        Text(comparisonRef.map { "up to date with \($0)" } ?? "no comparison branch")
-            .font(.system(size: 11))
-            .foregroundColor(theme.color("fg-faint"))
-            .padding(.horizontal, 12).padding(.vertical, 8)
-            .frame(maxWidth: .infinity, alignment: .leading)
+        CommitHistoryEmptyRow(text: comparisonRef.map { "up to date with \($0)" } ?? "no comparison branch")
     }
 
     private func dividerRow(label: String) -> some View {
-        HStack(spacing: 8) {
-            Rectangle()
-                .fill(theme.color("line"))
-                .frame(height: 1)
-            Text(label)
-                .font(.system(size: 10, design: .monospaced))
-                .foregroundColor(theme.color("fg-faint"))
-                .textCase(.uppercase)
-                .tracking(0.4)
-            Rectangle()
-                .fill(theme.color("line"))
-                .frame(height: 1)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
+        CommitHistoryDividerRow(label: label)
     }
 
     private func ggMenu(for commit: CommitInfo) -> GGCommitMenuModel? {
@@ -350,17 +342,64 @@ struct CommitsSectionView: View {
 
     @ViewBuilder
     private var footer: some View {
-        if isLoadingOlder {
+        CommitHistoryFooterRow(
+            isLoading: isLoadingOlder,
+            canLoadMore: hasMoreOlder,
+            hasOlderCommits: !olderCommits.isEmpty,
+            onLoadOlder: onLoadOlder
+        )
+    }
+}
+
+struct CommitHistoryEmptyRow: View {
+    let text: String
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11))
+            .foregroundColor(theme.color("fg-faint"))
+            .padding(.horizontal, 12).padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct CommitHistoryDividerRow: View {
+    let label: String
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Rectangle().fill(theme.color("line")).frame(height: 1)
+            Text(label)
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundColor(theme.color("fg-faint"))
+                .textCase(.uppercase)
+                .tracking(0.4)
+            Rectangle().fill(theme.color("line")).frame(height: 1)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+    }
+}
+
+struct CommitHistoryFooterRow: View {
+    let isLoading: Bool
+    let canLoadMore: Bool
+    let hasOlderCommits: Bool
+    let onLoadOlder: () -> Void
+    @Environment(\.theme) private var theme
+
+    @ViewBuilder
+    var body: some View {
+        if isLoading {
             HStack(spacing: 6) {
-                Spinner(lineWidth: 1.5, duration: 0.7)
-                    .frame(width: 10, height: 10)
-                Text("Loading…")
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.color("fg-faint"))
+                Spinner(lineWidth: 1.5, duration: 0.7).frame(width: 10, height: 10)
+                Text("Loading…").font(.system(size: 11)).foregroundColor(theme.color("fg-faint"))
             }
             .frame(maxWidth: .infinity, alignment: .center)
             .padding(.vertical, 8)
-        } else if hasMoreOlder {
+        } else if canLoadMore {
             Button(action: onLoadOlder) {
                 Text("↓ Load older commits")
                     .font(.system(size: 11))
@@ -370,7 +409,7 @@ struct CommitsSectionView: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-        } else if !olderCommits.isEmpty {
+        } else if hasOlderCommits {
             Text("End of history")
                 .font(.system(size: 11))
                 .foregroundColor(theme.color("fg-faint"))

--- a/Alas/Sources/Right/StashesSectionView.swift
+++ b/Alas/Sources/Right/StashesSectionView.swift
@@ -14,8 +14,6 @@ struct StashesSectionView: View {
     let onDrop: (GitStash) -> Void
     var dragPayload: ((GitStash, GitStashFile) -> DragOutPayload?)? = nil
 
-    @Environment(\.theme) private var theme
-
     var body: some View {
         if !stashes.isEmpty {
             Section {
@@ -39,9 +37,52 @@ struct StashesSectionView: View {
     @ViewBuilder
     private func stashRow(_ stash: GitStash) -> some View {
         let open = expandedRefs.contains(stash.ref)
-        Button {
-            onToggleStash(stash)
-        } label: {
+        StashSummaryRow(
+            stash: stash,
+            open: open,
+            loading: loadingRefs.contains(stash.ref),
+            onToggle: { onToggleStash(stash) },
+            onApply: { onApply(stash) },
+            onPop: { onPop(stash) },
+            onDrop: { onDrop(stash) }
+        )
+        if open {
+            expandedFiles(for: stash)
+        }
+    }
+
+    @ViewBuilder
+    private func expandedFiles(for stash: GitStash) -> some View {
+        let files = filesByRef[stash.ref] ?? []
+        if loadingRefs.contains(stash.ref) && files.isEmpty {
+            StashEmptyRow(loading: true)
+        } else if files.isEmpty {
+            StashEmptyRow(loading: false)
+        } else {
+            ForEach(files) { file in
+                StashFileRow(
+                    file: file,
+                    onSelect: { onSelectFile(stash, file) },
+                    dragPayload: { dragPayload?(stash, file) }
+                )
+            }
+        }
+    }
+}
+
+struct StashSummaryRow: View {
+    let stash: GitStash
+    let open: Bool
+    let loading: Bool
+    let onToggle: () -> Void
+    let onApply: () -> Void
+    let onPop: () -> Void
+    let onDrop: () -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Button(action: onToggle) {
             HStack(spacing: 6) {
                 Icon(name: open ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
                     .frame(width: 14, height: 14)
@@ -54,15 +95,12 @@ struct StashesSectionView: View {
                     .font(.system(size: 10, design: .monospaced))
                     .foregroundColor(theme.color("fg-faint"))
                 Spacer()
-                if loadingRefs.contains(stash.ref) {
-                    Spinner(lineWidth: 1.2, duration: 0.7)
-                        .frame(width: 10, height: 10)
-                }
+                if loading { Spinner(lineWidth: 1.2, duration: 0.7).frame(width: 10, height: 10) }
                 Menu {
-                    Button("Apply") { onApply(stash) }
-                    Button("Pop") { onPop(stash) }
+                    Button("Apply", action: onApply)
+                    Button("Pop", action: onPop)
                     Divider()
-                    Button("Drop…", role: .destructive) { onDrop(stash) }
+                    Button("Drop…", role: .destructive, action: onDrop)
                 } label: {
                     Image(systemName: "ellipsis")
                         .font(.system(size: 12, weight: .semibold))
@@ -79,66 +117,57 @@ struct StashesSectionView: View {
         }
         .buttonStyle(.plain)
         .contextMenu {
-            Button("Apply") { onApply(stash) }
-            Button("Pop") { onPop(stash) }
+            Button("Apply", action: onApply)
+            Button("Pop", action: onPop)
             Divider()
-            Button("Drop…", role: .destructive) { onDrop(stash) }
-        }
-        if open {
-            expandedFiles(for: stash)
+            Button("Drop…", role: .destructive, action: onDrop)
         }
     }
+}
 
-    @ViewBuilder
-    private func expandedFiles(for stash: GitStash) -> some View {
-        let files = filesByRef[stash.ref] ?? []
-        if loadingRefs.contains(stash.ref) && files.isEmpty {
+struct StashFileRow: View {
+    let file: GitStashFile
+    let onSelect: () -> Void
+    let dragPayload: () -> DragOutPayload?
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Button(action: onSelect) {
             HStack(spacing: 6) {
-                Spinner(lineWidth: 1.2, duration: 0.7)
-                    .frame(width: 10, height: 10)
-                Text("Loading stash files…")
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.color("fg-faint"))
+                FileTypeIconView(filename: (file.path as NSString).lastPathComponent, size: 16)
+                Text((file.path as NSString).lastPathComponent)
+                    .font(.system(size: 11.5, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer()
+                if file.add > 0 { Text("+\(file.add)").foregroundColor(theme.color("add")) }
+                if file.del > 0 { Text("-\(file.del)").foregroundColor(theme.color("del")) }
+                StatusBadge(status: file.status)
             }
+            .font(.system(size: 11, design: .monospaced))
             .padding(.leading, 32)
-            .padding(.vertical, 6)
-        } else if files.isEmpty {
-            Text("no files")
+            .padding(.trailing, 12)
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .dragOut(dragPayload)
+    }
+}
+
+struct StashEmptyRow: View {
+    let loading: Bool
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 6) {
+            if loading { Spinner(lineWidth: 1.2, duration: 0.7).frame(width: 10, height: 10) }
+            Text(loading ? "Loading stash files…" : "no files")
                 .font(.system(size: 11))
                 .foregroundColor(theme.color("fg-faint"))
-                .padding(.leading, 32)
-                .padding(.vertical, 6)
-        } else {
-            ForEach(files) { file in
-                Button {
-                    onSelectFile(stash, file)
-                } label: {
-                    HStack(spacing: 6) {
-                        FileTypeIconView(filename: (file.path as NSString).lastPathComponent, size: 16)
-                        Text((file.path as NSString).lastPathComponent)
-                            .font(.system(size: 11.5, design: .monospaced))
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                        Spacer()
-                        if file.add > 0 {
-                            Text("+\(file.add)")
-                                .foregroundColor(theme.color("add"))
-                        }
-                        if file.del > 0 {
-                            Text("-\(file.del)")
-                                .foregroundColor(theme.color("del"))
-                        }
-                        StatusBadge(status: file.status)
-                    }
-                    .font(.system(size: 11, design: .monospaced))
-                    .padding(.leading, 32)
-                    .padding(.trailing, 12)
-                    .padding(.vertical, 4)
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .dragOut { dragPayload?(stash, file) }
-            }
         }
+        .padding(.leading, 32)
+        .padding(.vertical, 6)
     }
 }

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -1,8 +1,38 @@
 import SwiftUI
 
+struct WorkingTreeFlatRow: Identifiable, Equatable {
+    let node: FileTreeNode
+    let depth: Int
+
+    var id: String { node.id }
+
+    static func make(
+        groups: [WorkingTreeChangeGroup],
+        collapsedPaths: Set<String>
+    ) -> [WorkingTreeFlatRow] {
+        let roots = ChangesTreeBuilder.build(files: groups.map(\.primaryEntry))
+        return roots.flatMap { flatten($0, depth: 0, collapsedPaths: collapsedPaths) }
+    }
+
+    private static func flatten(
+        _ node: FileTreeNode,
+        depth: Int,
+        collapsedPaths: Set<String>
+    ) -> [WorkingTreeFlatRow] {
+        let row = WorkingTreeFlatRow(node: node, depth: depth)
+        guard node.kind == .dir,
+              !collapsedPaths.contains("working-tree:\(node.path)")
+        else { return [row] }
+        return [row] + (node.children ?? []).flatMap {
+            flatten($0, depth: depth + 1, collapsedPaths: collapsedPaths)
+        }
+    }
+}
+
 struct WorkingTreeSectionView: View {
     let changes: [ChangedFile]
     @Binding var expanded: Bool
+    @Binding var collapsedChangePaths: Set<String>
     let onSelect: (ChangedFile) -> Void
     let fileContextTarget: (ChangedFile) -> FileContextMenuTarget
     var onStageAll: (([ChangedFile]) -> Void)? = nil
@@ -24,8 +54,6 @@ struct WorkingTreeSectionView: View {
     var dragPayload: ((ChangedFile) -> DragOutPayload?)? = nil
 
     @Environment(\.theme) private var theme
-
-    @State private var collapsedChangePaths: Set<String> = []
 
     private var staged:   [ChangedFile] { changes.filter { $0.stage == .staged   } }
     private var unstaged: [ChangedFile] { changes.filter { $0.stage == .unstaged } }
@@ -54,7 +82,12 @@ struct WorkingTreeSectionView: View {
                 }
             }
         } header: {
-            SectionHeader(
+            headerRow
+        }
+    }
+
+    var headerRow: some View {
+        SectionHeader(
                 role: .workingTree,
                 title: "Working tree",
                 count: changeGroups.count,
@@ -62,7 +95,7 @@ struct WorkingTreeSectionView: View {
                 onToggle: { expanded.toggle() },
                 stats: (add: totalAdd, del: totalDel)
             ) { }
-            .contextMenu {
+        .contextMenu {
                 if !unstaged.isEmpty {
                     Button("Stage All Changes") {
                         onStageAll?(unstaged)
@@ -84,207 +117,218 @@ struct WorkingTreeSectionView: View {
                     onDiscardAll?()
                 }
                 .disabled(changes.isEmpty)
-            }
         }
     }
 
     @ViewBuilder
     private func flatFileTree(groups: [WorkingTreeChangeGroup]) -> some View {
         let groupsByPath = Dictionary(uniqueKeysWithValues: groups.map { ($0.path, $0) })
-        let files = groups.map(\.primaryEntry)
-        ForEach(ChangesTreeBuilder.build(files: files)) { node in
-            renderNode(node, groups: groups, groupsByPath: groupsByPath, depth: 0)
+        ForEach(WorkingTreeFlatRow.make(groups: groups, collapsedPaths: collapsedChangePaths)) { row in
+            WorkingTreeFlatRowView(
+                row: row,
+                groups: groups,
+                groupsByPath: groupsByPath,
+                collapsedPaths: $collapsedChangePaths,
+                actions: rowActions
+            )
         }
     }
 
-    /// A ChangedFile is "untracked" when status parser produced ("A",
-    /// .unstaged). Staged adds parse to ("A", .staged) so the stage check
-    /// is required.
-    private func isUntracked(_ file: ChangedFile) -> Bool {
-        file.status == "A" && file.stage == .unstaged
+    var rowActions: WorkingTreeRowActions {
+        WorkingTreeRowActions(
+            onSelect: onSelect,
+            fileContextTarget: fileContextTarget,
+            onStageAll: onStageAll,
+            onUnstageAll: onUnstageAll,
+            onIgnore: onIgnore,
+            onDiscardFolder: onDiscardFolder,
+            onOpenFile: onOpenFile,
+            onCopyRelative: onCopyRelative,
+            onCopyFull: onCopyFull,
+            onCopyDiff: onCopyDiff,
+            onViewAtHEAD: onViewAtHEAD,
+            onCompareWithHEAD: onCompareWithHEAD,
+            onFileHistory: onFileHistory,
+            onDiscardFile: onDiscardFile,
+            isOpenFileEnabled: isOpenFileEnabled,
+            dragPayload: dragPayload
+        )
     }
+}
 
-    private func hasHeadVersion(_ group: WorkingTreeChangeGroup) -> Bool {
-        if group.entries.contains(where: { $0.status == "D" || $0.status == "R" }) {
-            return true
-        }
-        return !group.entries.contains { $0.status == "A" }
-    }
+struct WorkingTreeRowActions {
+    let onSelect: (ChangedFile) -> Void
+    let fileContextTarget: (ChangedFile) -> FileContextMenuTarget
+    let onStageAll: (([ChangedFile]) -> Void)?
+    let onUnstageAll: (([ChangedFile]) -> Void)?
+    let onIgnore: ((_ path: String, _ isDirectory: Bool, _ destination: IgnoreDestination) -> Void)?
+    let onDiscardFolder: ((String) -> Void)?
+    let onOpenFile: ((ChangedFile) -> Void)?
+    let onCopyRelative: ((ChangedFile) -> Void)?
+    let onCopyFull: ((ChangedFile) -> Void)?
+    let onCopyDiff: ((ChangedFile) -> Void)?
+    let onViewAtHEAD: ((ChangedFile) -> Void)?
+    let onCompareWithHEAD: ((ChangedFile) -> Void)?
+    let onFileHistory: ((ChangedFile) -> Void)?
+    let onDiscardFile: ((ChangedFile) -> Void)?
+    let isOpenFileEnabled: ((ChangedFile) -> Bool)?
+    let dragPayload: ((ChangedFile) -> DragOutPayload?)?
+}
 
-    /// True when every ChangedFile reachable through `node` is untracked.
-    /// Folders that contain any tracked entry get no Ignore menu.
-    private func isUntrackedSubtree(
-        _ node: FileTreeNode,
-        groupsByPath: [String: WorkingTreeChangeGroup]
-    ) -> Bool {
-        if node.kind == .file {
-            return groupsByPath[node.path]?.entries.allSatisfy(isUntracked) ?? false
-        }
-        guard let kids = node.children, !kids.isEmpty else { return false }
-        return kids.allSatisfy { isUntrackedSubtree($0, groupsByPath: groupsByPath) }
-    }
+struct WorkingTreeFlatRowView: View {
+    let row: WorkingTreeFlatRow
+    let groups: [WorkingTreeChangeGroup]
+    let groupsByPath: [String: WorkingTreeChangeGroup]
+    @Binding var collapsedPaths: Set<String>
+    let actions: WorkingTreeRowActions
+
+    @Environment(\.theme) private var theme
 
     @ViewBuilder
-    private func ignoreMenu(path: String, isDirectory: Bool) -> some View {
-        Menu("Ignore") {
-            Button("Add to .gitignore (repo root)") {
-                onIgnore?(path, isDirectory, .repoRoot)
-            }
-            Button("Add to nearest .gitignore") {
-                onIgnore?(path, isDirectory, .nearest)
-            }
-            Button("Add to .git/info/exclude") {
-                onIgnore?(path, isDirectory, .infoExclude)
-            }
+    var body: some View {
+        if row.node.kind == .dir {
+            folderRow
+        } else if let group = groupsByPath[row.node.path] {
+            fileRow(group)
         }
     }
 
-    private func renderNode(
-        _ node: FileTreeNode,
-        groups: [WorkingTreeChangeGroup],
-        groupsByPath: [String: WorkingTreeChangeGroup],
-        depth: Int
-    ) -> AnyView {
-        if node.kind == .dir {
-            let collapseKey = "working-tree:\(node.path)"
-            let open = !collapsedChangePaths.contains(collapseKey)
-            let folderGroups = groups.groups(under: node.path)
-            let stagedEntries = folderGroups.flatMap(\.stagedEntries)
-            let unstagedEntries = folderGroups.flatMap(\.unstagedEntries)
-            let folderState = folderStageState(staged: stagedEntries, unstaged: unstagedEntries)
-            let folderUntracked = isUntrackedSubtree(node, groupsByPath: groupsByPath)
-            return AnyView(
-                Group {
-                    Button {
-                        if open {
-                            collapsedChangePaths.insert(collapseKey)
-                        } else {
-                            collapsedChangePaths.remove(collapseKey)
-                        }
-                    } label: {
-                        HStack(spacing: 6) {
-                            StageChip(state: stageChipState(for: folderState)) {
-                                switch folderState {
-                                case .staged:           onUnstageAll?(stagedEntries)
-                                case .mixed, .unstaged: onStageAll?(unstagedEntries)
-                                }
-                            }
-                            FolderIconView(
-                                name: node.name,
-                                path: node.path,
-                                open: open,
-                                fallbackColor: open ? theme.color("accent") : theme.color("fg-dim")
-                            )
-                            Text(node.name)
-                                .font(.system(size: 11.5, design: .monospaced))
-                                .foregroundColor(theme.color("fg"))
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                            Spacer()
-                        }
-                        .padding(.leading, Self.directoryRowLeadingPadding(depth: depth))
-                        .padding(.trailing, 12)
-                        .padding(.vertical, 4)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .contextMenu {
-                        if !unstagedEntries.isEmpty {
-                            Button("Stage Changes") {
-                                onStageAll?(unstagedEntries)
-                            }
-                        }
-                        if !stagedEntries.isEmpty {
-                            Button("Unstage Changes") {
-                                onUnstageAll?(stagedEntries)
-                            }
-                        }
-                        if !stagedEntries.isEmpty || !unstagedEntries.isEmpty {
-                            Divider()
-                        }
-                        Button("Discard Changes…", role: .destructive) {
-                            onDiscardFolder?(node.path)
-                        }
-                        if folderUntracked {
-                            ignoreMenu(path: node.path, isDirectory: true)
-                        }
-                    }
-                    if open, let kids = node.children {
-                        ForEach(kids) {
-                            renderNode(
-                                $0,
-                                groups: groups,
-                                groupsByPath: groupsByPath,
-                                depth: depth + 1
-                            )
-                        }
+    private var folderRow: some View {
+        let node = row.node
+        let collapseKey = "working-tree:\(node.path)"
+        let open = !collapsedPaths.contains(collapseKey)
+        let folderGroups = groups.groups(under: node.path)
+        let stagedEntries = folderGroups.flatMap(\.stagedEntries)
+        let unstagedEntries = folderGroups.flatMap(\.unstagedEntries)
+        let folderState = Self.folderStageState(staged: stagedEntries, unstaged: unstagedEntries)
+        let folderUntracked = isUntrackedSubtree(node)
+        return Button {
+            if open { collapsedPaths.insert(collapseKey) }
+            else { collapsedPaths.remove(collapseKey) }
+        } label: {
+            HStack(spacing: 6) {
+                StageChip(state: Self.stageChipState(for: folderState)) {
+                    switch folderState {
+                    case .staged: actions.onUnstageAll?(stagedEntries)
+                    case .mixed, .unstaged: actions.onStageAll?(unstagedEntries)
                     }
                 }
-            )
-        } else if let group = groupsByPath[node.path] {
-            let file = group.primaryEntry
-            let fileUntracked = isUntracked(file)
-            let ignore: AnyView? = fileUntracked
-                ? AnyView(ignoreMenu(path: file.path, isDirectory: false))
-                : nil
-            let canStage = !group.unstagedEntries.isEmpty
-            let canUnstage = !group.stagedEntries.isEmpty
-            let headPathEntry = group.entries.first { $0.renameFrom != nil } ?? file
-            return AnyView(
-                ChangedRow(
-                    file: file,
-                    fileContextTarget: fileContextTarget(file),
-                    depth: depth,
-                    onSelect: { onSelect(file) },
-                    onStage: primaryStageAction(for: group),
-                    stageState: stageChipState(for: group.stageState),
-                    displayAdd: group.add,
-                    displayDel: group.del,
-                    onStageEntries: canStage ? { onStageAll?(group.unstagedEntries) } : nil,
-                    onUnstageEntries: canUnstage ? { onUnstageAll?(group.stagedEntries) } : nil,
-                    onOpenFile: onOpenFile.map { fn in { fn(file) } },
-                    onCopyRelative: onCopyRelative.map { fn in { fn(file) } },
-                    onCopyFull: onCopyFull.map { fn in { fn(file) } },
-                    onCopyDiff: onCopyDiff.map { fn in { fn(file) } },
-                    onViewAtHEAD: onViewAtHEAD.map { fn in { fn(headPathEntry) } },
-                    onCompareWithHEAD: onCompareWithHEAD.map { fn in { fn(headPathEntry) } },
-                    onFileHistory: onFileHistory.map { fn in { fn(headPathEntry) } },
-                    onDiscard: onDiscardFile.map { fn in { fn(file) } },
-                    openFileEnabled: isOpenFileEnabled?(file) ?? true,
-                    viewAtHEADEnabled: hasHeadVersion(group),
-                    ignoreMenu: ignore,
-                    dragPayload: dragPayload.map { fn in { fn(file) } }
+                FolderIconView(
+                    name: node.name,
+                    path: node.path,
+                    open: open,
+                    fallbackColor: open ? theme.color("accent") : theme.color("fg-dim")
                 )
-            )
-        } else {
-            return AnyView(EmptyView())
+                Text(node.name)
+                    .font(.system(size: 11.5, design: .monospaced))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer()
+            }
+            .padding(.leading, WorkingTreeSectionView.directoryRowLeadingPadding(depth: row.depth))
+            .padding(.trailing, 12)
+            .padding(.vertical, 4)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
+        .contextMenu {
+            if !unstagedEntries.isEmpty {
+                Button("Stage Changes") { actions.onStageAll?(unstagedEntries) }
+            }
+            if !stagedEntries.isEmpty {
+                Button("Unstage Changes") { actions.onUnstageAll?(stagedEntries) }
+            }
+            if !stagedEntries.isEmpty || !unstagedEntries.isEmpty { Divider() }
+            Button("Discard Changes…", role: .destructive) {
+                actions.onDiscardFolder?(node.path)
+            }
+            if folderUntracked { ignoreMenu(path: node.path, isDirectory: true) }
+        }
+    }
+
+    private func fileRow(_ group: WorkingTreeChangeGroup) -> some View {
+        let file = group.primaryEntry
+        let canStage = !group.unstagedEntries.isEmpty
+        let canUnstage = !group.stagedEntries.isEmpty
+        let headPathEntry = group.entries.first { $0.renameFrom != nil } ?? file
+        let ignore = Self.isUntracked(file)
+            ? AnyView(ignoreMenu(path: file.path, isDirectory: false))
+            : nil
+        return ChangedRow(
+            file: file,
+            fileContextTarget: actions.fileContextTarget(file),
+            depth: row.depth,
+            onSelect: { actions.onSelect(file) },
+            onStage: primaryStageAction(for: group),
+            stageState: Self.stageChipState(for: group.stageState),
+            displayAdd: group.add,
+            displayDel: group.del,
+            onStageEntries: canStage ? { actions.onStageAll?(group.unstagedEntries) } : nil,
+            onUnstageEntries: canUnstage ? { actions.onUnstageAll?(group.stagedEntries) } : nil,
+            onOpenFile: actions.onOpenFile.map { fn in { fn(file) } },
+            onCopyRelative: actions.onCopyRelative.map { fn in { fn(file) } },
+            onCopyFull: actions.onCopyFull.map { fn in { fn(file) } },
+            onCopyDiff: actions.onCopyDiff.map { fn in { fn(file) } },
+            onViewAtHEAD: actions.onViewAtHEAD.map { fn in { fn(headPathEntry) } },
+            onCompareWithHEAD: actions.onCompareWithHEAD.map { fn in { fn(headPathEntry) } },
+            onFileHistory: actions.onFileHistory.map { fn in { fn(headPathEntry) } },
+            onDiscard: actions.onDiscardFile.map { fn in { fn(file) } },
+            openFileEnabled: actions.isOpenFileEnabled?(file) ?? true,
+            viewAtHEADEnabled: Self.hasHeadVersion(group),
+            ignoreMenu: ignore,
+            dragPayload: actions.dragPayload.map { fn in { fn(file) } }
+        )
     }
 
     private func primaryStageAction(for group: WorkingTreeChangeGroup) -> (() -> Void)? {
         switch group.stageState {
         case .staged:
-            guard !group.stagedEntries.isEmpty else { return nil }
-            return { onUnstageAll?(group.stagedEntries) }
+            return group.stagedEntries.isEmpty ? nil : { actions.onUnstageAll?(group.stagedEntries) }
         case .mixed, .unstaged:
-            guard !group.unstagedEntries.isEmpty else { return nil }
-            return { onStageAll?(group.unstagedEntries) }
+            return group.unstagedEntries.isEmpty ? nil : { actions.onStageAll?(group.unstagedEntries) }
         }
     }
 
-    private func folderStageState(
+    @ViewBuilder
+    private func ignoreMenu(path: String, isDirectory: Bool) -> some View {
+        Menu("Ignore") {
+            Button("Add to .gitignore (repo root)") { actions.onIgnore?(path, isDirectory, .repoRoot) }
+            Button("Add to nearest .gitignore") { actions.onIgnore?(path, isDirectory, .nearest) }
+            Button("Add to .git/info/exclude") { actions.onIgnore?(path, isDirectory, .infoExclude) }
+        }
+    }
+
+    private func isUntrackedSubtree(_ node: FileTreeNode) -> Bool {
+        if node.kind == .file {
+            return groupsByPath[node.path]?.entries.allSatisfy { Self.isUntracked($0) } ?? false
+        }
+        guard let children = node.children, !children.isEmpty else { return false }
+        return children.allSatisfy { isUntrackedSubtree($0) }
+    }
+
+    private static func isUntracked(_ file: ChangedFile) -> Bool {
+        file.status == "A" && file.stage == .unstaged
+    }
+
+    private static func hasHeadVersion(_ group: WorkingTreeChangeGroup) -> Bool {
+        group.entries.contains(where: { $0.status == "D" || $0.status == "R" })
+            || !group.entries.contains { $0.status == "A" }
+    }
+
+    private static func folderStageState(
         staged: [ChangedFile],
         unstaged: [ChangedFile]
     ) -> WorkingTreeStageState {
         switch (staged.isEmpty, unstaged.isEmpty) {
         case (false, false): return .mixed
-        case (false, true):  return .staged
-        default:             return .unstaged
+        case (false, true): return .staged
+        default: return .unstaged
         }
     }
 
-    private func stageChipState(for state: WorkingTreeStageState) -> StageChip.DisplayState {
+    private static func stageChipState(for state: WorkingTreeStageState) -> StageChip.DisplayState {
         switch state {
         case .staged: return .staged
         case .mixed: return .mixed

--- a/Alas/Sources/Settings/AdvancedPane.swift
+++ b/Alas/Sources/Settings/AdvancedPane.swift
@@ -6,6 +6,7 @@ struct AdvancedPane: View {
     @State private var pendingAction: CleanupAction?
     @State private var cleanupMessage: String?
     @State private var isCleaningStaleProjects = false
+    @State private var usesAppKitChangesScroller = AppKitChangesScrollerFlag.isEnabled
 
     var body: some View {
         ScrollView {
@@ -14,6 +15,21 @@ struct AdvancedPane: View {
                 Text("Experimental features and destructive maintenance actions.")
                     .font(.system(size: 12.5)).foregroundColor(theme.color("fg-dim"))
                     .padding(.bottom, 12)
+
+                SettingsGroup(title: "Experimental") {
+                    SettingsRow(
+                        name: "AppKit Changes scroller",
+                        desc: "Uses the virtualized native scroller for working tree files, stashes, and commits."
+                    ) {
+                        AlasToggle(on: Binding(
+                            get: { usesAppKitChangesScroller },
+                            set: { enabled in
+                                usesAppKitChangesScroller = enabled
+                                AppKitChangesScrollerFlag.setOverride(enabled)
+                            }
+                        ))
+                    }
+                }
 
                 SettingsGroup(title: "Cleanup") {
                     SettingsRow(

--- a/AlasTests/AppKitChangesScrollerFlagTests.swift
+++ b/AlasTests/AppKitChangesScrollerFlagTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+struct AppKitChangesScrollerFlagTests {
+    @Test func explicitOverrideWinsBuildDefault() {
+        #expect(AppKitChangesScrollerFlag.resolve(override: true, isDebugBuild: false))
+        #expect(!AppKitChangesScrollerFlag.resolve(override: false, isDebugBuild: true))
+    }
+
+    @Test func missingOverrideUsesBuildDefault() {
+        #expect(AppKitChangesScrollerFlag.resolve(override: nil, isDebugBuild: true))
+        #expect(!AppKitChangesScrollerFlag.resolve(override: nil, isDebugBuild: false))
+    }
+
+    @Test func settingOverridePersistsAndNotifies() throws {
+        let suite = "AppKitChangesScrollerFlagTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        let notifications = NotificationCenter()
+        var received = false
+        let observer = notifications.addObserver(
+            forName: AppKitChangesScrollerFlag.overrideDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { _ in received = true }
+        defer {
+            notifications.removeObserver(observer)
+            defaults.removePersistentDomain(forName: suite)
+        }
+
+        AppKitChangesScrollerFlag.setOverride(
+            true,
+            in: defaults,
+            notificationCenter: notifications
+        )
+
+        #expect(AppKitChangesScrollerFlag.readOverride(from: defaults) == true)
+        #expect(received)
+    }
+}

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerReconcilerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerReconcilerTests.swift
@@ -311,6 +311,20 @@ struct AppKitDiffScrollerReconcilerTests {
         #expect(stack.pool.mountedIDs.contains("row-0"))
     }
 
+    @Test("sticky rows remain mounted at the viewport top")
+    func stickyRowsFollowViewport() throws {
+        let stack = makeStack()
+        let rows = [spec("header", height: 30, retention: .sticky)]
+            + (0..<100).map { spec("row-\($0)", height: 40) }
+        stack.reconciler.apply(plan: .init(rows: rows), contentWidth: stack.scrollView.contentWidth)
+        stack.reconciler.scroll(to: .init(
+            targetID: "row-50", fallbackID: nil, alignment: .top, animated: false, generation: 1
+        ))
+
+        let header = try #require(stack.pool.mountedView(id: "header"))
+        #expect(abs(header.frame.minY - stack.scrollView.scrollY) < 0.5)
+    }
+
     @Test("retention and owner-only updates are not treated as no-ops")
     func retentionAndOwnerOnlyUpdatesApply() {
         let stack = makeStack()

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffTilingControllerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffTilingControllerTests.swift
@@ -150,4 +150,19 @@ struct AppKitDiffTilingControllerTests {
 
         #expect(indexByID == ["a": 2, "b": 1])
     }
+
+    @Test("sticky header follows the viewport and yields to the next header")
+    func stickyHeaderLayout() {
+        let tiling = controller()
+        tiling.replaceAll(rows: [
+            .init(id: "working", ownerID: nil, height: 30),
+            .init(id: "file", ownerID: nil, height: 100),
+            .init(id: "commits", ownerID: nil, height: 30),
+            .init(id: "commit", ownerID: nil, height: 100),
+        ])
+
+        #expect(tiling.stickyRowLayout(ids: ["working", "commits"], viewportMinY: 50) == .init(id: "working", minY: 50))
+        #expect(tiling.stickyRowLayout(ids: ["working", "commits"], viewportMinY: 120) == .init(id: "working", minY: 100))
+        #expect(tiling.stickyRowLayout(ids: ["working", "commits"], viewportMinY: 150) == .init(id: "commits", minY: 150))
+    }
 }

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -4,6 +4,11 @@ import Testing
 
 @MainActor
 struct ChangesTabViewTests {
+    @Test func appKitCommitHeaderTracksCommitCounts() {
+        #expect(ChangesTabView.commitHeaderCountsToken(primary: 1, older: 23)
+            != ChangesTabView.commitHeaderCountsToken(primary: 12, older: 3))
+    }
+
     @Test func appKitCommitRowsTrackPrimaryRemote() {
         let primaryRemote = CodeHostRemote(
             kind: .github,

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -105,6 +105,32 @@ struct ChangesTabViewTests {
         ))
     }
 
+    @Test func appKitCommitRowsTrackComparisonState() {
+        #expect(ChangesTabView.commitRowsStateToken(
+            ggStack: nil,
+            ggModeActive: false,
+            comparisonRef: nil,
+            inFlightAction: nil,
+            pausedOperation: nil,
+            mergeOperation: nil,
+            selectionIsStale: false,
+            commitsNeedPush: false,
+            commitRemote: nil,
+            primaryCommitRemote: nil
+        ) != ChangesTabView.commitRowsStateToken(
+            ggStack: nil,
+            ggModeActive: false,
+            comparisonRef: "main",
+            inFlightAction: nil,
+            pausedOperation: nil,
+            mergeOperation: nil,
+            selectionIsStale: false,
+            commitsNeedPush: false,
+            commitRemote: nil,
+            primaryCommitRemote: nil
+        ))
+    }
+
     @Test func appKitRowsUseLatestActionsWithoutRebuilding() {
         let relay = ChangesAppKitActionRelay()
         var selections: [String] = []

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -1,8 +1,42 @@
+import Foundation
 import Testing
 @testable import Alas
 
 @MainActor
 struct ChangesTabViewTests {
+    @Test func appKitCommitRowsTrackPrimaryRemote() {
+        let primaryRemote = CodeHostRemote(
+            kind: .github,
+            host: "github.com",
+            owner: "owner",
+            repository: "repo",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/owner/repo")!
+        )
+        let withoutRemote = ChangesTabView.commitRowsStateToken(
+            ggStack: nil,
+            inFlightAction: nil,
+            pausedOperation: nil,
+            mergeOperation: nil,
+            selectionIsStale: false,
+            commitsNeedPush: false,
+            commitRemote: nil,
+            primaryCommitRemote: nil
+        )
+        let withRemote = ChangesTabView.commitRowsStateToken(
+            ggStack: nil,
+            inFlightAction: nil,
+            pausedOperation: nil,
+            mergeOperation: nil,
+            selectionIsStale: false,
+            commitsNeedPush: false,
+            commitRemote: nil,
+            primaryCommitRemote: primaryRemote
+        )
+
+        #expect(withoutRemote != withRemote)
+    }
+
     @Test func appKitRowsUseLatestActionsWithoutRebuilding() {
         let relay = ChangesAppKitActionRelay()
         var selections: [String] = []

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -3,6 +3,30 @@ import Testing
 
 @MainActor
 struct ChangesTabViewTests {
+    @Test func appKitRowsUseLatestActionsWithoutRebuilding() {
+        let relay = ChangesAppKitActionRelay()
+        var selections: [String] = []
+        relay.update(
+            onSelectFile: { selections.append("first:\($0.path)") },
+            onSelectCommit: { _ in },
+            onEditCommit: { _, _ in },
+            onReviewCommit: { _ in }
+        )
+        relay.update(
+            onSelectFile: { selections.append("second:\($0.path)") },
+            onSelectCommit: { _ in },
+            onEditCommit: { _, _ in },
+            onReviewCommit: { _ in }
+        )
+
+        relay.onSelectFile(ChangedFile(
+            path: "App.swift", status: "M", stage: .unstaged,
+            add: 1, del: 0, renameFrom: nil
+        ))
+
+        #expect(selections == ["second:App.swift"])
+    }
+
     @Test func genericOperationCardHiddenDuringPausedGGOperation() {
         let operation = MergeOperation.merge(sourceBranch: "main")
 

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -9,6 +9,11 @@ struct ChangesTabViewTests {
             != ChangesTabView.commitHeaderCountsToken(primary: 12, older: 3))
     }
 
+    @Test func appKitCommitRowsTrackTerminalPosition() {
+        #expect(ChangesTabView.commitRowTerminalToken(isLast: true)
+            != ChangesTabView.commitRowTerminalToken(isLast: false))
+    }
+
     @Test func appKitCommitRowsTrackPrimaryRemote() {
         let primaryRemote = CodeHostRemote(
             kind: .github,

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -76,6 +76,35 @@ struct ChangesTabViewTests {
         #expect(withoutGGMode != withGGMode)
     }
 
+    @Test func appKitCommitRowsTrackGGCapabilities() {
+        let unsupported = GGCapabilities(structuredSplit: false, keepCurrentUnstack: false)
+        let supported = GGCapabilities(structuredSplit: true, keepCurrentUnstack: false)
+
+        #expect(ChangesTabView.commitRowsStateToken(
+            ggStack: nil,
+            ggModeActive: false,
+            ggCapabilities: unsupported,
+            inFlightAction: nil,
+            pausedOperation: nil,
+            mergeOperation: nil,
+            selectionIsStale: false,
+            commitsNeedPush: false,
+            commitRemote: nil,
+            primaryCommitRemote: nil
+        ) != ChangesTabView.commitRowsStateToken(
+            ggStack: nil,
+            ggModeActive: false,
+            ggCapabilities: supported,
+            inFlightAction: nil,
+            pausedOperation: nil,
+            mergeOperation: nil,
+            selectionIsStale: false,
+            commitsNeedPush: false,
+            commitRemote: nil,
+            primaryCommitRemote: nil
+        ))
+    }
+
     @Test func appKitRowsUseLatestActionsWithoutRebuilding() {
         let relay = ChangesAppKitActionRelay()
         var selections: [String] = []

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -25,6 +25,7 @@ struct ChangesTabViewTests {
         )
         let withoutRemote = ChangesTabView.commitRowsStateToken(
             ggStack: nil,
+            ggModeActive: false,
             inFlightAction: nil,
             pausedOperation: nil,
             mergeOperation: nil,
@@ -35,6 +36,7 @@ struct ChangesTabViewTests {
         )
         let withRemote = ChangesTabView.commitRowsStateToken(
             ggStack: nil,
+            ggModeActive: false,
             inFlightAction: nil,
             pausedOperation: nil,
             mergeOperation: nil,
@@ -45,6 +47,33 @@ struct ChangesTabViewTests {
         )
 
         #expect(withoutRemote != withRemote)
+    }
+
+    @Test func appKitCommitRowsTrackGGMode() {
+        let withoutGGMode = ChangesTabView.commitRowsStateToken(
+            ggStack: nil,
+            ggModeActive: false,
+            inFlightAction: nil,
+            pausedOperation: nil,
+            mergeOperation: nil,
+            selectionIsStale: false,
+            commitsNeedPush: false,
+            commitRemote: nil,
+            primaryCommitRemote: nil
+        )
+        let withGGMode = ChangesTabView.commitRowsStateToken(
+            ggStack: nil,
+            ggModeActive: true,
+            inFlightAction: nil,
+            pausedOperation: nil,
+            mergeOperation: nil,
+            selectionIsStale: false,
+            commitsNeedPush: false,
+            commitRemote: nil,
+            primaryCommitRemote: nil
+        )
+
+        #expect(withoutGGMode != withGGMode)
     }
 
     @Test func appKitRowsUseLatestActionsWithoutRebuilding() {

--- a/AlasTests/WorkingTreeFlatRowTests.swift
+++ b/AlasTests/WorkingTreeFlatRowTests.swift
@@ -1,0 +1,25 @@
+import Testing
+@testable import Alas
+
+struct WorkingTreeFlatRowTests {
+    @Test func flattensVisibleTreeAndRespectsCollapsedFolders() {
+        let groups = WorkingTreeChangeGroup.group(files: [
+            ChangedFile(path: "Sources/App.swift", status: "M", stage: .unstaged, add: 1, del: 0, renameFrom: nil),
+            ChangedFile(path: "Sources/UI/Button.swift", status: "A", stage: .unstaged, add: 2, del: 0, renameFrom: nil),
+            ChangedFile(path: "README.md", status: "M", stage: .staged, add: 1, del: 1, renameFrom: nil),
+        ])
+
+        let expanded = WorkingTreeFlatRow.make(groups: groups, collapsedPaths: [])
+        #expect(expanded.map(\.id) == [
+            "dir:Sources", "dir:Sources/UI", "file:Sources/UI/Button.swift",
+            "file:Sources/App.swift", "file:README.md",
+        ])
+        #expect(expanded.map(\.depth) == [0, 1, 2, 1, 0])
+
+        let collapsed = WorkingTreeFlatRow.make(
+            groups: groups,
+            collapsedPaths: ["working-tree:Sources"]
+        )
+        #expect(collapsed.map(\.id) == ["dir:Sources", "file:README.md"])
+    }
+}


### PR DESCRIPTION
## Summary

- Add a feature-flagged AppKit-backed Changes scroller with sticky Working tree, Stashes, and Commits headers.
- Virtualize working-tree folders/files, stash rows/files, and commit rows to keep scrolling bounded for large repositories.
- Preserve the SwiftUI path as a live Debug setting; enabled by default in Debug builds and disabled in Release.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- Focused Changes/AppKit regressions and existing 20,000-row AppKit scroller stress tests\n\nThe full suite was attempted. It encountered unrelated, isolated-passing GG parallel-state failures and then an Xcode test-runner materialization hang.