### PR TITLE
feat(acp): support configurable adapter providers

### DIFF
--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -6,6 +6,7 @@ struct ACPInitializeOutcome: Equatable {
     let loadSession: Bool
     let sessionCapabilities: ACPInitializeResult.ACPAgentSessionCapabilities
     let mcpCapabilities: ACPMCPServerCapabilities
+    let providerCapabilities: EmptyObject?
 }
 
 /// Higher-level wrapper that owns one `ACPClient` and exposes typed
@@ -36,7 +37,8 @@ final class ACPConnection: @unchecked Sendable {
             authMethods: result.authMethods,
             loadSession: result.agentCapabilities?.loadSession ?? false,
             sessionCapabilities: result.agentCapabilities?.sessionCapabilities ?? .init(),
-            mcpCapabilities: result.agentCapabilities?.mcpCapabilities ?? .init()
+            mcpCapabilities: result.agentCapabilities?.mcpCapabilities ?? .init(),
+            providerCapabilities: result.agentCapabilities?.providerCapabilities
         )
     }
 
@@ -164,6 +166,30 @@ final class ACPConnection: @unchecked Sendable {
         let resp = try await client.send(ACPRequest(method: "session/set_model",
                                                     params: ACPSessionSetModelParams(sessionId: sessionId, modelId: modelId)))
         resp.acknowledgeDurableConsumption()
+    }
+
+    func listProviders() async throws -> [ACPProviderInfo] {
+        let response = try await client.send(ACPRequest(
+            method: "providers/list",
+            params: ACPProvidersListParams()
+        ))
+        defer { response.acknowledgeDurableConsumption() }
+        return try JSONDecoder().decode(ACPProvidersListResult.self, from: response.body).providers
+    }
+
+    func setProvider(_ params: ACPProviderSetParams) async throws -> [ACPProviderInfo] {
+        let response = try await client.send(ACPRequest(method: "providers/set", params: params))
+        response.acknowledgeDurableConsumption()
+        return try await listProviders()
+    }
+
+    func disableProvider(providerId: String) async throws -> [ACPProviderInfo] {
+        let response = try await client.send(ACPRequest(
+            method: "providers/disable",
+            params: ACPProviderDisableParams(providerId: providerId)
+        ))
+        response.acknowledgeDurableConsumption()
+        return try await listProviders()
     }
 
     /// Sends a config-option change and returns the agent's refreshed

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -204,17 +204,25 @@ struct ACPInitializeResult: Codable, Equatable {
         let loadSession: Bool
         let sessionCapabilities: ACPAgentSessionCapabilities
         let mcpCapabilities: ACPMCPServerCapabilities
+        let providerCapabilities: EmptyObject?
 
         init(
             promptCapabilities: ACPPromptCapabilities? = nil,
             loadSession: Bool = false,
             sessionCapabilities: ACPAgentSessionCapabilities = .init(),
-            mcpCapabilities: ACPMCPServerCapabilities = .init()
+            mcpCapabilities: ACPMCPServerCapabilities = .init(),
+            providerCapabilities: EmptyObject? = nil
         ) {
             self.promptCapabilities = promptCapabilities
             self.loadSession = loadSession
             self.sessionCapabilities = sessionCapabilities
             self.mcpCapabilities = mcpCapabilities
+            self.providerCapabilities = providerCapabilities
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case promptCapabilities, loadSession, sessionCapabilities, mcpCapabilities
+            case providerCapabilities = "providers"
         }
 
         init(from decoder: Decoder) throws {
@@ -226,6 +234,7 @@ struct ACPInitializeResult: Codable, Equatable {
                 forKey: .sessionCapabilities
             ) ?? .init()
             mcpCapabilities = try c.decodeIfPresent(ACPMCPServerCapabilities.self, forKey: .mcpCapabilities) ?? .init()
+            providerCapabilities = try? c.decodeIfPresent(EmptyObject.self, forKey: .providerCapabilities)
         }
     }
 
