### PR TITLE
feat(acp): preserve Codex phases and retries

### DIFF
--- a/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
+++ b/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
@@ -171,23 +171,44 @@ enum ACPSessionUpdate: Codable, Equatable {
     }
 }
 
+enum ACPMessagePhase: String, Codable, Equatable, Sendable {
+    case commentary
+    case finalAnswer = "final_answer"
+
+    static func codexPhase(in metadata: AnyCodable?) -> ACPMessagePhase? {
+        guard let metadata = metadata?.value as? [String: AnyCodable],
+              let codex = metadata["codex"]?.value as? [String: AnyCodable],
+              let value = codex["phase"]?.value as? String
+        else { return nil }
+        return ACPMessagePhase(rawValue: value)
+    }
+}
+
 struct ACPTextChunk: Codable, Equatable {
     let messageId: String?
     let content: ACPContentBlock
+    let metadata: AnyCodable?
 
-    init(messageId: String? = nil, content: ACPContentBlock) {
+    var phase: ACPMessagePhase? {
+        ACPMessagePhase.codexPhase(in: metadata)
+    }
+
+    init(messageId: String? = nil, content: ACPContentBlock, metadata: AnyCodable? = nil) {
         self.messageId = messageId
         self.content = content
+        self.metadata = metadata
     }
 
     private enum CodingKeys: String, CodingKey {
         case messageId, content
+        case metadata = "_meta"
     }
 
     func encodeFields(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
         try c.encodeIfPresent(messageId, forKey: .messageId)
         try c.encode(content, forKey: .content)
+        try c.encodeIfPresent(metadata, forKey: .metadata)
     }
 }
 

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -444,8 +444,8 @@ enum ACPMessageCodec {
     static func encode(_ m: ACPMessage) throws -> Data {
         switch m {
         case .user(_, let messageId, let text, let atts, let delegatedSource): return try encoder.encode(UserPayload(messageId: messageId, text: text, attachments: atts, delegatedSource: delegatedSource))
-        case .agent(_, let messageId, let buf):            return try encoder.encode(TextPayload(messageId: messageId, text: buf.value))
-        case .thought(_, let messageId, let buf):          return try encoder.encode(TextPayload(messageId: messageId, text: buf.value))
+        case .agent(_, let messageId, let buf):            return try encoder.encode(TextPayload(messageId: messageId, text: buf.value, metadata: buf.metadata))
+        case .thought(_, let messageId, let buf):          return try encoder.encode(TextPayload(messageId: messageId, text: buf.value, metadata: buf.metadata))
         case .toolCall(let tc):             return try encoder.encode(tc)
         case .fileEdit(_, let fe):          return try encoder.encode(fe)
         case .plan(_, let items):           return try encoder.encode(PlanPayload(items: items))
@@ -461,10 +461,10 @@ enum ACPMessageCodec {
             return .user(id: UUID(), messageId: p.messageId, text: p.text, attachments: p.attachments, delegatedSource: p.delegatedSource)
         case "agent":
             let p = try JSONDecoder().decode(TextPayload.self, from: payload)
-            return .agent(id: UUID(), messageId: p.messageId, StreamingText(p.text))
+            return .agent(id: UUID(), messageId: p.messageId, StreamingText(p.text, phase: ACPMessagePhase.codexPhase(in: p.metadata), metadata: p.metadata))
         case "thought":
             let p = try JSONDecoder().decode(TextPayload.self, from: payload)
-            return .thought(id: UUID(), messageId: p.messageId, StreamingText(p.text))
+            return .thought(id: UUID(), messageId: p.messageId, StreamingText(p.text, phase: ACPMessagePhase.codexPhase(in: p.metadata), metadata: p.metadata))
         case "tool_call":
             return .toolCall(try JSONDecoder().decode(ACPMessage.ToolCall.self, from: payload))
         case "file_edit":
@@ -481,10 +481,12 @@ enum ACPMessageCodec {
     private struct TextPayload: Codable {
         let messageId: String?
         let text: String
+        let metadata: AnyCodable?
 
-        init(messageId: String? = nil, text: String) {
+        init(messageId: String? = nil, text: String, metadata: AnyCodable? = nil) {
             self.messageId = messageId
             self.text = text
+            self.metadata = metadata
         }
     }
     private struct UserPayload: Codable {

--- a/Alas/Sources/ACP/Session/ACPMessageWire.swift
+++ b/Alas/Sources/ACP/Session/ACPMessageWire.swift
@@ -7,8 +7,8 @@ import Foundation
 /// place we allocate `StreamingText` (a `@MainActor` class).
 enum ACPMessageWire: Sendable {
     case user(messageId: String?, text: String, attachments: [ACPMessage.Attachment], delegatedSource: ACPDelegatedPromptSource?)
-    case agent(messageId: String?, text: String)
-    case thought(messageId: String?, text: String)
+    case agent(messageId: String?, text: String, phase: ACPMessagePhase?, metadata: AnyCodable?)
+    case thought(messageId: String?, text: String, phase: ACPMessagePhase?, metadata: AnyCodable?)
     case toolCall(ACPMessage.ToolCall)
     case fileEdit(ACPMessage.FileEdit)
     case plan([ACPMessage.PlanItem])
@@ -42,10 +42,10 @@ enum ACPMessageWire: Sendable {
             return .user(messageId: p.messageId, text: p.text, attachments: p.attachments, delegatedSource: p.delegatedSource)
         case "agent":
             let p = try decoder.decode(TextPayload.self, from: payload)
-            return .agent(messageId: p.messageId, text: p.text)
+            return .agent(messageId: p.messageId, text: p.text, phase: ACPMessagePhase.codexPhase(in: p.metadata), metadata: p.metadata)
         case "thought":
             let p = try decoder.decode(TextPayload.self, from: payload)
-            return .thought(messageId: p.messageId, text: p.text)
+            return .thought(messageId: p.messageId, text: p.text, phase: ACPMessagePhase.codexPhase(in: p.metadata), metadata: p.metadata)
         case "tool_call":
             return .toolCall(try decoder.decode(ACPMessage.ToolCall.self, from: payload))
         case "file_edit":
@@ -66,10 +66,10 @@ enum ACPMessageWire: Sendable {
         switch self {
         case .user(let messageId, let text, let attachments, let delegatedSource):
             return .user(id: UUID(), messageId: messageId, text: text, attachments: attachments, delegatedSource: delegatedSource)
-        case .agent(let messageId, let text):
-            return .agent(id: UUID(), messageId: messageId, StreamingText(text))
-        case .thought(let messageId, let text):
-            return .thought(id: UUID(), messageId: messageId, StreamingText(text))
+        case .agent(let messageId, let text, let phase, let metadata):
+            return .agent(id: UUID(), messageId: messageId, StreamingText(text, phase: phase, metadata: metadata))
+        case .thought(let messageId, let text, let phase, let metadata):
+            return .thought(id: UUID(), messageId: messageId, StreamingText(text, phase: phase, metadata: metadata))
         case .toolCall(let tc):
             return .toolCall(tc)
         case .fileEdit(let fe):
@@ -84,6 +84,7 @@ enum ACPMessageWire: Sendable {
     private struct TextPayload: Decodable {
         let messageId: String?
         let text: String
+        let metadata: AnyCodable?
     }
     private struct UserPayload: Decodable {
         let messageId: String?

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -28,6 +28,11 @@ struct ACPGoalState: Equatable, Hashable, Sendable {
     let tokenBudget: Int?
 }
 
+struct ACPRetryStatus: Equatable {
+    let turnId: String?
+    let detail: String?
+}
+
 @MainActor
 final class ACPSession: ObservableObject, Identifiable {
     typealias ID = String
@@ -58,6 +63,8 @@ final class ACPSession: ObservableObject, Identifiable {
     @Published var autoRunEnabled: Bool = false
     @Published var setupState: SetupState = .checking
     @Published var lastError: String?
+    /// Runtime-only state reported by Codex while its current turn retries.
+    @Published private(set) var retryStatus: ACPRetryStatus?
     @Published var contextRestoreWarning: ContextRestoreWarning?
     @Published var contextRecoveryStatus: ContextRecoveryStatus?
     /// Runtime-only transcript scroll intent. When true, the ACP message
@@ -165,6 +172,8 @@ final class ACPSession: ObservableObject, Identifiable {
         var display: String
         var raw: String
         var arrivalOrder: Int
+        var phase: ACPMessagePhase?
+        var metadata: AnyCodable?
     }
 
     private var reconciledLocalUserPromptMessageIds: Set<String> = []
@@ -379,7 +388,15 @@ final class ACPSession: ObservableObject, Identifiable {
     /// `.plan` or `.toolCallUpdate` can mutate a message anywhere in the
     /// transcript, not just the trailing row.
     @discardableResult
-    func apply(_ update: ACPSessionUpdate) -> Set<Int> {
+    func apply(_ update: ACPSessionUpdate, tracksRetryStatus: Bool = true) -> Set<Int> {
+        if tracksRetryStatus {
+            switch update {
+            case .agentMessageChunk, .agentThoughtChunk, .toolCall, .toolCallUpdate, .plan:
+                clearRetryStatus()
+            default:
+                break
+            }
+        }
         // Materialise held replay candidates in order before an update that
         // closes their message, so a suppressed short fragment (e.g. "I",
         // buffered because it is a substring of prior output) is emitted in
@@ -420,11 +437,19 @@ final class ACPSession: ObservableObject, Identifiable {
                 locateByMessageId: { id in transcript.messageIndex(messageId: id, kind: .agent) },
                 locateLegacy: { lastAgent() },
                 replayCandidateMatches: { text in existingMessageContains(kind: .agent, text) },
-                adoptContinuation: { candidate in
-                    chunk.messageId.flatMap { adoptReplayContinuation(kind: .agent, candidate: candidate, messageId: $0) }
+                adoptContinuation: { candidate, phase, metadata in
+                    chunk.messageId.flatMap {
+                        adoptReplayContinuation(
+                            kind: .agent, candidate: candidate, messageId: $0,
+                            phase: phase, metadata: metadata)
+                    }
                 },
                 flushedReplayIndices: &flushedForAgent,
-                makeNew: { text in .agent(id: UUID(), messageId: chunk.messageId, StreamingText(text)) }) else {
+                phase: chunk.phase,
+                metadata: chunk.metadata,
+                makeNew: { text, phase, metadata in
+                    .agent(id: UUID(), messageId: chunk.messageId, StreamingText(text, phase: phase, metadata: metadata))
+                }) else {
                 return flushedForAgent
             }
             return flushedForAgent.union([i])
@@ -450,11 +475,19 @@ final class ACPSession: ObservableObject, Identifiable {
                 locateByMessageId: { id in transcript.messageIndex(messageId: id, kind: .thought) },
                 locateLegacy: { lastThought() },
                 replayCandidateMatches: { text in existingMessageContains(kind: .thought, text) },
-                adoptContinuation: { candidate in
-                    chunk.messageId.flatMap { adoptReplayContinuation(kind: .thought, candidate: candidate, messageId: $0) }
+                adoptContinuation: { candidate, phase, metadata in
+                    chunk.messageId.flatMap {
+                        adoptReplayContinuation(
+                            kind: .thought, candidate: candidate, messageId: $0,
+                            phase: phase, metadata: metadata)
+                    }
                 },
                 flushedReplayIndices: &flushedForThought,
-                makeNew: { text in .thought(id: UUID(), messageId: chunk.messageId, StreamingText(text)) }) else {
+                phase: chunk.phase,
+                metadata: chunk.metadata,
+                makeNew: { text, phase, metadata in
+                    .thought(id: UUID(), messageId: chunk.messageId, StreamingText(text, phase: phase, metadata: metadata))
+                }) else {
                 return flushedForThought
             }
             return flushedForThought.union([i])
@@ -496,7 +529,7 @@ final class ACPSession: ObservableObject, Identifiable {
             }
             return touched.map { [$0] } ?? []
         case .sessionInfoUpdate(let info):
-            applySessionInfoUpdate(info)
+            applySessionInfoUpdate(info, tracksRetryStatus: tracksRetryStatus)
             return []
         case .plan(let entries):
             clearRestoredContextRecoveryStatus()
@@ -576,9 +609,9 @@ final class ACPSession: ObservableObject, Identifiable {
             let message: ACPMessage
             switch key.kind {
             case .agent:
-                message = .agent(id: UUID(), messageId: key.messageId, StreamingText(candidate.display))
+                message = .agent(id: UUID(), messageId: key.messageId, StreamingText(candidate.display, phase: candidate.phase, metadata: candidate.metadata))
             case .thought:
-                message = .thought(id: UUID(), messageId: key.messageId, StreamingText(candidate.display))
+                message = .thought(id: UUID(), messageId: key.messageId, StreamingText(candidate.display, phase: candidate.phase, metadata: candidate.metadata))
             case .user:
                 continue
             }
@@ -1252,6 +1285,7 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     func markCompletedOutputBoundary() {
+        clearRetryStatus()
         // The turn's output is complete; materialise any held replay
         // candidate now (before marking boundaries so the flushed final
         // message is itself recorded as a completed boundary). Otherwise a
@@ -1685,6 +1719,11 @@ final class ACPSession: ObservableObject, Identifiable {
         return raw as? String
     }
 
+    private static func metadataBool(_ value: AnyCodable?) -> Bool? {
+        guard let raw = value?.value, !(raw is NSNull) else { return nil }
+        return raw as? Bool
+    }
+
     private static func metadataInt(_ value: AnyCodable?) -> Int? {
         guard let raw = value?.value, !(raw is NSNull) else { return nil }
         if let int = raw as? Int { return int }
@@ -1885,7 +1924,10 @@ final class ACPSession: ObservableObject, Identifiable {
             ?? URL(fileURLWithPath: uri).lastPathComponent
     }
 
-    private func applySessionInfoUpdate(_ info: ACPSessionInfoUpdate) {
+    private func applySessionInfoUpdate(
+        _ info: ACPSessionInfoUpdate,
+        tracksRetryStatus: Bool
+    ) {
         switch info.title {
         case .absent:
             break
@@ -1902,6 +1944,35 @@ final class ACPSession: ObservableObject, Identifiable {
             }
         }
         applyGoalMetadata(info.metadata)
+        if tracksRetryStatus { applyRetryMetadata(info.metadata) }
+    }
+
+    func clearRetryStatus() {
+        retryStatus = nil
+    }
+
+    private func applyRetryMetadata(_ metadata: AnyCodable?) {
+        guard let root = Self.metadataObject(metadata),
+              let codex = Self.metadataObject(root["codex"]),
+              codex.keys.contains("error")
+        else { return }
+        guard let error = Self.metadataObject(codex["error"]),
+              Self.metadataBool(error["willRetry"]) == true
+        else {
+            clearRetryStatus()
+            return
+        }
+        retryStatus = ACPRetryStatus(
+            turnId: Self.metadataScalarString(error["turnId"]),
+            detail: Self.retryDetail(error["message"])
+        )
+    }
+
+    private static func retryDetail(_ value: AnyCodable?) -> String? {
+        guard let message = metadataScalarString(value) else { return nil }
+        let compact = message.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        guard !compact.isEmpty else { return nil }
+        return String(compact.prefix(240))
     }
 
     private func applyGoalMetadata(_ metadata: AnyCodable?) {
@@ -2231,7 +2302,13 @@ final class ACPSession: ObservableObject, Identifiable {
     /// boundary rules (a user prompt, tool call, or file edit closes the
     /// run; an agent row closes a thought; plans are skipped) stay
     /// consistent with the rest of streaming instead of being re-derived.
-    private func adoptReplayContinuation(kind: TextMessageKind, candidate: String, messageId: String) -> Int? {
+    private func adoptReplayContinuation(
+        kind: TextMessageKind,
+        candidate: String,
+        messageId: String,
+        phase: ACPMessagePhase?,
+        metadata: AnyCodable?
+    ) -> Int? {
         let trailingIndex: Int?
         switch kind {
         case .agent: trailingIndex = lastAgent()
@@ -2251,9 +2328,11 @@ final class ACPSession: ObservableObject, Identifiable {
         guard !suffix.isEmpty else { return nil }
         switch transcript.messages[i] {
         case .agent(let id, _, let buf):
+            buf.adopt(phase: phase, metadata: metadata)
             buf.append(suffix)
             transcript.replaceMessage(at: i, with: .agent(id: id, messageId: messageId, buf))
         case .thought(let id, _, let buf):
+            buf.adopt(phase: phase, metadata: metadata)
             buf.append(suffix)
             transcript.replaceMessage(at: i, with: .thought(id: id, messageId: messageId, buf))
         default:
@@ -2281,9 +2360,11 @@ final class ACPSession: ObservableObject, Identifiable {
                                  locateByMessageId: (String) -> Int?,
                                  locateLegacy: () -> Int?,
                                  replayCandidateMatches: (String) -> Bool,
-                                 adoptContinuation: (String) -> Int?,
+                                 adoptContinuation: (String, ACPMessagePhase?, AnyCodable?) -> Int?,
                                  flushedReplayIndices: inout Set<Int>,
-                                 makeNew: (String) -> ACPMessage) -> Int? {
+                                 phase: ACPMessagePhase?,
+                                 metadata: AnyCodable?,
+                                 makeNew: (String, ACPMessagePhase?, AnyCodable?) -> ACPMessage) -> Int? {
         // Any held candidates from a prior window are flushed (materialised)
         // by `apply` before this runs — once `allowsStreamingBoundaryCrossing`
         // is true, or on the closing non-text update — so they are never
@@ -2311,6 +2392,7 @@ final class ACPSession: ObservableObject, Identifiable {
             if !crossesCompletedBoundary || messageId != nil {
                 switch transcript.messages[i] {
                 case .agent(_, _, let buf), .thought(_, _, let buf):
+                    buf.adopt(phase: phase, metadata: metadata)
                     buf.append(Self.streamingSeparator(between: buf.value, and: addition) + addition)
                     transcript.noteStreamingChange(at: i)
                     return i
@@ -2336,6 +2418,8 @@ final class ACPSession: ObservableObject, Identifiable {
         // — adopt it (append only the divergent suffix) instead of
         // materialising a new row that duplicates the hydrated prefix.
         var newMessageText = addition
+        var newMessagePhase = phase
+        var newMessageMetadata = metadata
         if let messageId, !allowsStreamingBoundaryCrossing {
             let candidateKey = ReplayCandidateKey(kind: replayKind, messageId: messageId)
             let previous = pendingReplayCandidates[candidateKey]
@@ -2343,6 +2427,8 @@ final class ACPSession: ObservableObject, Identifiable {
             let previousRaw = previous?.raw ?? ""
             let display = previousDisplay + Self.streamingSeparator(between: previousDisplay, and: addition) + addition
             let raw = previousRaw + addition
+            let candidatePhase = previous?.phase ?? phase
+            let candidateMetadata = AnyCodable.mergingMetadata(previous?.metadata, metadata)
             // Match on both forms: the display form (as a live stream would
             // build it) and the raw concatenation, so a replay that splits
             // at a sentence boundary the original stream did not is still
@@ -2356,14 +2442,22 @@ final class ACPSession: ObservableObject, Identifiable {
                     arrivalOrder = replayCandidateArrivalCounter
                     replayCandidateArrivalCounter += 1
                 }
-                pendingReplayCandidates[candidateKey] = ReplayCandidate(display: display, raw: raw, arrivalOrder: arrivalOrder)
+                pendingReplayCandidates[candidateKey] = ReplayCandidate(
+                    display: display,
+                    raw: raw,
+                    arrivalOrder: arrivalOrder,
+                    phase: candidatePhase,
+                    metadata: candidateMetadata)
                 return nil
             }
             pendingReplayCandidates.removeValue(forKey: candidateKey)
-            if let adopted = adoptContinuation(display) ?? adoptContinuation(raw) {
+            if let adopted = adoptContinuation(display, candidatePhase, candidateMetadata)
+                ?? adoptContinuation(raw, candidatePhase, candidateMetadata) {
                 return adopted
             }
             newMessageText = display
+            newMessagePhase = candidatePhase
+            newMessageMetadata = candidateMetadata
         }
         // A new agent row is live output that closes an in-progress thought
         // (`lastThought()` stops at `.agent`); flush pending thoughts ahead of
@@ -2373,7 +2467,7 @@ final class ACPSession: ObservableObject, Identifiable {
         if replayKind == .agent {
             flushedReplayIndices.formUnion(flushPendingReplayCandidates(kinds: [.thought]))
         }
-        transcript.appendMessage(makeNew(newMessageText))
+        transcript.appendMessage(makeNew(newMessageText, newMessagePhase, newMessageMetadata))
         didAppendTranscriptMessage()
         return transcript.messages.count - 1
     }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -2392,10 +2392,16 @@ final class ACPSession: ObservableObject, Identifiable {
             if !crossesCompletedBoundary || messageId != nil {
                 switch transcript.messages[i] {
                 case .agent(_, _, let buf), .thought(_, _, let buf):
-                    buf.adopt(phase: phase, metadata: metadata)
-                    buf.append(Self.streamingSeparator(between: buf.value, and: addition) + addition)
-                    transcript.noteStreamingChange(at: i)
-                    return i
+                    let startsNewPhasedRow = messageId == nil
+                        && buf.phase != nil
+                        && phase != nil
+                        && buf.phase != phase
+                    if !startsNewPhasedRow {
+                        buf.adopt(phase: phase, metadata: metadata)
+                        buf.append(Self.streamingSeparator(between: buf.value, and: addition) + addition)
+                        transcript.noteStreamingChange(at: i)
+                        return i
+                    }
                 default:
                     break
                 }

--- a/Alas/Sources/ACP/Session/ACPSessionFork.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionFork.swift
@@ -179,7 +179,7 @@ enum ACPSessionForkSnapshotResolver {
             switch wire {
             case .user(_, let text, _, _):
                 text.isEmpty ? nil : .init(role: .user, text: text)
-            case .agent(_, let text):
+            case .agent(_, let text, _, _):
                 text.isEmpty ? nil : .init(role: .agent, text: text)
             case .thought, .toolCall, .fileEdit, .plan, .systemNotice:
                 nil
@@ -197,9 +197,9 @@ enum ACPSessionForkSnapshotResolver {
         switch (live, stored) {
         case let (.user(_, liveMessageID, liveText, _, _), .user(storedMessageID, storedText, _, _)):
             liveMessageID == storedMessageID && liveText == storedText
-        case let (.agent(_, liveMessageID, liveText), .agent(storedMessageID, storedText)):
+        case let (.agent(_, liveMessageID, liveText), .agent(storedMessageID, storedText, _, _)):
             liveMessageID == storedMessageID && liveText.value == storedText
-        case let (.thought(_, liveMessageID, liveText), .thought(storedMessageID, storedText)):
+        case let (.thought(_, liveMessageID, liveText), .thought(storedMessageID, storedText, _, _)):
             liveMessageID == storedMessageID && liveText.value == storedText
         case let (.toolCall(liveCall), .toolCall(storedCall)):
             liveCall.toolCallId == storedCall.toolCallId

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -954,7 +954,7 @@ final class ACPSessionManager: ObservableObject {
             switch wire {
             case let .user(_, text, _, _):
                 return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            case let .agent(_, text):
+            case let .agent(_, text, _, _):
                 return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             default:
                 return false

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -239,6 +239,7 @@ final class ACPSessionRunner {
     }
 
     func start() {
+        session.clearRetryStatus()
         updatesTask = Task { [weak self] in
             guard let self else { return }
             for await u in self.connection.client.incomingUpdates {
@@ -252,6 +253,7 @@ final class ACPSessionRunner {
             if Task.isCancelled { return }
             self.flushPendingIncomingUpdates(flushQueueWhenBoundaryReady: false)
             await MainActor.run {
+                self.session.clearRetryStatus()
                 self.session.agentState = .disconnected
                 self.session.transcript.streamingState = .idle
                 // No flushQueueIfIdle() here: the connection is dead, so
@@ -550,7 +552,10 @@ final class ACPSessionRunner {
         let preAppliedSessionInfoDirty: Set<Int>?
         if case .sessionInfoUpdate(let info) = params.update {
             flushStreamingPersist()
-            preAppliedSessionInfoDirty = session.apply(params.update)
+            preAppliedSessionInfoDirty = session.apply(
+                params.update,
+                tracksRetryStatus: !suppressingLoadReplay
+            )
             applySessionInfoTitle(info)
         } else {
             preAppliedSessionInfoDirty = nil
@@ -672,6 +677,7 @@ final class ACPSessionRunner {
             flushQueueWhenBoundaryReady: false,
             treatBufferedUpdatesAsPromptOwned: true
         )
+        session.clearRetryStatus()
         flushStreamingPersistOnStop()
         incomingUpdateFlushTask?.cancel()
         incomingUpdateFlushTask = nil
@@ -1059,6 +1065,7 @@ final class ACPSessionRunner {
     /// to `.idle`. Persists all mutations so they survive a reload.
     func userCancel(confirmingLease: Bool = true) async {
         flushPendingIncomingUpdates(flushQueueWhenBoundaryReady: false)
+        session.clearRetryStatus()
         // Capture the prompt + queue head the user INTENDED to stop
         // BEFORE awaiting `connection.cancel`. Without this snapshot, a
         // natural completion of the in-flight prompt during the cancel
@@ -1666,6 +1673,7 @@ extension ACPSessionRunner {
         onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
     ) {
         flushPendingIncomingUpdates()
+        session.clearRetryStatus()
         let promptID = nextPromptID
         nextPromptID += 1
         // Register ownership SYNCHRONOUSLY, before the Task spawn. Without
@@ -1815,6 +1823,7 @@ extension ACPSessionRunner {
                         }
                     }
                     if isActivePrompt {
+                        self.session.clearRetryStatus()
                         if queuedItemId != nil {
                             _ = self.session.popQueueHead()
                             if deliveredForkContext {
@@ -1841,6 +1850,7 @@ extension ACPSessionRunner {
                     let isActivePrompt = self.activePromptID == promptID
                     let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
                     if isActivePrompt {
+                        self.session.clearRetryStatus()
                         self.flushStreamingPersist()
                         let authReason = wasCancelled ? nil : ACPAuthFailure.message(from: error)
                         let errorMessage = authReason ?? error.localizedDescription

--- a/Alas/Sources/ACP/Session/ACPStreamingText.swift
+++ b/Alas/Sources/ACP/Session/ACPStreamingText.swift
@@ -29,6 +29,8 @@ final class StreamingText: ObservableObject {
     private(set) var utf8Length: Int
     private(set) var revision: UInt64 = 0
     private(set) var lastAppendedSuffix: String?
+    private(set) var phase: ACPMessagePhase?
+    private(set) var metadata: AnyCodable?
 
     /// Wall-clock time (`ProcessInfo.systemUptime`) of the last publish.
     private var lastPublish: TimeInterval = 0
@@ -40,9 +42,11 @@ final class StreamingText: ObservableObject {
     private(set) var publishCountForTests = 0
     #endif
 
-    init(_ initial: String = "") {
+    init(_ initial: String = "", phase: ACPMessagePhase? = nil, metadata: AnyCodable? = nil) {
         self.value = initial
         self.utf8Length = initial.utf8.count
+        self.phase = phase
+        self.metadata = metadata
     }
 
     deinit {
@@ -55,6 +59,11 @@ final class StreamingText: ObservableObject {
         revision &+= 1
         lastAppendedSuffix = s
         scheduleThrottledPublish()
+    }
+
+    func adopt(phase: ACPMessagePhase?, metadata: AnyCodable?) {
+        if self.phase == nil { self.phase = phase }
+        self.metadata = AnyCodable.mergingMetadata(self.metadata, metadata)
     }
 
     private func scheduleThrottledPublish() {
@@ -88,4 +97,25 @@ final class StreamingText: ObservableObject {
 
 extension StreamingText: Equatable {
     nonisolated static func == (lhs: StreamingText, rhs: StreamingText) -> Bool { lhs === rhs }
+}
+
+extension AnyCodable {
+    static func mergingMetadata(_ existing: AnyCodable?, _ update: AnyCodable?) -> AnyCodable? {
+        guard let update else { return existing }
+        guard var merged = metadataObject(existing), let incoming = metadataObject(update) else {
+            return update
+        }
+        for (key, value) in incoming {
+            merged[key] = mergingMetadata(merged[key], value)
+        }
+        return AnyCodable(merged)
+    }
+
+    private static func metadataObject(_ value: AnyCodable?) -> [String: AnyCodable]? {
+        if let object = value?.value as? [String: AnyCodable] { return object }
+        if let object = value?.value as? [String: Any] {
+            return object.mapValues { $0 as? AnyCodable ?? AnyCodable($0) }
+        }
+        return nil
+    }
 }

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -142,6 +142,9 @@ private struct ACPSessionView: View {
                 )
                 adapterBanner()
                 contextRestoreBanner()
+                if let retry = session.retryStatus {
+                    retryBanner(retry)
+                }
                 if isMirror {
                     mirrorBanner()
                 }
@@ -907,6 +910,23 @@ private struct ACPSessionView: View {
         .background(theme.color("del").opacity(0.10))
         .overlay(alignment: .bottom) {
             Rectangle().fill(theme.color("del").opacity(0.3)).frame(height: 0.5)
+        }
+    }
+
+    private func retryBanner(_ retry: ACPRetryStatus) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "arrow.trianglehead.2.clockwise.rotate.90")
+                .foregroundStyle(theme.color("warn"))
+            Text(retry.detail.map { "Retrying — \($0)" } ?? "Retrying")
+                .font(.system(size: 12))
+                .textSelection(.enabled)
+                .foregroundStyle(theme.color("fg"))
+            Spacer()
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+        .background(theme.color("warn").opacity(0.10))
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(theme.color("warn").opacity(0.3)).frame(height: 0.5)
         }
     }
 }

--- a/Alas/Sources/ACP/UI/ACPTranscriptMessageRows.swift
+++ b/Alas/Sources/ACP/UI/ACPTranscriptMessageRows.swift
@@ -91,3 +91,24 @@ struct AgentMessageRow: View {
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
+
+struct ACPCommentaryRow: View {
+    @ObservedObject var buffer: StreamingText
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label("Working", systemImage: "ellipsis.circle")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(theme.color("fg-faint"))
+            Text(buffer.value)
+                .font(.system(size: 12))
+                .foregroundStyle(theme.color("fg-dim"))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 9)
+        .background(theme.color("bg-2"), in: RoundedRectangle(cornerRadius: 6))
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPTranscriptRowContent.swift
+++ b/Alas/Sources/ACP/UI/ACPTranscriptRowContent.swift
@@ -14,6 +14,7 @@ struct ACPTranscriptRowContent: View, Equatable {
     let stableId: String
     let messageIndex: Int
     let message: ACPMessage
+    let messagePhase: ACPMessagePhase?
     let contentMaxWidth: CGFloat
     let typography: ACPChatTypography
     let trustedImageRoot: URL?
@@ -51,14 +52,17 @@ struct ACPTranscriptRowContent: View, Equatable {
     let onFork: (ACPForkMessageBoundary, String) -> Void
 
     static func == (lhs: Self, rhs: Self) -> Bool {
-        equalityKey(
+        guard lhs.messagePhase == rhs.messagePhase else { return false }
+        return equalityKey(
             stableId: lhs.stableId, message: lhs.message,
+            messagePhase: lhs.messagePhase,
             contentMaxWidth: lhs.contentMaxWidth, typography: lhs.typography,
             trustedImageRoot: lhs.trustedImageRoot,
             isForkEligible: lhs.isForkEligible, forkTargets: lhs.forkTargets
         )
         == equalityKey(
             stableId: rhs.stableId, message: rhs.message,
+            messagePhase: rhs.messagePhase,
             contentMaxWidth: rhs.contentMaxWidth, typography: rhs.typography,
             trustedImageRoot: rhs.trustedImageRoot,
             isForkEligible: rhs.isForkEligible, forkTargets: rhs.forkTargets
@@ -70,6 +74,7 @@ struct ACPTranscriptRowContent: View, Equatable {
     static func equalityKey(
         stableId: String,
         message: ACPMessage,
+        messagePhase: ACPMessagePhase? = nil,
         contentMaxWidth: CGFloat,
         typography: ACPChatTypography,
         trustedImageRoot: URL?,
@@ -77,7 +82,9 @@ struct ACPTranscriptRowContent: View, Equatable {
         forkTargets: [ACPSessionForkTarget] = []
     ) -> EqualityKey {
         EqualityKey(
-            stableId: stableId, message: message, contentMaxWidth: contentMaxWidth,
+            stableId: stableId, message: message,
+            messagePhase: messagePhase ?? presentationPhase(of: message),
+            contentMaxWidth: contentMaxWidth,
             typography: typography, trustedImageRoot: trustedImageRoot,
             isForkEligible: isForkEligible, forkTargets: forkTargets
         )
@@ -86,11 +93,17 @@ struct ACPTranscriptRowContent: View, Equatable {
     struct EqualityKey: Equatable {
         let stableId: String
         let message: ACPMessage
+        let messagePhase: ACPMessagePhase?
         let contentMaxWidth: CGFloat
         let typography: ACPChatTypography
         let trustedImageRoot: URL?
         let isForkEligible: Bool
         let forkTargets: [ACPSessionForkTarget]
+    }
+
+    static func presentationPhase(of message: ACPMessage) -> ACPMessagePhase? {
+        guard case .agent(_, _, let buffer) = message else { return nil }
+        return buffer.phase
     }
 
     var body: some View {
@@ -119,12 +132,16 @@ struct ACPTranscriptRowContent: View, Equatable {
                 onQuote: onQuote,
                 onFork: onFork
             ) {
-                AgentMessageRow(
-                    messageId: stableId,
-                    transcript: transcript,
-                    buffer: buf,
-                    typography: typography
-                )
+                if buf.phase == .commentary {
+                    ACPCommentaryRow(buffer: buf)
+                } else {
+                    AgentMessageRow(
+                        messageId: stableId,
+                        transcript: transcript,
+                        buffer: buf,
+                        typography: typography
+                    )
+                }
             }
         case .thought(_, _, let buf):
             ACPThoughtView(buffer: buf)

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -361,8 +361,10 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             )
             for row in rows where transcript.messages.indices.contains(row.index) {
                 let message = transcript.messages[row.index]
+                let messagePhase = ACPTranscriptRowContent.presentationPhase(of: message)
                 let rowToken = token(ACPTranscriptRowContent.equalityKey(
                     stableId: row.stableId, message: message,
+                    messagePhase: messagePhase,
                     contentMaxWidth: host.contentMaxWidth, typography: host.typography,
                     trustedImageRoot: host.trustedImageRoot,
                     isForkEligible: host.session.canForkMessage(at: row.index),
@@ -395,6 +397,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 stableId: row.stableId,
                 messageIndex: row.index,
                 message: message,
+                messagePhase: ACPTranscriptRowContent.presentationPhase(of: message),
                 contentMaxWidth: host.contentMaxWidth,
                 typography: host.typography,
                 trustedImageRoot: host.trustedImageRoot,

--- a/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
+++ b/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
@@ -39,6 +39,55 @@ struct ACPSessionUpdateTests {
         }
     }
 
+    @Test("preserves chunk metadata and recognizes Codex phases")
+    func chunkMetadataAndPhase() throws {
+        let json = """
+        {
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "commentary-1",
+          "content": { "type": "text", "text": "Working" },
+          "_meta": {
+            "codex": { "phase": "commentary", "future": true },
+            "adapter": { "trace": "kept" }
+          }
+        }
+        """
+        let update = try JSONDecoder().decode(ACPSessionUpdate.self, from: Data(json.utf8))
+        guard case .agentMessageChunk(let chunk) = update else {
+            Issue.record("expected agentMessageChunk")
+            return
+        }
+
+        #expect(chunk.phase == .commentary)
+        let metadata = try #require(chunk.metadata?.value as? [String: AnyCodable])
+        #expect((metadata["adapter"]?.value as? [String: AnyCodable])?["trace"]?.value as? String == "kept")
+        let encoded = try JSONEncoder().encode(update)
+        let decoded = try JSONDecoder().decode(ACPSessionUpdate.self, from: encoded)
+        #expect(decoded == update)
+
+        let chunks: [ACPSessionUpdate] = [
+            .userMessageChunk(.init(messageId: "user-1", content: .text("prompt"), metadata: chunk.metadata)),
+            .agentMessageChunk(chunk),
+            .agentThoughtChunk(.init(messageId: "thought-1", content: .text("thinking"), metadata: chunk.metadata))
+        ]
+        for chunkUpdate in chunks {
+            let roundTripped = try JSONDecoder().decode(
+                ACPSessionUpdate.self,
+                from: JSONEncoder().encode(chunkUpdate))
+            #expect(roundTripped == chunkUpdate)
+        }
+    }
+
+    @Test("unknown and missing chunk phases use the compatibility fallback")
+    func unknownChunkPhase() throws {
+        let unknown = ACPTextChunk(
+            messageId: "agent-1",
+            content: .text("answer"),
+            metadata: AnyCodable(["codex": AnyCodable(["phase": AnyCodable("future_phase")])]))
+        #expect(unknown.phase == nil)
+        #expect(ACPTextChunk(content: .text("answer")).phase == nil)
+    }
+
     @Test("decodes tool call (initial)")
     func toolCall() throws {
         let env = try decode("session-update-tool-call")

--- a/AlasTests/ACP/Session/ACPMessageWireTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageWireTests.swift
@@ -42,13 +42,48 @@ struct ACPMessageWireTests {
         let original: ACPMessage = .agent(id: UUID(), messageId: "agent-1", StreamingText("agent prose"))
         let payload = try ACPMessageCodec.encode(original)
         let wire = try ACPMessageWire.decode(kind: "agent", payload: payload)
-        guard case let .agent(messageId, text) = wire else {
+        guard case let .agent(messageId, text, _, _) = wire else {
             #expect(Bool(false), "expected .agent, got \(wire)")
             return
         }
         #expect(messageId == "agent-1")
         #expect(text == "agent prose")
         #expect(wire.toMessage().stableId == "acp-agent:agent-1")
+    }
+
+    @Test("agent phase and metadata survive persistence")
+    func agentPhaseRoundTrip() throws {
+        let metadata = AnyCodable(["codex": AnyCodable(["phase": AnyCodable("commentary")]), "future": AnyCodable(true)])
+        let original: ACPMessage = .agent(
+            id: UUID(), messageId: "commentary-1",
+            StreamingText("working", phase: .commentary, metadata: metadata))
+
+        let wire = try ACPMessageWire.decode(kind: "agent", payload: ACPMessageCodec.encode(original))
+        guard case .agent(let messageId, let text, let phase, let decodedMetadata) = wire else {
+            Issue.record("expected agent wire payload")
+            return
+        }
+        #expect(messageId == "commentary-1")
+        #expect(text == "working")
+        #expect(phase == .commentary)
+        #expect(decodedMetadata == metadata)
+        guard case .agent(_, _, let buffer) = wire.toMessage() else {
+            Issue.record("expected agent message")
+            return
+        }
+        #expect(buffer.phase == .commentary)
+        #expect(buffer.metadata == metadata)
+    }
+
+    @Test("legacy agent payload still decodes without a phase")
+    func legacyAgentPayload() throws {
+        let wire = try ACPMessageWire.decode(kind: "agent", payload: Data(#"{"messageId":"agent-1","text":"answer"}"#.utf8))
+        guard case .agent(_, _, let phase, let metadata) = wire else {
+            Issue.record("expected agent wire payload")
+            return
+        }
+        #expect(phase == nil)
+        #expect(metadata == nil)
     }
 
     @Test("decode round-trips tool call")
@@ -161,7 +196,7 @@ struct ACPMessageWireTests {
 
     @Test("toMessage produces ACPMessage with fresh ids")
     func toMessage() throws {
-        let wire: ACPMessageWire = .agent(messageId: nil, text: "x")
+        let wire: ACPMessageWire = .agent(messageId: nil, text: "x", phase: nil, metadata: nil)
         let m1 = wire.toMessage()
         let m2 = wire.toMessage()
         // Same wire, different UUIDs each call (matches existing decode behavior).

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -57,6 +57,10 @@ struct ACPSessionRunnerTests {
     func sendReportsSuccessfulCompletionWhenPromptSucceeds() async throws {
         let (runner, mock) = try makeRunner()
         mock.script(method: "session/prompt") { _ in Data("{}".utf8) }
+        let retry = AnyCodable(["codex": AnyCodable(["error": AnyCodable([
+            "willRetry": AnyCodable(true), "message": AnyCodable("Retrying")
+        ])])])
+        runner.session.apply(.sessionInfoUpdate(.init(title: nil, metadata: retry)))
 
         let succeeded = await withCheckedContinuation { continuation in
             runner.send(text: "hello", attachments: []) { succeeded in
@@ -66,7 +70,39 @@ struct ACPSessionRunnerTests {
 
         #expect(succeeded == true)
         #expect(runner.session.lastError == nil)
+        #expect(runner.session.retryStatus == nil)
         #expect(runner.session.transcript.streamingState == .idle)
+    }
+
+    @Test("user cancellation clears retryable Codex status")
+    func userCancellationClearsRetryStatus() async throws {
+        let (runner, _) = try makeRunner()
+        let retry = AnyCodable(["codex": AnyCodable(["error": AnyCodable([
+            "willRetry": AnyCodable(true), "message": AnyCodable("Retrying")
+        ])])])
+        runner.session.apply(.sessionInfoUpdate(.init(title: nil, metadata: retry)))
+
+        await runner.userCancel()
+
+        #expect(runner.session.retryStatus == nil)
+    }
+
+    @Test("permanent prompt failure clears retryable Codex status")
+    func promptFailureClearsRetryStatus() async throws {
+        let (runner, _) = try makeRunner()
+        let retry = AnyCodable(["codex": AnyCodable(["error": AnyCodable([
+            "willRetry": AnyCodable(true), "message": AnyCodable("Retrying")
+        ])])])
+        runner.session.apply(.sessionInfoUpdate(.init(title: nil, metadata: retry)))
+
+        let succeeded = await withCheckedContinuation { continuation in
+            runner.send(text: "hello", attachments: []) { succeeded in
+                continuation.resume(returning: succeeded)
+            }
+        }
+
+        #expect(succeeded == false)
+        #expect(runner.session.retryStatus == nil)
     }
 
     @Test("recording a submitted prompt keeps the suspended composer draft until prompt completion")
@@ -812,6 +848,45 @@ struct ACPSessionRunnerTests {
         #expect(row.title == "Replayed Adapter Title")
         #expect(row.titleSource == .generated)
         #expect(session.transcript.messages.isEmpty)
+    }
+
+    @Test("suppressed retry history does not affect live retry status")
+    func suppressedRetryHistoryDoesNotAffectLiveStatus() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rn-retry-replay-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "codex", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 1, updatedAt: 2, lastOpenedAt: 3, archived: false
+        ))
+        let retry = AnyCodable(["codex": AnyCodable(["error": AnyCodable([
+            "willRetry": AnyCodable(true), "message": AnyCodable("Temporary")
+        ])])])
+        let mock = ACPMockClient()
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "t")
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            suppressingLoadReplay: true
+        )
+        runner.start()
+        defer { runner.stop() }
+
+        mock.emit(.init(sessionId: "s", update: .sessionInfoUpdate(.init(
+            title: "Replayed title", metadata: retry))))
+        mock.emit(.init(sessionId: "s", update: .agentMessageChunk(.text("replayed"))))
+        try await waitUntil { session.title == "Replayed title" }
+        #expect(session.retryStatus == nil)
+
+        runner.finishSuppressingLoadReplay(throughYieldedUpdateCount: mock.yieldedUpdateCount)
+        mock.emit(.init(sessionId: "s", update: .sessionInfoUpdate(.init(title: nil, metadata: retry))))
+        try await waitUntil { session.retryStatus != nil }
+        mock.emit(.init(sessionId: "s", update: .agentMessageChunk(.text("resumed"))))
+        try await waitUntil { session.retryStatus == nil }
     }
 
     @Test("delayed load replay finish keeps active prompt boundary crossing")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -94,6 +94,27 @@ struct ACPSessionTests {
         #expect(finalBuffer.phase == .finalAnswer)
     }
 
+    @Test("id-less phase transition starts a new agent row")
+    func idlessPhaseTransitionStartsNewRow() {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        let commentary = AnyCodable(["codex": AnyCodable(["phase": AnyCodable("commentary")])])
+        let final = AnyCodable(["codex": AnyCodable(["phase": AnyCodable("final_answer")])])
+
+        session.apply(.agentMessageChunk(.init(content: .text("Checking files"), metadata: commentary)))
+        session.apply(.agentMessageChunk(.init(content: .text("Done"), metadata: final)))
+
+        guard session.transcript.messages.count == 2,
+              case .agent(_, _, let commentaryBuffer) = session.transcript.messages[0],
+              case .agent(_, _, let finalBuffer) = session.transcript.messages[1] else {
+            Issue.record("expected separate commentary and final rows")
+            return
+        }
+        #expect(commentaryBuffer.value == "Checking files")
+        #expect(commentaryBuffer.phase == .commentary)
+        #expect(finalBuffer.value == "Done")
+        #expect(finalBuffer.phase == .finalAnswer)
+    }
+
     @Test("a phase introduced by a later chunk survives persistence")
     func laterChunkPhaseSurvivesPersistence() throws {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -70,6 +70,84 @@ struct ACPSessionTests {
         else { Issue.record("expected single agent message") }
     }
 
+    @Test("interleaved commentary and final chunks keep their own phase and message rows")
+    func interleavedPhasedChunks() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        let commentary = AnyCodable(["codex": AnyCodable(["phase": AnyCodable("commentary")])])
+        let final = AnyCodable(["codex": AnyCodable(["phase": AnyCodable("final_answer")])])
+
+        session.apply(.agentMessageChunk(.init(messageId: "commentary-1", content: .text("Checking"), metadata: commentary)))
+        session.apply(.agentMessageChunk(.init(messageId: "final-1", content: .text("Done"), metadata: final)))
+        session.apply(.agentMessageChunk(.init(messageId: "commentary-1", content: .text(" files"), metadata: commentary)))
+
+        #expect(session.transcript.messages.count == 2)
+        guard case .agent(_, let commentaryID, let commentaryBuffer) = session.transcript.messages[0],
+              case .agent(_, let finalID, let finalBuffer) = session.transcript.messages[1] else {
+            Issue.record("expected phased agent messages")
+            return
+        }
+        #expect(commentaryID == "commentary-1")
+        #expect(commentaryBuffer.value == "Checking files")
+        #expect(commentaryBuffer.phase == .commentary)
+        #expect(finalID == "final-1")
+        #expect(finalBuffer.value == "Done")
+        #expect(finalBuffer.phase == .finalAnswer)
+    }
+
+    @Test("a phase introduced by a later chunk survives persistence")
+    func laterChunkPhaseSurvivesPersistence() throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        let firstMetadata = AnyCodable(["future": AnyCodable("kept")])
+        let commentary = AnyCodable(["codex": AnyCodable(["phase": AnyCodable("commentary")])])
+
+        session.apply(.agentMessageChunk(.init(
+            messageId: "message-1", content: .text("Checking"), metadata: firstMetadata)))
+        session.apply(.agentMessageChunk(.init(
+            messageId: "message-1", content: .text(" files"), metadata: commentary)))
+
+        guard case .agent(_, _, let buffer) = session.transcript.messages.first else {
+            Issue.record("expected agent message")
+            return
+        }
+        #expect(buffer.phase == .commentary)
+        let metadata = try #require(buffer.metadata?.value as? [String: AnyCodable])
+        #expect(metadata["future"]?.value as? String == "kept")
+        #expect(metadata["codex"] != nil)
+
+        let wire = try ACPMessageWire.decode(
+            kind: "agent", payload: ACPMessageCodec.encode(session.transcript.messages[0]))
+        guard case .agent(_, _, let phase, let persistedMetadata) = wire else {
+            Issue.record("expected persisted agent message")
+            return
+        }
+        #expect(phase == .commentary)
+        #expect(persistedMetadata == buffer.metadata)
+    }
+
+    @Test("phased replay does not duplicate or change hydrated output")
+    func phasedReplayPreservesHydratedMessage() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        let metadata = AnyCodable(["codex": AnyCodable(["phase": AnyCodable("commentary")])])
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "commentary-1", StreamingText("Checking files", phase: .commentary, metadata: metadata)),
+            .user(id: UUID(), messageId: "user-1", text: "next", attachments: [])
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        let changed = session.apply(.agentMessageChunk(.init(
+            messageId: "commentary-1", content: .text(" replay"), metadata: metadata)))
+
+        #expect(changed == [0])
+        #expect(session.transcript.messages.count == 2)
+        guard case .agent(_, _, let buffer) = session.transcript.messages[0] else {
+            Issue.record("expected agent message")
+            return
+        }
+        #expect(buffer.value == "Checking files")
+        #expect(buffer.phase == .commentary)
+        #expect(buffer.metadata == metadata)
+    }
+
     @Test("agent chunks split at a sentence boundary get a newline separator")
     func chunksSplitAtSentenceGetNewline() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
@@ -688,6 +766,61 @@ struct ACPSessionTests {
         #expect(after == ["hello world!"])
     }
 
+    @Test("regenerated replay continuation keeps the accumulated phase metadata")
+    func replayContinuationKeepsAccumulatedPhaseMetadata() throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        let commentary = AnyCodable(["codex": AnyCodable(["phase": AnyCodable("commentary")])])
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("hello"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        session.apply(.agentMessageChunk(.init(
+            messageId: "regen-1", content: .text("hello"), metadata: commentary)))
+        session.apply(.agentMessageChunk(.init(
+            messageId: "regen-1", content: .text(" world"))))
+
+        guard case .agent(_, _, let buffer) = session.transcript.messages.first else {
+            Issue.record("expected agent message")
+            return
+        }
+        #expect(buffer.value == "hello world")
+        #expect(buffer.phase == .commentary)
+        #expect(buffer.metadata == commentary)
+        let wire = try ACPMessageWire.decode(
+            kind: "agent", payload: ACPMessageCodec.encode(session.transcript.messages[0]))
+        guard case .agent(_, _, let phase, let metadata) = wire else {
+            Issue.record("expected persisted agent message")
+            return
+        }
+        #expect(phase == .commentary)
+        #expect(metadata == commentary)
+    }
+
+    @Test("a diverged replay candidate materializes with its accumulated phase metadata")
+    func divergedReplayCandidateKeepsAccumulatedPhaseMetadata() {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        let commentary = AnyCodable(["codex": AnyCodable(["phase": AnyCodable("commentary")])])
+        session.transcript.messages = [
+            .agent(id: UUID(), messageId: "agent-1", StreamingText("hello there"))
+        ]
+        session.allowsStreamingBoundaryCrossing = false
+
+        session.apply(.agentMessageChunk(.init(
+            messageId: "regen-1", content: .text("hello"), metadata: commentary)))
+        session.apply(.agentMessageChunk(.init(
+            messageId: "regen-1", content: .text("!"))))
+
+        guard session.transcript.messages.count == 2,
+              case .agent(_, _, let buffer) = session.transcript.messages[1] else {
+            Issue.record("expected materialized agent message")
+            return
+        }
+        #expect(buffer.value == "hello!")
+        #expect(buffer.phase == .commentary)
+        #expect(buffer.metadata == commentary)
+    }
+
     @Test("replay continuation is still adopted across a trailing plan row")
     func replayContinuationAdoptedAcrossTrailingPlan() async {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
@@ -1240,6 +1373,64 @@ struct ACPSessionTests {
         #expect(goal.objective == "Surface richer ACP events")
         #expect(goal.status == "in_progress")
         #expect(goal.tokenBudget == 12_000)
+    }
+
+    @Test("retryable Codex session error exposes only its safe message")
+    func retryableCodexErrorUsesSafeMessage() async throws {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.transcript.streamingState = .streaming
+
+        session.apply(.sessionInfoUpdate(.init(
+            title: nil,
+            metadata: AnyCodable([
+                "codex": AnyCodable([
+                    "error": AnyCodable([
+                        "willRetry": AnyCodable(true),
+                        "turnId": AnyCodable("turn-42"),
+                        "message": AnyCodable("Temporary service issue\nplease wait"),
+                        "codexErrorInfo": AnyCodable("internal-stack-trace"),
+                        "additionalDetails": AnyCodable("unsafe diagnostic")
+                    ])
+                ])
+            ]))))
+
+        let retry = try #require(session.retryStatus)
+        #expect(retry.turnId == "turn-42")
+        #expect(retry.detail == "Temporary service issue please wait")
+        #expect(session.lastError == nil)
+        #expect(session.transcript.streamingState == .streaming)
+    }
+
+    @Test("agent progress and completion clear retryable Codex status")
+    func retryStatusClearsOnProgressAndCompletion() {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        let retry = AnyCodable(["codex": AnyCodable(["error": AnyCodable([
+            "willRetry": AnyCodable(true), "message": AnyCodable("Retrying")
+        ])])])
+
+        session.apply(.sessionInfoUpdate(.init(title: nil, metadata: retry)))
+        session.apply(.agentMessageChunk(.text("resumed output")))
+        #expect(session.retryStatus == nil)
+
+        session.apply(.sessionInfoUpdate(.init(title: nil, metadata: retry)))
+        session.markCompletedOutputBoundary()
+        #expect(session.retryStatus == nil)
+    }
+
+    @Test("permanent Codex error clears retryable status")
+    func permanentCodexErrorClearsRetryStatus() {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        let retry = AnyCodable(["codex": AnyCodable(["error": AnyCodable([
+            "willRetry": AnyCodable(true), "message": AnyCodable("Retrying")
+        ])])])
+        let permanent = AnyCodable(["codex": AnyCodable(["error": AnyCodable([
+            "willRetry": AnyCodable(false), "message": AnyCodable("Permanent failure")
+        ])])])
+
+        session.apply(.sessionInfoUpdate(.init(title: nil, metadata: retry)))
+        session.apply(.sessionInfoUpdate(.init(title: nil, metadata: permanent)))
+
+        #expect(session.retryStatus == nil)
     }
 
     @Test("session info applies top-level goal metadata")

--- a/AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift
@@ -47,6 +47,7 @@ struct ACPTranscriptRowContentTests {
                 stableId: message.stableId,
                 messageIndex: 0,
                 message: message,
+                messagePhase: ACPTranscriptRowContent.presentationPhase(of: message),
                 contentMaxWidth: 800,
                 typography: .default,
                 trustedImageRoot: nil,
@@ -92,6 +93,41 @@ struct ACPTranscriptRowContentTests {
             stableId: "s1", message: msgB, contentMaxWidth: 800,
             typography: .default, trustedImageRoot: nil)
         #expect(a != b)
+    }
+
+    @Test("row equality detects a phase adopted by its streaming buffer")
+    @MainActor
+    func rowContentEqualityDetectsAdoptedPhase() {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        let buffer = StreamingText("working")
+        let message = ACPMessage.agent(id: UUID(), messageId: "agent-1", buffer)
+
+        func row() -> ACPTranscriptRowContent {
+            ACPTranscriptRowContent(
+                stableId: message.stableId,
+                messageIndex: 0,
+                message: message,
+                messagePhase: ACPTranscriptRowContent.presentationPhase(of: message),
+                contentMaxWidth: 800,
+                typography: .default,
+                trustedImageRoot: nil,
+                transcript: session.transcript,
+                session: session,
+                onOpenDiff: { _ in },
+                onLoadFullToolCallContent: { _ in nil },
+                isForkEligible: false,
+                forkTargets: [],
+                onFork: { _, _ in }
+            )
+        }
+
+        let before = row()
+        buffer.adopt(
+            phase: .commentary,
+            metadata: AnyCodable(["codex": AnyCodable(["phase": AnyCodable("commentary")])]))
+        let after = row()
+
+        #expect(before != after)
     }
 
     @Test("equality detects a content-width change")


### PR DESCRIPTION
## Summary

- preserve raw ACP chunk metadata and typed Codex commentary/final-answer phases across streaming, replay, and persistence
- render commentary separately from final assistant answers while keeping compatibility fallbacks
- surface retryable Codex turn errors as non-terminal status and clear them across all lifecycle outcomes

## Verification

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination platform=macOS -quiet build`
- 263 tests across the affected ACP protocol, persistence, session, runner, and transcript-row suites

Closes #1057