### PR TITLE
feat(diff): Enable selectable diff text

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -677,7 +677,6 @@ final class DiffPaneTextScrollView: NSScrollView {
     }
     var allowsReviewLineSelection: Bool = true {
         didSet {
-            textView.allowsReviewLineSelection = allowsReviewLineSelection
             (verticalRulerView as? DiffPaneLineNumberRulerView)?.allowsReviewLineSelection = allowsReviewLineSelection
         }
     }
@@ -739,7 +738,6 @@ final class DiffPaneTextScrollView: NSScrollView {
             self?.onReviewLineSelected(anchor)
         }
         verticalRulerView = ruler
-        textView.allowsReviewLineSelection = allowsReviewLineSelection
         textView.onReviewLineSelected = onReviewLineSelected
 
         textView.isEditable = false
@@ -1286,7 +1284,6 @@ final class DiffPaneCodeTextView: NSTextView {
     var flagsChangedHandler: ((NSEvent) -> Void)?
     var mouseExitedHandler: (() -> Void)?
     var contextExpansionHandler: DiffContextExpansionHandler = { _, _, _ in }
-    var allowsReviewLineSelection = true
     var onReviewLineSelected: (DiffReviewLineAnchor) -> Void = { _ in }
     var lspContext: DiffPaneLSPContext?
     var allowedLSPSide: DiffLineSide = .new
@@ -1383,6 +1380,7 @@ final class DiffPaneCodeTextView: NSTextView {
             NSCursor.pointingHand.set()
             didSetPointerCursor = true
         } else {
+            NSCursor.iBeam.set()
             didSetPointerCursor = false
         }
     }
@@ -1397,13 +1395,6 @@ final class DiffPaneCodeTextView: NSTextView {
         }
         if event.modifierFlags.contains(.command), let commandClickHandler {
             commandClickHandler(point)
-            return
-        }
-        if allowsReviewLineSelection,
-           event.clickCount == 1,
-           let anchor = reviewLineAnchor(at: point)
-        {
-            onReviewLineSelected(anchor)
             return
         }
         super.mouseDown(with: event)