@@ -793,6 +802,66 @@ struct ACPSessionSetModeParams: Codable, Equatable {
 struct ACPSessionSetModelParams: Codable, Equatable {
     let sessionId: String
     let modelId: String
+}
+
+// MARK: - providers
+
+struct ACPProvidersListParams: Codable, Equatable {}
+
+struct ACPProviderCurrentConfig: Codable, Equatable, Hashable {
+    let apiType: String
+    let baseUrl: String
+}
+
+struct ACPProviderInfo: Codable, Equatable, Hashable, Identifiable {
+    var id: String { providerId }
+
+    let providerId: String
+    let name: String?
+    let supported: [String]
+    let required: Bool
+    let current: ACPProviderCurrentConfig?
+
+    init(
+        providerId: String,
+        name: String? = nil,
+        supported: [String],
+        required: Bool,
+        current: ACPProviderCurrentConfig?
+    ) {
+        self.providerId = providerId
+        self.name = name
+        self.supported = supported
+        self.required = required
+        self.current = current
+    }
+}
+
+struct ACPProvidersListResult: Codable, Equatable {
+    let providers: [ACPProviderInfo]
+}
+
+struct ACPProviderSetParams: Codable, Equatable {
+    let providerId: String
+    let apiType: String
+    let baseUrl: String
+    let headers: [String: String]?
+
+    init(
+        providerId: String,
+        apiType: String,
+        baseUrl: String,
+        headers: [String: String]? = nil
+    ) {
+        self.providerId = providerId
+        self.apiType = apiType
+        self.baseUrl = baseUrl
+        self.headers = headers
+    }
+}
+
+struct ACPProviderDisableParams: Codable, Equatable {
+    let providerId: String
 }
 
 // MARK: - session/prompt

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -47,6 +47,9 @@ final class ACPSession: ObservableObject, Identifiable {
     @Published var availableModels: [ACPModelInfo] = []
     @Published var availableModes: [ACPModeInfo] = []
     @Published var availableConfigOptions: [ACPConfigOption] = []
+    /// Runtime-only provider state learned from the adapter on each attach.
+    @Published var providerCapabilities: EmptyObject?
+    @Published var availableProviders: [ACPProviderInfo] = []
     @Published var currentModel: String?
     @Published var contextUsage: ACPUsageInfo?
     @Published var currentMode: String?
@@ -183,6 +186,14 @@ final class ACPSession: ObservableObject, Identifiable {
     var currentModelDisplayName: String? {
         guard let id = currentModel else { return nil }
         return availableModels.first { $0.id == id }?.name ?? id
+    }
+
+    var currentProviderDisplayName: String? {
+        guard agentState == .ready, providerCapabilities != nil else { return nil }
+        let names = availableProviders
+            .filter { $0.current != nil }
+            .map { $0.name ?? $0.providerId }
+        return names.isEmpty ? nil : names.joined(separator: ", ")
     }
 
     enum AgentState: Equatable {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2943,6 +2943,8 @@ extension ACPSessionManager {
         session.lastError = nil
         session.contextRestoreWarning = nil
         session.contextRecoveryStatus = nil
+        session.providerCapabilities = nil
+        session.availableProviders = []
         session.agentState = .spawning
 
         guard let spec = ACPLaunchCatalog.spec(for: session.agentId) else {
@@ -3567,6 +3569,11 @@ extension ACPSessionManager {
                     session.contextRecoveryStatus = .sendingTranscript
                 }
             }
+            let providers: [ACPProviderInfo] = if initialized.providerCapabilities != nil {
+                (try? await connection.listProviders()) ?? []
+            } else {
+                []
+            }
             // Start the built-in MCP registration grace ONLY now — session
             // creation/restoration above has succeeded, which is when the
             // adapter actually received `wireMCPServers` and could spawn or
@@ -3665,6 +3672,8 @@ extension ACPSessionManager {
             session.currentMode = result.currentMode
             session.promptSuggestions = result.promptSuggestions
             session.availableConfigOptions = result.configOptions
+            session.providerCapabilities = initialized.providerCapabilities
+            session.availableProviders = providers
             session.contextRestoreWarning = restoreWarning
             guard await persistSessionRemoteId(session) else {
                 session.remoteSessionId = persistedRows[sessionId]?.remoteSessionId

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -265,6 +265,9 @@ struct ACPComposer: View {
                 ForEach(booleanConfigOptions) { option in
                     booleanConfigToggle(option)
                 }
+                if let providerName = session.currentProviderDisplayName {
+                    providerPill(providerName)
+                }
                 if let mode = session.chipState.mode {
                     modeChip(mode)
                 }
@@ -344,6 +347,18 @@ struct ACPComposer: View {
             .background(theme.color("bg-0").opacity(0.7))
             .clipShape(RoundedRectangle(cornerRadius: 3))
             .overlay(RoundedRectangle(cornerRadius: 3).strokeBorder(theme.color("line"), lineWidth: 0.5))
+    }
+
+    private func providerPill(_ name: String) -> some View {
+        Text("Provider: \(name)")
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(theme.color("fg-muted"))
+            .padding(.horizontal, 8)
+            .frame(height: 24)
+            .background(RoundedRectangle(cornerRadius: 6).fill(theme.color("bg-3").opacity(0.7)))
+            .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line"), lineWidth: 0.75))
+            .accessibilityLabel("Provider, \(name)")
+            .help("Provider selected by the adapter")
     }
 
     private var borderColor: Color {

--- a/AlasTests/ACP/Protocol/ACPConnectionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConnectionTests.swift
@@ -349,6 +349,109 @@ struct ACPConnectionTests {
         let result = try await conn.setConfigOption(sessionId: "s", configId: "effort", value: .string("high"))
         #expect(result.isEmpty)
     }
+
+    @Test("listProviders sends an empty providers/list request and decodes non-secret state")
+    func listProvidersRPC() async throws {
+        let mock = ACPMockClient()
+        mock.script(method: "providers/list") { _ in
+            Data("""
+            {
+              "providers": [{
+                "providerId": "main",
+                "name": "Company gateway",
+                "supported": ["anthropic", "future-protocol"],
+                "required": false,
+                "current": {
+                  "apiType": "anthropic",
+                  "baseUrl": "https://gateway.example/v1",
+                  "headers": { "Authorization": "Bearer secret" },
+                  "future": true
+                },
+                "future": { "field": true }
+              }],
+              "future": true
+            }
+            """.utf8)
+        }
+
+        let providers = try await ACPConnection(client: mock).listProviders()
+
+        #expect(mock.sent.last?.method == "providers/list")
+        #expect(mock.sent.last?.params is ACPProvidersListParams)
+        #expect(providers == [ACPProviderInfo(
+            providerId: "main",
+            name: "Company gateway",
+            supported: ["anthropic", "future-protocol"],
+            required: false,
+            current: .init(apiType: "anthropic", baseUrl: "https://gateway.example/v1")
+        )])
+        #expect(String(describing: providers).contains("secret") == false)
+    }
+
+    @Test("setProvider sends the complete providers/set shape then refreshes adapter state")
+    func setProviderRPC() async throws {
+        let mock = ACPMockClient()
+        mock.script(method: "providers/set") { _ in Data("{}".utf8) }
+        mock.script(method: "providers/list") { _ in
+            Data("""
+            {"providers":[{"providerId":"main","supported":["anthropic"],"required":false,
+              "current":{"apiType":"anthropic","baseUrl":"https://gateway.example/v1"}}]}
+            """.utf8)
+        }
+        let connection = ACPConnection(client: mock)
+
+        let providers = try await connection.setProvider(.init(
+            providerId: "main",
+            apiType: "anthropic",
+            baseUrl: "https://gateway.example/v1",
+            headers: ["Authorization": "Bearer secret"]
+        ))
+
+        #expect(mock.sent.map(\.method).suffix(2) == ["providers/set", "providers/list"])
+        let params = try #require(mock.sent.dropLast().last?.params as? ACPProviderSetParams)
+        #expect(params.providerId == "main")
+        #expect(params.apiType == "anthropic")
+        #expect(params.baseUrl == "https://gateway.example/v1")
+        #expect(params.headers == ["Authorization": "Bearer secret"])
+        #expect(providers.first?.current?.baseUrl == "https://gateway.example/v1")
+    }
+
+    @Test("provider mutation errors propagate without listing stale state")
+    func setProviderErrorPropagation() async throws {
+        let mock = ACPMockClient()
+        let expected = JSONRPCError(code: -32602, message: "unsupported provider", data: nil)
+        mock.script(method: "providers/set") { _ in throw expected }
+        let connection = ACPConnection(client: mock)
+
+        do {
+            _ = try await connection.setProvider(.init(
+                providerId: "main",
+                apiType: "anthropic",
+                baseUrl: "https://gateway.example/v1"
+            ))
+            Issue.record("Expected providers/set to fail")
+        } catch let error as JSONRPCError {
+            #expect(error == expected)
+        }
+
+        #expect(mock.sent.map(\.method) == ["providers/set"])
+    }
+
+    @Test("disableProvider sends providers/disable then refreshes adapter state")
+    func disableProviderRPC() async throws {
+        let mock = ACPMockClient()
+        mock.script(method: "providers/disable") { _ in Data("{}".utf8) }
+        mock.script(method: "providers/list") { _ in
+            Data("{\"providers\":[{\"providerId\":\"main\",\"supported\":[\"anthropic\"],\"required\":false,\"current\":null}]}".utf8)
+        }
+
+        let providers = try await ACPConnection(client: mock).disableProvider(providerId: "main")
+
+        #expect(mock.sent.map(\.method).suffix(2) == ["providers/disable", "providers/list"])
+        let params = try #require(mock.sent.dropLast().last?.params as? ACPProviderDisableParams)
+        #expect(params.providerId == "main")
+        #expect(providers.first?.current == nil)
+    }
 }
 
 private final class DurableAcknowledgementRecorder: @unchecked Sendable {

--- a/AlasTests/ACP/Protocol/ACPInitializeTests.swift
+++ b/AlasTests/ACP/Protocol/ACPInitializeTests.swift
@@ -149,6 +149,36 @@ struct ACPInitializeTests {
         #expect(result.agentCapabilities?.promptCapabilities?.embeddedContext == true)
     }
 
+    @Test("decodes absent, supported, and extended provider capabilities")
+    func decodeProviderCapabilities() throws {
+        let absent = try JSONDecoder().decode(ACPInitializeResult.self, from: Data("""
+        { "protocolVersion": 1, "agentCapabilities": {} }
+        """.utf8))
+        #expect(absent.agentCapabilities?.providerCapabilities == nil)
+
+        let supported = try JSONDecoder().decode(ACPInitializeResult.self, from: Data("""
+        {
+          "protocolVersion": 1,
+          "agentCapabilities": { "providers": {} }
+        }
+        """.utf8))
+        #expect(supported.agentCapabilities?.providerCapabilities != nil)
+
+        let extended = try JSONDecoder().decode(ACPInitializeResult.self, from: Data("""
+        {
+          "protocolVersion": 1,
+          "agentCapabilities": {
+            "providers": {
+              "version": 2,
+              "switchesLoadedSessions": true,
+              "future": { "nested": [1, 2, 3] }
+            }
+          }
+        }
+        """.utf8))
+        #expect(extended.agentCapabilities?.providerCapabilities != nil)
+    }
+
     @Test("decodes agent session lifecycle capabilities with conservative defaults")
     func decodeSessionLifecycleCapabilities() throws {
         let supported = try JSONDecoder().decode(ACPInitializeResult.self, from: Data("""

--- a/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
@@ -29,6 +29,34 @@ struct ACPSessionAgentStateTests {
         session.agentState = .failed("boom")
         #expect(session.agentState == .failed("boom"))
     }
+
+    @Test("provider state is runtime-only and isolated per session")
+    func providerStateIsIsolated() {
+        let first = ACPSession(id: "s1", agentId: "claude", worktreeId: "wt", title: "one")
+        let second = ACPSession(id: "s2", agentId: "codex", worktreeId: "wt", title: "two")
+        first.providerCapabilities = .init()
+        first.availableProviders = [.init(
+            providerId: "claude",
+            name: "Enterprise Gateway",
+            supported: ["anthropic"],
+            required: true,
+            current: .init(apiType: "anthropic", baseUrl: "https://gateway.example")
+        ), .init(
+            providerId: "fallback",
+            name: nil,
+            supported: ["openai"],
+            required: false,
+            current: .init(apiType: "openai", baseUrl: "https://fallback.example")
+        )]
+
+        #expect(first.currentProviderDisplayName == nil)
+        first.agentState = .ready
+        #expect(first.currentProviderDisplayName == "Enterprise Gateway, fallback")
+        first.agentState = .disconnected
+        #expect(first.currentProviderDisplayName == nil)
+        #expect(second.currentProviderDisplayName == nil)
+        #expect(second.availableProviders.isEmpty)
+    }
 }
 
 @MainActor
@@ -108,6 +136,13 @@ struct ACPSessionManagerAttachStateTests {
         // the top of attach should happen first).
         let session = mgr.createSession(agentId: "no-such-agent-\(UUID().uuidString)")
         session.lastError = "previous failure that should not leak"
+        session.providerCapabilities = .init()
+        session.availableProviders = [.init(
+            providerId: "stale",
+            supported: ["anthropic"],
+            required: false,
+            current: .init(apiType: "anthropic", baseUrl: "https://stale.example")
+        )]
         session.agentState = .disconnected
 
         await mgr.attach(to: session.id, freshlyCreated: false)
@@ -116,6 +151,8 @@ struct ACPSessionManagerAttachStateTests {
         // stale one. (The spec-missing branch doesn't set lastError, so
         // it should now be nil — only the agentState carries the failure.)
         #expect(session.lastError == nil || session.lastError?.contains("previous failure") == false)
+        #expect(session.providerCapabilities == nil)
+        #expect(session.availableProviders.isEmpty)
     }
 }
 

--- a/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
@@ -5,6 +5,28 @@ import Testing
 @MainActor
 @Suite("ACPSessionManager remote restore")
 struct ACPSessionManagerRemoteRestoreTests {
+    @Test("loaded sessions refresh advertised provider state")
+    func loadedSessionRefreshesProviders() async throws {
+        let (manager, _, client, session) = try fixture(origin: .agentImported)
+        scriptInitialize(client, canLoad: true, canResume: false, providers: true)
+        scriptSessionResult(client, method: "session/load", sessionId: "remote-id")
+        client.script(method: "providers/list") { _ in
+            try JSONEncoder().encode(ACPProvidersListResult(providers: [.init(
+                providerId: "claude",
+                name: "Enterprise Gateway",
+                supported: ["anthropic"],
+                required: true,
+                current: .init(apiType: "anthropic", baseUrl: "https://gateway.example")
+            )]))
+        }
+
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/load", "providers/list"])
+        #expect(session.currentProviderDisplayName == "Enterprise Gateway")
+        await manager.detach(sessionId: session.id)
+    }
+
     @Test("Alas-owned sessions use resume when advertised")
     func localSessionUsesResume() async throws {
         let (manager, store, client, session) = try fixture(origin: .alasCreated)
@@ -365,13 +387,19 @@ struct ACPSessionManagerRemoteRestoreTests {
         return (manager, store, client, session)
     }
 
-    private func scriptInitialize(_ client: ACPMockClient, canLoad: Bool, canResume: Bool) {
+    private func scriptInitialize(
+        _ client: ACPMockClient,
+        canLoad: Bool,
+        canResume: Bool,
+        providers: Bool = false
+    ) {
         client.script(method: "initialize") { _ in
             try JSONEncoder().encode(ACPInitializeResult(
                 protocolVersion: 1,
                 agentCapabilities: .init(
                     loadSession: canLoad,
-                    sessionCapabilities: .init(resume: canResume ? .init() : nil)
+                    sessionCapabilities: .init(resume: canResume ? .init() : nil),
+                    providerCapabilities: providers ? .init() : nil
                 ),
                 authMethods: []
             ))


### PR DESCRIPTION
## Summary
- Decode ACP provider capabilities tolerantly and add typed `providers/list`, `providers/set`, and `providers/disable` operations.
- Refresh adapter-owned provider state after session creation or load, clearing stale runtime state on reconnect.
- Show active adapter provider names read-only in the ACP composer; provider credentials and headers are never persisted or displayed.

## Verification
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Focused ACP regression suite: 47 tests passed.

The repository-wide test command was attempted but is currently blocked by unrelated `RightPaneGGStackTests` failures and Xcode test-runner cleanup hangs.

Closes #1055