### PR TITLE
fix(worktree): long branch name input wrapping

### DIFF
--- a/Alas/Sources/UI/AlasField.swift
+++ b/Alas/Sources/UI/AlasField.swift
@@ -173,6 +173,38 @@ private struct AlasNSTextField: NSViewRepresentable {
     }
 }
 
-private class AlasNSTextFieldView: NSTextField {
+class AlasNSTextFieldView: NSTextField {
     var focusOnAppear = false
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        configureCell()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureCell()
+    }
+
+    private func configureCell() {
+        cell = AlasNSTextFieldCell(textCell: "")
+        lineBreakMode = .byClipping
+        cell?.usesSingleLineMode = true
+        cell?.isScrollable = true
+        cell?.wraps = false
+    }
+}
+
+final class AlasNSTextFieldCell: NSTextFieldCell {
+    override func setUpFieldEditorAttributes(_ textObj: NSText) -> NSText {
+        let editor = super.setUpFieldEditorAttributes(textObj)
+        guard let textView = editor as? NSTextView else { return editor }
+
+        textView.isHorizontallyResizable = true
+        textView.isVerticallyResizable = false
+        textView.textContainer?.widthTracksTextView = false
+        textView.textContainer?.lineBreakMode = .byClipping
+        textView.textContainer?.maximumNumberOfLines = 1
+        return textView
+    }
 }

--- a/AlasTests/AlasFieldTests.swift
+++ b/AlasTests/AlasFieldTests.swift
@@ -46,6 +46,19 @@ struct AlasFieldTests {
         #expect(Self.firstTextField(in: controller.view)?.isEnabled == false)
     }
 
+    @Test func nativeFieldKeepsLongInputOnOneScrollableLine() {
+        let field = AlasNSTextFieldView()
+        let cell = field.cell as! AlasNSTextFieldCell
+        let editor = cell.setUpFieldEditorAttributes(NSTextView()) as! NSTextView
+
+        #expect(field.lineBreakMode == .byClipping)
+        #expect(editor.isHorizontallyResizable)
+        #expect(!editor.isVerticallyResizable)
+        #expect(editor.textContainer?.widthTracksTextView == false)
+        #expect(editor.textContainer?.lineBreakMode == .byClipping)
+        #expect(editor.textContainer?.maximumNumberOfLines == 1)
+    }
+
     private static func firstTextField(in view: NSView) -> NSTextField? {
         if let field = view as? NSTextField { return field }
         for subview in view.subviews {


### PR DESCRIPTION
## Summary

Long worktree branch names could wrap inside the native field editor, leaving the value clipped in the new-worktree dialog. Keep the editor single-line and horizontally scrollable instead of imposing a branch-name limit.

## Changes

- Configure the shared AppKit-backed field and its editor to clip rather than wrap.
- Add regression coverage for the single-line editor behavior.

## Verification

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/AlasFieldTests test -quiet`\n\n## Notes for reviewers\n\nThe complete suite was started, but an unrelated existing timeout occurred in `AppStateCleanupTests.successfulInheritCreationKeepsGGWorktreeModesSparse`.