### PR TITLE
perf(diff): Speed up diff review rendering and selection persistence

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 		2735F19DF0AD717CA3CF3B23 /* WorktreeServiceCreatedAtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA2F208DBC024A64D0ED065 /* WorktreeServiceCreatedAtTests.swift */; };
 		279BAFE41DCB69286B64CFB9 /* AdapterUpdateState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F239EBD79AA346B7976B544 /* AdapterUpdateState.swift */; };
 		27F842092C9CA4D871B6127A /* DraftReviewRequestDiffSessionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615B4D8618F0BDEAEB216942 /* DraftReviewRequestDiffSessionBuilder.swift */; };
+		27F8B3029CA5F11982515486 /* DiffReviewRenderContextCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC9FF2675A6904A01CAEE52 /* DiffReviewRenderContextCacheTests.swift */; };
 		281C65FD7F2B509B963B74ED /* AlasHookCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */; };
 		2843F603A4D71AEEA4C09317 /* CloseTabConfirmationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78D0715973BD840FDE95AA2 /* CloseTabConfirmationPolicy.swift */; };
 		285BEFDF742866D620398EB3 /* StartupRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB18B529D24C1BAE68B443B /* StartupRecoveryTests.swift */; };
@@ -1282,6 +1283,7 @@
 		D2D5D79EE8DE82FC44C2D36A /* CompletionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D510DACCD80A328B2DFABDC0 /* CompletionFeature.swift */; };
 		D36A33178D064DBD5DFD9B6D /* PairedAuthoredContentSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBB557833D3939208D75FB7 /* PairedAuthoredContentSurfaceTests.swift */; };
 		D397C3E94E3F00F012CBE5AE /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27595490B7D883CF5D9FFD5 /* Tab.swift */; };
+		D3A67696B13E8F9E31B10DC0 /* DiffReviewRailThreadCountsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E933EFC52B5E3D12133B1306 /* DiffReviewRailThreadCountsTests.swift */; };
 		D3C333539943019DB3439AE6 /* DiffReviewRenderBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34971259AB0FE69892952670 /* DiffReviewRenderBudget.swift */; };
 		D3EAFAA986CE4441B7F103F9 /* HookCommandShellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */; };
 		D45D14487117192F9E5D7F0E /* ACPSessionHydratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */; };
@@ -2312,6 +2314,7 @@
 		7B22D5EBE7EDAC07C943C91D /* WebSocketFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketFrame.swift; sourceTree = "<group>"; };
 		7B75422E0FA09B32F72F311D /* AppKitChangesScrollerFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitChangesScrollerFlagTests.swift; sourceTree = "<group>"; };
 		7BA6DF8E37E9B38C627B030A /* ACPTranscriptRowHostingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptRowHostingView.swift; sourceTree = "<group>"; };
+		7BC9FF2675A6904A01CAEE52 /* DiffReviewRenderContextCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRenderContextCacheTests.swift; sourceTree = "<group>"; };
 		7BEC4E033DB3BA44C825D453 /* EmojiPickerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiPickerButton.swift; sourceTree = "<group>"; };
 		7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnvironment.swift; sourceTree = "<group>"; };
 		7C38FA009B7044E9DC5480A7 /* ACPSessionsButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionsButton.swift; sourceTree = "<group>"; };
@@ -2982,6 +2985,7 @@
 		E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeLanguageDetailViewTests.swift; sourceTree = "<group>"; };
 		E91EB168941D6B9502D30082 /* GGFollowEntryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGFollowEntryModel.swift; sourceTree = "<group>"; };
 		E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSectionTests.swift; sourceTree = "<group>"; };
+		E933EFC52B5E3D12133B1306 /* DiffReviewRailThreadCountsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewRailThreadCountsTests.swift; sourceTree = "<group>"; };
 		E940D4265B42839BBC7681DC /* AppStateCreateWorktreeSymlinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCreateWorktreeSymlinkTests.swift; sourceTree = "<group>"; };
 		E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionPickerTests.swift; sourceTree = "<group>"; };
 		E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabStateMarkdownCodableTests.swift; sourceTree = "<group>"; };
@@ -3453,8 +3457,10 @@
 				86D12B948CADE546FFD3A54C /* DiffReviewImageStateTests.swift */,
 				1A3BB27D40FCCB5D76C622DA /* DiffReviewInlineFeedbackMarkdownTests.swift */,
 				A172B476A5BF7E4016431E6A /* DiffReviewModelsTests.swift */,
+				E933EFC52B5E3D12133B1306 /* DiffReviewRailThreadCountsTests.swift */,
 				D153832D43BF352B94E34430 /* DiffReviewRenderableContentEqualityTests.swift */,
 				AEE54F0320B9F40BEF46FB85 /* DiffReviewRenderBudgetTests.swift */,
+				7BC9FF2675A6904A01CAEE52 /* DiffReviewRenderContextCacheTests.swift */,
 				A723CF5BB46FABA23D8C9543 /* DiffReviewRenderEligibilityTests.swift */,
 				F649B493D42787FEA6D8E67B /* DiffReviewScrollSpyTests.swift */,
 				E0F10B6B1311831E53DA45C0 /* DiffReviewStagedMutationActionsTests.swift */,
@@ -7102,7 +7108,9 @@
 				239B5F18337203930900D06B /* DiffReviewImageStateTests.swift in Sources */,
 				559D6091E849B5D61F4FA8D0 /* DiffReviewInlineFeedbackMarkdownTests.swift in Sources */,
 				59AF95D3DFDFE7736051EF4A /* DiffReviewModelsTests.swift in Sources */,
+				D3A67696B13E8F9E31B10DC0 /* DiffReviewRailThreadCountsTests.swift in Sources */,
 				DE33366A35436471AE0DAE96 /* DiffReviewRenderBudgetTests.swift in Sources */,
+				27F8B3029CA5F11982515486 /* DiffReviewRenderContextCacheTests.swift in Sources */,
 				BF887495CBAAA98792FBF74D /* DiffReviewRenderEligibilityTests.swift in Sources */,
 				0E680F7AAD6CBD2A4A829A52 /* DiffReviewRenderableContentEqualityTests.swift in Sources */,
 				14D70126BAF735B2A66A23C5 /* DiffReviewScrollSpyTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -263,6 +263,7 @@
 		2B4CBD06D1568EBC1BD327E0 /* SemanticVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF2EE8A6AAA7F9B45DACC0C /* SemanticVersionTests.swift */; };
 		2B823A7361BB54D8D93D7C99 /* ACPMentionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */; };
 		2B85898841D3090D3C7E3169 /* RunScriptMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93ED8BA7A9EE46B37ED48EC /* RunScriptMetadataTests.swift */; };
+		2C35CA31DD223EC68FF917E9 /* DiffPaneDocumentCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B42075B231828DA553EA92 /* DiffPaneDocumentCache.swift */; };
 		2C4EDD06B2D26DCBB18DC2D1 /* SettingsBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A190D4B29B35C457AA9829F /* SettingsBinding.swift */; };
 		2C520D1FB289610CEB70BDB6 /* GitServiceDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */; };
 		2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */; };
@@ -318,6 +319,7 @@
 		33376EB37508D556E2385D33 /* ACPSessionUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */; };
 		3388D5141427C0046BD8CCC7 /* LanguageRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */; };
 		33A0FC862C45CDFF47053A04 /* ACPComposerActionButtonMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7ADCB7C4178FE036A31214 /* ACPComposerActionButtonMetricsTests.swift */; };
+		33A617BC5DE8DAA9F67E239D /* DiffPaneDocumentCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98E7424CBFF07A59BCB703A /* DiffPaneDocumentCacheTests.swift */; };
 		342C28B197D5048F78D2E8D6 /* RemotePairingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F77AE52695B7B19A9F11B89 /* RemotePairingService.swift */; };
 		34F18AB368DC5D93196056CA /* ACPComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C496549308D5C3DD20E988AD /* ACPComposer.swift */; };
 		35024237A37355969D6FA76A /* MergeResultPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC787CE0F5625F8114C9F6F /* MergeResultPane.swift */; };
@@ -2549,6 +2551,7 @@
 		A53358B7D4D68BE2471187D4 /* ACPImageStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageStagingTests.swift; sourceTree = "<group>"; };
 		A5848B9AAD7985BF7BFB87F6 /* MergeConflictAnnotationStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictAnnotationStrip.swift; sourceTree = "<group>"; };
 		A5A981A28B0FED8C3D95B107 /* ACPTranscriptTilingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptTilingController.swift; sourceTree = "<group>"; };
+		A5B42075B231828DA553EA92 /* DiffPaneDocumentCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneDocumentCache.swift; sourceTree = "<group>"; };
 		A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUpdateTests.swift; sourceTree = "<group>"; };
 		A5E1462C85D0E49127BCED81 /* ACPImageThumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageThumbnail.swift; sourceTree = "<group>"; };
 		A5F05845D656B4B93B09AF5C /* GGSplitTabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGSplitTabsManagerTests.swift; sourceTree = "<group>"; };
@@ -2672,6 +2675,7 @@
 		B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceMergeTests.swift; sourceTree = "<group>"; };
 		B9830BAAE86AA0A20A77731D /* ProcessMemoryProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMemoryProbeTests.swift; sourceTree = "<group>"; };
 		B98658E85103DE518E9A5561 /* GGSplitCommitModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGSplitCommitModel.swift; sourceTree = "<group>"; };
+		B98E7424CBFF07A59BCB703A /* DiffPaneDocumentCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneDocumentCacheTests.swift; sourceTree = "<group>"; };
 		B9A252BAD78A56343D68E782 /* RemoteFileAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileAccessTests.swift; sourceTree = "<group>"; };
 		BA5820BB012E55F3A0C1272B /* RightPaneGGStackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneGGStackTests.swift; sourceTree = "<group>"; };
 		BA59378FB8733DBAC67592A3 /* RemotePairingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePairingServiceTests.swift; sourceTree = "<group>"; };
@@ -3440,6 +3444,7 @@
 				729DDA22CA94FA0DC8810057 /* DiffInlineCommentModelTests.swift */,
 				61D4F5B30CE2AA0220A3E45C /* DiffInlineHighlighterTests.swift */,
 				2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */,
+				B98E7424CBFF07A59BCB703A /* DiffPaneDocumentCacheTests.swift */,
 				AD920E9E496F1DC3BB894B8B /* DiffPaneLSPTests.swift */,
 				8501B285B416ECC49BCC22C3 /* DiffPaneTextDocumentBuilderTests.swift */,
 				E5A257562FAB9C5932A6BD69 /* DiffPaneViewTests.swift */,
@@ -4462,6 +4467,7 @@
 				7EFAD7C8BA328957C381C3B0 /* DiffHighlightPrewarmer.swift */,
 				22CF502ECFD2763E52CB022F /* DiffInlineCommentModel.swift */,
 				6561C6DA70F49EDBC69BA854 /* DiffInlineHighlighter.swift */,
+				A5B42075B231828DA553EA92 /* DiffPaneDocumentCache.swift */,
 				B58BD62080F250E0F0DD057F /* DiffPaneLSP.swift */,
 				52E5D3E9FAA7B6B251C3883D /* DiffPaneTextDocumentBuilder.swift */,
 				ACCA6B39E2B172FADFD9E0E6 /* DiffPaneTextDocumentView.swift */,
