### PR TITLE
fix(input): paired quote cursor placement

### DIFF
--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -8,6 +8,11 @@ class PairedDelimiterTextView: NSTextView {
     /// delimiter can still wrap the selection the user had before pressing it.
     private var selectionReplacedByMarkedText: NSAttributedString?
 
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        isAutomaticQuoteSubstitutionEnabled = false
+    }
+
     override func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
         if !hasMarkedText() {
             let replaced = replacementRange.location == NSNotFound ? self.selectedRange() : replacementRange

--- a/AlasTests/PairedComposerTextControlsTests.swift
+++ b/AlasTests/PairedComposerTextControlsTests.swift
@@ -54,6 +54,19 @@ struct PairedComposerTextControlsTests {
         #expect(textView.selectedRange() == NSRange(location: 2, length: 0))
     }
 
+    @Test func pairedComposerDisablesNativeQuoteRewriting() {
+        let textView = makePairedTextView()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 120),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = textView
+
+        #expect(!textView.isAutomaticQuoteSubstitutionEnabled)
+    }
+
     @Test func multiCharacterAndMarkedTextUseNativeInsertion() {
         let pastedTextView = makePairedTextView()
 


### PR DESCRIPTION
- Disable native quote substitution in paired text controls
- Cover the AppKit setting with a regression test