### PR TITLE
fix(diff): fallback glyph diff row heights

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -871,9 +871,16 @@ final class DiffPaneTextScrollView: NSScrollView {
             var candidateLineHeight: CGFloat?
             var lineCount = 1
             if let targetHeight {
-                let lineCountHeight = previousLineHeight ?? lineHeight()
-                lineCount = max(1, Int(round(currentRows[index].height / max(lineCountHeight, 1))))
-                let computed = targetHeight / CGFloat(lineCount)
+                let appliedLineHeight = previousLineHeight ?? lineHeight()
+                lineCount = max(1, Int(round(currentRows[index].height / max(appliedLineHeight, 1))))
+                // A fallback glyph can make the measured row taller than its
+                // paragraph line height. Correct existing padding by the
+                // measured delta so that extra height is not added again.
+                let computed = if previousLineHeight != nil {
+                    appliedLineHeight + (targetHeight - currentRows[index].height) / CGFloat(lineCount)
+                } else {
+                    targetHeight / CGFloat(lineCount)
+                }
                 if computed > lineHeight() + 0.5 {
                     candidateLineHeight = computed
                 }

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -8,6 +8,52 @@ import Testing
 struct DiffPaneViewTests {
     private func theme() -> Theme { try! ThemeStore().current }
 
+    @Test func splitRowHeightSyncConvergesForUnicodeFallbackGlyph() throws {
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let text = #"        printProgress("  ⟳ Pressing $label...")"#
+        let line = DiffDisplayLine(
+            id: "ScoutOrchestrator.kt:new:344",
+            anchor: DiffLineAnchor(
+                filePath: "ScoutOrchestrator.kt",
+                hunkIndex: 0,
+                rowIndex: 0,
+                side: .new,
+                oldLine: nil,
+                newLine: 344
+            ),
+            text: text,
+            lineNumber: 344,
+            kind: .add,
+            inlineSpans: [],
+            noTrailingNewline: false
+        )
+        let row = DiffDisplayRow(
+            id: "ScoutOrchestrator.kt:344",
+            kind: .add,
+            old: nil,
+            new: line,
+            collapsedLineCount: 0
+        )
+        let container = DiffPaneTextDocumentContainerView(frame: NSRect(x: 0, y: 0, width: 900, height: 1))
+        container.update(
+            rows: [row],
+            layoutMode: .split,
+            wrapLines: true,
+            showWhitespace: false,
+            fileExtension: "kt",
+            font: font,
+            theme: theme(),
+            lspContext: nil
+        )
+
+        let initialHeight = container.intrinsicContentSize.height
+        for _ in 0..<20 {
+            container.layout()
+        }
+
+        #expect(container.intrinsicContentSize.height <= initialHeight + 1)
+    }
+
     @Test func diffRowRectsReturnOnlyIndicesIntersectingDirtyVerticalRange() {
         let rows = [
             NSRect(x: 0, y: 0, width: 100, height: 10),


### PR DESCRIPTION
## Summary

Split diff rows could repeatedly add height when an AppKit fallback glyph made the measured line taller than its paragraph line height. Correct existing padding from the measured delta so the layout converges.

## Verification

- Reproduced with the Android ScoutOrchestrator progress glyph.
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneViewTests/splitRowHeightSyncConvergesForUnicodeFallbackGlyph\(\) test`\n- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n\n## Where to start\n\n- `Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift` — split-row height correction.\n- `AlasTests/DiffPaneViewTests.swift` — exact fallback-glyph regression.