### PR TITLE
feat(diff): Speed up stack entry picker

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -2263,6 +2263,17 @@ final class AppState {
         guard let worktree = worktree(withId: worktreeID) else { return }
         let currentGGID = followedStackEntryGGID(worktreeID: worktreeID, tabID: tabID)
         let displayedSHA = displayedCommitSHA(worktreeID: worktreeID, tabID: tabID)
+        if let rightPaneState = rightPaneStore.activeState(worktreeId: worktreeID),
+           rightPaneState.ggStackLoadState == .loaded,
+           rightPaneState.ggStackCommitsKey == rightPaneState.currentGGStackCommitsKey,
+           let stack = rightPaneState.ggStack {
+            pendingFollowStackEntry?.state = .loaded(GGFollowEntryModel.make(
+                entries: stack.entries,
+                currentGGID: currentGGID,
+                displayedSHA: displayedSHA
+            ))
+            return
+        }
         Task { @MainActor in
             let state: GGFollowEntryLoadState
             do {

--- a/Alas/Sources/Integrations/GG/GGFollowEntrySheet.swift
+++ b/Alas/Sources/Integrations/GG/GGFollowEntrySheet.swift
@@ -91,7 +91,7 @@ struct GGFollowEntrySheet: View {
                 .lineLimit(1)
             Spacer(minLength: 8)
             if let number = candidate.prNumber {
-                Text("#\(number)")
+                Text(verbatim: "#\(number)")
                     .font(.system(size: 10.5, design: .monospaced))
                     .foregroundStyle(theme.color("fg-dim"))
             }

--- a/AlasTests/AppStateFollowStackEntryTests.swift
+++ b/AlasTests/AppStateFollowStackEntryTests.swift
@@ -4,6 +4,16 @@ import Testing
 
 @MainActor
 struct AppStateFollowStackEntryTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        let projects: ProjectsFile
+
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+
+        func readIfExists<T: Decodable>(_ type: T.Type, from _: URL) throws -> T? {
+            type == ProjectsFile.self ? projects as? T : nil
+        }
+    }
+
     @Test func noPrefillRoutesToTheExpressionPrompt() {
         #expect(FollowRevisionPromptRoute.route(prefill: nil, stackEntrySupported: true)
             == .expressionPrompt(prefill: nil, isEditing: false))
@@ -77,5 +87,56 @@ struct AppStateFollowStackEntryTests {
 
         rightPaneState.ggContext = .inactive(reason: .policyOff)
         #expect(!state.ggFollowSupported(worktreeID: worktree.id))
+    }
+
+    @Test func pickerUsesTheLoadedChangesStackImmediately() throws {
+        let path = URL(fileURLWithPath: "/tmp/alas-follow-stack")
+        let project = ProjectConfig(
+            id: "project", name: "Alas", path: path.path, color: "blue", addedAt: .distantPast
+        )
+        let worktree = Worktree(
+            id: Worktree.makeId(path: path),
+            projectId: project.id,
+            name: "feature",
+            branch: "feature",
+            path: path,
+            status: .clean,
+            lastActivity: .distantPast
+        )
+        let state = AppState(store: MemoryStore(projects: .init(projects: [project])))
+        state.projectsManager.insertOptimisticWorktree(worktree)
+        let rightPaneState = state.rightPaneStore.state(
+            for: worktree,
+            baseBranch: "main",
+            comparisonMode: .manual
+        )
+        rightPaneState.currentBranch = worktree.branch
+        rightPaneState.ggContext = .active(stackName: "stack")
+        rightPaneState.ggStack = GGStack(
+            name: "stack",
+            base: "main",
+            totalCommits: 1,
+            syncedCommits: 0,
+            currentPosition: 1,
+            behindBase: 0,
+            entries: [GGStackEntry(
+                position: 1,
+                sha: "abc1234",
+                title: "Fast picker",
+                ggId: "c-abc1234"
+            )]
+        )
+        rightPaneState.ggStackLoadState = .loaded
+        rightPaneState.ggStackCommitsKey = rightPaneState.currentGGStackCommitsKey
+        let tab = state.tabs.appendCommit(worktreeId: worktree.id, sha: "abc1234", title: "Fast picker")
+
+        state.promptFollowStackEntry(worktreeID: worktree.id, tabID: tab.id)
+
+        let presentation = try #require(state.pendingFollowStackEntry)
+        guard case .loaded(let model) = presentation.state else {
+            Issue.record("Expected the picker to reuse the loaded Changes stack")
+            return
+        }
+        #expect(model.candidates.map(\.ggID) == ["c-abc1234"])
     }
 }


### PR DESCRIPTION
Summary

- Reuse the already-loaded Changes gg stack when opening the follow stack entry picker, so the sheet can populate immediately when the data is fresh.
- Render PR numbers with verbatim Text so SwiftUI does not format them.
- Add a focused AppState regression test for the fast path.

Testing

- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppStateFollowStackEntryTests -quiet
- Full local xcodebuild test hit existing RightPaneGGStackTests failures and then Xcode hung during test cleanup.