@@ -1442,7 +1433,7 @@ final class DiffPaneCodeTextView: NSTextView {
         super.mouseExited(with: event)
         hoverExpansionTarget = nil
         // Restore the default cursor when leaving the view, otherwise a pointing
-        // hand set over an expandable/source row can linger over the surrounding
+        // hand set over an expandable row can linger over the surrounding
         // non-interactive chrome until the next cursor update.
         if didSetPointerCursor {
             NSCursor.arrow.set()
@@ -1722,7 +1713,7 @@ final class DiffPaneCodeTextView: NSTextView {
         // A selectable NSTextView asserts its I-beam through `cursorUpdate(with:)`
         // on its own cursor-update tracking areas, which overrides the legacy
         // `addCursorRect`/`resetCursorRects` mechanism. Override it here so
-        // expandable-context and reviewable source rows show the pointer instead.
+        // expandable-context controls show the pointer instead.
         let point = convert(event.locationInWindow, from: nil)
         if shouldUsePointingHandCursor(at: point) {
             NSCursor.pointingHand.set()
@@ -1734,17 +1725,7 @@ final class DiffPaneCodeTextView: NSTextView {
     }
 
     private func shouldUsePointingHandCursor(at point: NSPoint) -> Bool {
-        if expansionTarget(at: point) != nil {
-            return true
-        }
-        guard let row = reviewLineRow(at: point) else { return false }
-        return rowShouldUsePointingHandCursor(row)
-    }
-
-    private func rowShouldUsePointingHandCursor(_ row: Int) -> Bool {
-        guard lineMetadata.indices.contains(row) else { return false }
-        let metadata = lineMetadata[row]
-        return metadata.sourceLine != nil
+        expansionTarget(at: point) != nil
     }
 
     func invokeExpansionForTesting(row: Int, optionKey: Bool) {

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
@@ -32,6 +32,7 @@ final class AppKitDiffReviewFileState: ObservableObject {
     @Published var pendingDraftAnchor: DiffReviewLineAnchor? { didSet { structuralDidChange.send() } }
     @Published var pendingDraftBody = ""
     @Published var draftComposerFocusRequestGeneration = 0 { didSet { structuralDidChange.send() } }
+    @Published var quoteInsertionGeneration = 0 { didSet { structuralDidChange.send() } }
     var expandedCollapsedRowIDs: Set<String> {
         get { hunkPresentationState.expandedCollapsedRowIDs }
         set { hunkPresentationState.setExpandedCollapsedRowIDs(newValue) }

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -161,12 +161,14 @@ struct AppKitDiffReviewRowInput {
     func beginPendingDraft(at anchor: DiffReviewLineAnchor) {
         state.pendingDraftAnchor = anchor
         state.pendingDraftBody = ""
+        state.quoteInsertionGeneration = 0
         state.draftComposerFocusRequestGeneration &+= 1
     }
 
     func clearPendingDraft() {
         state.pendingDraftAnchor = nil
         state.pendingDraftBody = ""
+        state.quoteInsertionGeneration = 0
         state.isDraftComposerFocused = false
     }
 
@@ -530,7 +532,9 @@ enum AppKitDiffReviewRowPlanBuilder {
                         &rows,
                         id: composerID,
                         input: input,
-                        signature: input.state.draftComposerFocusRequestGeneration,
+                        signature: String(
+                            "\(input.state.draftComposerFocusRequestGeneration):\(input.state.quoteInsertionGeneration)"
+                        ).hashValue,
                         height: 132,
                         retention: input.state.isDraftComposerFocused ? .pinned : .recyclable
                     ) {
@@ -1454,6 +1458,10 @@ struct AppKitDiffReviewComposerRowBody: View {
                     theme: input.theme,
                     isFocused: $isFocused,
                     focusRequestGeneration: input.state.draftComposerFocusRequestGeneration,
+                    quoteMarkdown: input.state.pendingDraftAnchor.map {
+                        ReviewDraftQuote.markdown(path: $0.path, selectedText: $0.selectedText)
+                    },
+                    quoteInsertionGeneration: input.state.quoteInsertionGeneration,
                     onSave: input.savePendingDraft,
                     onCancel: input.clearPendingDraft
                 )
@@ -1471,6 +1479,13 @@ struct AppKitDiffReviewComposerRowBody: View {
                         .stroke(input.theme.color("accent").opacity(0.65), lineWidth: 0.75))
                     .accessibilityIdentifier("diff-review-draft-composer")
                 HStack {
+                    Button("Quote lines") { input.state.quoteInsertionGeneration &+= 1 }
+                        .buttonStyle(.plain).font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(input.theme.color("fg-muted"))
+                        .padding(.horizontal, 8).frame(height: 24)
+                        .background(input.theme.color("bg-3"))
+                        .clipShape(RoundedRectangle(cornerRadius: 5))
+                        .accessibilityIdentifier("diff-review-draft-composer-quote")
                     Spacer()
                     Button("Cancel", action: input.clearPendingDraft)
                         .buttonStyle(.plain).font(.system(size: 10, weight: .semibold))

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -27,6 +27,7 @@ struct DiffReviewFilePresentationSignature: Equatable {
     let pendingDraftAnchor: DiffReviewLineAnchor?
     let pendingDraftBody: String
     let draftComposerFocusRequestGeneration: Int
+    let quoteInsertionGeneration: Int
     let expandedCollapsedRowIDs: Set<String>
     let contextSnapshot: DiffReviewFileContextSnapshot?
     let contextExpansion: DiffContextExpansionState
@@ -45,6 +46,7 @@ struct DiffReviewFilePresentationSignature: Equatable {
         pendingDraftAnchor = state.pendingDraftAnchor
         pendingDraftBody = state.pendingDraftBody
         draftComposerFocusRequestGeneration = state.draftComposerFocusRequestGeneration
+        quoteInsertionGeneration = state.quoteInsertionGeneration
         expandedCollapsedRowIDs = state.expandedCollapsedRowIDs
         contextSnapshot = state.contextSnapshot
         contextExpansion = state.contextExpansion
@@ -1063,11 +1065,41 @@ enum ReviewDraftComposerKeyboardAction: Equatable {
     }
 }
 
+enum ReviewDraftQuote {
+    static func markdown(path: String, selectedText: String) -> String {
+        let code = selectedText.trimmingCharacters(in: .newlines)
+        var longestBacktickRun = 0
+        var currentBacktickRun = 0
+        for character in code {
+            if character == "`" {
+                currentBacktickRun += 1
+                longestBacktickRun = max(longestBacktickRun, currentBacktickRun)
+            } else {
+                currentBacktickRun = 0
+            }
+        }
+        let fence = String(repeating: "`", count: max(3, longestBacktickRun + 1))
+        let language = LanguageRegistry.highlighterExtension(forPath: path)
+        return "\(fence)\(language)\n\(code)\n\(fence)"
+    }
+
+    static func insertion(markdown: String, in text: String, replacing range: NSRange) -> String {
+        let text = text as NSString
+        let before = text.substring(to: range.location)
+        let after = text.substring(from: NSMaxRange(range))
+        let prefix = before.isEmpty || before.hasSuffix("\n") ? "" : "\n\n"
+        let suffix = after.isEmpty || after.hasPrefix("\n") ? "" : "\n\n"
+        return prefix + markdown + suffix
+    }
+}
+
 struct ReviewDraftComposerTextEditor: NSViewRepresentable {
     @Binding var text: String
     let theme: Theme
     let isFocused: FocusState<Bool>.Binding
     let focusRequestGeneration: Int
+    let quoteMarkdown: String?
+    let quoteInsertionGeneration: Int
     let onSave: () -> Void
     let onCancel: () -> Void
 
@@ -1076,6 +1108,8 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         theme: Theme,
         isFocused: FocusState<Bool>.Binding,
         focusRequestGeneration: Int = 0,
+        quoteMarkdown: String? = nil,
+        quoteInsertionGeneration: Int = 0,
         onSave: @escaping () -> Void,
         onCancel: @escaping () -> Void
     ) {
@@ -1083,6 +1117,8 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         self.theme = theme
         self.isFocused = isFocused
         self.focusRequestGeneration = focusRequestGeneration
+        self.quoteMarkdown = quoteMarkdown
+        self.quoteInsertionGeneration = quoteInsertionGeneration
         self.onSave = onSave
         self.onCancel = onCancel
     }
@@ -1143,11 +1179,13 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
             coordinator?.requestFocusIfNeeded()
         }
         applyTheme(to: scrollView, textView: textView)
+        context.coordinator.requestQuoteInsertionIfNeeded()
         context.coordinator.requestFocusIfNeeded()
     }
 
     static func dismantleNSView(_ scrollView: NSScrollView, coordinator: Coordinator) {
         coordinator.cancelScheduledFocusRequest()
+        coordinator.cancelScheduledQuoteInsertion()
         guard let textView = scrollView.documentView as? ReviewDraftComposerNSTextView else { return }
         textView.onKeyboardAction = nil
         textView.onWindowChanged = nil
@@ -1169,6 +1207,8 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         var parent: ReviewDraftComposerTextEditor
         weak var textView: NSTextView?
         private var latestFulfilledFocusRequestGeneration = 0
+        private var latestQuoteInsertionGeneration = 0
+        private var scheduledQuoteInsertionTask: Task<Void, Never>?
 
         func undoManager(for view: NSTextView) -> UndoManager? { editorUndoManager }
         private var scheduledFocusRequestGeneration: Int?
@@ -1180,6 +1220,7 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
 
         deinit {
             scheduledFocusTask?.cancel()
+            scheduledQuoteInsertionTask?.cancel()
         }
 
         func textDidChange(_ notification: Notification) {
@@ -1193,6 +1234,37 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
 
         func textDidEndEditing(_ notification: Notification) {
             parent.isFocused.wrappedValue = false
+        }
+
+        func requestQuoteInsertionIfNeeded() {
+            let generation = parent.quoteInsertionGeneration
+            if generation == 0 {
+                latestQuoteInsertionGeneration = 0
+                scheduledQuoteInsertionTask?.cancel()
+                return
+            }
+            guard generation != latestQuoteInsertionGeneration else { return }
+            latestQuoteInsertionGeneration = generation
+            scheduledQuoteInsertionTask?.cancel()
+            scheduledQuoteInsertionTask = Task { @MainActor [weak self] in
+                await Task.yield()
+                guard !Task.isCancelled,
+                      let self,
+                      self.parent.quoteInsertionGeneration == generation,
+                      let markdown = self.parent.quoteMarkdown,
+                      let textView = self.textView as? PairedDelimiterTextView
+                else { return }
+                let range = textView.selectedRange()
+                let insertion = ReviewDraftQuote.insertion(markdown: markdown, in: textView.string, replacing: range)
+                textView.performNativeTextInsertion {
+                    textView.insertText(insertion, replacementRange: range)
+                }
+            }
+        }
+
+        func cancelScheduledQuoteInsertion() {
+            scheduledQuoteInsertionTask?.cancel()
+            scheduledQuoteInsertionTask = nil
         }
 
         func requestFocusIfNeeded() {

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -47,6 +47,7 @@ struct DiffTabView: View {
     @State private var pendingDraftAnchor: DiffReviewLineAnchor?
     @State private var pendingDraftBody = ""
     @State private var draftComposerFocusRequestGeneration = 0
+    @State private var quoteInsertionGeneration = 0
     @State private var reviewExpandedCollapsedRowIDs: Set<String> = []
     @State private var wrapLines = false
     @State private var showWhitespace = false
@@ -546,12 +547,14 @@ struct DiffTabView: View {
     private func clearPendingDraft() {
         pendingDraftAnchor = nil
         pendingDraftBody = ""
+        quoteInsertionGeneration = 0
         draftComposerFocused = false
     }
 
     private func beginPendingDraft(at anchor: DiffReviewLineAnchor) {
         pendingDraftAnchor = anchor
         pendingDraftBody = ""
+        quoteInsertionGeneration = 0
         draftComposerFocusRequestGeneration &+= 1
     }
 
@@ -869,6 +872,10 @@ struct DiffTabView: View {
                 theme: theme,
                 isFocused: $draftComposerFocused,
                 focusRequestGeneration: draftComposerFocusRequestGeneration,
+                quoteMarkdown: pendingDraftAnchor.map {
+                    ReviewDraftQuote.markdown(path: $0.path, selectedText: $0.selectedText)
+                },
+                quoteInsertionGeneration: quoteInsertionGeneration,
                 onSave: savePendingDraft,
                 onCancel: clearPendingDraft
             )
@@ -878,6 +885,15 @@ struct DiffTabView: View {
             .overlay(RoundedRectangle(cornerRadius: 6).stroke(theme.color("line"), lineWidth: 0.5))
             .accessibilityIdentifier("diff-review-draft-composer")
             HStack(spacing: 6) {
+                Button("Quote lines") { quoteInsertionGeneration &+= 1 }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(theme.color("fg-muted"))
+                    .padding(.horizontal, 8)
+                    .frame(height: 24)
+                    .background(theme.color("bg-3"))
+                    .clipShape(RoundedRectangle(cornerRadius: 5))
+                    .accessibilityIdentifier("diff-review-draft-composer-quote")
                 Spacer(minLength: 0)
                 Button("Cancel") { clearPendingDraft() }
                     .buttonStyle(.plain)

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -3411,7 +3411,7 @@ let second = true
         #expect(selectedAnchor == anchor)
     }
 
-    @Test @MainActor func codeTextViewInvokesReviewSelectionForContextRows() throws {
+    @Test @MainActor func codeTextViewLeavesReviewSelectionToTheGutter() throws {
         let theme = theme()
         let font = CenterTypography.resolveCodeFont(family: "", size: 13)
         let text = "let value = 1"
@@ -3475,13 +3475,22 @@ let second = true
             clickCount: 1,
             pressure: 1
         ))
+        let upEvent = try #require(NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+        NSApp.postEvent(upEvent, atStart: false)
 
         textView.mouseDown(with: event)
 
-        #expect(selectedAnchor?.path == "Sources/App.swift")
-        #expect(selectedAnchor?.side == .new)
-        #expect(selectedAnchor?.line == 12)
-        #expect(selectedAnchor?.selectedText == text)
+        #expect(selectedAnchor == nil)
     }
 
     @Test func splitDocumentBuildsSeparateCodeAndGutterColumns() throws {
@@ -4824,7 +4833,7 @@ let second = true
         #expect(NSCursor.current == NSCursor.pointingHand)
     }
 
-    @Test func diffPaneCodeTextViewShowsPointingHandOverSourceCodeRow() throws {
+    @Test func diffPaneCodeTextViewShowsIBeamOverSelectableSourceCode() throws {
         let sourceLine = DiffDisplayLine(
             id: "a.swift:new:0:0",
             anchor: DiffLineAnchor(filePath: "a.swift", hunkIndex: 0, rowIndex: 0, side: .new, oldLine: nil, newLine: 1),
@@ -4852,7 +4861,7 @@ let second = true
         NSCursor.arrow.set()
         textView.mouseMoved(with: event)
 
-        #expect(NSCursor.current == NSCursor.pointingHand)
+        #expect(NSCursor.current == NSCursor.iBeam)
     }
 
     @Test func diffPaneCodeTextViewDoesNotShowPointingHandOverNonInteractiveRow() throws {

--- a/AlasTests/PairedReviewComposerSurfaceTests.swift
+++ b/AlasTests/PairedReviewComposerSurfaceTests.swift
@@ -6,6 +6,37 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct PairedReviewComposerSurfaceTests {
+    @Test func reviewDraftQuoteUsesTheFileLanguageAndAConflictFreeFence() {
+        #expect(ReviewDraftQuote.markdown(path: "Sources/App.swift", selectedText: "let value = 1") == """
+        ```swift
+        let value = 1
+        ```
+        """)
+        #expect(ReviewDraftQuote.markdown(path: "README", selectedText: "contains ``` here") == """
+        ````
+        contains ``` here
+        ````
+        """)
+    }
+
+    @Test func reviewDraftComposerInsertsRequestedQuoteAtTheSelection() async throws {
+        let quote = ReviewDraftQuote.markdown(path: "Sources/App.swift", selectedText: "let value = 1")
+        let model = ReviewDraftComposerCapture(text: "beforeafter", quoteMarkdown: quote)
+        let controller = NSHostingController(
+            rootView: ReviewDraftComposerCaptureHarness(model: model, theme: try! ThemeStore().current)
+        )
+        let window = attach(controller)
+        await drain(controller.view)
+
+        let composer = try #require(textView(containing: model.text, in: controller.view))
+        composer.setSelectedRange(NSRange(location: 6, length: 0))
+        model.quoteInsertionGeneration += 1
+        await drain(controller.view)
+
+        #expect(model.text == "before\n\n\(quote)\n\nafter")
+        window.orderOut(nil)
+    }
+
     @Test func reviewDraftComposerWrapsSelectionAndRoutesKeyboardActions() async throws {
         let model = ReviewDraftComposerCapture(text: "review body")
         let controller = NSHostingController(
@@ -212,11 +243,14 @@ struct PairedReviewComposerSurfaceTests {
 @MainActor
 private final class ReviewDraftComposerCapture: ObservableObject {
     @Published var text: String
+    @Published var quoteInsertionGeneration = 0
+    let quoteMarkdown: String?
     var saveCount = 0
     var cancelCount = 0
 
-    init(text: String) {
+    init(text: String, quoteMarkdown: String? = nil) {
         self.text = text
+        self.quoteMarkdown = quoteMarkdown
     }
 }
 
@@ -231,6 +265,8 @@ private struct ReviewDraftComposerCaptureHarness: View {
             text: $model.text,
             theme: theme,
             isFocused: $isFocused,
+            quoteMarkdown: model.quoteMarkdown,
+            quoteInsertionGeneration: model.quoteInsertionGeneration,
             onSave: { model.saveCount += 1 },
             onCancel: { model.cancelCount += 1 }
         )


### PR DESCRIPTION
## Summary

- allow native drag selection and copying in diff code panes while retaining LSP hover and command-click navigation
- keep review line anchoring in the gutter
- add a Quote lines composer action that inserts language-tagged fenced code at the caret
- cover selection routing, cursor behavior, safe fences, and quote insertion

## Verification

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet -only-testing:AlasTests/DiffPaneViewTests test`\n- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet -only-testing:AlasTests/PairedReviewComposerSurfaceTests test`