@@ -6288,6 +6294,7 @@
 				94B884D1DB09DB562A0DCC20 /* DiffInlineCommentModel.swift in Sources */,
 				6FDE6E6F5087E811451A6AD8 /* DiffInlineHighlighter.swift in Sources */,
 				5C9EB59AAA68656BD7190044 /* DiffOpenFileAvailability.swift in Sources */,
+				2C35CA31DD223EC68FF917E9 /* DiffPaneDocumentCache.swift in Sources */,
 				B94F61E5170AA8102AA2A022 /* DiffPaneLSP.swift in Sources */,
 				4E06212EA28C05F474BB4A8D /* DiffPaneRowPlan.swift in Sources */,
 				5C6F0DC6F76FC0B55F2F4051 /* DiffPaneTextDocumentBuilder.swift in Sources */,
@@ -7085,6 +7092,7 @@
 				172298A09BC94456A27EFCB7 /* DiffInlineHighlighterTests.swift in Sources */,
 				9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */,
 				3068E2E9A175FD2430C684D1 /* DiffPaneAppKitScrollerTests.swift in Sources */,
+				33A617BC5DE8DAA9F67E239D /* DiffPaneDocumentCacheTests.swift in Sources */,
 				F4796D2FCBA83BD5E71F4398 /* DiffPaneLSPTests.swift in Sources */,
 				45662ECAA60BB27895E0B0EB /* DiffPaneRowPlanTests.swift in Sources */,
 				FF77548C74703C8DDC9B480B /* DiffPaneTextDocumentBuilderTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		01CBEF6793755D3D9B000BC1 /* CodeLanguageDetailViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */; };
 		01D2A32A3366C5CF6A225004 /* GhosttyConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */; };
 		01F51F05BA5DD24D4FBC4B4B /* ShortcutActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00057A43DD2D53F8F79FAC43 /* ShortcutActionTests.swift */; };
+		022BF67765AB1906AF7BB156 /* ReviewSessionSelectionPersisterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772D5EBDD036102D88C9B8B3 /* ReviewSessionSelectionPersisterTests.swift */; };
 		0237F9775763E3C43D2D849A /* InstallNudgeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25CBAF6618B6D11EC3B9CC76 /* InstallNudgeResolver.swift */; };
 		02425EBF61592A01B1FCC7D0 /* DiffParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1703FC5CD7DF16F4450E274 /* DiffParser.swift */; };
 		026C8FB815E41D31C8E9421B /* AlasCLICommandRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */; };
@@ -330,6 +331,7 @@
 		370EA3E196540ACC6174D5CC /* GitLabCLIProviderVerdictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D95FBEE2C9BF1AD1A602C28 /* GitLabCLIProviderVerdictTests.swift */; };
 		3739AAA93F150060DDAADACA /* SSHCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8351793355009D8A73AA91A2 /* SSHCommand.swift */; };
 		376A08C73011C5CA9E445C4B /* ImageDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7D83CD76ABF9FED3B29F62 /* ImageDiffView.swift */; };
+		377280589802FA5CFA45B065 /* ReviewSessionSelectionPersister.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4556BB4983FEF2A4E4A12D /* ReviewSessionSelectionPersister.swift */; };
 		37DD3F3B818131973DAA2B9B /* ACPMessageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F79A184C86BE6C6BF72EB57 /* ACPMessageList.swift */; };
 		387EF12B6875648E422956F7 /* Highlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */; };
 		38A19A8CE98216F87C522952 /* DiffCodeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50700F7960B44D0116F09C8 /* DiffCodeText.swift */; };
@@ -2288,6 +2290,7 @@
 		76942B028C3CBAED16BC4CC1 /* ImageDiffPairResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairResolverTests.swift; sourceTree = "<group>"; };
 		76B767602C3F8E5909A44B7C /* CodeEditorLineNumberRulerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorLineNumberRulerView.swift; sourceTree = "<group>"; };
 		76F2498E56CBAF84CB67166C /* HarnessKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessKind.swift; sourceTree = "<group>"; };
+		772D5EBDD036102D88C9B8B3 /* ReviewSessionSelectionPersisterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionSelectionPersisterTests.swift; sourceTree = "<group>"; };
 		77D4715E250A33AA278F6270 /* AppStateCreateWorktreeCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCreateWorktreeCompletionTests.swift; sourceTree = "<group>"; };
 		781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionPicker.swift; sourceTree = "<group>"; };
 		7831AEE2807254F6BCC5B65B /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = .build/ghostty/GhosttyKit.xcframework; sourceTree = "<group>"; };
@@ -2584,6 +2587,7 @@
 		AB9D4FBF08CBAB59C08BBF1D /* ACPQuestionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionRequest.swift; sourceTree = "<group>"; };
 		ABC94CFEB59F22E028DA462F /* ACPTranscriptRowSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptRowSpec.swift; sourceTree = "<group>"; };
 		ABF9F7D29F77AE8524E06EFA /* GGStackGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackGate.swift; sourceTree = "<group>"; };
+		AC4556BB4983FEF2A4E4A12D /* ReviewSessionSelectionPersister.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionSelectionPersister.swift; sourceTree = "<group>"; };
 		ACAF0D9BAB4658B356FBBBAA /* RunScriptPaletteModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptPaletteModelTests.swift; sourceTree = "<group>"; };
 		ACCA6B39E2B172FADFD9E0E6 /* DiffPaneTextDocumentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneTextDocumentView.swift; sourceTree = "<group>"; };
 		ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEmptyState.swift; sourceTree = "<group>"; };
@@ -3603,6 +3607,7 @@
 				DC73B8AC6AC57FB3A3253F40 /* ReviewScopeSelectionTests.swift */,
 				ADC27B340A795F13EA4E0765 /* ReviewSessionLoaderTests.swift */,
 				AB8CA584A5F9F1BDE903E8D2 /* ReviewSessionModelsTests.swift */,
+				772D5EBDD036102D88C9B8B3 /* ReviewSessionSelectionPersisterTests.swift */,
 				F63C0C3F29FDD890239300E5 /* ReviewSessionStoreTests.swift */,
 				F4120556B9870D6246D0F30A /* ReviewSessionTabViewTests.swift */,
 				4C3C11FFC65FA56B722E2E7D /* ReviewSessionTargetTests.swift */,
@@ -5332,6 +5337,7 @@
 				E87C04CBE6911062CBE1134E /* ReviewHandoffProgress.swift */,
 				2C17465AF6747EDCD8CCE416 /* ReviewSessionLoader.swift */,
 				2F7E37886988A6F285BEA163 /* ReviewSessionModels.swift */,
+				AC4556BB4983FEF2A4E4A12D /* ReviewSessionSelectionPersister.swift */,
 				0704EBDA62931ADE79B04F30 /* ReviewSessionStore.swift */,
 				64C593F9F14DD962C9822C64 /* ReviewSessionTabView.swift */,
 			);
@@ -6649,6 +6655,7 @@
 				C6991F6E93C1EBCFCD5EE003 /* ReviewScopeSelection.swift in Sources */,
 				C10DDFA9216B53E3C9527F8C /* ReviewSessionLoader.swift in Sources */,
 				58B2E8C756F6D3CB08FB3B10 /* ReviewSessionModels.swift in Sources */,
+				377280589802FA5CFA45B065 /* ReviewSessionSelectionPersister.swift in Sources */,
 				5723C73E91B9143B73554042 /* ReviewSessionStore.swift in Sources */,
 				4FE322C88A2B06C317DDA9B5 /* ReviewSessionTabView.swift in Sources */,
 				999C8421F3610FF682CE9D0E /* ReviewTabView.swift in Sources */,
@@ -7369,6 +7376,7 @@
 				11D58647F9E3AB8677C09493 /* ReviewScopeSelectionTests.swift in Sources */,
 				E6B5EDEA2C41C783ECA67FD9 /* ReviewSessionLoaderTests.swift in Sources */,
 				60F31F7C4A8A69EDE77363FB /* ReviewSessionModelsTests.swift in Sources */,
+				022BF67765AB1906AF7BB156 /* ReviewSessionSelectionPersisterTests.swift in Sources */,
 				DECBF7BD8E09E75F70340CF3 /* ReviewSessionStoreTests.swift in Sources */,
 				5255F92036DF00CB48082526 /* ReviewSessionTabViewTests.swift in Sources */,
 				735B86E1E8F8F593049937BB /* ReviewSessionTargetTests.swift in Sources */,

--- a/Alas/Sources/Center/Diff/DiffHighlightPrewarmer.swift
+++ b/Alas/Sources/Center/Diff/DiffHighlightPrewarmer.swift
@@ -55,15 +55,20 @@ enum DiffHighlightPrewarmer {
         )
     }
 
