### PR TITLE
fix(changes): stale changes after GG mutations

### DIFF
--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -516,8 +516,8 @@ final class GGMutationCoordinator {
             return
         }
 
-        await context.refreshStack()
         await context.refreshGitChanges()
+        await context.refreshStack()
         if request.touchesRemote {
             await context.refreshProviderReviews()
         }

--- a/AlasTests/Integrations/GGMutationCoordinatorTests.swift
+++ b/AlasTests/Integrations/GGMutationCoordinatorTests.swift
@@ -629,7 +629,7 @@ struct GGMutationCoordinatorTests {
 
         try await harness.coordinator.apply(.sync, confirmedAgainst: nil)
 
-        #expect(harness.refreshes == [.stack, .gitChanges, .providerReviews, .inbox])
+        #expect(harness.refreshes == [.gitChanges, .stack, .providerReviews, .inbox])
         #expect(harness.actionState.lastActionSummary == "Synced")
         #expect(harness.actionState.syncProgress.isEmpty)
     }
@@ -755,8 +755,22 @@ struct GGMutationCoordinatorTests {
             try await harness.coordinator.apply(.drop(target: "change-2"), confirmedAgainst: nil)
         }
 
-        #expect(harness.refreshes == [.stack, .gitChanges, .inbox])
+        #expect(harness.refreshes == [.gitChanges, .stack, .inbox])
         #expect(harness.actionState.lastError == "partially rewritten")
+    }
+
+    @Test func amendRefreshesGitChangesBeforeWaitingForStackRefresh() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        let refresh = FirstRefreshSuspension()
+        harness.onRefreshStack = { await refresh.suspend() }
+
+        let task = try #require(harness.coordinator.startApplying(.amendCurrent, confirmedAgainst: nil))
+        await refresh.waitUntilSuspended()
+
+        #expect(harness.refreshes == [.gitChanges, .stack])
+
+        await refresh.resume()
+        try await task.value
     }
 
     @Test func topologyRefreshRunsOnlyForCleanAndWorktreeCreatingUnstack() async throws {
@@ -787,14 +801,14 @@ struct GGMutationCoordinatorTests {
             .unstack(target: "change-2", name: "upper", createWorktree: true),
             confirmedAgainst: nil
         )
-        #expect(withWorktree.refreshes == [.stack, .gitChanges, .inbox, .topology])
+        #expect(withWorktree.refreshes == [.gitChanges, .stack, .inbox, .topology])
         #expect(withWorktree.selectedPaths == ["/repo/upper"])
     }
 
     @Test func checkoutDoesNotInvalidateProjectInbox() async throws {
         let harness = GGMutationHarness(stacks: [stack(head: "a")])
         try await harness.coordinator.apply(.checkout(target: "change-1"), confirmedAgainst: nil)
-        #expect(harness.refreshes == [.stack, .gitChanges])
+        #expect(harness.refreshes == [.gitChanges, .stack])
     }
 
     @Test func conflictFailurePreservesPausedAction() async {
@@ -1677,7 +1691,7 @@ struct GGMutationCoordinatorTests {
 
         try await harness.coordinator.apply(.land(target: "change-2"), confirmedAgainst: nil)
 
-        #expect(harness.refreshes == [.stack, .gitChanges, .providerReviews, .inbox])
+        #expect(harness.refreshes == [.gitChanges, .stack, .providerReviews, .inbox])
         #expect(harness.actionState.lastError == nil)
     }
 }


### PR DESCRIPTION
## Summary

Refresh Git changes before waiting for the GG stack after a mutation, so a successful amend immediately clears its staged rows instead of leaving the UI stale while GG reloads.

## Changes

- Refresh Git status before the GG stack for non-clean GG mutations.
- Add a regression test that holds the stack refresh and verifies the changes refresh occurs first.

## Where to start

- `Alas/Sources/Integrations/GG/GGMutationCoordinator.swift` — shared post-mutation refresh ordering.