### PR TITLE
feat(mcp): Import MCP configs from clipboard

### DIFF
--- a/Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift
+++ b/Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift
@@ -174,12 +174,12 @@ enum ProjectMCPConfigImporter {
     }
 
     private static func rawServers(from text: String) -> [String: Any]? {
-        let normalized = text
+        let original = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalized = original
             .replacingOccurrences(of: "“", with: "\"")
             .replacingOccurrences(of: "”", with: "\"")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
 
-        for candidate in [normalized, "{\(normalized)}"] {
+        for candidate in [original, "{\(original)}", normalized, "{\(normalized)}"] {
             guard let data = candidate.data(using: .utf8),
                   let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let servers = object["mcpServers"] as? [String: Any] else { continue }

--- a/Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift
+++ b/Alas/Sources/Dialogs/ProjectMCPServerEditorPolicy.swift
@@ -149,3 +149,75 @@ enum ProjectMCPServerEditorPolicy {
             + String(value[authorityEnd...])
     }
 }
+
+enum ProjectMCPConfigImporter {
+    static func servers(
+        from text: String,
+        excluding existing: [ProjectMCPServer] = []
+    ) -> [ProjectMCPServer] {
+        guard let rawServers = rawServers(from: text) else { return [] }
+        var names = Set(existing.map { $0.name.trimmingCharacters(in: .whitespacesAndNewlines) })
+
+        return rawServers.compactMap { rawName, value in
+            let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty,
+                  !names.contains(name),
+                  let config = value as? [String: Any],
+                  config["disabled"] as? Bool != true,
+                  let transport = transport(from: config) else { return nil }
+
+            let server = ProjectMCPServer(id: UUID().uuidString, name: name, transport: transport)
+            guard ProjectMCPServerEditorPolicy.canSave([server]) else { return nil }
+            names.insert(name)
+            return server
+        }
+    }
+
+    private static func rawServers(from text: String) -> [String: Any]? {
+        let normalized = text
+            .replacingOccurrences(of: "“", with: "\"")
+            .replacingOccurrences(of: "”", with: "\"")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        for candidate in [normalized, "{\(normalized)}"] {
+            guard let data = candidate.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let servers = object["mcpServers"] as? [String: Any] else { continue }
+            return servers
+        }
+        return nil
+    }
+
+    private static func transport(from config: [String: Any]) -> ProjectMCPTransport? {
+        let kind = (config["type"] as? String)?.lowercased()
+            ?? (config["command"] != nil ? "stdio" : config["url"] != nil ? "http" : nil)
+
+        switch kind {
+        case "stdio":
+            guard let command = config["command"] as? String,
+                  let args = stringArray(config["args"]),
+                  let environment = keyValues(config["env"]) else { return nil }
+            return .stdio(command: command, args: args, environment: environment)
+        case "http", "sse":
+            guard let url = config["url"] as? String,
+                  let headers = keyValues(config["headers"]) else { return nil }
+            return kind == "http" ? .http(url: url, headers: headers) : .sse(url: url, headers: headers)
+        default:
+            return nil
+        }
+    }
+
+    private static func stringArray(_ value: Any?) -> [String]? {
+        value == nil ? [] : value as? [String]
+    }
+
+    private static func keyValues(_ value: Any?) -> [MCPKeyValue]? {
+        guard let value else { return [] }
+        guard let dictionary = value as? [String: Any],
+              dictionary.values.allSatisfy({ $0 is String }) else { return nil }
+        return dictionary.keys.sorted().compactMap { key in
+            guard let value = dictionary[key] as? String else { return nil }
+            return MCPKeyValue(id: UUID().uuidString, name: key, value: value)
+        }
+    }
+}

--- a/Alas/Sources/Dialogs/ProjectMCPServerManager.swift
+++ b/Alas/Sources/Dialogs/ProjectMCPServerManager.swift
@@ -6,6 +6,7 @@ struct ProjectMCPServerManager: View {
     @State private var draft: [ProjectMCPServer]
     @State private var editor: ProjectMCPServerEditorTarget?
     @State private var deleteTarget: ProjectMCPServer?
+    @State private var didImportClipboard = false
     @Environment(\.dismiss) private var dismiss
     @Environment(\.theme) private var theme
 
@@ -45,6 +46,7 @@ struct ProjectMCPServerManager: View {
                 AlasButton(title: "Add Server", icon: "plus", action: {
                     editor = .new
                 })
+                AlasButton(title: "Import from Clipboard", icon: "doc.on.clipboard", action: importFromClipboard)
                 Spacer()
                 AlasButton(title: "Cancel", style: .subtle, action: { dismiss() })
                 AlasButton(title: "Done", style: .primary, action: commit)
@@ -55,6 +57,11 @@ struct ProjectMCPServerManager: View {
         .padding(24)
         .frame(width: 620)
         .background(theme.color("bg-1"))
+        .onAppear {
+            guard !didImportClipboard else { return }
+            didImportClipboard = true
+            importFromClipboard()
+        }
         .sheet(item: $editor) { target in
             ProjectMCPServerEditor(server: target.server) { saved in
                 save(saved, replacing: target.existingID)
@@ -127,6 +134,11 @@ struct ProjectMCPServerManager: View {
         guard ProjectMCPServerEditorPolicy.canSave(draft) else { return }
         servers = draft
         dismiss()
+    }
+
+    private func importFromClipboard() {
+        guard let text = NSPasteboard.general.string(forType: .string) else { return }
+        draft.append(contentsOf: ProjectMCPConfigImporter.servers(from: text, excluding: draft))
     }
 
     private var deleteConfirmationTitle: String {

--- a/AlasTests/ProjectMCPServerEditorPolicyTests.swift
+++ b/AlasTests/ProjectMCPServerEditorPolicyTests.swift
@@ -97,3 +97,86 @@ struct ProjectMCPServerEditorPolicyTests {
         #expect(ProjectMCPServerEditorPolicy.transportLabel(for: .sse(url: "https://example.com/sse", headers: [])) == "Legacy SSE")
     }
 }
+
+@Suite("Project MCP config importer")
+struct ProjectMCPConfigImporterTests {
+    @Test func importsSupportedTransportsFromWrappedConfig() throws {
+        let text = #"""
+        {
+          "mcpServers": {
+            "local": {
+              "command": "npx",
+              "args": ["-y", "server"],
+              "env": { "TOKEN": "${MCP_TOKEN}" }
+            },
+            "remote": {
+              "url": "https://mcp.example.com/mcp",
+              "headers": { "Authorization": "Bearer ${MCP_TOKEN}" }
+            },
+            "events": {
+              "type": "sse",
+              "url": "https://mcp.example.com/sse"
+            }
+          }
+        }
+        """#
+
+        let servers = ProjectMCPConfigImporter.servers(from: text)
+        let local = try #require(servers.first { $0.name == "local" })
+        let remote = try #require(servers.first { $0.name == "remote" })
+        let events = try #require(servers.first { $0.name == "events" })
+
+        #expect(servers.count == 3)
+        guard case let .stdio(command, args, environment) = local.transport else {
+            Issue.record("Expected stdio transport")
+            return
+        }
+        #expect(command == "npx")
+        #expect(args == ["-y", "server"])
+        #expect(environment.count == 1)
+        #expect(environment.first?.name == "TOKEN")
+        #expect(environment.first?.value == "${MCP_TOKEN}")
+        guard case let .http(url, headers) = remote.transport else {
+            Issue.record("Expected HTTP transport")
+            return
+        }
+        #expect(url == "https://mcp.example.com/mcp")
+        #expect(headers.count == 1)
+        #expect(headers.first?.name == "Authorization")
+        #expect(headers.first?.value == "Bearer ${MCP_TOKEN}")
+        #expect(events.transport == .sse(url: "https://mcp.example.com/sse", headers: []))
+    }
+
+    @Test func importsBraceLessConfigWithSmartQuotes() throws {
+        let text = #"“mcpServers”: { “scout”: { “type”: “http”, “url”: “http://localhost:3001/mcp”, “disabled”: false } }"#
+
+        let servers = ProjectMCPConfigImporter.servers(from: text)
+        let scout = try #require(servers.first)
+
+        #expect(servers.count == 1)
+        #expect(scout.name == "scout")
+        #expect(scout.transport == .http(url: "http://localhost:3001/mcp", headers: []))
+    }
+
+    @Test func skipsDisabledMalformedUnsupportedAndExistingServers() {
+        let text = #"""
+        {
+          "mcpServers": {
+            "existing": { "type": "http", "url": "https://replacement.example.com" },
+            "disabled": { "type": "http", "url": "https://disabled.example.com", "disabled": true },
+            "broken": { "type": "http", "url": "not a url" },
+            "unsupported": { "type": "websocket", "url": "wss://example.com" },
+            "usable": { "type": "stdio", "command": "mcp-server" }
+          }
+        }
+        """#
+        let existing = [ProjectMCPServer.stdio(name: " existing ", command: "keep-me")]
+
+        let servers = ProjectMCPConfigImporter.servers(from: text, excluding: existing)
+
+        #expect(servers.count == 1)
+        #expect(servers.first?.name == "usable")
+        #expect(servers.first?.transport == .stdio(command: "mcp-server", args: [], environment: []))
+        #expect(ProjectMCPConfigImporter.servers(from: "not JSON").isEmpty)
+    }
+}

--- a/AlasTests/ProjectMCPServerEditorPolicyTests.swift
+++ b/AlasTests/ProjectMCPServerEditorPolicyTests.swift
@@ -158,6 +158,24 @@ struct ProjectMCPConfigImporterTests {
         #expect(scout.transport == .http(url: "http://localhost:3001/mcp", headers: []))
     }
 
+    @Test func preservesCurlyQuotesInValidJSONValues() throws {
+        let text = #"""
+        {
+          "mcpServers": {
+            "echo": { "command": "node", "args": ["Say “hello”"] }
+          }
+        }
+        """#
+
+        let server = try #require(ProjectMCPConfigImporter.servers(from: text).first)
+
+        guard case let .stdio(_, args, _) = server.transport else {
+            Issue.record("Expected stdio transport")
+            return
+        }
+        #expect(args == ["Say “hello”"])
+    }
+
     @Test func skipsDisabledMalformedUnsupportedAndExistingServers() {
         let text = #"""
         {


### PR DESCRIPTION
## Summary

Project MCP configuration can now be imported directly from the clipboard, reducing manual entry when users copy standard MCP configuration snippets.

## Changes

- Parse wrapped and brace-less `mcpServers` JSON, including smart quotes.
- Import stdio, HTTP, and SSE server definitions while skipping disabled, invalid, unsupported, and duplicate entries.
- Import once when the manager opens and provide an explicit Import from Clipboard action.
- Cover supported transports, partial invalid input, and duplicate handling with focused tests.

## Verification

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- Focused `ProjectMCPConfigImporterTests`\n\nThe full suite was also started but hit unrelated existing failures in `ProjectsManagerTests` and `RightPaneGGStackTests`, then Xcode stalled while cleaning up the test session.