### PR TITLE
feat(acp): restore ACP model after restart

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3692,10 +3692,14 @@ extension ACPSessionManager {
             // choice before dispatching queued or transcript-recovery prompts.
             if let m = pendingModel.removeValue(forKey: sessionId) ?? persistedModel,
                m != result.currentModel {
-                session.currentModel = m
-                persist(session)
                 let remoteId = session.remoteSessionId ?? sessionId
-                try? await runner.connection.setModel(sessionId: remoteId, modelId: m)
+                do {
+                    try await runner.connection.setModel(sessionId: remoteId, modelId: m)
+                    session.currentModel = m
+                    persist(session)
+                } catch {
+                    persist(session)
+                }
             }
             if let m = pendingMode.removeValue(forKey: sessionId) {
                 session.currentMode = m

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3689,6 +3689,7 @@ extension ACPSessionManager {
             // The load result just above overwrote `currentModel`/`currentMode`
             // with the agent's restored values. Reapply + persist the user's
             // choice before dispatching queued or transcript-recovery prompts.
+            let loadedMode = session.currentMode
             if let m = pendingModel.removeValue(forKey: sessionId) ?? persistedModel,
                m != result.currentModel {
                 let loadedModel = session.currentModel
@@ -3705,7 +3706,8 @@ extension ACPSessionManager {
                     }
                 }
             }
-            if let m = pendingMode.removeValue(forKey: sessionId) {
+            if let m = pendingMode.removeValue(forKey: sessionId),
+               session.currentMode == loadedMode {
                 session.currentMode = m
                 persist(session)
                 let remoteId = session.remoteSessionId ?? sessionId

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3722,6 +3722,7 @@ extension ACPSessionManager {
                     && !isDisposed
             }
             guard attachmentStillCurrent else {
+                attachSucceeded = false
                 if runners[sessionId] === runner {
                     runners[sessionId] = nil
                     runner.stop()

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3686,6 +3686,23 @@ extension ACPSessionManager {
             keepElicitationCoordinator = true
             attachSucceeded = true
             session.agentState = .ready
+            // Drain a pending model/mode picked during the post-takeover window.
+            // The load result just above overwrote `currentModel`/`currentMode`
+            // with the agent's restored values. Reapply + persist the user's
+            // choice before dispatching queued or transcript-recovery prompts.
+            if let m = pendingModel.removeValue(forKey: sessionId) ?? persistedModel,
+               m != result.currentModel {
+                session.currentModel = m
+                persist(session)
+                let remoteId = session.remoteSessionId ?? sessionId
+                try? await runner.connection.setModel(sessionId: remoteId, modelId: m)
+            }
+            if let m = pendingMode.removeValue(forKey: sessionId) {
+                session.currentMode = m
+                persist(session)
+                let remoteId = session.remoteSessionId ?? sessionId
+                try? await runner.connection.setMode(sessionId: remoteId, modeId: m)
+            }
             if let remoteMCPNotice {
                 runner.appendAndPersistSystemNotice(remoteMCPNotice)
             }
@@ -3693,25 +3710,6 @@ extension ACPSessionManager {
                 sendTranscriptAsContext(sessionId: sessionId, agentName: nil)
             } else {
                 runner.flushQueueIfIdle()
-            }
-            // Drain a pending model/mode picked during the post-takeover window.
-            // The load result just above overwrote `currentModel`/`currentMode`
-            // with the agent's restored values, so reapply + persist the user's
-            // choice before firing the RPC — `session/set_model` returns nothing
-            // and not every agent emits a follow-up update, so the local config
-            // and stored row would otherwise drift off the agent's actual state.
-            if let m = pendingModel.removeValue(forKey: sessionId) ?? persistedModel,
-               m != result.currentModel {
-                session.currentModel = m
-                persist(session)
-                let remoteId = session.remoteSessionId ?? sessionId
-                Task { try? await runner.connection.setModel(sessionId: remoteId, modelId: m) }
-            }
-            if let m = pendingMode.removeValue(forKey: sessionId) {
-                session.currentMode = m
-                persist(session)
-                let remoteId = session.remoteSessionId ?? sessionId
-                Task { try? await runner.connection.setMode(sessionId: remoteId, modeId: m) }
             }
             stderrTask.cancel()
         } catch {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3680,6 +3680,7 @@ extension ACPSessionManager {
                 await releaseWriterLease(sessionId: sessionId)
                 return
             }
+            let localModelAfterRemoteIdPersist = session.currentModel
             connection.acknowledgeDurableSessionResponses()
             startRunnerIfNeeded()
             runners[sessionId] = runner
@@ -3690,7 +3691,9 @@ extension ACPSessionManager {
             // with the agent's restored values. Reapply + persist the user's
             // choice before dispatching queued or transcript-recovery prompts.
             let loadedMode = session.currentMode
-            if let m = pendingModel.removeValue(forKey: sessionId) ?? persistedModel,
+            let modelToRestore = pendingModel.removeValue(forKey: sessionId)
+                ?? (localModelAfterRemoteIdPersist != result.currentModel ? localModelAfterRemoteIdPersist : persistedModel)
+            if let m = modelToRestore,
                m != result.currentModel {
                 let loadedModel = session.currentModel
                 let remoteId = session.remoteSessionId ?? sessionId

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3711,6 +3711,7 @@ extension ACPSessionManager {
                 let remoteId = session.remoteSessionId ?? sessionId
                 try? await runner.connection.setMode(sessionId: remoteId, modeId: m)
             }
+            guard session.agentState == .spawning else { return }
             let attachmentStillCurrent: Bool
             if isDisposed || sessions[sessionId] !== session || runners[sessionId] !== runner {
                 attachmentStillCurrent = false

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3685,20 +3685,24 @@ extension ACPSessionManager {
             runners[sessionId] = runner
             keepElicitationCoordinator = true
             attachSucceeded = true
-            session.agentState = .ready
             // Drain a pending model/mode picked during the post-takeover window.
             // The load result just above overwrote `currentModel`/`currentMode`
             // with the agent's restored values. Reapply + persist the user's
             // choice before dispatching queued or transcript-recovery prompts.
             if let m = pendingModel.removeValue(forKey: sessionId) ?? persistedModel,
                m != result.currentModel {
+                let loadedModel = session.currentModel
                 let remoteId = session.remoteSessionId ?? sessionId
                 do {
                     try await runner.connection.setModel(sessionId: remoteId, modelId: m)
-                    session.currentModel = m
-                    persist(session)
+                    if session.currentModel == loadedModel {
+                        session.currentModel = m
+                        persist(session)
+                    }
                 } catch {
-                    persist(session)
+                    if session.currentModel == loadedModel {
+                        persist(session)
+                    }
                 }
             }
             if let m = pendingMode.removeValue(forKey: sessionId) {
@@ -3707,6 +3711,7 @@ extension ACPSessionManager {
                 let remoteId = session.remoteSessionId ?? sessionId
                 try? await runner.connection.setMode(sessionId: remoteId, modeId: m)
             }
+            session.agentState = .ready
             if let remoteMCPNotice {
                 runner.appendAndPersistSystemNotice(remoteMCPNotice)
             }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2860,6 +2860,7 @@ extension ACPSessionManager {
         case .spawning, .ready: return
         case .idle, .disconnected, .failed: break
         }
+        let persistedModel = freshlyCreated ? nil : session.currentModel
         let firstRunAttach = freshlyCreated
             && !session.restoredFromPersistence
             && session.transcript.messages.isEmpty
@@ -3699,7 +3700,8 @@ extension ACPSessionManager {
             // choice before firing the RPC — `session/set_model` returns nothing
             // and not every agent emits a follow-up update, so the local config
             // and stored row would otherwise drift off the agent's actual state.
-            if let m = pendingModel.removeValue(forKey: sessionId) {
+            if let m = pendingModel.removeValue(forKey: sessionId) ?? persistedModel,
+               m != result.currentModel {
                 session.currentModel = m
                 persist(session)
                 let remoteId = session.remoteSessionId ?? sessionId

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3711,6 +3711,31 @@ extension ACPSessionManager {
                 let remoteId = session.remoteSessionId ?? sessionId
                 try? await runner.connection.setMode(sessionId: remoteId, modeId: m)
             }
+            let attachmentStillCurrent: Bool
+            if isDisposed || sessions[sessionId] !== session || runners[sessionId] !== runner {
+                attachmentStillCurrent = false
+            } else {
+                attachmentStillCurrent = await confirmedWriterLease(for: sessionId)
+                    && sessions[sessionId] === session
+                    && runners[sessionId] === runner
+                    && !isDisposed
+            }
+            guard attachmentStillCurrent else {
+                if runners[sessionId] === runner {
+                    runners[sessionId] = nil
+                    runner.stop()
+                    await runner.flushPersistence()
+                    if isDisposed {
+                        await runner.connection.shutdown()
+                    } else {
+                        await runner.connection.detach()
+                        session.agentState = .idle
+                        beginMirroring(sessionId: sessionId)
+                    }
+                    await releaseWriterLease(sessionId: sessionId)
+                }
+                return
+            }
             session.agentState = .ready
             if let remoteMCPNotice {
                 runner.appendAndPersistSystemNotice(remoteMCPNotice)

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -678,7 +678,14 @@ struct ACPComposer: View {
         manager.persist(session)
 
         Task { @MainActor in
-            guard let runner = manager.runners[sid] else { return }
+            guard let runner = manager.runners[sid] else {
+                switch spec.source {
+                case .mode: manager.pendingMode[sid] = selectedId
+                case .model: manager.pendingModel[sid] = selectedId
+                case .configOption: break
+                }
+                return
+            }
             switch spec.source {
             case .mode:
                 try? await runner.connection.setMode(sessionId: remoteId, modeId: selectedId)

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -525,6 +525,56 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(session.currentModel == "sonnet")
     }
 
+    @Test("reopened session restores its model before flushing queued prompts")
+    func reopenedSessionRestoresModelBeforeFlushingQueuedPrompts() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(
+            remoteSessionId: "remote-old",
+            agentId: "codex",
+            currentModel: "sonnet"
+        ))
+        try store.upsertQueue(sessionId: "local", items: [
+            QueuedPrompt(blocks: [.text("queued prompt")])
+        ])
+        let client = ACPMockClient()
+        let modelGate = PromptGate()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-old",
+                availableModels: [
+                    .init(id: "sonnet", name: "Sonnet"),
+                    .init(id: "opus", name: "Opus"),
+                ],
+                availableModes: [],
+                currentModel: "opus",
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+        client.scriptAsync(method: "session/set_model") { _ in
+            await modelGate.waitInPrompt()
+            return Data("{}".utf8)
+        }
+        client.script(method: "session/prompt") { _ in Data("null".utf8) }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        let attachTask = Task {
+            await manager.attach(to: session.id, freshlyCreated: false)
+        }
+
+        try await waitUntilAsync { await modelGate.hasEntered }
+        #expect(client.sent.filter { $0.method == "session/prompt" }.isEmpty)
+        await modelGate.release()
+        await attachTask.value
+
+        try await waitUntil {
+            client.sent.map(\.method) == ["initialize", "session/load", "session/set_model", "session/prompt"]
+        }
+    }
+
     @Test("replayed load history is ignored when a session is already hydrated")
     func replayedLoadHistoryIgnoredWhenHydrated() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -486,6 +486,45 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(try store.loadSession(id: "local")?.remoteSessionId == "remote-old")
     }
 
+    @Test("reopened session reapplies its persisted model after load")
+    func reopenedSessionReappliesPersistedModel() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(
+            remoteSessionId: "remote-old",
+            agentId: "codex",
+            currentModel: "sonnet"
+        ))
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-old",
+                availableModels: [
+                    .init(id: "sonnet", name: "Sonnet"),
+                    .init(id: "opus", name: "Opus"),
+                ],
+                availableModes: [],
+                currentModel: "opus",
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+        client.script(method: "session/set_model") { _ in Data("{}".utf8) }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        try await waitUntil {
+            client.sent.map(\.method) == ["initialize", "session/load", "session/set_model"]
+        }
+        let params = try #require(client.sent.last?.params as? ACPSessionSetModelParams)
+        #expect(params.sessionId == "remote-old")
+        #expect(params.modelId == "sonnet")
+        #expect(session.currentModel == "sonnet")
+    }
+
     @Test("replayed load history is ignored when a session is already hydrated")
     func replayedLoadHistoryIgnoredWhenHydrated() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())
@@ -1827,14 +1866,18 @@ struct ACPSessionManagerAttachRestoreTests {
         }
     }
 
-    private func row(remoteSessionId: String?) -> ACPSessionRow {
+    private func row(
+        remoteSessionId: String?,
+        agentId: String = "claude",
+        currentModel: String? = nil
+    ) -> ACPSessionRow {
         ACPSessionRow(
             id: "local",
-            agentId: "claude",
+            agentId: agentId,
             title: "Stored session",
             titleSource: .placeholder,
             remoteSessionId: remoteSessionId,
-            currentModel: nil,
+            currentModel: currentModel,
             currentMode: nil,
             autoRun: false,
             createdAt: 0,

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -615,6 +615,51 @@ struct ACPSessionManagerAttachRestoreTests {
         }
     }
 
+    @Test("reopened session stays detached when closed during model restoration")
+    func reopenedSessionStaysDetachedWhenClosedDuringModelRestoration() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(
+            remoteSessionId: "remote-old",
+            agentId: "codex",
+            currentModel: "sonnet"
+        ))
+        let client = ACPMockClient()
+        let modelGate = PromptGate()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-old",
+                availableModels: [
+                    .init(id: "sonnet", name: "Sonnet"),
+                    .init(id: "opus", name: "Opus"),
+                ],
+                availableModes: [],
+                currentModel: "opus",
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+        client.scriptAsync(method: "session/set_model") { _ in
+            await modelGate.waitInPrompt()
+            return Data("{}".utf8)
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        let attachTask = Task {
+            await manager.attach(to: session.id, freshlyCreated: false)
+        }
+
+        try await waitUntilAsync { await modelGate.hasEntered }
+        await manager.detach(sessionId: session.id)
+        await modelGate.release()
+        await attachTask.value
+
+        #expect(session.agentState == .idle)
+        #expect(manager.runners[session.id] == nil)
+    }
+
     @Test("replayed load history is ignored when a session is already hydrated")
     func replayedLoadHistoryIgnoredWhenHydrated() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -707,6 +707,58 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(session.agentState == .disconnected)
     }
 
+    @Test("reopened session preserves newer mode selected during model restoration")
+    func reopenedSessionPreservesNewerModeSelectedDuringModelRestoration() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(
+            remoteSessionId: "remote-old",
+            agentId: "codex",
+            currentModel: "sonnet"
+        ))
+        let client = ACPMockClient()
+        let modelGate = PromptGate()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-old",
+                availableModels: [
+                    .init(id: "sonnet", name: "Sonnet"),
+                    .init(id: "opus", name: "Opus"),
+                ],
+                availableModes: [
+                    .init(id: "default", name: "Default"),
+                    .init(id: "plan", name: "Plan"),
+                    .init(id: "act", name: "Act"),
+                ],
+                currentModel: "opus",
+                currentMode: "default",
+                promptSuggestions: []
+            ))
+        }
+        client.scriptAsync(method: "session/set_model") { _ in
+            await modelGate.waitInPrompt()
+            return Data("{}".utf8)
+        }
+        client.script(method: "session/set_mode") { _ in Data("{}".utf8) }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        manager.pendingMode[session.id] = "plan"
+        let attachTask = Task {
+            await manager.attach(to: session.id, freshlyCreated: false)
+        }
+
+        try await waitUntilAsync { await modelGate.hasEntered }
+        await manager.setMode(for: session.id, modeId: "act")
+        await modelGate.release()
+        await attachTask.value
+
+        #expect(session.currentMode == "act")
+        let modeParams = client.sent.compactMap { $0.params as? ACPSessionSetModeParams }
+        #expect(modeParams.map(\.modeId) == ["act"])
+    }
+
     @Test("replayed load history is ignored when a session is already hydrated")
     func replayedLoadHistoryIgnoredWhenHydrated() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -660,6 +660,53 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(manager.runners[session.id] == nil)
     }
 
+    @Test("reopened session stays disconnected when stream ends during model restoration")
+    func reopenedSessionStaysDisconnectedWhenStreamEndsDuringModelRestoration() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(
+            remoteSessionId: "remote-old",
+            agentId: "codex",
+            currentModel: "sonnet"
+        ))
+        let client = ACPMockClient()
+        let modelGate = PromptGate()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-old",
+                availableModels: [
+                    .init(id: "sonnet", name: "Sonnet"),
+                    .init(id: "opus", name: "Opus"),
+                ],
+                availableModes: [],
+                currentModel: "opus",
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+        client.scriptAsync(method: "session/set_model") { _ in
+            await modelGate.waitInPrompt()
+            return Data("{}".utf8)
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        let attachTask = Task {
+            await manager.attach(to: session.id, freshlyCreated: false)
+        }
+
+        try await waitUntilAsync { await modelGate.hasEntered }
+        await client.shutdown()
+        try await waitUntil {
+            session.agentState == .disconnected
+        }
+        await modelGate.release()
+        await attachTask.value
+
+        #expect(session.agentState == .disconnected)
+    }
+
     @Test("replayed load history is ignored when a session is already hydrated")
     func replayedLoadHistoryIgnoredWhenHydrated() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -525,6 +525,46 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(session.currentModel == "sonnet")
     }
 
+    @Test("reopened session keeps the loaded model when restoration fails")
+    func reopenedSessionKeepsLoadedModelWhenRestorationFails() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(
+            remoteSessionId: "remote-old",
+            agentId: "codex",
+            currentModel: "sonnet"
+        ))
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-old",
+                availableModels: [
+                    .init(id: "opus", name: "Opus"),
+                ],
+                availableModes: [],
+                currentModel: "opus",
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+        client.script(method: "session/set_model") { _ in
+            throw ACPClientError.noScript(method: "session/set_model")
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        try await waitUntil {
+            client.sent.map(\.method) == ["initialize", "session/load", "session/set_model"]
+        }
+        #expect(session.currentModel == "opus")
+        try await waitUntil {
+            (try? store.loadSession(id: "local"))?.currentModel == "opus"
+        }
+    }
+
     @Test("reopened session restores its model before flushing queued prompts")
     func reopenedSessionRestoresModelBeforeFlushingQueuedPrompts() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())


### PR DESCRIPTION
## Summary

Restored ACP sessions could adopt the model returned by the agent during
`session/load`, losing the model the user had selected before restart. Preserve
the stored choice for every ACP provider, including Codex and Claude.

## Changes

- Reapply a restored session's persisted model after loading its remote state.
- Keep a model selected during attachment as the higher-priority choice.
- Add regression coverage for a restored Codex session whose loaded model
  differs from its persisted selection.

## Verification

- `xcodegen`
- macOS build
- `ACPSessionManagerAttachRestoreTests` (51 passing tests)

## Notes

The full suite has unrelated existing failures and an Xcode runner hang;
`CommitMessageEditorViewTests/pairedSubjectAndBodyWrapSelectedText()` also
fails independently.