-    /// Signature over everything that changes which sources get tokenized.
-    /// Font and theme are excluded on purpose: spans depend only on source
-    /// text and language.
+    /// Signature over everything that changes what gets prewarmed. Font and
+    /// theme are included even though tree-sitter spans don't depend on
+    /// them: `warm` also populates `DiffPaneDocumentCache`, whose key does
+    /// include them, so excluding them here would let a font or theme
+    /// change skip re-prewarming while row mounts still miss the document
+    /// cache and rebuild synchronously mid-scroll.
     static func signature(
         groups: [DiffDisplayGroup],
         expandedCollapsedRowIDs: Set<String>,
         layoutMode: DiffLayoutMode,
         fileExtension: String,
-        showWhitespace: Bool
+        font: NSFont,
+        showWhitespace: Bool,
+        theme: Theme
     ) -> Int {
         var hasher = Hasher()
         for group in groups {
@@ -72,7 +77,10 @@ enum DiffHighlightPrewarmer {
         hasher.combine(expandedCollapsedRowIDs)
         hasher.combine(layoutMode)
         hasher.combine(fileExtension)
+        hasher.combine(font.fontName)
+        hasher.combine(font.pointSize)
         hasher.combine(showWhitespace)
+        hasher.combine(theme)
         return hasher.finalize()
     }
 

--- a/Alas/Sources/Center/Diff/DiffHighlightPrewarmer.swift
+++ b/Alas/Sources/Center/Diff/DiffHighlightPrewarmer.swift
@@ -1,12 +1,14 @@
 import AppKit
 
-/// Warms `HighlightSpanCache` for a diff's hunks off the scroll path.
+/// Warms `DiffPaneDocumentCache` (and, transitively, `HighlightSpanCache`)
+/// for a diff's hunks off the scroll path.
 ///
-/// Mounting a virtualized diff row tokenizes its hunk synchronously inside
-/// the scroll tick; a cold 80-line hunk costs tens of milliseconds and reads
-/// as a fling hiccup. Prewarming performs the same document build on a
-/// background queue when the row plan is first created, so row mounts hit the
-/// span cache instead of parsing mid-fling.
+/// Mounting a virtualized diff row builds its hunk's attributed documents
+/// synchronously inside the scroll tick; a cold 80-line hunk costs tens of
+/// milliseconds and reads as a fling hiccup. Prewarming performs the same
+/// document build on a background queue when the row plan is first created
+/// and keeps the result in the shared document cache, so row mounts reuse
+/// the finished documents instead of rebuilding mid-fling.
 enum DiffHighlightPrewarmer {
     private static let queue = DispatchQueue(label: "io.nlopez.alas.diff-highlight-prewarm", qos: .utility)
 
@@ -84,20 +86,22 @@ enum DiffHighlightPrewarmer {
         theme: Theme
     ) {
         for group in groups {
+            let rows = DiffPaneRowProjection.visibleRows(
+                in: group,
+                expandedCollapsedRowIDs: expandedCollapsedRowIDs
+            )
             switch layoutMode {
             case .split:
-                _ = DiffPaneTextDocumentBuilder.buildSplit(
-                    group: group,
-                    expandedCollapsedRowIDs: expandedCollapsedRowIDs,
+                _ = DiffPaneDocumentCache.shared.splitResult(
+                    rows: rows,
                     fileExtension: fileExtension,
                     font: font,
                     showWhitespace: showWhitespace,
                     theme: theme
                 )
             case .stacked:
-                _ = DiffPaneTextDocumentBuilder.buildStacked(
-                    group: group,
-                    expandedCollapsedRowIDs: expandedCollapsedRowIDs,
+                _ = DiffPaneDocumentCache.shared.stackedResult(
+                    rows: rows,
                     fileExtension: fileExtension,
                     font: font,
                     showWhitespace: showWhitespace,

--- a/Alas/Sources/Center/Diff/DiffInlineCommentModel.swift
+++ b/Alas/Sources/Center/Diff/DiffInlineCommentModel.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct DiffInlineAnnotation: Identifiable, Equatable {
+struct DiffInlineAnnotation: Identifiable, Equatable, Hashable {
     let id: String
     let checkName: String
     let newLine: Int
@@ -22,7 +22,7 @@ extension DiffInlineAnnotation {
     }
 }
 
-struct DiffInlineCommentThread: Identifiable, Equatable {
+struct DiffInlineCommentThread: Identifiable, Equatable, Hashable {
     let id: String
     let filePath: String
     let newLine: Int
@@ -40,7 +40,7 @@ struct DiffInlineCommentThread: Identifiable, Equatable {
     }
 }
 
-struct DiffInlineComment: Identifiable, Equatable {
+struct DiffInlineComment: Identifiable, Equatable, Hashable {
     let id: String
     let author: String
     let body: String

--- a/Alas/Sources/Center/Diff/DiffPaneDocumentCache.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneDocumentCache.swift
@@ -1,0 +1,160 @@
+import AppKit
+
+/// Memoizes built diff text documents so row mounts don't rebuild them on the
+/// main thread inside the scroll tick.
+///
+/// The prewarmer already performs the full document build on a background
+/// queue; before this cache existed it threw the result away and only the
+/// tree-sitter span cache survived, so every mount still paid the whole
+/// attributed-string assembly (and every *re*mount paid it again, because the
+/// signature guard lives on the text view instance that recycling replaces).
+/// Keying on content + presentation inputs makes entries immutable, so there
+/// is no invalidation: stale entries age out via the size cap.
+///
+/// Thread safety: lock-guarded, populated from the background prewarm queue
+/// and read on the main actor. The cached values are immutable
+/// (`NSAttributedString` plus value-type metadata); text views copy the
+/// attributed string into their own storage on set, so sharing is safe.
+final class DiffPaneDocumentCache: @unchecked Sendable {
+    static let shared = DiffPaneDocumentCache()
+
+    private let lock = NSLock()
+    private var splitStorage: [Int: DiffPaneTextDocumentBuilder.SplitResult] = [:]
+    private var stackedStorage: [Int: DiffPaneTextDocumentBuilder.StackedResult] = [:]
+    private let entryLimit: Int
+
+    init(entryLimit: Int = 64) {
+        self.entryLimit = entryLimit
+    }
+
+    #if DEBUG
+    private var hits = 0
+    private var misses = 0
+
+    /// Document builds avoided (`hits`) versus performed (`misses`).
+    var statisticsForTests: (hits: Int, misses: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (hits, misses)
+    }
+
+    func resetStatisticsForTests() {
+        lock.lock()
+        defer { lock.unlock() }
+        hits = 0
+        misses = 0
+    }
+    #endif
+
+    func splitResult(
+        rows: [DiffDisplayRow],
+        rowsSignature: DiffDisplayRowsSignature? = nil,
+        fileExtension: String,
+        font: NSFont,
+        showWhitespace: Bool,
+        theme: Theme
+    ) -> DiffPaneTextDocumentBuilder.SplitResult {
+        let key = key(
+            rowsSignature: rowsSignature ?? DiffDisplayRowsSignature(rows),
+            fileExtension: fileExtension,
+            font: font,
+            showWhitespace: showWhitespace,
+            theme: theme
+        )
+        if let cached = cachedSplit(forKey: key) { return cached }
+        let result = DiffPaneTextDocumentBuilder.buildSplit(
+            rows: rows,
+            fileExtension: fileExtension,
+            font: font,
+            showWhitespace: showWhitespace,
+            theme: theme
+        )
+        store(result, forKey: key)
+        return result
+    }
+
+    func stackedResult(
+        rows: [DiffDisplayRow],
+        rowsSignature: DiffDisplayRowsSignature? = nil,
+        fileExtension: String,
+        font: NSFont,
+        showWhitespace: Bool,
+        theme: Theme
+    ) -> DiffPaneTextDocumentBuilder.StackedResult {
+        let key = key(
+            rowsSignature: rowsSignature ?? DiffDisplayRowsSignature(rows),
+            fileExtension: fileExtension,
+            font: font,
+            showWhitespace: showWhitespace,
+            theme: theme
+        )
+        if let cached = cachedStacked(forKey: key) { return cached }
+        let result = DiffPaneTextDocumentBuilder.buildStacked(
+            rows: rows,
+            fileExtension: fileExtension,
+            font: font,
+            showWhitespace: showWhitespace,
+            theme: theme
+        )
+        store(result, forKey: key)
+        return result
+    }
+
+    func removeAll() {
+        lock.lock()
+        defer { lock.unlock() }
+        splitStorage.removeAll(keepingCapacity: true)
+        stackedStorage.removeAll(keepingCapacity: true)
+    }
+
+    private func key(
+        rowsSignature: DiffDisplayRowsSignature,
+        fileExtension: String,
+        font: NSFont,
+        showWhitespace: Bool,
+        theme: Theme
+    ) -> Int {
+        var hasher = Hasher()
+        hasher.combine(rowsSignature)
+        hasher.combine(fileExtension)
+        hasher.combine(font.fontName)
+        hasher.combine(font.pointSize)
+        hasher.combine(showWhitespace)
+        hasher.combine(theme)
+        return hasher.finalize()
+    }
+
+    private func cachedSplit(forKey key: Int) -> DiffPaneTextDocumentBuilder.SplitResult? {
+        lock.lock()
+        defer { lock.unlock() }
+        let value = splitStorage[key]
+        #if DEBUG
+        if value == nil { misses += 1 } else { hits += 1 }
+        #endif
+        return value
+    }
+
+    private func cachedStacked(forKey key: Int) -> DiffPaneTextDocumentBuilder.StackedResult? {
+        lock.lock()
+        defer { lock.unlock() }
+        let value = stackedStorage[key]
+        #if DEBUG
+        if value == nil { misses += 1 } else { hits += 1 }
+        #endif
+        return value
+    }
+
+    private func store(_ result: DiffPaneTextDocumentBuilder.SplitResult, forKey key: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        if splitStorage.count >= entryLimit { splitStorage.removeAll(keepingCapacity: true) }
+        splitStorage[key] = result
+    }
+
+    private func store(_ result: DiffPaneTextDocumentBuilder.StackedResult, forKey key: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        if stackedStorage.count >= entryLimit { stackedStorage.removeAll(keepingCapacity: true) }
+        stackedStorage[key] = result
+    }
+}

--- a/Alas/Sources/Center/Diff/DiffPaneDocumentCache.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneDocumentCache.swift
@@ -19,9 +19,27 @@ final class DiffPaneDocumentCache: @unchecked Sendable {
     static let shared = DiffPaneDocumentCache()
 
     private let lock = NSLock()
-    private var splitStorage: [Int: DiffPaneTextDocumentBuilder.SplitResult] = [:]
-    private var stackedStorage: [Int: DiffPaneTextDocumentBuilder.StackedResult] = [:]
+    private var splitStorage: [Int: SplitEntry] = [:]
+    private var stackedStorage: [Int: StackedEntry] = [:]
     private let entryLimit: Int
+    /// Monotonic stamp bumped on every read and write, so recency is tracked
+    /// without comparing keys or reordering an array. A full review can
+    /// easily exceed `entryLimit` distinct hunks, and clearing the whole
+    /// storage on overflow would wipe every already-warmed document each
+    /// time a new one arrives — negating the prewarmer for exactly the
+    /// large reviews it matters most for. Evict only the single oldest
+    /// entry instead.
+    private var accessStamp: UInt64 = 0
+
+    private struct SplitEntry {
+        let result: DiffPaneTextDocumentBuilder.SplitResult
+        var lastAccess: UInt64
+    }
+
+    private struct StackedEntry {
+        let result: DiffPaneTextDocumentBuilder.StackedResult
+        var lastAccess: UInt64
+    }
 
     init(entryLimit: Int = 64) {
         self.entryLimit = entryLimit
@@ -105,6 +123,7 @@ final class DiffPaneDocumentCache: @unchecked Sendable {
         defer { lock.unlock() }
         splitStorage.removeAll(keepingCapacity: true)
         stackedStorage.removeAll(keepingCapacity: true)
+        accessStamp = 0
     }
 
     private func key(
@@ -127,34 +146,64 @@ final class DiffPaneDocumentCache: @unchecked Sendable {
     private func cachedSplit(forKey key: Int) -> DiffPaneTextDocumentBuilder.SplitResult? {
         lock.lock()
         defer { lock.unlock() }
-        let value = splitStorage[key]
+        accessStamp &+= 1
+        guard let entry = splitStorage[key] else {
+            #if DEBUG
+            misses += 1
+            #endif
+            return nil
+        }
         #if DEBUG
-        if value == nil { misses += 1 } else { hits += 1 }
+        hits += 1
         #endif
-        return value
+        splitStorage[key]?.lastAccess = accessStamp
+        return entry.result
     }
 
     private func cachedStacked(forKey key: Int) -> DiffPaneTextDocumentBuilder.StackedResult? {
         lock.lock()
         defer { lock.unlock() }
-        let value = stackedStorage[key]
+        accessStamp &+= 1
+        guard let entry = stackedStorage[key] else {
+            #if DEBUG
+            misses += 1
+            #endif
+            return nil
+        }
         #if DEBUG
-        if value == nil { misses += 1 } else { hits += 1 }
+        hits += 1
         #endif
-        return value
+        stackedStorage[key]?.lastAccess = accessStamp
+        return entry.result
     }
 
     private func store(_ result: DiffPaneTextDocumentBuilder.SplitResult, forKey key: Int) {
         lock.lock()
         defer { lock.unlock() }
-        if splitStorage.count >= entryLimit { splitStorage.removeAll(keepingCapacity: true) }
-        splitStorage[key] = result
+        accessStamp &+= 1
+        if splitStorage.count >= entryLimit, splitStorage[key] == nil {
+            evictOldest(from: &splitStorage)
+        }
+        splitStorage[key] = SplitEntry(result: result, lastAccess: accessStamp)
     }
 
     private func store(_ result: DiffPaneTextDocumentBuilder.StackedResult, forKey key: Int) {
         lock.lock()
         defer { lock.unlock() }
-        if stackedStorage.count >= entryLimit { stackedStorage.removeAll(keepingCapacity: true) }
-        stackedStorage[key] = result
+        accessStamp &+= 1
+        if stackedStorage.count >= entryLimit, stackedStorage[key] == nil {
+            evictOldest(from: &stackedStorage)
+        }
+        stackedStorage[key] = StackedEntry(result: result, lastAccess: accessStamp)
+    }
+
+    private func evictOldest(from storage: inout [Int: SplitEntry]) {
+        guard let oldest = storage.min(by: { $0.value.lastAccess < $1.value.lastAccess })?.key else { return }
+        storage.removeValue(forKey: oldest)
+    }
+
+    private func evictOldest(from storage: inout [Int: StackedEntry]) {
+        guard let oldest = storage.min(by: { $0.value.lastAccess < $1.value.lastAccess })?.key else { return }
+        storage.removeValue(forKey: oldest)
     }
 }

--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -345,11 +345,17 @@ final class DiffPaneTextDocumentContainerView: NSView {
         dividerView.wantsLayer = true
         dividerView.layer?.backgroundColor = NSColor(theme.color("line")).cgColor
 
+        // Mounting happens inside the scroll tick; the shared document cache
+        // (warmed by DiffHighlightPrewarmer, and by earlier mounts of the
+        // same content) keeps the full attributed-string build off this path.
+        let visibleRows = DiffPaneRowProjection.visibleRows(
+            in: group,
+            expandedCollapsedRowIDs: expandedCollapsedRowIDs
+        )
         switch layoutMode {
         case .split:
-            let result = DiffPaneTextDocumentBuilder.buildSplit(
-                group: group,
-                expandedCollapsedRowIDs: expandedCollapsedRowIDs,
+            let result = DiffPaneDocumentCache.shared.splitResult(
+                rows: visibleRows,
                 fileExtension: fileExtension,
                 font: font,
                 showWhitespace: showWhitespace,
@@ -378,9 +384,8 @@ final class DiffPaneTextDocumentContainerView: NSView {
             stackedPane.clearLSPContext()
             measuredHeight = max(oldPane.documentHeight, newPane.documentHeight)
         case .stacked:
-            let result = DiffPaneTextDocumentBuilder.buildStacked(
-                group: group,
-                expandedCollapsedRowIDs: expandedCollapsedRowIDs,
+            let result = DiffPaneDocumentCache.shared.stackedResult(
+                rows: visibleRows,
                 fileExtension: fileExtension,
                 font: font,
                 showWhitespace: showWhitespace,
@@ -547,8 +552,9 @@ final class DiffPaneTextDocumentContainerView: NSView {
 
         switch layoutMode {
         case .split:
-            let result = DiffPaneTextDocumentBuilder.buildSplit(
+            let result = DiffPaneDocumentCache.shared.splitResult(
                 rows: rows,
+                rowsSignature: signature.rowsSignature,
                 fileExtension: fileExtension,
                 font: font,
                 showWhitespace: showWhitespace,
@@ -577,8 +583,9 @@ final class DiffPaneTextDocumentContainerView: NSView {
             stackedPane.clearLSPContext()
             measuredHeight = max(oldPane.documentHeight, newPane.documentHeight)
         case .stacked:
-            let result = DiffPaneTextDocumentBuilder.buildStacked(
+            let result = DiffPaneDocumentCache.shared.stackedResult(
                 rows: rows,
+                rowsSignature: signature.rowsSignature,
                 fileExtension: fileExtension,
                 font: font,
                 showWhitespace: showWhitespace,

--- a/Alas/Sources/Center/Diff/DiffPaneView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneView.swift
@@ -231,9 +231,13 @@ enum DiffPaneStaticHeightEstimator {
         hasher.combine(codeFont.fontName)
         hasher.combine(codeFont.pointSize)
         hasher.combine(showWhitespace)
-        // Only expansions belonging to this group change its height.
-        for row in group.rows where row.kind == .collapsed && expandedCollapsedRowIDs.contains(row.id) {
-            hasher.combine(row.id)
+        // Only expansions belonging to this group change its height. The
+        // guard matters: with no expansions (the common case) the walk would
+        // combine nothing, so skip the O(rows) scan entirely.
+        if !expandedCollapsedRowIDs.isEmpty {
+            for row in group.rows where row.kind == .collapsed && expandedCollapsedRowIDs.contains(row.id) {
+                hasher.combine(row.id)
+            }
         }
         let key = hasher.finalize()
 

--- a/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
+++ b/Alas/Sources/Center/Diff/Scroller/DiffPaneRowPlan.swift
@@ -207,12 +207,15 @@ enum DiffPaneRowPlanBuilder {
 
     @MainActor
     private static func prewarmHighlightsIfNeeded(input: DiffPaneRowPlanInput, state: DiffPanePresentationState) {
+        let font = CenterTypography.resolveCodeFont(family: input.codeFontFamily, size: input.codeFontSize)
         let signature = DiffHighlightPrewarmer.signature(
             groups: input.model.groups,
             expandedCollapsedRowIDs: state.expandedCollapsedRowIDs,
             layoutMode: input.layoutMode,
             fileExtension: input.fileExtension,
-            showWhitespace: input.showWhitespace
+            font: font,
+            showWhitespace: input.showWhitespace,
+            theme: input.theme
         )
         guard state.registerHighlightPrewarm(signature: signature) else { return }
         DiffHighlightPrewarmer.prewarm(
@@ -220,7 +223,7 @@ enum DiffPaneRowPlanBuilder {
             expandedCollapsedRowIDs: state.expandedCollapsedRowIDs,
             layoutMode: input.layoutMode,
             fileExtension: input.fileExtension,
-            font: CenterTypography.resolveCodeFont(family: input.codeFontFamily, size: input.codeFontSize),
+            font: font,
             showWhitespace: input.showWhitespace,
             theme: input.theme
         )

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -504,13 +504,13 @@ enum AppKitDiffReviewRowPlanBuilder {
                     switch block {
                     case let .rows(rowBlock):
                         let blockID = AppKitDiffReviewRowID.segment(fileID: input.file.id, segmentID: segment.id, blockID: rowBlock.id)
-                        append(&rows, id: blockID, input: input, signature: String(reflecting: rowBlock.rowsSignature).hashValue, height: segmentHeight(rowBlock.rows.count, input: input), includesActiveHighlight: true) {
+                        append(&rows, id: blockID, input: input, signature: rowBlock.rowsSignature.hashValue, height: segmentHeight(rowBlock.rows.count, input: input), includesActiveHighlight: true) {
                             AnyView(AppKitDiffReviewSegmentRowBody(rows: rowBlock.rows, rowsSignature: rowBlock.rowsSignature, group: group.displayGroup, input: input))
                         }
                     case let .thread(thread):
                         let threadID = AppKitDiffReviewRowID.thread(fileID: input.file.id, threadID: thread.id)
                         append(
-                            &rows, id: threadID, input: input, signature: String(reflecting: thread).hashValue,
+                            &rows, id: threadID, input: input, signature: thread.hashValue,
                             height: 112, retention: input.state.activeThreadID == thread.id ? .pinned : .recyclable,
                             threadEditorState: input.state.threadCommentEditors[thread.id]
                         ) {
@@ -518,7 +518,7 @@ enum AppKitDiffReviewRowPlanBuilder {
                         }
                     case let .annotation(annotation):
                         let annotationID = AppKitDiffReviewRowID.annotation(fileID: input.file.id, annotationID: annotation.id)
-                        append(&rows, id: annotationID, input: input, signature: String(reflecting: annotation).hashValue, height: 52) {
+                        append(&rows, id: annotationID, input: input, signature: annotation.hashValue, height: 52) {
                             AnyView(AppKitDiffReviewAnnotationRowBody(annotation: annotation, rows: segment.rows, input: input))
                         }
                     }
@@ -532,9 +532,7 @@ enum AppKitDiffReviewRowPlanBuilder {
                         &rows,
                         id: composerID,
                         input: input,
-                        signature: String(
-                            "\(input.state.draftComposerFocusRequestGeneration):\(input.state.quoteInsertionGeneration)"
-                        ).hashValue,
+                        signature: composerSignature(input.state),
                         height: 132,
                         retention: input.state.isDraftComposerFocused ? .pinned : .recyclable
                     ) {
@@ -586,7 +584,7 @@ enum AppKitDiffReviewRowPlanBuilder {
                 &rows,
                 id: AppKitDiffReviewRowID.thread(fileID: input.file.id, threadID: thread.id),
                 input: input,
-                signature: String(reflecting: thread).hashValue,
+                signature: thread.hashValue,
                 height: 112,
                 retention: input.state.activeThreadID == thread.id ? .pinned : .recyclable,
                 threadEditorState: input.state.threadCommentEditors[thread.id]
@@ -599,7 +597,7 @@ enum AppKitDiffReviewRowPlanBuilder {
                 &rows,
                 id: AppKitDiffReviewRowID.annotation(fileID: input.file.id, annotationID: annotation.id),
                 input: input,
-                signature: String(reflecting: annotation).hashValue,
+                signature: annotation.hashValue,
                 height: 52
             ) {
                 AnyView(AppKitDiffReviewImageAnnotationRowBody(annotation: annotation, input: input))
@@ -676,12 +674,19 @@ enum AppKitDiffReviewRowPlanBuilder {
         fallbacks[id] = id
     }
 
-    private static func accessorySignature(_ value: some Any, contextRows: [DiffDisplayRow]?) -> Int {
+    private static func accessorySignature(_ value: some Hashable, contextRows: [DiffDisplayRow]?) -> Int {
         var hasher = Hasher()
-        hasher.combine(String(reflecting: value))
+        hasher.combine(value)
         if let contextRows {
             hasher.combine(DiffDisplayRowsSignature(contextRows))
         }
+        return hasher.finalize()
+    }
+
+    private static func composerSignature(_ state: AppKitDiffReviewFileState) -> Int {
+        var hasher = Hasher()
+        hasher.combine(state.draftComposerFocusRequestGeneration)
+        hasher.combine(state.quoteInsertionGeneration)
         return hasher.finalize()
     }
 

--- a/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewModels.swift
@@ -22,7 +22,7 @@ struct DiffReviewInlineFeedbackAnchor: Hashable, Codable, Equatable, Sendable {
     var isFileLevel: Bool { line == nil }
 }
 
-struct DiffReviewInlineFeedback: Identifiable, Codable, Equatable, Sendable {
+struct DiffReviewInlineFeedback: Identifiable, Codable, Equatable, Hashable, Sendable {
     let id: String
     let providerName: String
     let author: String?

--- a/Alas/Sources/Center/DiffReview/DiffReviewRail.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewRail.swift
@@ -7,6 +7,40 @@ enum DiffReviewRailTooltip {
     }
 }
 
+/// Open-thread counts per path plus the rail-wide totals, derived in a single
+/// pass. The rail evaluates on every review-surface body pass — including the
+/// ones a scroll-spy file change triggers mid-fling — so counting per visible
+/// row rescanned every thread each time.
+struct DiffReviewRailThreadCounts: Equatable {
+    private let openByPath: [String: Int]
+    let openTotal: Int
+    let resolvedTotal: Int
+
+    init(threads: [ReviewThread]) {
+        var openByPath: [String: Int] = [:]
+        var openTotal = 0
+        var resolvedTotal = 0
+        for thread in threads {
+            if thread.isResolved {
+                resolvedTotal += 1
+                continue
+            }
+            guard !thread.isOutdated else { continue }
+            openTotal += 1
+            if let path = thread.path {
+                openByPath[path, default: 0] += 1
+            }
+        }
+        self.openByPath = openByPath
+        self.openTotal = openTotal
+        self.resolvedTotal = resolvedTotal
+    }
+
+    func openCount(forPath path: String) -> Int {
+        openByPath[path] ?? 0
+    }
+}
+
 struct DiffReviewRail: View {
     let session: DiffReviewSessionModel
     @Binding var selectedFileID: DiffReviewFileID
@@ -36,20 +70,6 @@ struct DiffReviewRail: View {
         self.onSelectFile = onSelectFile
     }
 
-    // MARK: - Thread counts
-
-    private func openThreadCount(for path: String) -> Int {
-        threads.filter { $0.path == path && !$0.isResolved && !$0.isOutdated }.count
-    }
-
-    private var openThreadTotal: Int {
-        threads.filter { !$0.isResolved && !$0.isOutdated }.count
-    }
-
-    private var resolvedThreadTotal: Int {
-        threads.filter { $0.isResolved }.count
-    }
-
     private var filteredSession: DiffReviewSessionModel {
         DiffReviewRailFilter.session(session, matching: filterQuery)
     }
@@ -70,6 +90,7 @@ struct DiffReviewRail: View {
 
     private var expandedBody: some View {
         let visibleSession = filteredSession
+        let threadCounts = DiffReviewRailThreadCounts(threads: threads)
         return VStack(spacing: 0) {
             expandedHeader
             ScrollViewReader { proxy in
@@ -89,7 +110,7 @@ struct DiffReviewRail: View {
                                 )
                         } else {
                             ForEach(DiffReviewRailRows.rows(for: visibleSession)) { row in
-                                expandedRow(row)
+                                expandedRow(row, threadCounts: threadCounts)
                             }
                         }
                     }
@@ -105,18 +126,18 @@ struct DiffReviewRail: View {
                     }
                 }
             }
-            if openThreadTotal > 0 || resolvedThreadTotal > 0 {
-                threadSummaryStrip
+            if threadCounts.openTotal > 0 || threadCounts.resolvedTotal > 0 {
+                threadSummaryStrip(threadCounts)
             }
         }
     }
 
-    private var threadSummaryStrip: some View {
+    private func threadSummaryStrip(_ counts: DiffReviewRailThreadCounts) -> some View {
         HStack(spacing: 4) {
             Image(systemName: "bubble.left")
                 .font(.system(size: 10, weight: .medium))
                 .foregroundColor(theme.color("fg-faint"))
-            Text(threadSummaryLabel)
+            Text(Self.threadSummaryLabel(counts))
                 .font(.caption)
                 .foregroundColor(theme.color("fg-muted"))
             Spacer(minLength: 0)
@@ -127,8 +148,8 @@ struct DiffReviewRail: View {
         .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .top)
     }
 
-    private var threadSummaryLabel: String {
-        switch (openThreadTotal, resolvedThreadTotal) {
+    private static func threadSummaryLabel(_ counts: DiffReviewRailThreadCounts) -> String {
+        switch (counts.openTotal, counts.resolvedTotal) {
         case (let o, 0):
             return "\(o) open"
         case (0, let r):
@@ -217,14 +238,17 @@ struct DiffReviewRail: View {
     }
 
     @ViewBuilder
-    private func expandedRow(_ row: DiffReviewRailRow) -> some View {
+    private func expandedRow(
+        _ row: DiffReviewRailRow,
+        threadCounts: DiffReviewRailThreadCounts
+    ) -> some View {
         switch row.kind {
         case let .sourceHeader(id, title, fileCount):
             sourceHeader(id: id, title: title, fileCount: fileCount)
         case let .directory(name, depth):
             directoryRow(name: name, depth: depth)
         case let .file(file, depth, name):
-            fileRow(file, depth: depth, name: name)
+            fileRow(file, depth: depth, name: name, threadCounts: threadCounts)
         case .divider:
             Divider()
                 .overlay(theme.color("line"))
@@ -271,7 +295,12 @@ struct DiffReviewRail: View {
         .frame(height: 22)
     }
 
-    private func fileRow(_ file: DiffReviewFileSummary, depth: Int, name: String) -> some View {
+    private func fileRow(
+        _ file: DiffReviewFileSummary,
+        depth: Int,
+        name: String,
+        threadCounts: DiffReviewRailThreadCounts
+    ) -> some View {
         let selected = selectedFileID == file.id
         return Button {
             selectedFileID = file.id
@@ -309,7 +338,7 @@ struct DiffReviewRail: View {
                     }
                 }
                 Spacer(minLength: 4)
-                let openCount = openThreadCount(for: file.path)
+                let openCount = threadCounts.openCount(forPath: file.path)
                 if openCount > 0 {
                     threadBadge(openCount)
                 }

--- a/Alas/Sources/Center/DiffReview/DiffReviewRenderContext.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewRenderContext.swift
@@ -183,8 +183,18 @@ enum DiffReviewRenderContextBuilder {
 @MainActor
 final class DiffReviewRenderContextCache: ObservableObject {
     private let maximumEntryCount: Int
-    private var storage: [DiffReviewRenderContextKey: DiffReviewRenderContext] = [:]
-    private var recency: [DiffReviewRenderContextKey] = []
+    private var storage: [DiffReviewRenderContextKey: Entry] = [:]
+    /// Monotonic stamp handed out on every access, so recency is tracked
+    /// without comparing keys. These keys carry per-comment and per-boundary
+    /// signatures, and the cache is consulted once per file on every row-plan
+    /// rebuild — scanning a recency array meant a deep comparison against
+    /// every retained key just to record a hit.
+    private var accessStamp: UInt64 = 0
+
+    private struct Entry {
+        let context: DiffReviewRenderContext
+        var lastAccess: UInt64
+    }
 
     #if DEBUG
     private(set) var missCount = 0
@@ -204,9 +214,10 @@ final class DiffReviewRenderContextCache: ObservableObject {
         key: DiffReviewRenderContextKey,
         build: () -> DiffReviewRenderContext
     ) -> DiffReviewRenderContext {
+        accessStamp &+= 1
         if let cached = storage[key] {
-            markRecentlyUsed(key)
-            return cached
+            storage[key]?.lastAccess = accessStamp
+            return cached.context
         }
 
         #if DEBUG
@@ -214,8 +225,7 @@ final class DiffReviewRenderContextCache: ObservableObject {
         #endif
 
         let context = build()
-        storage[key] = context
-        markRecentlyUsed(key)
+        storage[key] = Entry(context: context, lastAccess: accessStamp)
         pruneIfNeeded()
         return context
     }
@@ -268,21 +278,16 @@ final class DiffReviewRenderContextCache: ObservableObject {
 
     func removeAll() {
         storage.removeAll()
-        recency.removeAll()
+        accessStamp = 0
         #if DEBUG
         missCount = 0
         #endif
     }
 
-    private func markRecentlyUsed(_ key: DiffReviewRenderContextKey) {
-        recency.removeAll { $0 == key }
-        recency.append(key)
-    }
-
     private func pruneIfNeeded() {
-        while recency.count > maximumEntryCount {
-            let key = recency.removeFirst()
-            storage.removeValue(forKey: key)
+        while storage.count > maximumEntryCount {
+            guard let oldest = storage.min(by: { $0.value.lastAccess < $1.value.lastAccess })?.key else { return }
+            storage.removeValue(forKey: oldest)
         }
     }
 }

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -368,7 +368,11 @@ struct DiffReviewSurface: View {
     }
 
     private func appKitRowInputs(for session: DiffReviewLoadedSession) -> [AppKitDiffReviewRowInput] {
-        session.files.map { file in
+        // Computed once per input build: without an override this derives a
+        // sorted source description from every file, which is quadratic when
+        // evaluated inside the per-file map below.
+        let feedbackTarget = effectiveReviewFeedbackTarget
+        return session.files.map { file in
             let state = appKitPresentationStore.state(for: file)
             state.synchronize(file: file, contextSignature: DiffReviewContextStateSignature(
                 fileID: file.id.rawValue,
@@ -441,7 +445,7 @@ struct DiffReviewSurface: View {
                     hunkUnstageEnabled: file.stagedMutationActions?.unstageEnabledBase ?? false
                 ),
                 lspContext: lspContextForFile(file),
-                reviewFeedbackTarget: effectiveReviewFeedbackTarget,
+                reviewFeedbackTarget: feedbackTarget,
                 draftCommentActions: appKitDraftActions,
                 onContextExpansionActivated: { contextExpandedFileIDs.insert(file.id) }
             )

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
@@ -142,14 +142,14 @@ enum ReviewDraftCommentAuthor: Codable, Equatable, Hashable, Sendable {
     }
 }
 
-struct ReviewCommentReply: Codable, Equatable, Identifiable, Sendable {
+struct ReviewCommentReply: Codable, Equatable, Hashable, Identifiable, Sendable {
     let id: String
     let author: ReviewDraftCommentAuthor
     let bodyMarkdown: String
     let createdAt: Date
 }
 
-struct ReviewDraftProviderPublish: Codable, Equatable, Sendable {
+struct ReviewDraftProviderPublish: Codable, Equatable, Hashable, Sendable {
     let provider: CodeHostKind
     let host: String
     let repositorySlug: String
@@ -160,13 +160,13 @@ struct ReviewDraftProviderPublish: Codable, Equatable, Sendable {
     let publishedAt: Date
 }
 
-struct ReviewDraftProviderError: Codable, Equatable, Sendable {
+struct ReviewDraftProviderError: Codable, Equatable, Hashable, Sendable {
     let provider: CodeHostKind
     let message: String
     let occurredAt: Date
 }
 
-struct ReviewDraftComment: Codable, Equatable, Identifiable, Sendable {
+struct ReviewDraftComment: Codable, Equatable, Hashable, Identifiable, Sendable {
     var id: String
     var sessionID: ReviewDraftSessionID
     var fileID: DiffReviewFileID

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionSelectionPersister.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionSelectionPersister.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Debounces review-session selection persistence so scroll-spy driven
+/// selection changes don't perform synchronous disk writes on every file
+/// boundary crossed during a fling. In-memory state updates immediately at
+/// the call site; only the disk write is deferred. Re-scheduling replaces
+/// the pending write, so a fling across many files produces one write once
+/// scrolling settles. `flush()` forces the pending write to run now — call
+/// it before any path that reloads state from disk, so the store never
+/// serves a selection older than the one on screen.
+@MainActor
+final class ReviewSessionSelectionPersister {
+    private let debounceNanos: UInt64
+    private var pendingTask: Task<Void, Never>?
+    private var pendingWrite: (() -> Void)?
+
+    init(debounceNanos: UInt64 = 400_000_000) {
+        self.debounceNanos = debounceNanos
+    }
+
+    func schedule(_ write: @escaping () -> Void) {
+        pendingWrite = write
+        pendingTask?.cancel()
+        pendingTask = Task { [weak self, debounceNanos] in
+            try? await Task.sleep(nanoseconds: debounceNanos)
+            guard !Task.isCancelled else { return }
+            self?.flush()
+        }
+    }
+
+    func flush() {
+        pendingTask?.cancel()
+        pendingTask = nil
+        guard let write = pendingWrite else { return }
+        pendingWrite = nil
+        write()
+    }
+}

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -1234,20 +1234,39 @@ struct ReviewSessionTabView: View {
         guard persistsState else { return }
         // Scroll-spy selection changes arrive on every file boundary crossed
         // during a fling; a synchronous write here (snapshot decode + two
-        // JSON encodes + two atomic replaces) stalls the scroll. The write
-        // reads `record` at flush time so it never clobbers newer state
-        // persisted by an interleaved immediate write.
+        // JSON encodes + two atomic replaces) stalls the scroll.
+        //
+        // The write must not save the in-memory `record` wholesale: another
+        // path (e.g. AppState.persistReviewRetargeting) can replace this
+        // session's stored record — even under a new id — while our write is
+        // still pending, and `record` won't reflect that until this view's
+        // own load cycle runs. Saving it as-is would either clobber the
+        // fresher target/handoffs or, if the id changed, resurrect the
+        // record `replace` just removed. Reload the latest stored record at
+        // flush time and merge only the selection onto it instead.
+        let sessionID = current.id
         selectionPersister.schedule {
-            guard let latest = record else { return }
+            guard let latest = try? sessionStore.load(id: sessionID) else { return }
+            let pendingFileID = record?.selectedFileID
+            let merged = Self.mergingSelectedFile(into: latest, fileID: pendingFileID, now: now())
             do {
-                try sessionStore.save(latest)
+                try sessionStore.save(merged)
             } catch {
                 loadError = error.localizedDescription
             }
             updateTabState { state in
-                state.selectedFileID = latest.selectedFileID
+                state.selectedFileID = merged.selectedFileID
             }
         }
+    }
+
+    static func mergingSelectedFile(
+        into latest: ReviewSessionRecord,
+        fileID: DiffReviewFileID?,
+        now: Date
+    ) -> ReviewSessionRecord {
+        guard latest.selectedFileID != fileID else { return latest }
+        return latest.selectingFile(fileID, now: now)
     }
 
     private func persistFocusedComment(_ commentID: String?) {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -93,6 +93,7 @@ struct ReviewSessionTabView: View {
     @State private var inlineFeedbackScrollController = DiffReviewInlineFeedbackScrollController()
     @State private var loadCoordinator = ReviewSessionTabLoadCoordinator()
     @State private var loadGeneration = 0
+    @State private var selectionPersister = ReviewSessionSelectionPersister()
     @State private var providerPublishConfirmation: ProviderReviewPublishConfirmationState?
     @State private var selectedProviderDecision = ProviderReviewDecision.comment
     @State private var providerReviewSummaryBody = ""
@@ -209,6 +210,7 @@ struct ReviewSessionTabView: View {
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .alasReviewDraftCommentsDidChangeExternally)) { _ in
+            selectionPersister.flush()
             try? draftCommentController?.load()
             if let refreshed = try? sessionStore.load(id: tabState.sessionID) {
                 record = refreshed
@@ -216,6 +218,9 @@ struct ReviewSessionTabView: View {
         }
         .onChange(of: tabState.sessionID) { _, _ in
             rekeyDraftControllerForCurrentSession()
+        }
+        .onDisappear {
+            selectionPersister.flush()
         }
     }
 
@@ -556,6 +561,7 @@ struct ReviewSessionTabView: View {
     }
 
     private func loadReviewSession(token: ReviewSessionTabLoadToken) async -> Bool {
+        selectionPersister.flush()
         do {
             guard let storedRecord = try sessionStore.load(id: tabState.sessionID) else {
                 throw ReviewSessionTabError.missingSession(tabState.sessionID)
@@ -739,6 +745,7 @@ struct ReviewSessionTabView: View {
     }
 
     private func rekeyDraftControllerForCurrentSession() {
+        selectionPersister.flush()
         guard persistsState,
               let refreshed = try? sessionStore.load(id: tabState.sessionID)
         else { return }
@@ -1223,10 +1230,23 @@ struct ReviewSessionTabView: View {
     private func persistSelectedFile(_ fileID: DiffReviewFileID?) {
         guard let current = record else { return }
         guard current.selectedFileID != fileID else { return }
-        let updated = current.selectingFile(fileID, now: now())
-        persist(updated)
-        updateTabState { state in
-            state.selectedFileID = fileID
+        record = current.selectingFile(fileID, now: now())
+        guard persistsState else { return }
+        // Scroll-spy selection changes arrive on every file boundary crossed
+        // during a fling; a synchronous write here (snapshot decode + two
+        // JSON encodes + two atomic replaces) stalls the scroll. The write
+        // reads `record` at flush time so it never clobbers newer state
+        // persisted by an interleaved immediate write.
+        selectionPersister.schedule {
+            guard let latest = record else { return }
+            do {
+                try sessionStore.save(latest)
+            } catch {
+                loadError = error.localizedDescription
+            }
+            updateTabState { state in
+                state.selectedFileID = latest.selectedFileID
+            }
         }
     }
 

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -1244,11 +1244,18 @@ struct ReviewSessionTabView: View {
         // fresher target/handoffs or, if the id changed, resurrect the
         // record `replace` just removed. Reload the latest stored record at
         // flush time and merge only the selection onto it instead.
+        //
+        // The selection itself must come from this call's `fileID`
+        // parameter, not from reading `record` at flush time: a handoff or
+        // send failure completing during the debounce window reassigns
+        // `record` from a fresh disk load (`ReviewSessionHandoffPersistence`
+        // prefers disk over the in-memory value), which would revert
+        // `record.selectedFileID` to whatever was on disk before this write
+        // flushes — silently losing the user's latest selection.
         let sessionID = current.id
         selectionPersister.schedule {
             guard let latest = try? sessionStore.load(id: sessionID) else { return }
-            let pendingFileID = record?.selectedFileID
-            let merged = Self.mergingSelectedFile(into: latest, fileID: pendingFileID, now: now())
+            let merged = Self.mergingSelectedFile(into: latest, fileID: fileID, now: now())
             do {
                 try sessionStore.save(merged)
             } catch {

--- a/Alas/Sources/Theme/Theme.swift
+++ b/Alas/Sources/Theme/Theme.swift
@@ -2,7 +2,7 @@ import AppKit
 import Foundation
 import SwiftUI
 
-struct Theme: Codable, Equatable {
+struct Theme: Codable, Equatable, Hashable {
     let id: String
     let name: String
     let tokens: [String: String]   // raw OKLCH strings
@@ -33,6 +33,16 @@ struct Theme: Codable, Equatable {
             && lhs.tokens == rhs.tokens
             && lhs.accentOverrideHex == rhs.accentOverrideHex
             && lhs.resolvedColorOverrides == rhs.resolvedColorOverrides
+    }
+
+    // Hashes exactly the fields `==` compares; `resolvedColors` stays
+    // excluded from both because it is derived from `tokens`.
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(name)
+        hasher.combine(tokens)
+        hasher.combine(accentOverrideHex)
+        hasher.combine(resolvedColorOverrides)
     }
 
     static let bundledIds = ["cool-slate", "light"]

--- a/AlasTests/DiffPaneDocumentCacheTests.swift
+++ b/AlasTests/DiffPaneDocumentCacheTests.swift
@@ -1,0 +1,96 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct DiffPaneDocumentCacheTests {
+    @Test func secondBuildWithSameInputsIsAHit() throws {
+        let cache = DiffPaneDocumentCache()
+        let rows = try rows()
+        let font = CenterTypography.resolveCodeFont(family: "SF Mono", size: 13)
+        let theme = try ThemeStore().current
+
+        let first = cache.splitResult(
+            rows: rows, fileExtension: "swift", font: font, showWhitespace: false, theme: theme
+        )
+        let second = cache.splitResult(
+            rows: rows, fileExtension: "swift", font: font, showWhitespace: false, theme: theme
+        )
+
+        #expect(first.newCode.attributedString === second.newCode.attributedString)
+        #expect(cache.statisticsForTests == (hits: 1, misses: 1))
+    }
+
+    @Test func presentationInputsAreCacheKeys() throws {
+        let cache = DiffPaneDocumentCache()
+        let rows = try rows()
+        let small = CenterTypography.resolveCodeFont(family: "SF Mono", size: 11)
+        let large = CenterTypography.resolveCodeFont(family: "SF Mono", size: 17)
+        let theme = try ThemeStore().current
+
+        _ = cache.splitResult(rows: rows, fileExtension: "swift", font: small, showWhitespace: false, theme: theme)
+        _ = cache.splitResult(rows: rows, fileExtension: "swift", font: large, showWhitespace: false, theme: theme)
+        _ = cache.splitResult(rows: rows, fileExtension: "swift", font: small, showWhitespace: true, theme: theme)
+        _ = cache.splitResult(rows: rows, fileExtension: "txt", font: small, showWhitespace: false, theme: theme)
+
+        #expect(cache.statisticsForTests == (hits: 0, misses: 4))
+    }
+
+    @Test func splitAndStackedDoNotShareEntries() throws {
+        let cache = DiffPaneDocumentCache()
+        let rows = try rows()
+        let font = CenterTypography.resolveCodeFont(family: "SF Mono", size: 13)
+        let theme = try ThemeStore().current
+
+        _ = cache.splitResult(rows: rows, fileExtension: "swift", font: font, showWhitespace: false, theme: theme)
+        _ = cache.stackedResult(rows: rows, fileExtension: "swift", font: font, showWhitespace: false, theme: theme)
+
+        #expect(cache.statisticsForTests == (hits: 0, misses: 2))
+    }
+
+    @Test func prewarmerPopulatesTheSharedCacheForRowMounts() throws {
+        let theme = try ThemeStore().current
+        let font = CenterTypography.resolveCodeFont(family: "SF Mono", size: 13)
+        let group = try group()
+
+        DiffPaneDocumentCache.shared.removeAll()
+        DiffHighlightPrewarmer.prewarmSynchronously(
+            groups: [group], expandedCollapsedRowIDs: [], layoutMode: .split,
+            fileExtension: "swift", font: font, showWhitespace: false, theme: theme
+        )
+
+        // A row mount projects the group's visible rows and asks the cache;
+        // after a prewarm that must not build anything.
+        DiffPaneDocumentCache.shared.resetStatisticsForTests()
+        _ = DiffPaneDocumentCache.shared.splitResult(
+            rows: DiffPaneRowProjection.visibleRows(in: group, expandedCollapsedRowIDs: []),
+            fileExtension: "swift", font: font, showWhitespace: false, theme: theme
+        )
+
+        let stats = DiffPaneDocumentCache.shared.statisticsForTests
+        #expect(stats.hits == 1)
+        #expect(stats.misses == 0)
+    }
+
+    private func rows() throws -> [DiffDisplayRow] {
+        try group().rows.filter { $0.kind != .collapsed }
+    }
+
+    private func group() throws -> DiffDisplayGroup {
+        let lines = (0..<24).map { index -> ParsedDiff.Hunk.Line in
+            let text = "let value\(index) = compute(\(index))"
+            switch index % 3 {
+            case 0:
+                return .init(kind: .delete, text: text, oldNumber: index + 1, newNumber: nil)
+            case 1:
+                return .init(kind: .add, text: text, oldNumber: nil, newNumber: index + 1)
+            default:
+                return .init(kind: .context, text: text, oldNumber: index + 1, newNumber: index + 1)
+            }
+        }
+        let hunk = ParsedDiff.Hunk(header: "@@ -1,24 +1,24 @@", oldStart: 1, newStart: 1, lines: lines)
+        let model = DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [hunk]), filePath: "Cache.swift")
+        return try #require(model.groups.first)
+    }
+}

--- a/AlasTests/DiffPaneDocumentCacheTests.swift
+++ b/AlasTests/DiffPaneDocumentCacheTests.swift
@@ -73,6 +73,65 @@ struct DiffPaneDocumentCacheTests {
         #expect(stats.misses == 0)
     }
 
+    /// Regression for a font/theme change leaving the row-mount path cold:
+    /// `DiffPaneRowPlanBuilder.prewarmHighlightsIfNeeded` dedupes on
+    /// `DiffHighlightPrewarmer.signature`, and `warm` populates
+    /// `DiffPaneDocumentCache`, whose key includes font and theme. If the
+    /// signature didn't also vary with font/theme, a font-size or theme
+    /// change would be treated as "already prewarmed" and every row mount
+    /// after that would miss the document cache and rebuild synchronously
+    /// during scroll.
+    @Test func prewarmDedupeSignatureVariesWithFontAndTheme() throws {
+        let theme = try ThemeStore().current
+        var otherTheme = theme
+        otherTheme.accentOverrideHex = "#ff0000"
+        let small = CenterTypography.resolveCodeFont(family: "SF Mono", size: 11)
+        let large = CenterTypography.resolveCodeFont(family: "SF Mono", size: 17)
+        let group = try group()
+
+        func signature(font: NSFont, theme: Theme) -> Int {
+            DiffHighlightPrewarmer.signature(
+                groups: [group], expandedCollapsedRowIDs: [], layoutMode: .split,
+                fileExtension: "swift", font: font, showWhitespace: false, theme: theme
+            )
+        }
+
+        let base = signature(font: small, theme: theme)
+        #expect(signature(font: large, theme: theme) != base)
+        #expect(signature(font: small, theme: otherTheme) != base)
+    }
+
+    /// A font change must both re-trigger the prewarm (the dedupe signature
+    /// differs) and leave the document cache warm for the new font, so the
+    /// subsequent row mount at that font is a cache hit rather than a
+    /// synchronous rebuild.
+    @Test func prewarmingAtANewFontWarmsTheCacheForThatFont() throws {
+        let theme = try ThemeStore().current
+        let originalFont = CenterTypography.resolveCodeFont(family: "SF Mono", size: 11)
+        let newFont = CenterTypography.resolveCodeFont(family: "SF Mono", size: 17)
+        let group = try group()
+
+        DiffPaneDocumentCache.shared.removeAll()
+        DiffHighlightPrewarmer.prewarmSynchronously(
+            groups: [group], expandedCollapsedRowIDs: [], layoutMode: .split,
+            fileExtension: "swift", font: originalFont, showWhitespace: false, theme: theme
+        )
+        DiffHighlightPrewarmer.prewarmSynchronously(
+            groups: [group], expandedCollapsedRowIDs: [], layoutMode: .split,
+            fileExtension: "swift", font: newFont, showWhitespace: false, theme: theme
+        )
+
+        DiffPaneDocumentCache.shared.resetStatisticsForTests()
+        _ = DiffPaneDocumentCache.shared.splitResult(
+            rows: DiffPaneRowProjection.visibleRows(in: group, expandedCollapsedRowIDs: []),
+            fileExtension: "swift", font: newFont, showWhitespace: false, theme: theme
+        )
+
+        let stats = DiffPaneDocumentCache.shared.statisticsForTests
+        #expect(stats.hits == 1)
+        #expect(stats.misses == 0)
+    }
+
     private func rows() throws -> [DiffDisplayRow] {
         try group().rows.filter { $0.kind != .collapsed }
     }

--- a/AlasTests/DiffPaneDocumentCacheTests.swift
+++ b/AlasTests/DiffPaneDocumentCacheTests.swift
@@ -132,13 +132,43 @@ struct DiffPaneDocumentCacheTests {
         #expect(stats.misses == 0)
     }
 
-    private func rows() throws -> [DiffDisplayRow] {
-        try group().rows.filter { $0.kind != .collapsed }
+    /// A full review can easily exceed `entryLimit` distinct hunks. Filling
+    /// the cache must evict only the single least-recently-used entry, not
+    /// clear the whole storage — clearing on every overflow would wipe every
+    /// already-warmed document each time a new hunk gets prewarmed,
+    /// negating the prewarmer for exactly the large reviews it matters most
+    /// for.
+    @Test func overflowEvictsOnlyTheLeastRecentlyUsedEntry() throws {
+        let cache = DiffPaneDocumentCache(entryLimit: 2)
+        let font = CenterTypography.resolveCodeFont(family: "SF Mono", size: 13)
+        let theme = try ThemeStore().current
+        let a = try rows(salt: "A")
+        let b = try rows(salt: "B")
+        let c = try rows(salt: "C")
+
+        _ = cache.splitResult(rows: a, fileExtension: "swift", font: font, showWhitespace: false, theme: theme)
+        _ = cache.splitResult(rows: b, fileExtension: "swift", font: font, showWhitespace: false, theme: theme)
+        // Touching A makes B the least recently used entry.
+        _ = cache.splitResult(rows: a, fileExtension: "swift", font: font, showWhitespace: false, theme: theme)
+        _ = cache.splitResult(rows: c, fileExtension: "swift", font: font, showWhitespace: false, theme: theme)
+
+        cache.resetStatisticsForTests()
+        _ = cache.splitResult(rows: a, fileExtension: "swift", font: font, showWhitespace: false, theme: theme)
+        _ = cache.splitResult(rows: c, fileExtension: "swift", font: font, showWhitespace: false, theme: theme)
+        #expect(cache.statisticsForTests == (hits: 2, misses: 0))
+
+        // B was evicted, so it has to be rebuilt.
+        _ = cache.splitResult(rows: b, fileExtension: "swift", font: font, showWhitespace: false, theme: theme)
+        #expect(cache.statisticsForTests == (hits: 2, misses: 1))
     }
 
-    private func group() throws -> DiffDisplayGroup {
+    private func rows(salt: String = "") throws -> [DiffDisplayRow] {
+        try group(salt: salt).rows.filter { $0.kind != .collapsed }
+    }
+
+    private func group(salt: String = "") throws -> DiffDisplayGroup {
         let lines = (0..<24).map { index -> ParsedDiff.Hunk.Line in
-            let text = "let value\(index) = compute(\(index))"
+            let text = "let value\(index)\(salt) = compute(\(index))"
             switch index % 3 {
             case 0:
                 return .init(kind: .delete, text: text, oldNumber: index + 1, newNumber: nil)

--- a/AlasTests/DiffReviewRailThreadCountsTests.swift
+++ b/AlasTests/DiffReviewRailThreadCountsTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct DiffReviewRailThreadCountsTests {
+    @Test func perPathCountExcludesResolvedAndOutdatedThreads() {
+        let counts = DiffReviewRailThreadCounts(threads: [
+            thread(id: "1", path: "A.swift"),
+            thread(id: "2", path: "A.swift"),
+            thread(id: "3", path: "A.swift", isResolved: true),
+            thread(id: "4", path: "A.swift", isOutdated: true),
+            thread(id: "5", path: "B.swift"),
+        ])
+
+        #expect(counts.openCount(forPath: "A.swift") == 2)
+        #expect(counts.openCount(forPath: "B.swift") == 1)
+        #expect(counts.openCount(forPath: "Missing.swift") == 0)
+    }
+
+    @Test func totalsMatchWholeThreadListSemantics() {
+        let counts = DiffReviewRailThreadCounts(threads: [
+            thread(id: "1", path: "A.swift"),
+            thread(id: "2", path: nil),
+            thread(id: "3", path: "B.swift", isResolved: true),
+            thread(id: "4", path: "B.swift", isResolved: true, isOutdated: true),
+            thread(id: "5", path: "C.swift", isOutdated: true),
+        ])
+
+        // Open excludes resolved and outdated; a nil-path thread still counts.
+        #expect(counts.openTotal == 2)
+        // Resolved counts resolved threads even when they are also outdated.
+        #expect(counts.resolvedTotal == 2)
+    }
+
+    @Test func emptyThreadListHasNoCounts() {
+        let counts = DiffReviewRailThreadCounts(threads: [])
+
+        #expect(counts.openTotal == 0)
+        #expect(counts.resolvedTotal == 0)
+        #expect(counts.openCount(forPath: "A.swift") == 0)
+    }
+
+    private func thread(
+        id: String,
+        path: String?,
+        isResolved: Bool = false,
+        isOutdated: Bool = false
+    ) -> ReviewThread {
+        ReviewThread(
+            id: id,
+            path: path,
+            line: 1,
+            startLine: nil,
+            originalLine: nil,
+            diffHunk: nil,
+            isResolved: isResolved,
+            isOutdated: isOutdated,
+            isFileLevel: false,
+            comments: [],
+            viewerCanResolve: true,
+            viewerCanReply: true,
+            url: nil
+        )
+    }
+}

--- a/AlasTests/DiffReviewRenderContextCacheTests.swift
+++ b/AlasTests/DiffReviewRenderContextCacheTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct DiffReviewRenderContextCacheTests {
+    @Test func evictsLeastRecentlyUsedEntry() {
+        let cache = DiffReviewRenderContextCache(limit: 2)
+        let a = key(path: "A.swift")
+        let b = key(path: "B.swift")
+        let c = key(path: "C.swift")
+
+        _ = cache.context(key: a, build: emptyContext)
+        _ = cache.context(key: b, build: emptyContext)
+        // Touching A makes B the least recently used entry.
+        _ = cache.context(key: a, build: emptyContext)
+        _ = cache.context(key: c, build: emptyContext)
+
+        let missesBefore = cache.missCountForTests
+        _ = cache.context(key: a, build: emptyContext)
+        _ = cache.context(key: c, build: emptyContext)
+        #expect(cache.missCountForTests == missesBefore)
+
+        // B was evicted, so it has to be rebuilt.
+        _ = cache.context(key: b, build: emptyContext)
+        #expect(cache.missCountForTests == missesBefore + 1)
+    }
+
+    @Test func repeatedHitsDoNotEvict() {
+        let cache = DiffReviewRenderContextCache(limit: 2)
+        let a = key(path: "A.swift")
+        let b = key(path: "B.swift")
+
+        _ = cache.context(key: a, build: emptyContext)
+        _ = cache.context(key: b, build: emptyContext)
+        for _ in 0..<10 {
+            _ = cache.context(key: a, build: emptyContext)
+            _ = cache.context(key: b, build: emptyContext)
+        }
+
+        #expect(cache.missCountForTests == 2)
+    }
+
+    private func emptyContext() -> DiffReviewRenderContext {
+        DiffReviewRenderContextBuilder.build(
+            fileID: DiffReviewFileID(namespace: "review", path: "A.swift"),
+            displayModel: model(path: "A.swift"),
+            contextSnapshot: nil,
+            contextProviderAvailable: false,
+            contextExpansion: DiffContextExpansionState(),
+            inlineFeedback: [],
+            draftComments: [],
+            pendingDraftAnchor: nil,
+            canCreateDraftComment: true,
+            threads: [],
+            annotations: []
+        )
+    }
+
+    private func key(path: String) -> DiffReviewRenderContextKey {
+        DiffReviewRenderContextKey(
+            fileID: DiffReviewFileID(namespace: "review", path: path),
+            displayModel: model(path: path),
+            contextSnapshot: nil,
+            contextProviderAvailable: false,
+            contextExpansion: DiffContextExpansionState(),
+            inlineFeedback: [],
+            draftComments: [],
+            pendingDraftAnchor: nil,
+            canCreateDraftComment: true,
+            threads: [],
+            annotations: []
+        )
+    }
+
+    private func model(path: String) -> DiffDisplayModel {
+        let hunk = ParsedDiff.Hunk(
+            header: "@@ -1,1 +1,1 @@",
+            oldStart: 1,
+            newStart: 1,
+            lines: [.init(kind: .add, text: "let a = 1", oldNumber: nil, newNumber: 1)]
+        )
+        return DiffDisplayModelBuilder.build(diff: ParsedDiff(hunks: [hunk]), filePath: path)
+    }
+}

--- a/AlasTests/ReviewSessionSelectionPersisterTests.swift
+++ b/AlasTests/ReviewSessionSelectionPersisterTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct ReviewSessionSelectionPersisterTests {
+    @Test func coalescesBurstIntoSingleLatestWrite() async throws {
+        let persister = ReviewSessionSelectionPersister(debounceNanos: 20_000_000)
+        var writes: [String] = []
+
+        persister.schedule { writes.append("first") }
+        persister.schedule { writes.append("second") }
+        persister.schedule { writes.append("third") }
+        #expect(writes.isEmpty)
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(writes == ["third"])
+    }
+
+    @Test func flushRunsPendingWriteImmediatelyAndOnlyOnce() async throws {
+        let persister = ReviewSessionSelectionPersister(debounceNanos: 20_000_000)
+        var writes: [String] = []
+
+        persister.schedule { writes.append("pending") }
+        persister.flush()
+        #expect(writes == ["pending"])
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(writes == ["pending"])
+    }
+
+    @Test func flushWithoutPendingWriteIsNoOp() {
+        let persister = ReviewSessionSelectionPersister(debounceNanos: 20_000_000)
+        persister.flush()
+    }
+
+    @Test func scheduleAfterFlushStartsFreshDebounce() async throws {
+        let persister = ReviewSessionSelectionPersister(debounceNanos: 20_000_000)
+        var writes: [String] = []
+
+        persister.schedule { writes.append("first") }
+        persister.flush()
+        persister.schedule { writes.append("second") }
+        #expect(writes == ["first"])
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(writes == ["first", "second"])
+    }
+}

--- a/AlasTests/ReviewSessionSelectionPersisterTests.swift
+++ b/AlasTests/ReviewSessionSelectionPersisterTests.swift
@@ -153,6 +153,76 @@ struct ReviewSessionSelectionPersisterTests {
         #expect(reloaded.selectedFileID == pendingFileID)
     }
 
+    /// Reproduces the other half of the flush race: `recordSessionHandoff`
+    /// reassigns the view's in-memory record from a fresh disk load, which
+    /// reverts `selectedFileID` to whatever was on disk before the pending
+    /// selection write flushes. The flush must persist the selection
+    /// captured when it was scheduled, not read it back off a record that
+    /// may have just been reverted underneath it. Uses the real
+    /// `ReviewSessionHandoffPersistence.record` — the same function
+    /// `recordSessionHandoff` calls — composed with a real store.
+    @Test func flushPersistsTheScheduledSelectionEvenAfterAHandoffRevertsRecord() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-sessions.json")
+        let store = ReviewSessionStore(url: url)
+
+        let target = ReviewSessionTarget.commit(
+            worktreeID: "wt-1", repositoryPath: URL(fileURLWithPath: "/repo"), sha: "aaa", title: "Review aaa"
+        )
+        let fileA = DiffReviewFileID(namespace: "commit", path: "A.swift")
+        let fileB = DiffReviewFileID(namespace: "commit", path: "B.swift")
+        let originalRecord = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            selectedFileID: fileA,
+            createdAt: .init(timeIntervalSince1970: 1),
+            updatedAt: .init(timeIntervalSince1970: 1)
+        )
+        try store.save(originalRecord)
+
+        // The user selects B: in-memory record updates immediately, and the
+        // debounced write captures B — but hasn't flushed to disk yet, so
+        // disk still has A.
+        let recordAfterSelection = originalRecord.selectingFile(fileB, now: .init(timeIntervalSince1970: 2))
+        let scheduledFileID = fileB
+
+        // Before the flush fires, a send completes. recordSessionHandoff's
+        // real code path reloads from disk (still selectedFileID == A) in
+        // preference to the in-memory record, reverting the local snapshot.
+        let handoff = ReviewFeedbackHandoff(
+            id: "handoff-1",
+            sessionID: target.id,
+            commentIDs: ["draft-1"],
+            target: .existingSession(worktreeID: "wt-1", sessionID: "acp-1", title: "Codex"),
+            createdAt: .init(timeIntervalSince1970: 3),
+            promptRevision: "revision-1",
+            status: .sent
+        )
+        let recordAfterHandoff = ReviewSessionHandoffPersistence.record(
+            handoff,
+            currentRecord: recordAfterSelection,
+            sessionStore: store,
+            persistsState: true,
+            now: { .init(timeIntervalSince1970: 3) }
+        )
+        // Confirms the precondition: the handoff path really does revert
+        // the local selection back to what was on disk.
+        #expect(recordAfterHandoff?.selectedFileID == fileA)
+
+        // The flush: merge the selection captured at schedule time onto
+        // whatever is live in the store now (the handoff-updated record).
+        let latest = try #require(try store.load(id: target.id))
+        let merged = ReviewSessionTabView.mergingSelectedFile(
+            into: latest, fileID: scheduledFileID, now: .init(timeIntervalSince1970: 4)
+        )
+        try store.save(merged)
+
+        let reloaded = try #require(try store.load(id: target.id))
+        #expect(reloaded.selectedFileID == fileB)
+        #expect(reloaded.handoffs == [handoff])
+    }
+
     @Test func scheduleAfterFlushStartsFreshDebounce() async throws {
         let persister = ReviewSessionSelectionPersister(debounceNanos: 20_000_000)
         var writes: [String] = []

--- a/AlasTests/ReviewSessionSelectionPersisterTests.swift
+++ b/AlasTests/ReviewSessionSelectionPersisterTests.swift
@@ -34,6 +34,125 @@ struct ReviewSessionSelectionPersisterTests {
         persister.flush()
     }
 
+    // MARK: - mergingSelectedFile
+
+    @Test func mergingSelectedFileOverridesOnlySelectionAndTimestamp() {
+        let target = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "aaa",
+            title: "Review aaa"
+        )
+        let latest = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            selectedFileID: DiffReviewFileID(namespace: "commit", path: "A.swift"),
+            status: .sent,
+            handoffs: [],
+            createdAt: .init(timeIntervalSince1970: 1),
+            updatedAt: .init(timeIntervalSince1970: 2)
+        )
+        let newFileID = DiffReviewFileID(namespace: "commit", path: "B.swift")
+        let now = Date(timeIntervalSince1970: 99)
+
+        let merged = ReviewSessionTabView.mergingSelectedFile(into: latest, fileID: newFileID, now: now)
+
+        #expect(merged.selectedFileID == newFileID)
+        #expect(merged.updatedAt == now)
+        #expect(merged.target == latest.target)
+        #expect(merged.status == latest.status)
+    }
+
+    @Test func mergingSelectedFileIsANoOpWhenSelectionAlreadyMatches() {
+        let target = ReviewSessionTarget.commit(
+            worktreeID: "wt-1",
+            repositoryPath: URL(fileURLWithPath: "/repo"),
+            sha: "aaa",
+            title: "Review aaa"
+        )
+        let fileID = DiffReviewFileID(namespace: "commit", path: "A.swift")
+        let latest = ReviewSessionRecord(
+            id: target.id,
+            target: target,
+            selectedFileID: fileID,
+            createdAt: .init(timeIntervalSince1970: 1),
+            updatedAt: .init(timeIntervalSince1970: 2)
+        )
+
+        let merged = ReviewSessionTabView.mergingSelectedFile(into: latest, fileID: fileID, now: .init(timeIntervalSince1970: 99))
+
+        // No selection change means no write-worthy mutation: updatedAt must
+        // not bump on every redundant flush.
+        #expect(merged == latest)
+    }
+
+    /// Reproduces the race a debounced flush can hit: another path (e.g.
+    /// `AppState.persistReviewRetargeting`) replaces this session's stored
+    /// record — under a *new* id — while a selection write is still
+    /// pending. The flush must merge onto whatever is live at flush time,
+    /// not resurrect the record the replace just removed or clobber its
+    /// fresher fields.
+    @Test func flushMergesOntoRecordReplacedDuringTheDebounceWindow() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-sessions.json")
+        let store = ReviewSessionStore(url: url)
+
+        let oldTarget = ReviewSessionTarget.commit(
+            worktreeID: "wt-1", repositoryPath: URL(fileURLWithPath: "/repo"), sha: "aaa", title: "Review aaa"
+        )
+        let originalRecord = ReviewSessionRecord(
+            id: oldTarget.id,
+            target: oldTarget,
+            selectedFileID: DiffReviewFileID(namespace: "commit", path: "A.swift"),
+            createdAt: .init(timeIntervalSince1970: 1),
+            updatedAt: .init(timeIntervalSince1970: 1)
+        )
+        try store.save(originalRecord)
+
+        // A selection change is scheduled while `originalRecord.id` is still
+        // the live id — this is the id a debounced flush would capture.
+        let scheduledSessionID = originalRecord.id
+        let pendingFileID = DiffReviewFileID(namespace: "commit", path: "B.swift")
+
+        // Before the flush fires, a retarget replaces the record under a
+        // new id, carrying forward a handoff the flush must not lose.
+        let newTarget = ReviewSessionTarget.commit(
+            worktreeID: "wt-1", repositoryPath: URL(fileURLWithPath: "/repo"), sha: "bbb", title: "Review bbb"
+        )
+        let handoff = ReviewFeedbackHandoff(
+            id: "handoff-1",
+            sessionID: newTarget.id,
+            commentIDs: ["draft-1"],
+            target: .existingSession(worktreeID: "wt-1", sessionID: "acp-1", title: "Codex"),
+            createdAt: .init(timeIntervalSince1970: 5),
+            promptRevision: "revision-1",
+            status: .sent
+        )
+        let retargetedRecord = ReviewSessionRecord(
+            id: newTarget.id,
+            target: newTarget,
+            selectedFileID: originalRecord.selectedFileID,
+            handoffs: [handoff],
+            createdAt: originalRecord.createdAt,
+            updatedAt: .init(timeIntervalSince1970: 5)
+        )
+        try store.replace(id: originalRecord.id, with: retargetedRecord)
+
+        // The flush: load whatever is live via the id captured at schedule
+        // time (following the replacement), then merge the pending
+        // selection onto it.
+        let latest = try #require(try store.load(id: scheduledSessionID))
+        let merged = ReviewSessionTabView.mergingSelectedFile(into: latest, fileID: pendingFileID, now: .init(timeIntervalSince1970: 9))
+        try store.save(merged)
+
+        let reloaded = try #require(try store.load(id: scheduledSessionID))
+        #expect(reloaded.id == newTarget.id)
+        #expect(reloaded.target == newTarget)
+        #expect(reloaded.handoffs == [handoff])
+        #expect(reloaded.selectedFileID == pendingFileID)
+    }
+
     @Test func scheduleAfterFlushStartsFreshDebounce() async throws {
         let persister = ReviewSessionSelectionPersister(debounceNanos: 20_000_000)
         var writes: [String] = []


### PR DESCRIPTION
## Summary
- Cache built diff pane documents so prewarmed rows and remounts reuse attributed documents instead of rebuilding them during scroll.
- Reduce review rebuild cost by tracking render-context recency with stamps, hashing row-plan signatures directly, and counting rail thread totals in one pass.
- Debounce review-session selection writes so scroll-spy file changes do not force synchronous disk persistence mid-scroll.

## Testing
- Added Swift Testing coverage for diff document cache reuse, rail thread counts, render-context cache eviction, and selection persistence debouncing.