### PR TITLE
fix(gg): Show GG amend failures in Changes

### DIFF
--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -53,6 +53,13 @@ struct ChangesPreparationCard: View {
                         ggDestinationButton(action)
                     }
                 }
+                if let error = model.mutationError {
+                    Text(error)
+                        .font(.system(size: 11))
+                        .foregroundStyle(theme.color("warn"))
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("changes-preparation-gg-error")
+                }
             } else if model.draftAction != nil || !model.reviewRequestActions.isEmpty {
                 ViewThatFits(in: .horizontal) {
                     secondaryActionsHorizontal

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -56,12 +56,16 @@ struct ChangesPreparationModel: Equatable {
     let reviewRequestActions: [ReviewRequestAction]
     let reconciliationAction: GGStackReadinessModel.Action?
     let ggActions: [GGAction]
+    let mutationError: String?
 
     var primaryAction: ReviewAction? { reviewAction }
 
     var isVisible: Bool {
         if !ggActions.isEmpty {
-            return reconciliationAction != nil || reviewAction != nil || ggAction(.newStackCommit)?.isEnabled == true
+            return mutationError != nil
+                || reconciliationAction != nil
+                || reviewAction != nil
+                || ggAction(.newStackCommit)?.isEnabled == true
         }
         return reviewAction != nil || draftAction != nil || !reviewRequestActions.isEmpty
     }
@@ -104,6 +108,7 @@ struct ChangesPreparationModel: Equatable {
         draftAction = builtDraftAction
         reconciliationAction = nil
         ggActions = []
+        mutationError = nil
         let builtActions = Self.compactReviewRequestActions(from: readinessActions)
         let effectiveAheadCommitCount = local?.aheadCommitCount ?? aheadCommitCount
         reviewRequestActions = Self.applyingHideRules(
@@ -122,6 +127,7 @@ struct ChangesPreparationModel: Equatable {
         hasLoadedCommit: Bool = true,
         mutationDisabledReason: String? = nil,
         newCommitDisabledReason: String? = nil,
+        mutationError: String? = nil,
         reconciliationAction: GGStackReadinessModel.Action? = nil
     ) -> ChangesPreparationModel {
         let summary = ReviewChangesTriggerSummary.summary(for: changes)
@@ -138,6 +144,7 @@ struct ChangesPreparationModel: Equatable {
             hasLoadedCommit: hasLoadedCommit,
             mutationDisabledReason: mutationDisabledReason,
             newCommitDisabledReason: newCommitDisabledReason,
+            mutationError: mutationError,
             reconciliationAction: reconciliationAction,
             reviewSummary: summary
         )
@@ -150,6 +157,7 @@ struct ChangesPreparationModel: Equatable {
         hasLoadedCommit: Bool = true,
         mutationDisabledReason: String? = nil,
         newCommitDisabledReason: String? = nil,
+        mutationError: String? = nil,
         reconciliationAction: GGStackReadinessModel.Action? = nil
     ) -> ChangesPreparationModel {
         let summary = staged.hasChanges
@@ -166,6 +174,7 @@ struct ChangesPreparationModel: Equatable {
             hasLoadedCommit: hasLoadedCommit,
             mutationDisabledReason: mutationDisabledReason,
             newCommitDisabledReason: newCommitDisabledReason,
+            mutationError: mutationError,
             reconciliationAction: reconciliationAction,
             reviewSummary: summary
         )
@@ -182,6 +191,7 @@ struct ChangesPreparationModel: Equatable {
         hasLoadedCommit: Bool,
         mutationDisabledReason: String?,
         newCommitDisabledReason: String?,
+        mutationError: String?,
         reconciliationAction: GGStackReadinessModel.Action?,
         reviewSummary: ReviewChangesTriggerSummary?
     ) -> ChangesPreparationModel {
@@ -207,6 +217,7 @@ struct ChangesPreparationModel: Equatable {
         return ChangesPreparationModel(
             reviewAction: reviewAction,
             reconciliationAction: reconciliationAction,
+            mutationError: mutationError,
             ggActions: [
                 GGAction(
                     kind: .newStackCommit,
@@ -236,12 +247,14 @@ struct ChangesPreparationModel: Equatable {
     private init(
         reviewAction: ReviewAction?,
         reconciliationAction: GGStackReadinessModel.Action?,
+        mutationError: String?,
         ggActions: [GGAction]
     ) {
         self.reviewAction = reviewAction
         draftAction = nil
         reviewRequestActions = []
         self.reconciliationAction = reconciliationAction
+        self.mutationError = mutationError
         self.ggActions = ggActions
     }
 

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -35,6 +35,7 @@ struct ChangesTabView: View {
                     stack: rps.ggStack,
                     currentHeadSHA: rps.currentHeadSHA
                 ),
+                mutationError: rps.ggActionState.lastError,
                 reconciliationAction: Self.reconciliationAction(from: ggReadinessModel)
             )
         }

--- a/AlasTests/Right/ChangesPreparationModelTests.swift
+++ b/AlasTests/Right/ChangesPreparationModelTests.swift
@@ -103,6 +103,18 @@ struct ChangesPreparationModelTests {
         #expect(model.ggAction(.absorbIntoStack)?.stats == .init(files: 2, insertions: 8, deletions: 3))
     }
 
+    @Test func ggPreparationCarriesMutationError() {
+        let model = ChangesPreparationModel.makeGG(
+            staged: .zero,
+            hasDraft: false,
+            capabilities: stagedOnlyCapabilities,
+            mutationError: "Unstaged changes detected."
+        )
+
+        #expect(model.mutationError == "Unstaged changes detected.")
+        #expect(model.isVisible)
+    }
+
     @Test func emptyGGPreparationIsHiddenButKeepsStableDestinations() {
         let model = ChangesPreparationModel.makeGG(
             staged: .zero,


### PR DESCRIPTION
## Summary

Makes GG safety failures visible in the Changes tab, so a failed staged amend no longer looks like it silently did nothing.

## Changes

- Pass the existing GG mutation error into the preparation model.
- Show it below the GG actions and keep that card visible.
- Add regression coverage for the error state.

## Testing

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination "platform=macOS" -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination "platform=macOS" -quiet test -only-testing:AlasTests/ChangesPreparationModelTests`

## Notes for reviewers

A full suite run exposed unrelated existing failures and then hung during Xcode test cleanup.