### PR TITLE
fix(worktree): branch name field focus

### DIFF
--- a/Alas/Sources/UI/AlasField.swift
+++ b/Alas/Sources/UI/AlasField.swift
@@ -188,6 +188,8 @@ class AlasNSTextFieldView: NSTextField {
 
     private func configureCell() {
         cell = AlasNSTextFieldCell(textCell: "")
+        isEditable = true
+        isSelectable = true
         lineBreakMode = .byClipping
         cell?.usesSingleLineMode = true
         cell?.isScrollable = true

--- a/AlasTests/AlasFieldTests.swift
+++ b/AlasTests/AlasFieldTests.swift
@@ -59,6 +59,22 @@ struct AlasFieldTests {
         #expect(editor.textContainer?.maximumNumberOfLines == 1)
     }
 
+    @Test func nativeFieldCanBecomeEditable() {
+        let field = AlasNSTextFieldView(frame: NSRect(x: 0, y: 0, width: 200, height: 28))
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 28),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = field
+
+        #expect(field.isEditable)
+        #expect(field.isSelectable)
+        #expect(window.makeFirstResponder(field))
+        #expect(field.currentEditor() != nil)
+    }
+
     private static func firstTextField(in view: NSView) -> NSTextField? {
         if let field = view as? NSTextField { return field }
         for subview in view.subviews {


### PR DESCRIPTION
## Summary
Restores editability on the custom AppKit text-field cell so branch names can receive focus when creating a worktree. Adds a regression test for first-responder editing.

## Changes
- Restore editable and selectable state after installing the custom cell.
- Verify the field becomes first responder and creates its editor.