### PR TITLE
fix(acp): hide required default provider

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -190,8 +190,9 @@ final class ACPSession: ObservableObject, Identifiable {
 
     var currentProviderDisplayName: String? {
         guard agentState == .ready, providerCapabilities != nil else { return nil }
-        let names = availableProviders
-            .filter { $0.current != nil }
+        let currentProviders = availableProviders.filter { $0.current != nil }
+        guard currentProviders.count != 1 || !currentProviders[0].required else { return nil }
+        let names = currentProviders
             .map { $0.name ?? $0.providerId }
         return names.isEmpty ? nil : names.joined(separator: ", ")
     }

--- a/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
@@ -57,6 +57,21 @@ struct ACPSessionAgentStateTests {
         #expect(second.currentProviderDisplayName == nil)
         #expect(second.availableProviders.isEmpty)
     }
+
+    @Test("lone required provider is hidden")
+    func loneRequiredProviderIsHidden() {
+        let session = ACPSession(id: "s1", agentId: "codex", worktreeId: "wt", title: "one")
+        session.providerCapabilities = .init()
+        session.availableProviders = [.init(
+            providerId: "openai",
+            supported: ["openai"],
+            required: true,
+            current: .init(apiType: "openai", baseUrl: "https://api.openai.com")
+        )]
+        session.agentState = .ready
+
+        #expect(session.currentProviderDisplayName == nil)
+    }
 }
 
 @MainActor

--- a/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerRemoteRestoreTests.swift
@@ -23,7 +23,8 @@ struct ACPSessionManagerRemoteRestoreTests {
         await manager.attach(to: session.id, freshlyCreated: false)
 
         #expect(client.sent.map(\.method) == ["initialize", "session/load", "providers/list"])
-        #expect(session.currentProviderDisplayName == "Enterprise Gateway")
+        #expect(session.availableProviders.first?.name == "Enterprise Gateway")
+        #expect(session.currentProviderDisplayName == nil)
         await manager.detach(sessionId: session.id)
     }
 


### PR DESCRIPTION
## Summary

Codex now exposes its built-in OpenAI provider through ACP even though the provider is required and cannot be changed. Hide that lone default from the composer while preserving the provider control when the agent exposes an actual choice.

## Changes

- Hide the provider label when exactly one active provider is required.
- Keep optional and multi-provider configurations visible.
- Add regression coverage for Codex's required OpenAI provider.

## Verification

- Focused ACP session tests pass.
- macOS build passes.
- The full local suite reached unrelated existing UI and GG stack failures, then Xcode hung while cleaning up the failed run.