### PR TITLE
feat(diff): Improve diff scrolling and highlighting

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentBuilder.swift
@@ -725,6 +725,7 @@ struct DiffPaneTextDocumentBuilder {
                 lines: document.lines,
                 startIndex: segment.startIndex,
                 endIndex: segment.endIndex,
+                fileExtension: fileExtension,
                 theme: theme
             )
         }
@@ -776,6 +777,7 @@ struct DiffPaneTextDocumentBuilder {
         lines: [LineMetadata],
         startIndex: Int,
         endIndex: Int,
+        fileExtension: String,
         theme: Theme
     ) {
         var spansByLine = Array(repeating: [HighlightSpan](), count: endIndex - startIndex + 1)
@@ -815,9 +817,28 @@ struct DiffPaneTextDocumentBuilder {
             }
         }
 
-        for (offset, lineSpans) in spansByLine.enumerated() where !lineSpans.isEmpty {
+        for offset in spansByLine.indices {
             let line = lines[startIndex + offset]
             guard let sourceRange = line.sourceRange else { continue }
+            var lineSpans = spansByLine[offset]
+            if line.tone == .add || line.tone == .delete,
+               let sourceLine = line.sourceLine {
+                for fallback in TreeSitterHighlighter.tokenize(
+                    line: sourceLine.text,
+                    fileExtension: fileExtension
+                ) {
+                    let overlapsStructuralSpan = lineSpans.contains {
+                        ($0.capture == .comment || $0.capture == .string)
+                            && NSIntersectionRange($0.range, fallback.range).length > 0
+                    }
+                    guard !overlapsStructuralSpan else { continue }
+                    lineSpans.removeAll {
+                        NSIntersectionRange($0.range, fallback.range).length > 0
+                    }
+                    lineSpans.append(fallback)
+                }
+            }
+            guard !lineSpans.isEmpty else { continue }
             DiffCodeText.applySyntaxSpans(
                 to: output,
                 spans: lineSpans,

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -961,7 +961,6 @@ final class DiffPaneTextScrollView: NSScrollView {
         }
 
         super.layout()
-        tile()
         let configuration = desiredTextLayoutConfiguration()
         let configurationChanged = !textLayoutConfigurationMatches(configuration)
         if configurationChanged, configuration.wraps {

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowHostingView.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffRowHostingView.swift
@@ -9,6 +9,9 @@ final class AppKitDiffRowHostingView: NSHostingView<AnyView> {
 
     private var baseRootView: AnyView
     private(set) var lastMeasuredWidth: CGFloat?
+    private(set) var layoutPassCountForTests = 0
+    private var hasLaidOutCurrentRootView = false
+    private var suppressesNextStableLayout = false
 
     required init(rootView: AnyView) {
         baseRootView = rootView
@@ -20,7 +23,19 @@ final class AppKitDiffRowHostingView: NSHostingView<AnyView> {
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("not supported") }
 
+    override func layout() {
+        if suppressesNextStableLayout {
+            suppressesNextStableLayout = false
+            return
+        }
+        layoutPassCountForTests += 1
+        super.layout()
+        hasLaidOutCurrentRootView = true
+    }
+
     override func invalidateIntrinsicContentSize() {
+        suppressesNextStableLayout = false
+        hasLaidOutCurrentRootView = false
         super.invalidateIntrinsicContentSize()
         if let representedRowID {
             onIntrinsicSizeInvalidated?(representedRowID)
@@ -28,6 +43,8 @@ final class AppKitDiffRowHostingView: NSHostingView<AnyView> {
     }
 
     func updateRootView(_ newRootView: AnyView) {
+        suppressesNextStableLayout = false
+        hasLaidOutCurrentRootView = false
         baseRootView = newRootView
         if let lastMeasuredWidth {
             rootView = AnyView(newRootView.frame(width: lastMeasuredWidth, alignment: .topLeading))
@@ -38,8 +55,15 @@ final class AppKitDiffRowHostingView: NSHostingView<AnyView> {
 
     func measuredHeight(forWidth width: CGFloat) -> CGFloat {
         guard width > 0 else { return 0 }
+        suppressesNextStableLayout = false
+        hasLaidOutCurrentRootView = false
         rootView = AnyView(baseRootView.frame(width: width, alignment: .topLeading))
         lastMeasuredWidth = width
         return intrinsicContentSize.height
+    }
+
+    func suppressNextLayoutForStableScroll() {
+        guard hasLaidOutCurrentRootView else { return }
+        suppressesNextStableLayout = true
     }
 }

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScrollerReconciler.swift
@@ -24,6 +24,7 @@ final class AppKitDiffScrollerReconciler {
     #if DEBUG
     private(set) var fullPlanApplyCountForTests = 0
     private(set) var layoutPassCountForTests = 0
+    private(set) var frameAssignmentCountForTests = 0
     private(set) var retentionInspectionCountForTests = 0
     var pinnedRowIDsForTests: Set<String> { pinnedRowIDs }
     #endif
@@ -265,6 +266,8 @@ final class AppKitDiffScrollerReconciler {
             pool.releaseAll(except: keep)
 
             var geometryChanged = false
+            var mountedViews: [(id: String, view: AppKitDiffRowHostingView, isStable: Bool)] = []
+            var measuredHeightUpdates: [String: CGFloat] = [:]
             for id in keep {
                 guard let spec = specsByID[id], let row = tiling.row(withID: id) else { continue }
                 let result = pool.view(for: spec)
@@ -275,27 +278,43 @@ final class AppKitDiffScrollerReconciler {
                 let shouldMeasure = result.contentChanged
                     || view.lastMeasuredWidth != contentWidth
                     || invalidatedRowIDs.remove(id) != nil
+                mountedViews.append((id, view, !shouldMeasure))
                 if shouldMeasure {
                     let height = max(0, view.measuredHeight(forWidth: contentWidth))
                     measuredHeights[id] = height
-                    let compensation = tiling.updateHeight(
-                        id: id,
-                        to: height,
-                        viewportMinY: scrollView.scrollY
-                    )
-                    if compensation != 0 {
-                        scrollView.setDocumentHeight(tiling.documentHeight)
-                        scrollView.setScrollY(scrollView.scrollY + compensation, animated: false)
+                    if row.height != height {
+                        measuredHeightUpdates[id] = height
                     }
                     geometryChanged = geometryChanged || abs(row.height - height) > 0.01
                 }
+            }
+
+            let compensation = tiling.updateHeights(
+                measuredHeightUpdates,
+                viewportMinY: scrollView.scrollY
+            )
+            if compensation != 0 {
+                scrollView.setDocumentHeight(tiling.documentHeight)
+                scrollView.setScrollY(scrollView.scrollY + compensation, animated: false)
+            }
+            for (id, view, isStable) in mountedViews {
                 if let updatedRow = tiling.row(withID: id) {
-                    view.frame = NSRect(
+                    let frame = NSRect(
                         x: contentInsets.left,
                         y: updatedRow.minY,
                         width: contentWidth,
                         height: updatedRow.height
                     )
+                    guard view.frame != frame else {
+                        if isStable {
+                            view.suppressNextLayoutForStableScroll()
+                        }
+                        continue
+                    }
+                    #if DEBUG
+                    frameAssignmentCountForTests += 1
+                    #endif
+                    view.frame = frame
                 }
             }
             scrollView.setDocumentHeight(tiling.documentHeight)

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffTilingController.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffTilingController.swift
@@ -35,6 +35,10 @@ final class AppKitDiffTilingController {
 
     private(set) var documentHeight: CGFloat = 0
 
+    #if DEBUG
+    private(set) var retilePassCountForTests = 0
+    #endif
+
     init(metrics: Metrics = Metrics()) {
         self.metrics = metrics
     }
@@ -59,12 +63,23 @@ final class AppKitDiffTilingController {
     }
 
     func updateHeight(id: String, to height: CGFloat, viewportMinY: CGFloat) -> CGFloat {
-        guard let index = index(ofID: id), rows[index].height != height else { return 0 }
-        let old = rows[index]
-        let delta = height - old.height
-        rows[index].height = height
-        retile()
-        return old.maxY <= viewportMinY ? delta : 0
+        updateHeights([id: height], viewportMinY: viewportMinY)
+    }
+
+    func updateHeights(_ heightsByID: [String: CGFloat], viewportMinY: CGFloat) -> CGFloat {
+        var compensation: CGFloat = 0
+        var changed = false
+        for (id, height) in heightsByID {
+            guard let index = index(ofID: id), rows[index].height != height else { continue }
+            let old = rows[index]
+            if old.maxY <= viewportMinY {
+                compensation += height - old.height
+            }
+            rows[index].height = height
+            changed = true
+        }
+        if changed { retile() }
+        return compensation
     }
 
     func anchor(viewportMinY: CGFloat) -> AppKitDiffScrollAnchor? {
@@ -153,6 +168,9 @@ final class AppKitDiffTilingController {
     }
 
     private func retile() {
+        #if DEBUG
+        retilePassCountForTests += 1
+        #endif
         var y = metrics.topPadding
         for index in rows.indices {
             rows[index].minY = y

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerReconcilerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerReconcilerTests.swift
@@ -392,6 +392,36 @@ struct AppKitDiffScrollerReconcilerTests {
         #expect(stack.reconciler.layoutPassCountForTests > layoutCount)
     }
 
+    @Test("steady-state layout does not rewrite stable mounted host frames")
+    func steadyStateLayoutDoesNotRewriteStableMountedHostFrames() {
+        let stack = makeStack()
+        stack.reconciler.apply(plan: plan(), contentWidth: stack.scrollView.contentWidth)
+        let assignmentsAfterApply = stack.reconciler.frameAssignmentCountForTests
+
+        stack.reconciler.layoutVisibleRows()
+
+        #expect(stack.reconciler.frameAssignmentCountForTests == assignmentsAfterApply)
+    }
+
+    @Test("pure scrolling does not relayout stable mounted hosts")
+    func pureScrollingDoesNotRelayoutStableMountedHosts() {
+        let stack = makeStack()
+        stack.reconciler.apply(plan: plan(), contentWidth: stack.scrollView.contentWidth)
+        stack.window.layoutIfNeeded()
+        let hosts = stack.pool.mountedIDs.compactMap(stack.pool.mountedView(id:))
+        let layoutPasses = hosts.map(\.layoutPassCountForTests)
+        #expect(layoutPasses.allSatisfy { $0 > 0 })
+
+        for y in stride(from: CGFloat(10), through: 200, by: 10) {
+            stack.scrollView.contentView.scroll(to: NSPoint(x: 0, y: y))
+            stack.scrollView.reflectScrolledClipView(stack.scrollView.contentView)
+            stack.reconciler.layoutVisibleRows()
+            stack.window.layoutIfNeeded()
+        }
+
+        #expect(hosts.map(\.layoutPassCountForTests) == layoutPasses)
+    }
+
     @Test("scroll requests use requested alignment and a fallback target")
     func scrollRequestAlignmentAndFallback() {
         let stack = makeStack()

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerStressTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerStressTests.swift
@@ -6,6 +6,18 @@ import Testing
 @MainActor
 @Suite("AppKit diff scroller stress and accessibility")
 struct AppKitDiffScrollerStressTests {
+    @Test("measuring a viewport batches row geometry corrections")
+    func measuredRowsRetileOnce() {
+        let stack = makeStack()
+        let rows = (0..<200).map { index in
+            row(id: "row-\(index)", estimatedHeight: 20, actualHeight: 40)
+        }
+
+        stack.reconciler.apply(plan: AppKitDiffRowPlan(rows: rows), contentWidth: stack.scrollView.contentWidth)
+
+        #expect(stack.tiling.retilePassCountForTests == 2)
+    }
+
     @Test("twenty thousand rows keep a bounded mount band and preserve anchors")
     func twentyThousandRows() throws {
         let stack = makeStack()
@@ -140,12 +152,18 @@ struct AppKitDiffScrollerStressTests {
         id: String,
         ownerID: String? = nil,
         token: Int = 0,
-        height: CGFloat = 40
+        height: CGFloat = 40,
+        estimatedHeight: CGFloat? = nil,
+        actualHeight: CGFloat? = nil
     ) -> AppKitDiffRowSpec {
         .init(
-            id: id, ownerID: ownerID, equalityToken: .init(token), contentSignature: token, estimatedHeight: height
+            id: id,
+            ownerID: ownerID,
+            equalityToken: .init(token),
+            contentSignature: token,
+            estimatedHeight: estimatedHeight ?? height
         ) {
-            AnyView(Color.clear.frame(height: height))
+            AnyView(Color.clear.frame(height: actualHeight ?? height))
         }
     }
 

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -3886,6 +3886,40 @@ let second = true
         #expect(result.newCode.lines[0].syntaxGroup == result.newCode.lines[1].syntaxGroup)
     }
 
+    @Test func changedLineSyntaxOverridesPartialFileParseErrors() throws {
+        let theme = theme()
+        let diff = ParsedDiff(hunks: [
+            ParsedDiff.Hunk(
+                header: "@@ -40,2 +40,3 @@",
+                oldStart: 40,
+                newStart: 40,
+                lines: [
+                    .init(kind: .context, text: "    someCall(", oldNumber: 40, newNumber: 40),
+                    .init(kind: .add, text: "        let changed = 2", oldNumber: nil, newNumber: 41),
+                    .init(kind: .context, text: "    )", oldNumber: 41, newNumber: 42),
+                ]
+            ),
+        ])
+        let model = DiffDisplayModelBuilder.build(diff: diff, filePath: "Sources/App.swift")
+        let result = DiffPaneTextDocumentBuilder.buildSplit(
+            group: try #require(model.groups.first),
+            expandedCollapsedRowIDs: [],
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            showWhitespace: false,
+            theme: theme
+        )
+        let rendered = result.newCode.attributedString.string as NSString
+        let keywordStart = rendered.range(of: "let changed").location
+        let foreground = try #require(result.newCode.attributedString.attribute(
+            .foregroundColor,
+            at: keywordStart,
+            effectiveRange: nil
+        ) as? NSColor)
+
+        #expect(colorComponents(foreground).isClose(to: colorComponents(NSColor(theme.color("syntax-keyword")))))
+    }
+
     @Test func stackedDocumentDoesNotCarrySyntaxFromDeletedLinesIntoAddedLines() throws {
         let theme = theme()
         let diff = ParsedDiff(hunks: [


### PR DESCRIPTION
## Summary

- Batch diff row height corrections and avoid redundant frame assignments and SwiftUI layouts while scrolling.
- Preserve the first real layout for new or reused rows so diff contents never appear as empty black boxes.
- Apply line-level tree-sitter fallback tokens to changed lines when parsing a partial existing-file hunk misses syntax captures.
- Add regression coverage for geometry batching, stable scrolling, initial rendering, and changed-line highlighting.

## Root cause

Visible diff rows were individually retiling and reassigning unchanged host frames during scroll, causing every mounted SwiftUI host to lay out on each scroll event. Separately, tree-sitter parses of partial hunks can produce incomplete captures for changed lines in existing files.

## Verification

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Focused `AppKitDiffScrollerReconcilerTests`, `AppKitDiffScrollerStressTests`, and `DiffPaneViewTests`
- Manual side-by-side validation of initial rendering and scrolling

A full local suite run was interrupted after failures outside this diff in remote-web cache-version and GG stack tests, followed by an Xcode test-runner hang.