### PR TITLE
fix(chat): input-request scroll jumps

### DIFF
--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -943,6 +943,9 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 update(host: host)
                 return
             }
+            // ponytail: keep the grow-only window while an input form is open;
+            // restore anchor-based compaction if the retained window becomes a memory issue.
+            guard host.transcript.pendingUserInputs.isEmpty else { return }
             guard host.transcript.visibleTailBound - host.transcript.visibleHead
                     > ACPTranscript.maxVisibleRows,
                   let globalIndex = currentTopGlobalMessageIndex(),

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerLiveScrollTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerLiveScrollTests.swift
@@ -153,6 +153,46 @@ struct ACPTranscriptScrollerLiveScrollTests {
         withExtendedLifetime(coordinator) {}
     }
 
+    @Test("settling an input-request chat does not compact the reading window")
+    func settlingInputRequestChatDoesNotCompactReadingWindow() async throws {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.followsTranscriptTail = false
+        let host = makeLiveScrollHost(session: session)
+        host.transcript.messages = (0..<240).map { index in
+            .systemNotice(id: UUID(), text: String(repeating: "message \(index) ", count: 20))
+        }
+        host.transcript.visibleHead = 0
+        host.transcript.visibleTail = nil
+        host.transcript.streamingState = .awaitingInput
+        host.transcript.pendingUserInputs = [
+            ACPUserInputRequest(
+                id: UUID(),
+                source: .cursor(
+                    id: .string("question"),
+                    params: ACPQuestionRequestParams(toolCallId: "tool", title: "Question", questions: [])
+                ),
+                title: "Question",
+                message: "Question",
+                fields: [],
+                mode: .form
+            ),
+        ]
+
+        let scroller = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 600, height: 500))
+        let coordinator = ACPTranscriptScroller.Coordinator()
+        coordinator.attach(scroller: scroller, host: host)
+        scroller.layoutSubtreeIfNeeded()
+        scroller.setScrollY(scroller.contentHeight / 2)
+
+        liveScroll(scroller, to: scroller.scrollY - 80)
+        let expectedMessage = coordinator.topVisibleMessageIdForTesting
+        try await Task.sleep(for: .milliseconds(700))
+
+        #expect(host.transcript.visibleTailBound - host.transcript.visibleHead > ACPTranscript.maxVisibleRows)
+        #expect(coordinator.topVisibleMessageIdForTesting == expectedMessage)
+        withExtendedLifetime(coordinator) {}
+    }
+
     @Test("live-scroll activity lapses after the gesture settles")
     func userScrollActivityLapses() {
         let (_, scroller, coordinator) = tailFollowingHost()


### PR DESCRIPTION
## Summary

Keep an ACP transcript’s temporary history window stable while an input form is pending, so the delayed scroll-settle callback cannot move the message being read.

## Changes

- Skip window compaction while user input is pending.
- Add regression coverage for the delayed post-scroll callback.

## Verification

- `xcodegen`
- `swiftc -parse AlasTests/ACP/UI/ACPTranscriptScrollerLiveScrollTests.swift Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift`
- `git diff --check`

The full macOS Xcode test run is currently blocked in this worktree before compilation because Xcode rejects the generated `.build/ghostty/GhosttyKit.xcframework`.