### PR TITLE
feat(acp): render ACP context compaction events

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		10557FBC430EEAB1196D9575 /* AgentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2071DA26A16E9A4A5AC5B3C3 /* AgentDetector.swift */; };
 		106120CBE8107E0AC4EA353A /* ProcessKiller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3A345F0B643467352DB5F3 /* ProcessKiller.swift */; };
 		1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8B52175A7F6144B4C52010 /* EditorTabView.swift */; };
+		107D5EC59DC4F2E708D74865 /* session-update-context-compaction-partial.json in Resources */ = {isa = PBXBuildFile; fileRef = 1C8926C5ABBB7B8157ACFEF3 /* session-update-context-compaction-partial.json */; };
 		10C27B7147AF2D41AD109E9A /* session-update-session-info-goal.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D751485790AD46EBC15A979 /* session-update-session-info-goal.json */; };
 		10D0D26BCE0EF4D8677CEA79 /* GGServiceInboxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF688C3B9D43B4F5FF48F7D3 /* GGServiceInboxTests.swift */; };
 		10F83C7DA89B3BF168E47310 /* DiffSelectableTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34ED0F4DB5FB6620993ECFC /* DiffSelectableTextTests.swift */; };
@@ -153,6 +154,7 @@
 		17EA736FA0386E75D8D42B2E /* AttachIssueDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098AA369AE6B2740439CD504 /* AttachIssueDialog.swift */; };
 		188AF4E4D85149D0535251F9 /* GGInboxModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4DA46E3A858D293B9E6C34 /* GGInboxModels.swift */; };
 		188D02B853162BF4533020E2 /* ChevronStabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */; };
+		18CDE0CC16BC53EE02F1D773 /* ACPContextCompactionPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F08BFB7C0F034F695811C85 /* ACPContextCompactionPresentationTests.swift */; };
 		18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */; };
 		1901EE20123215C998400B25 /* ACPAdapterInstallCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2F61CCAFB23F6C394ACD8D /* ACPAdapterInstallCoordinatorTests.swift */; };
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
@@ -781,6 +783,7 @@
 		81D04C212B3AAA34F55069C5 /* ACPRemoteAdapterManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC147F9FE645065318A7B175 /* ACPRemoteAdapterManagement.swift */; };
 		81F6E32B97FCE84E5F986A31 /* MCPRegistrationRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5EA9E4B728B9C4FDA2E104 /* MCPRegistrationRegistry.swift */; };
 		82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */; };
+		822CF2A0C5B9A94B7DDE062A /* session-update-context-compaction-failed.json in Resources */ = {isa = PBXBuildFile; fileRef = 85C63F59DC811B24059183A0 /* session-update-context-compaction-failed.json */; };
 		823AA3E801A11C535C9438BD /* ACPPermissionScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4457B30E0C8A22BF06D0BC4B /* ACPPermissionScope.swift */; };
 		824FA55A813A3AE1034EE7D1 /* AlasMCPHTTPSupervisor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E1A57CB48427C32D4F1249 /* AlasMCPHTTPSupervisor.swift */; };
 		82544FFCF9960E0BA0FD2C7F /* ProcessMemoryProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9830BAAE86AA0A20A77731D /* ProcessMemoryProbeTests.swift */; };
@@ -820,6 +823,7 @@
 		877BEC66CEBB5C495536FA20 /* ReviewLoopHandoffBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F7DB6F391F1AAA9FED1A86 /* ReviewLoopHandoffBuilder.swift */; };
 		87A20CF7F67C277344D97D45 /* RemoteQueueProjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DE51A11B5F4C7A84D715B4 /* RemoteQueueProjectionTests.swift */; };
 		87ECE63567C08B2847844EDE /* ClaudeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */; };
+		8814D8EE15F78DE6D549EC84 /* session-update-compaction-summary-chunk.json in Resources */ = {isa = PBXBuildFile; fileRef = D8A14E0E9529665F98F57A86 /* session-update-compaction-summary-chunk.json */; };
 		881AE2B2D456B36573346AD6 /* DraftCommitTabsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB0C89AA6E07A2402934FD2 /* DraftCommitTabsManagerTests.swift */; };
 		881EB8E37CE9D947A2C74564 /* GitRefNameInputFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D6BBD77A210BB378E217FC /* GitRefNameInputFilterTests.swift */; };
 		8824EFBA6EA3673F13244C6D /* MergeSingleResolvePromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 749E3289E4C70DA7E4DD80E6 /* MergeSingleResolvePromptEditorWindow.swift */; };
@@ -837,6 +841,7 @@
 		89A5E5AD13431B6C9E16669B /* ImageFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */; };
 		89E952C361337F8D9FB279D5 /* IconSymbolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705B34DF3EE049FA52E8ECFB /* IconSymbolTests.swift */; };
 		89F58C7178B661EAE0057622 /* ACPTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8802F19E02CED256495755 /* ACPTerminalTests.swift */; };
+		8A0587F13E14C737218FF73A /* session-update-context-compaction-running.json in Resources */ = {isa = PBXBuildFile; fileRef = 31853A88896328990E6FDA78 /* session-update-context-compaction-running.json */; };
 		8AB55E8E05AAC87F71CD5DF0 /* BreadcrumbView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF671D3D8D5F1D59AFBD8BF /* BreadcrumbView.swift */; };
 		8ACF2EE38E46F72F5466DB01 /* SettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */; };
 		8ADC05EBB9FE7D278508A941 /* GGStackReadinessModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D59124348BCE765816A0C6C /* GGStackReadinessModel.swift */; };
@@ -1141,6 +1146,7 @@
 		BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DBB72EE97F0E906442919B /* CommitTabView.swift */; };
 		BC4B8B193F020CBEA02B01A6 /* ACPMessageWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */; };
 		BC98C2BCDB4F6C88C66117A6 /* InlineErrorStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */; };
+		BD0A00FF47FCA4BED994EEB1 /* session-update-context-compaction-completed.json in Resources */ = {isa = PBXBuildFile; fileRef = 7C82DDE43A00B915984134F0 /* session-update-context-compaction-completed.json */; };
 		BD0DE08853936F416EFD377C /* ACPMCPServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C53CBDB829C193CF9294E28D /* ACPMCPServerTests.swift */; };
 		BD1CDAECF2D1928C95796F63 /* ACPSessionStoreQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */; };
 		BD8E82E61D1E23931FE69C1D /* SidebarVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */; };
@@ -1306,6 +1312,7 @@
 		D675E5B1E5E95E7239F3A89F /* InstallRecipeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB4C80D9DD6DA28DE182955 /* InstallRecipeTests.swift */; };
 		D6A8D3925ACCB69DAC380B95 /* AgentPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58DD85A6E01972B39F2D8AD /* AgentPath.swift */; };
 		D6B39CE8878BB196FF2277B6 /* AgentDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */; };
+		D6D8AE009601D3A71C19C34C /* session-update-context-compaction-unknown.json in Resources */ = {isa = PBXBuildFile; fileRef = EA5C852BB7704D7714C28E3A /* session-update-context-compaction-unknown.json */; };
 		D6F28C27DB02285A62C969A4 /* ReleaseInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35004DC60214F616FA84ED8B /* ReleaseInfo.swift */; };
 		D70B9B1A92771F7E71A092B7 /* RunScriptFailurePresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200B570859DFA8572F150B85 /* RunScriptFailurePresentationTests.swift */; };
 		D7201A9F55E26C033F188DE8 /* ACPRemoteAdapterInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E0789D49881A17137010D0 /* ACPRemoteAdapterInstallerTests.swift */; };
@@ -1410,6 +1417,7 @@
 		E540B305B2426590C219622C /* CommitDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */; };
 		E541E14A713FB78AF4595FEB /* ReviewRequestContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039C5E652B7A9457EB13BD70 /* ReviewRequestContextBuilder.swift */; };
 		E54D3F52599B1C8FA6791D5F /* IssuePromptBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD08CC47344CBCA5FC635822 /* IssuePromptBuilder.swift */; };
+		E54E7BA373F131366C6A3960 /* ACPContextCompactionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CEAAB5A1851AAC887017ACB /* ACPContextCompactionView.swift */; };
 		E551A81EBC839478D6999A97 /* ACPComposerDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */; };
 		E5648509F3F1EA4297E856A1 /* GGStackCreateMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B7A6EC8A1372E76F0B934D /* GGStackCreateMode.swift */; };
 		E5D32C15B08F30DF3B46CA74 /* DiffReviewScrollSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D73C433B373577FD515FECD3 /* DiffReviewScrollSpy.swift */; };
@@ -1465,6 +1473,7 @@
 		EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */; };
 		EF276F4856AA2E82C2ECDC7E /* CodeHostModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96C5E43E973803E6FD1528C /* CodeHostModels.swift */; };
 		F0440F0D4E6B9BD0ACD7B0C9 /* GGReorderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111B9EB86E55850C982CEEFA /* GGReorderSheet.swift */; };
+		F049CEA88BF52C7C98F2D6F8 /* session-update-compaction-update.json in Resources */ = {isa = PBXBuildFile; fileRef = 2C0350206BA233AD3B54B3C7 /* session-update-compaction-update.json */; };
 		F04E4353813EB99D4459750F /* ReviewRequestDiffLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0A56D300AE7380A16F1D42 /* ReviewRequestDiffLoader.swift */; };
 		F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1841997CCBDB9611576B930C /* AlasToggle.swift */; };
 		F09324E122712405CCB0389A /* RunScriptStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15CFDEF63A656129A3EFEEB /* RunScriptStoreTests.swift */; };
@@ -1739,8 +1748,10 @@
 		1C0479721D1BC95DC664D4CB /* IssueWorktreeLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueWorktreeLaunchTests.swift; sourceTree = "<group>"; };
 		1C53EA4D34091E3711B0ED54 /* GGProjectMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGProjectMode.swift; sourceTree = "<group>"; };
 		1C63CBD839A151565AE577AE /* SSHIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHIntegrationTests.swift; sourceTree = "<group>"; };
+		1C8926C5ABBB7B8157ACFEF3 /* session-update-context-compaction-partial.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-context-compaction-partial.json"; sourceTree = "<group>"; };
 		1C8F14A2CEAE4B8404213C73 /* AlasSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasSegmentedControl.swift; sourceTree = "<group>"; };
 		1CA759D2C99D1FEE3C67A1BA /* RemoteImageCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageCacheTests.swift; sourceTree = "<group>"; };
+		1CEAAB5A1851AAC887017ACB /* ACPContextCompactionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextCompactionView.swift; sourceTree = "<group>"; };
 		1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateSyncStatusTests.swift; sourceTree = "<group>"; };
 		1D4A5200C6EBB6434DD6B8BD /* ShortcutReservationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservationsTests.swift; sourceTree = "<group>"; };
 		1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionHydrationStateTests.swift; sourceTree = "<group>"; };
@@ -1824,6 +1835,7 @@
 		2B9E3F080F847EF069137844 /* ShortcutBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutBinding.swift; sourceTree = "<group>"; };
 		2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffOpenFileAvailabilityTests.swift; sourceTree = "<group>"; };
 		2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchPicker.swift; sourceTree = "<group>"; };
+		2C0350206BA233AD3B54B3C7 /* session-update-compaction-update.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-compaction-update.json"; sourceTree = "<group>"; };
 		2C051018EB105E225122750C /* ACPMCPStatusPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPStatusPolicy.swift; sourceTree = "<group>"; };
 		2C17465AF6747EDCD8CCE416 /* ReviewSessionLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionLoader.swift; sourceTree = "<group>"; };
 		2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistryTests.swift; sourceTree = "<group>"; };
@@ -1866,6 +1878,7 @@
 		3111744632DAC342A40DB62A /* ACPAdapterUpdateBannerDecider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterUpdateBannerDecider.swift; sourceTree = "<group>"; };
 		311B7CA55176621C35DE3E92 /* AlasCLIWorktreeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIWorktreeResolverTests.swift; sourceTree = "<group>"; };
 		312DC027D433B496FD010F85 /* DiffReviewSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewSurfaceTests.swift; sourceTree = "<group>"; };
+		31853A88896328990E6FDA78 /* session-update-context-compaction-running.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-context-compaction-running.json"; sourceTree = "<group>"; };
 		318E4E3130F42671D888DC5C /* WorkingTreeFlatRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeFlatRowTests.swift; sourceTree = "<group>"; };
 		31CE012ED93AA22C257FEB8A /* MergeConflictBinaryDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictBinaryDetectionTests.swift; sourceTree = "<group>"; };
 		31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowController.swift; sourceTree = "<group>"; };
@@ -2152,6 +2165,7 @@
 		5E4EE1C8C8564C2920CC8DAF /* AppKitDiffReviewPresentationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffReviewPresentationState.swift; sourceTree = "<group>"; };
 		5E76A376D202F7144C03F221 /* NewWorktreeIssueState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorktreeIssueState.swift; sourceTree = "<group>"; };
 		5EF6536F169B7C7B2C339B1C /* ACPAdapterVersionCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterVersionCheckerTests.swift; sourceTree = "<group>"; };
+		5F08BFB7C0F034F695811C85 /* ACPContextCompactionPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextCompactionPresentationTests.swift; sourceTree = "<group>"; };
 		5F128D8543DA5FC5C39C22E9 /* ACPPermissionDecisionLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionDecisionLog.swift; sourceTree = "<group>"; };
 		5F30C23C9CD0842373F29D1F /* BuildIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildIdentity.swift; sourceTree = "<group>"; };
 		5F77AE52695B7B19A9F11B89 /* RemotePairingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePairingService.swift; sourceTree = "<group>"; };
@@ -2321,6 +2335,7 @@
 		7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewAutoPairTests.swift; sourceTree = "<group>"; };
 		7C421FFAE27A92B2510D87C9 /* GGStackActionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackActionStateTests.swift; sourceTree = "<group>"; };
 		7C80F21C310F35EBA6FBDF58 /* CompletionFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionFeatureTests.swift; sourceTree = "<group>"; };
+		7C82DDE43A00B915984134F0 /* session-update-context-compaction-completed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-context-compaction-completed.json"; sourceTree = "<group>"; };
 		7CCF73DAD392176A774ABA67 /* ACPMarkdownInlineTextViewHeightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownInlineTextViewHeightTests.swift; sourceTree = "<group>"; };
 		7D223B9B905C2BBEFDE50E36 /* MemoryDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDiagnostics.swift; sourceTree = "<group>"; };
 		7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandle.swift; sourceTree = "<group>"; };
@@ -2376,6 +2391,7 @@
 		8528D2A61E1FC9F51296C9F6 /* ACPLaunchSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchSpec.swift; sourceTree = "<group>"; };
 		856607304A9F2409EF40BD5F /* PendingDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscardTests.swift; sourceTree = "<group>"; };
 		85AC3FB0255285382EF24D8D /* RemoteHTTPResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHTTPResponder.swift; sourceTree = "<group>"; };
+		85C63F59DC811B24059183A0 /* session-update-context-compaction-failed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-context-compaction-failed.json"; sourceTree = "<group>"; };
 		85C6579202DFD8E5FBF26DE5 /* RemoteTerminalScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTerminalScript.swift; sourceTree = "<group>"; };
 		85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerPlaceholderTests.swift; sourceTree = "<group>"; };
 		866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeSectionView.swift; sourceTree = "<group>"; };
@@ -2875,6 +2891,7 @@
 		D7860DF249939BC7FC1EBD76 /* GGStackDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackDrawer.swift; sourceTree = "<group>"; };
 		D831DF53F0548536E919CA30 /* DiffPaneRowPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneRowPlanTests.swift; sourceTree = "<group>"; };
 		D837246E56472EBA3993F515 /* RemoteWorktreePoll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreePoll.swift; sourceTree = "<group>"; };
+		D8A14E0E9529665F98F57A86 /* session-update-compaction-summary-chunk.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-compaction-summary-chunk.json"; sourceTree = "<group>"; };
 		D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigCodeInstallTests.swift; sourceTree = "<group>"; };
 		D8D583586BC5171D2FE91F6C /* ReviewScopeSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScopeSelection.swift; sourceTree = "<group>"; };
 		D8FDA5449911989623B0F755 /* AttachIssueDialogModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachIssueDialogModelTests.swift; sourceTree = "<group>"; };
@@ -2990,6 +3007,7 @@
 		E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionPickerTests.swift; sourceTree = "<group>"; };
 		E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabStateMarkdownCodableTests.swift; sourceTree = "<group>"; };
 		E9F849F92835C6A4EEA765B7 /* ACPTranscriptScroller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScroller.swift; sourceTree = "<group>"; };
+		EA5C852BB7704D7714C28E3A /* session-update-context-compaction-unknown.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-context-compaction-unknown.json"; sourceTree = "<group>"; };
 		EA74519F0A93299751407753 /* AppConfigCodeTextRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigCodeTextRenderingTests.swift; sourceTree = "<group>"; };
 		EAA78FF7BA562DC4423AC35D /* ACPSessionVisibleQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionVisibleQueueTests.swift; sourceTree = "<group>"; };
 		EAD81CB1D751F983C64191FF /* ACPRemoteAdapterManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteAdapterManagementTests.swift; sourceTree = "<group>"; };
@@ -4221,6 +4239,7 @@
 				A637073E5D65DAA4E0CF6EA4 /* ACPComposerImageExtractTests.swift */,
 				0E8A1143A53C09FD0B4D5CF6 /* ACPComposerPairedDelimiterTests.swift */,
 				85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */,
+				5F08BFB7C0F034F695811C85 /* ACPContextCompactionPresentationTests.swift */,
 				ECD9419E685AD7EED286006B /* ACPContextRingTests.swift */,
 				DC76F9150CC29A324D785C29 /* ACPDelayedHoverVisibilityTests.swift */,
 				AE0235A58C8825D42F1C406C /* ACPDelegatedSessionsPolicyTests.swift */,
@@ -4624,6 +4643,7 @@
 				FF1494739C8FBECE52DAAAE3 /* ACPComposerFocusPolicy.swift */,
 				906D92F7AD84F313508D9CFD /* ACPComposerShell.swift */,
 				DFBD2A49431277EB68106AAA /* ACPConnectingPlaceholder.swift */,
+				1CEAAB5A1851AAC887017ACB /* ACPContextCompactionView.swift */,
 				AF522B02666DB6AC4C82339E /* ACPContextRing.swift */,
 				8AD22187C951174C9ECEC4C4 /* ACPContextUsageButton.swift */,
 				BE3D3BB0A631D42AD22DBE0F /* ACPDelayedHoverVisibility.swift */,
@@ -4743,8 +4763,15 @@
 				E7C070765F0474DF1C4ACEF0 /* session-new-response.json */,
 				4D63B166AF2C533BE6E59365 /* session-update-agent-chunk.json */,
 				1B0785F1FFC8008C74009584 /* session-update-available-models.json */,
+				D8A14E0E9529665F98F57A86 /* session-update-compaction-summary-chunk.json */,
+				2C0350206BA233AD3B54B3C7 /* session-update-compaction-update.json */,
 				0C5373F76231F229D3F96AF3 /* session-update-config-option.json */,
 				97DA8F50DDCDAA15CCEA2004 /* session-update-config-options.json */,
+				7C82DDE43A00B915984134F0 /* session-update-context-compaction-completed.json */,
+				85C63F59DC811B24059183A0 /* session-update-context-compaction-failed.json */,
+				1C8926C5ABBB7B8157ACFEF3 /* session-update-context-compaction-partial.json */,
+				31853A88896328990E6FDA78 /* session-update-context-compaction-running.json */,
+				EA5C852BB7704D7714C28E3A /* session-update-context-compaction-unknown.json */,
 				02347E4D2EA79A5CB8DF82DC /* session-update-current-model.json */,
 				7094534860369BA79FC5A877 /* session-update-plan.json */,
 				2D751485790AD46EBC15A979 /* session-update-session-info-goal.json */,
@@ -5809,8 +5836,15 @@
 				6AD85D472EF03EAE992D65D0 /* session-new-response.json in Resources */,
 				5C9791E96E80858B5A037941 /* session-update-agent-chunk.json in Resources */,
 				8D22459A108B6BF47AEA71F7 /* session-update-available-models.json in Resources */,
+				8814D8EE15F78DE6D549EC84 /* session-update-compaction-summary-chunk.json in Resources */,
+				F049CEA88BF52C7C98F2D6F8 /* session-update-compaction-update.json in Resources */,
 				70F0096BEEECA74B24A3BF70 /* session-update-config-option.json in Resources */,
 				2434A66A45EDF2609BA9F1D3 /* session-update-config-options.json in Resources */,
+				BD0A00FF47FCA4BED994EEB1 /* session-update-context-compaction-completed.json in Resources */,
+				822CF2A0C5B9A94B7DDE062A /* session-update-context-compaction-failed.json in Resources */,
+				107D5EC59DC4F2E708D74865 /* session-update-context-compaction-partial.json in Resources */,
+				8A0587F13E14C737218FF73A /* session-update-context-compaction-running.json in Resources */,
+				D6D8AE009601D3A71C19C34C /* session-update-context-compaction-unknown.json in Resources */,
 				BF0A3B3A162F31E86DB13404 /* session-update-current-model.json in Resources */,
 				85C7E65296AB9500FF52060A /* session-update-plan.json in Resources */,
 				10C27B7147AF2D41AD109E9A /* session-update-session-info-goal.json in Resources */,
@@ -6010,6 +6044,7 @@
 				1298147855092677E3184AC2 /* ACPConfigOption.swift in Sources */,
 				809972779548945B012F8B6C /* ACPConnectingPlaceholder.swift in Sources */,
 				C7EC6D85810513194F831F13 /* ACPConnection.swift in Sources */,
+				E54E7BA373F131366C6A3960 /* ACPContextCompactionView.swift in Sources */,
 				9CF654B4AB74CC1A9FBCE55F /* ACPContextRing.swift in Sources */,
 				0DFC9AB26DDCC406CEAA3825 /* ACPContextUsageButton.swift in Sources */,
 				85B8A8B929BD4ED4DC21FEDD /* ACPDelayedHoverVisibility.swift in Sources */,
@@ -6833,6 +6868,7 @@
 				FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */,
 				30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */,
 				839AF384DDFF728207769920 /* ACPContentBlockImageTests.swift in Sources */,
+				18CDE0CC16BC53EE02F1D773 /* ACPContextCompactionPresentationTests.swift in Sources */,
 				316ABEA3944051EA41569FDC /* ACPContextRingTests.swift in Sources */,
 				DADDDA3FA289B52415EF4379 /* ACPDelayedHoverVisibilityTests.swift in Sources */,
 				4AFE4A55AF808EEFE3AA4DE2 /* ACPDelegatedSessionsPolicyTests.swift in Sources */,

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -104,22 +104,27 @@ struct ACPClientCapabilities: Codable, Equatable {
 
 struct ACPSessionCapabilities: Codable, Equatable {
     static let booleanConfigOptions = ACPSessionCapabilities(
-        configOptions: .init(boolean: .init()))
+        configOptions: .init(boolean: .init()),
+        compaction: .init())
 
     let configOptions: ConfigOptions
+    /// Experimental ACP context-compaction updates. `{}` advertises support.
+    let compaction: EmptyObject?
 
-    init(configOptions: ConfigOptions = .init(boolean: nil)) {
+    init(configOptions: ConfigOptions = .init(boolean: nil), compaction: EmptyObject? = nil) {
         self.configOptions = configOptions
+        self.compaction = compaction
     }
 
     enum CodingKeys: String, CodingKey {
-        case configOptions
+        case configOptions, compaction
     }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         configOptions = try c.decodeIfPresent(ConfigOptions.self, forKey: .configOptions)
             ?? .init(boolean: nil)
+        compaction = try? c.decodeIfPresent(EmptyObject.self, forKey: .compaction)
     }
 
     struct ConfigOptions: Codable, Equatable {

--- a/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
+++ b/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
@@ -51,6 +51,8 @@ enum ACPSessionUpdate: Codable, Equatable {
     case availableCommandsUpdate([ACPPromptSuggestion])
     case usageUpdate(ACPUsageInfo)
     case sessionInfoUpdate(ACPSessionInfoUpdate)
+    case compactionUpdate(ACPCompactionUpdate)
+    case compactionSummaryChunk(ACPCompactionSummaryChunk)
     case unknown(String)
 
     static func userMessageChunk(_ content: ACPContentBlock) -> ACPSessionUpdate {
@@ -110,6 +112,10 @@ enum ACPSessionUpdate: Codable, Equatable {
             self = .usageUpdate(try ACPUsageInfo(from: decoder))
         case "session_info_update":
             self = .sessionInfoUpdate(try ACPSessionInfoUpdate(from: decoder))
+        case "compaction_update":
+            self = .compactionUpdate(try ACPCompactionUpdate(from: decoder))
+        case "compaction_summary_chunk":
+            self = .compactionSummaryChunk(try ACPCompactionSummaryChunk(from: decoder))
         default:
             self = .unknown(kind)
         }
@@ -165,7 +171,8 @@ enum ACPSessionUpdate: Codable, Equatable {
             try info.encodeFields(to: encoder)
         case .availableCommandsUpdate:
             break
-        case .toolCall, .toolCallUpdate, .usageUpdate, .unknown:
+        case .toolCall, .toolCallUpdate, .usageUpdate, .compactionUpdate,
+             .compactionSummaryChunk, .unknown:
             break
         }
     }
@@ -181,6 +188,81 @@ enum ACPMessagePhase: String, Codable, Equatable, Sendable {
               let value = codex["phase"]?.value as? String
         else { return nil }
         return ACPMessagePhase(rawValue: value)
+    }
+}
+
+/// Experimental ACP compaction lifecycle update. Optional fields decode
+/// defensively because this wire format is still evolving.
+struct ACPCompactionUpdate: Codable, Equatable {
+    let compactionId: String
+    let status: String
+    let summary: [ACPContentBlock]?
+    let summaryWasProvided: Bool
+    let summaryWasNull: Bool
+    let error: String?
+    let errorWasProvided: Bool
+    let errorWasNull: Bool
+    let metadata: AnyCodable?
+
+    private enum CodingKeys: String, CodingKey {
+        case compactionId, status, summary, error
+        case metadata = "_meta"
+    }
+
+    init(
+        compactionId: String,
+        status: String,
+        summary: [ACPContentBlock]? = nil,
+        error: String? = nil,
+        metadata: AnyCodable? = nil
+    ) {
+        self.compactionId = compactionId
+        self.status = status
+        self.summary = summary
+        self.summaryWasProvided = summary != nil
+        self.summaryWasNull = false
+        self.error = error
+        self.errorWasProvided = error != nil
+        self.errorWasNull = false
+        self.metadata = metadata
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        compactionId = try c.decode(String.self, forKey: .compactionId)
+        status = try c.decode(String.self, forKey: .status)
+        summaryWasProvided = c.contains(.summary)
+        summaryWasNull = summaryWasProvided ? try c.decodeNil(forKey: .summary) : false
+        summary = summaryWasNull ? nil : try? c.decodeIfPresent([ACPContentBlock].self, forKey: .summary)
+        errorWasProvided = c.contains(.error)
+        errorWasNull = errorWasProvided ? try c.decodeNil(forKey: .error) : false
+        error = errorWasNull ? nil : try? c.decodeIfPresent(String.self, forKey: .error)
+        metadata = try? c.decodeIfPresent(AnyCodable.self, forKey: .metadata)
+    }
+}
+
+/// Experimental ACP chunk appended to an in-progress compaction summary.
+struct ACPCompactionSummaryChunk: Codable, Equatable {
+    let compactionId: String
+    let content: ACPContentBlock
+    let metadata: AnyCodable?
+
+    private enum CodingKeys: String, CodingKey {
+        case compactionId, content
+        case metadata = "_meta"
+    }
+
+    init(compactionId: String, content: ACPContentBlock, metadata: AnyCodable? = nil) {
+        self.compactionId = compactionId
+        self.content = content
+        self.metadata = metadata
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        compactionId = try c.decode(String.self, forKey: .compactionId)
+        content = try c.decode(ACPContentBlock.self, forKey: .content)
+        metadata = try? c.decodeIfPresent(AnyCodable.self, forKey: .metadata)
     }
 }
 

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -433,6 +433,72 @@ enum ACPMessage: Equatable {
     }
 }
 
+/// The documented, versioned context-compaction facts carried on a synthetic
+/// tool call. Unknown metadata is intentionally not projected into the UI.
+struct ACPContextCompaction: Equatable, Sendable {
+    enum Status: Equatable, Sendable {
+        case inProgress
+        case completed
+        case failed
+        case cancelled
+        case other(String)
+    }
+
+    let id: String
+    let status: Status
+    let trigger: String?
+    let tokensBefore: Int?
+    let tokensAfter: Int?
+    let durationMs: Int?
+    let error: String?
+
+    init?(toolCall: ACPMessage.ToolCall) {
+        guard let root = Self.object(toolCall.metadata),
+              let raw = root["contextCompaction"],
+              let compaction = Self.object(raw),
+              Self.int(compaction["version"]) == 1 else {
+            return nil
+        }
+        id = toolCall.toolCallId
+        status = Self.status(toolCall.status)
+        trigger = Self.string(compaction["trigger"])
+        tokensBefore = Self.int(compaction["preTokens"])
+        tokensAfter = Self.int(compaction["postTokens"])
+        durationMs = Self.int(compaction["durationMs"])
+        error = Self.string(compaction["error"])
+    }
+
+    private static func object(_ value: AnyCodable?) -> [String: AnyCodable]? {
+        value.flatMap(object)
+    }
+
+    private static func object(_ value: AnyCodable) -> [String: AnyCodable]? {
+        if let object = value.value as? [String: AnyCodable] { return object }
+        if let object = value.value as? [String: Any] {
+            return object.mapValues { AnyCodable($0) }
+        }
+        return nil
+    }
+
+    private static func string(_ value: AnyCodable?) -> String? {
+        value?.value as? String
+    }
+
+    private static func int(_ value: AnyCodable?) -> Int? {
+        value?.value as? Int
+    }
+
+    private static func status(_ raw: String) -> Status {
+        switch raw {
+        case "in_progress", "running": .inProgress
+        case "completed", "success": .completed
+        case "failed", "error": .failed
+        case "cancelled", "canceled": .cancelled
+        default: .other(raw)
+        }
+    }
+}
+
 enum ACPMessageCodec {
     private static let encoder: JSONEncoder = {
         let e = JSONEncoder()

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -459,7 +459,7 @@ struct ACPContextCompaction: Equatable, Sendable {
               Self.int(compaction["version"]) == 1 else {
             return nil
         }
-        id = toolCall.toolCallId
+        id = Self.string(compaction["id"]) ?? toolCall.toolCallId
         status = Self.status(toolCall.status)
         trigger = Self.string(compaction["trigger"])
         tokensBefore = Self.int(compaction["preTokens"])

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -417,7 +417,7 @@ final class ACPSession: ObservableObject, Identifiable {
             kindsToFlush = [.agent, .thought]
         } else {
             switch update {
-            case .toolCall, .plan:
+            case .toolCall, .plan, .compactionUpdate, .compactionSummaryChunk:
                 kindsToFlush = [.agent, .thought]
             default:
                 kindsToFlush = []
@@ -528,6 +528,12 @@ final class ACPSession: ObservableObject, Identifiable {
                 applyToolCallMetadata(u.metadata)
             }
             return touched.map { [$0] } ?? []
+        case .compactionUpdate(let update):
+            clearRestoredContextRecoveryStatus()
+            return applyContextCompaction(update)
+        case .compactionSummaryChunk(let chunk):
+            clearRestoredContextRecoveryStatus()
+            return appendContextCompactionSummary(chunk)
         case .sessionInfoUpdate(let info):
             applySessionInfoUpdate(info, tracksRetryStatus: tracksRetryStatus)
             return []
@@ -572,6 +578,80 @@ final class ACPSession: ObservableObject, Identifiable {
         }
         }()
         return flushed.union(result)
+    }
+
+    private func applyContextCompaction(_ update: ACPCompactionUpdate) -> Set<Int> {
+        let toolCallId = Self.contextCompactionToolCallId(update.compactionId)
+        let content = update.summary.map { $0.map(ACPToolCallContent.content) }
+        let metadata = Self.contextCompactionMetadata(
+            trigger: nil,
+            error: update.errorWasNull ? AnyCodable(NSNull()) : update.error.map { AnyCodable($0) },
+            metadata: update.metadata
+        )
+
+        if let existing = transcript.toolCallIndex(toolCallId: toolCallId) {
+            return updateToolCall(id: toolCallId) { toolCall in
+                toolCall.status = update.status
+                toolCall.metadata = Self.mergeMetadata(toolCall.metadata, metadata)
+                if update.summaryWasProvided {
+                    Self.applyToolCallContent(
+                        items: update.summaryWasNull ? [] : (content ?? []),
+                        isFinal: Self.isFinalStatus(toolCall.status),
+                        rawOutputAssets: [],
+                        rawOutputChanged: false,
+                        metadataChanged: true,
+                        to: &toolCall)
+                }
+            }.map { [$0] } ?? [existing]
+        }
+
+        let items = content ?? []
+        let raw = Self.flatten(items)
+        transcript.appendMessage(.toolCall(.init(
+            toolCallId: toolCallId,
+            title: "Compacting context",
+            kind: "context_compaction",
+            status: update.status,
+            content: Self.stripWrappingFence(raw, isFinal: Self.isFinalStatus(update.status)),
+            preview: Self.previewLine(raw),
+            metadata: metadata
+        )))
+        didAppendTranscriptMessage()
+        transcript.completedOutputBoundaryMessageIds.removeAll()
+        return [transcript.messages.count - 1]
+    }
+
+    private func appendContextCompactionSummary(_ chunk: ACPCompactionSummaryChunk) -> Set<Int> {
+        let toolCallId = Self.contextCompactionToolCallId(chunk.compactionId)
+        guard let index = updateToolCall(id: toolCallId, { toolCall in
+            let chunkText = text(of: chunk.content)
+            guard !chunkText.isEmpty else { return }
+            toolCall.replaceContent(toolCall.content + chunkText)
+            toolCall.preview = Self.previewLine(toolCall.content)
+        }) else {
+            return []
+        }
+        return [index]
+    }
+
+    private static func contextCompactionToolCallId(_ id: String) -> String {
+        "context-compaction:\(id)"
+    }
+
+    private static func contextCompactionMetadata(
+        trigger: String?,
+        error: AnyCodable?,
+        metadata: AnyCodable?
+    ) -> AnyCodable {
+        var facts: [String: AnyCodable] = ["version": AnyCodable(1)]
+        if let trigger { facts["trigger"] = AnyCodable(trigger) }
+        if let error { facts["error"] = error }
+        if let metadata = metadata?.value as? [String: AnyCodable] {
+            for key in ["preTokens", "postTokens", "durationMs"] {
+                if let value = metadata[key] { facts[key] = value }
+            }
+        }
+        return AnyCodable(["contextCompaction": AnyCodable(facts)])
     }
 
     /// Materialise held replay candidates of the given `kinds` as new rows
@@ -1605,7 +1685,13 @@ final class ACPSession: ObservableObject, Identifiable {
             return update
         }
         for (key, value) in updateObject {
-            merged[key] = value
+            if key == "contextCompaction",
+               let existingCompaction = Self.metadataObject(merged[key]),
+               let updatedCompaction = Self.metadataObject(value) {
+                merged[key] = AnyCodable(existingCompaction.merging(updatedCompaction) { _, update in update })
+            } else {
+                merged[key] = value
+            }
         }
         return AnyCodable(merged)
     }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -584,6 +584,7 @@ final class ACPSession: ObservableObject, Identifiable {
         let toolCallId = Self.contextCompactionToolCallId(update.compactionId)
         let content = update.summary.map { $0.map(ACPToolCallContent.content) }
         let metadata = Self.contextCompactionMetadata(
+            id: update.compactionId,
             trigger: nil,
             error: update.errorWasNull ? AnyCodable(NSNull()) : update.error.map { AnyCodable($0) },
             metadata: update.metadata
@@ -634,16 +635,18 @@ final class ACPSession: ObservableObject, Identifiable {
         return [index]
     }
 
-    private static func contextCompactionToolCallId(_ id: String) -> String {
+    static func contextCompactionToolCallId(_ id: String) -> String {
         "context-compaction:\(id)"
     }
 
     private static func contextCompactionMetadata(
+        id: String,
         trigger: String?,
         error: AnyCodable?,
         metadata: AnyCodable?
     ) -> AnyCodable {
         var facts: [String: AnyCodable] = ["version": AnyCodable(1)]
+        facts["id"] = AnyCodable(id)
         if let trigger { facts["trigger"] = AnyCodable(trigger) }
         if let error { facts["error"] = error }
         if let metadata = metadata?.value as? [String: AnyCodable] {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -513,7 +513,8 @@ final class ACPSessionRunner {
             }.map { [$0] } ?? []
         case .toolCallUpdate(let update):
             return session.transcript.toolCallIndex(toolCallId: update.toolCallId).map { [$0] } ?? []
-        case .toolCall, .userMessageChunk, .plan, .availableModelsUpdate,
+        case .toolCall, .compactionUpdate, .compactionSummaryChunk,
+             .userMessageChunk, .plan, .availableModelsUpdate,
              .currentModeUpdate, .currentModelUpdate, .sessionInfoUpdate,
              .sessionConfigOptionsUpdate, .availableCommandsUpdate,
              .usageUpdate, .unknown:
@@ -2078,7 +2079,8 @@ extension ACPSessionRunner {
         switch update {
         case .agentMessageChunk, .agentThoughtChunk, .toolCallUpdate:
             return true
-        case .userMessageChunk, .toolCall, .plan, .availableModelsUpdate,
+        case .userMessageChunk, .toolCall, .compactionUpdate, .compactionSummaryChunk,
+             .plan, .availableModelsUpdate,
              .currentModeUpdate, .currentModelUpdate, .sessionInfoUpdate,
              .sessionConfigOptionsUpdate, .availableCommandsUpdate,
              .usageUpdate, .unknown:

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -513,7 +513,11 @@ final class ACPSessionRunner {
             }.map { [$0] } ?? []
         case .toolCallUpdate(let update):
             return session.transcript.toolCallIndex(toolCallId: update.toolCallId).map { [$0] } ?? []
-        case .toolCall, .compactionUpdate, .compactionSummaryChunk,
+        case .compactionSummaryChunk(let chunk):
+            return session.transcript.toolCallIndex(
+                toolCallId: ACPSession.contextCompactionToolCallId(chunk.compactionId)
+            ).map { [$0] } ?? []
+        case .toolCall, .compactionUpdate,
              .userMessageChunk, .plan, .availableModelsUpdate,
              .currentModeUpdate, .currentModelUpdate, .sessionInfoUpdate,
              .sessionConfigOptionsUpdate, .availableCommandsUpdate,
@@ -2077,9 +2081,9 @@ extension ACPSessionRunner {
             return false
         }
         switch update {
-        case .agentMessageChunk, .agentThoughtChunk, .toolCallUpdate:
+        case .agentMessageChunk, .agentThoughtChunk, .toolCallUpdate, .compactionSummaryChunk:
             return true
-        case .userMessageChunk, .toolCall, .compactionUpdate, .compactionSummaryChunk,
+        case .userMessageChunk, .toolCall, .compactionUpdate,
              .plan, .availableModelsUpdate,
              .currentModeUpdate, .currentModelUpdate, .sessionInfoUpdate,
              .sessionConfigOptionsUpdate, .availableCommandsUpdate,

--- a/Alas/Sources/ACP/UI/ACPContextCompactionView.swift
+++ b/Alas/Sources/ACP/UI/ACPContextCompactionView.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+/// A non-interactive transcript marker for a context compaction lifecycle.
+struct ACPContextCompactionView: View {
+    let compaction: ACPContextCompaction
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(theme.color("accent"))
+                    .frame(width: 18, height: 18)
+                    .background(theme.color("bg-0").opacity(0.8), in: RoundedRectangle(cornerRadius: 4))
+                Text(compaction.label)
+                    .font(.system(size: 10.5, weight: .semibold))
+                    .tracking(0.6)
+                    .textCase(.uppercase)
+                    .foregroundStyle(theme.color("fg-faint"))
+                Spacer(minLength: 6)
+                status
+            }
+
+            if let details = compaction.details { Text(details)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(theme.color("fg-faint"))
+            }
+            if let error = compaction.error, !error.isEmpty {
+                Text(error)
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.color("del"))
+            }
+        }
+        .padding(.horizontal, 10).padding(.vertical, 7)
+        .background(theme.color("bg-1").opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(theme.color("line"), lineWidth: 0.5))
+        .accessibilityElement(children: .combine)
+    }
+
+    @ViewBuilder
+    private var status: some View {
+        switch compaction.status {
+        case .inProgress:
+            Spinner(lineWidth: 1.5, duration: 0.7).frame(width: 11, height: 11)
+        case .completed:
+            Image(systemName: "checkmark")
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(theme.color("add"))
+        case .failed:
+            Image(systemName: "xmark")
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(theme.color("del"))
+        case .cancelled:
+            Image(systemName: "stop.fill")
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(theme.color("fg-faint"))
+        case .other(let status):
+            Text(status)
+                .font(.system(size: 10))
+                .foregroundStyle(theme.color("fg-faint"))
+        }
+    }
+
+}
+
+extension ACPContextCompaction {
+    var label: String {
+        switch status {
+        case .inProgress: "Compacting context"
+        case .completed: "Context compacted"
+        case .failed: "Context compaction failed"
+        case .cancelled: "Context compaction cancelled"
+        case .other: "Context compaction"
+        }
+    }
+
+    var details: String? {
+        let prefix = trigger.map { "\($0) · " } ?? ""
+        let values: String?
+        switch (tokensBefore, tokensAfter, durationMs) {
+        case let (before?, after?, duration?):
+            values = "\(before) → \(after) tokens · \(duration) ms"
+        case let (before?, after?, nil):
+            values = "\(before) → \(after) tokens"
+        case let (before?, nil, duration?):
+            values = "\(before) tokens · \(duration) ms"
+        case let (nil, after?, duration?):
+            values = "\(after) tokens · \(duration) ms"
+        case let (before?, nil, nil):
+            values = "\(before) tokens"
+        case let (nil, after?, nil):
+            values = "\(after) tokens"
+        case let (nil, nil, duration?):
+            values = "\(duration) ms"
+        case (nil, nil, nil):
+            values = nil
+        }
+        return values.map { prefix + $0 } ?? (trigger == nil ? nil : String(prefix.dropLast(3)))
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPContextCompactionView.swift
+++ b/Alas/Sources/ACP/UI/ACPContextCompactionView.swift
@@ -62,7 +62,6 @@ struct ACPContextCompactionView: View {
                 .foregroundStyle(theme.color("fg-faint"))
         }
     }
-
 }
 
 extension ACPContextCompaction {

--- a/Alas/Sources/ACP/UI/ACPTranscriptRowContent.swift
+++ b/Alas/Sources/ACP/UI/ACPTranscriptRowContent.swift
@@ -146,11 +146,15 @@ struct ACPTranscriptRowContent: View, Equatable {
         case .thought(_, _, let buf):
             ACPThoughtView(buffer: buf)
         case .toolCall(let tc):
-            ACPToolCallCard(
-                toolCall: tc,
-                trustedImageRoot: trustedImageRoot,
-                loadFullContent: tc.isContentTruncated ? onLoadFullToolCallContent : nil)
-                .environment(\.acpTerminalHost, session.terminalHost)
+            if let compaction = ACPContextCompaction(toolCall: tc) {
+                ACPContextCompactionView(compaction: compaction)
+            } else {
+                ACPToolCallCard(
+                    toolCall: tc,
+                    trustedImageRoot: trustedImageRoot,
+                    loadFullContent: tc.isContentTruncated ? onLoadFullToolCallContent : nil)
+                    .environment(\.acpTerminalHost, session.terminalHost)
+            }
         case .fileEdit(_, let edit):
             ACPFileEditCard(edit: edit, onOpenDiff: onOpenDiff)
         case .plan:

--- a/AlasTests/ACP/Fixtures/session-update-compaction-summary-chunk.json
+++ b/AlasTests/ACP/Fixtures/session-update-compaction-summary-chunk.json
@@ -1,0 +1,12 @@
+{
+  "jsonrpc": "2.0",
+  "method": "session/update",
+  "params": {
+    "sessionId": "s1",
+    "update": {
+      "sessionUpdate": "compaction_summary_chunk",
+      "compactionId": "standard-compact-1",
+      "content": { "type": "text", "text": "Kept decisions." }
+    }
+  }
+}

--- a/AlasTests/ACP/Fixtures/session-update-compaction-update.json
+++ b/AlasTests/ACP/Fixtures/session-update-compaction-update.json
@@ -1,0 +1,12 @@
+{
+  "jsonrpc": "2.0",
+  "method": "session/update",
+  "params": {
+    "sessionId": "s1",
+    "update": {
+      "sessionUpdate": "compaction_update",
+      "compactionId": "standard-compact-1",
+      "status": "in_progress"
+    }
+  }
+}

--- a/AlasTests/ACP/Fixtures/session-update-context-compaction-completed.json
+++ b/AlasTests/ACP/Fixtures/session-update-context-compaction-completed.json
@@ -1,0 +1,12 @@
+{
+  "jsonrpc": "2.0", "method": "session/update", "params": {
+    "sessionId": "s1", "update": {
+      "sessionUpdate": "tool_call", "toolCallId": "codex-compact-2",
+      "title": "Compact conversation", "kind": "think", "status": "completed",
+      "_meta": { "contextCompaction": {
+        "version": 1, "trigger": "automatic",
+        "preTokens": 128000, "postTokens": 16000, "durationMs": 950
+      }}
+    }
+  }
+}

--- a/AlasTests/ACP/Fixtures/session-update-context-compaction-failed.json
+++ b/AlasTests/ACP/Fixtures/session-update-context-compaction-failed.json
@@ -1,0 +1,12 @@
+{
+  "jsonrpc": "2.0", "method": "session/update", "params": {
+    "sessionId": "s1", "update": {
+      "sessionUpdate": "tool_call", "toolCallId": "codex-compact-3",
+      "title": "Compact conversation", "kind": "think", "status": "failed",
+      "_meta": { "contextCompaction": {
+        "version": 1,
+        "error": "Context limit exceeded"
+      }}
+    }
+  }
+}

--- a/AlasTests/ACP/Fixtures/session-update-context-compaction-partial.json
+++ b/AlasTests/ACP/Fixtures/session-update-context-compaction-partial.json
@@ -1,0 +1,11 @@
+{
+  "jsonrpc": "2.0", "method": "session/update", "params": {
+    "sessionId": "s1", "update": {
+      "sessionUpdate": "tool_call", "toolCallId": "codex-compact-4",
+      "title": "Compact conversation", "kind": "think", "status": "completed",
+      "_meta": { "contextCompaction": {
+        "version": 1, "preTokens": 128000
+      }}
+    }
+  }
+}

--- a/AlasTests/ACP/Fixtures/session-update-context-compaction-running.json
+++ b/AlasTests/ACP/Fixtures/session-update-context-compaction-running.json
@@ -1,0 +1,20 @@
+{
+  "jsonrpc": "2.0",
+  "method": "session/update",
+  "params": {
+    "sessionId": "s1",
+    "update": {
+      "sessionUpdate": "tool_call",
+      "toolCallId": "codex-compact-1",
+      "title": "Compact conversation",
+      "kind": "think",
+      "status": "in_progress",
+      "_meta": {
+        "contextCompaction": {
+          "version": 1,
+          "trigger": "automatic"
+        }
+      }
+    }
+  }
+}

--- a/AlasTests/ACP/Fixtures/session-update-context-compaction-unknown.json
+++ b/AlasTests/ACP/Fixtures/session-update-context-compaction-unknown.json
@@ -1,0 +1,11 @@
+{
+  "jsonrpc": "2.0", "method": "session/update", "params": {
+    "sessionId": "s1", "update": {
+      "sessionUpdate": "tool_call", "toolCallId": "codex-compact-5",
+      "title": "Compact conversation", "kind": "think", "status": "completed",
+      "_meta": { "contextCompaction": {
+        "version": 1, "futureField": "ignored"
+      }}
+    }
+  }
+}

--- a/AlasTests/ACP/Protocol/ACPInitializeTests.swift
+++ b/AlasTests/ACP/Protocol/ACPInitializeTests.swift
@@ -113,6 +113,7 @@ struct ACPInitializeTests {
         let session = try #require(capabilities["session"] as? [String: Any])
         let configOptions = try #require(session["configOptions"] as? [String: Any])
         #expect(configOptions["boolean"] as? [String: Any] != nil)
+        #expect(session["compaction"] as? [String: Any] != nil)
         #expect(capabilities["terminal"] as? Bool == true)
         let elicitation = try #require(capabilities["elicitation"] as? [String: Any])
         #expect(elicitation["form"] as? [String: Any] != nil)

--- a/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
+++ b/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
@@ -296,11 +296,149 @@ struct ACPSessionUpdateTests {
         #expect(cmds.allSatisfy { $0.hint == nil })
     }
 
+    @Test("decodes Codex version 1 context compaction metadata")
+    func codexContextCompactionMetadata() throws {
+        let env = try decode("session-update-context-compaction-running")
+        guard case .toolCall(let toolCall) = env.params?.update,
+              let compaction = ACPContextCompaction(toolCall: .init(
+                toolCallId: toolCall.toolCallId,
+                title: toolCall.title,
+                kind: toolCall.kind,
+                status: toolCall.status,
+                metadata: toolCall.metadata
+              )) else {
+            Issue.record("expected a normalized context compaction")
+            return
+        }
+
+        #expect(compaction.id == "codex-compact-1")
+        #expect(compaction.status == .inProgress)
+        #expect(compaction.trigger == "automatic")
+        #expect(compaction.tokensBefore == nil)
+        #expect(compaction.tokensAfter == nil)
+        #expect(compaction.durationMs == nil)
+    }
+
+    @Test("decodes completed and failed Codex compaction metadata without fabricated values")
+    func codexCompactionCompletionStates() throws {
+        let completed = try toolCallCompaction(
+            id: "compact-completed",
+            status: "completed",
+            facts: "\"trigger\": \"manual\", \"preTokens\": 120000, \"postTokens\": 18000, \"durationMs\": 840")
+        let failed = try toolCallCompaction(
+            id: "compact-failed",
+            status: "failed",
+            facts: "\"error\": \"compaction timed out\"")
+
+        #expect(completed.status == .completed)
+        #expect(completed.trigger == "manual")
+        #expect(completed.tokensBefore == 120_000)
+        #expect(completed.tokensAfter == 18_000)
+        #expect(completed.durationMs == 840)
+        #expect(failed.status == .failed)
+        #expect(failed.error == "compaction timed out")
+        #expect(failed.tokensBefore == nil)
+        #expect(failed.tokensAfter == nil)
+        #expect(failed.durationMs == nil)
+    }
+
+    @Test("decodes documented context compaction metadata variants")
+    func codexContextCompactionMetadataVariants() throws {
+        let expectations: [(String, ACPContextCompaction.Status, Int?, Int?, Int?, String?)] = [
+            ("session-update-context-compaction-completed", .completed, 128_000, 16_000, 950, nil),
+            ("session-update-context-compaction-failed", .failed, nil, nil, nil, "Context limit exceeded"),
+            ("session-update-context-compaction-partial", .completed, 128_000, nil, nil, nil),
+            ("session-update-context-compaction-unknown", .completed, nil, nil, nil, nil)
+        ]
+
+        for (fixture, status, before, after, duration, error) in expectations {
+            let env = try decode(fixture)
+            guard case .toolCall(let toolCall) = env.params?.update,
+                  let compaction = ACPContextCompaction(toolCall: .init(
+                    toolCallId: toolCall.toolCallId,
+                    title: toolCall.title,
+                    kind: toolCall.kind,
+                    status: toolCall.status,
+                    metadata: toolCall.metadata
+                  )) else {
+                Issue.record("expected a normalized context compaction from \(fixture)")
+                continue
+            }
+            #expect(compaction.status == status)
+            #expect(compaction.tokensBefore == before)
+            #expect(compaction.tokensAfter == after)
+            #expect(compaction.durationMs == duration)
+            #expect(compaction.error == error)
+        }
+    }
+
+    @Test("decodes experimental compaction updates")
+    func compactionUpdates() throws {
+        let running = try decode("session-update-compaction-update")
+        guard case .compactionUpdate(let update) = running.params?.update else {
+            Issue.record("expected compactionUpdate")
+            return
+        }
+        #expect(update.compactionId == "standard-compact-1")
+        #expect(update.status == "in_progress")
+        #expect(update.summary == nil)
+
+        let patch = try JSONDecoder().decode(ACPSessionUpdateParams.self, from: Data("""
+        { "sessionId": "s", "update": { "sessionUpdate": "compaction_update", "compactionId": "standard-compact-1", "status": "failed", "summary": null, "error": null, "future": true } }
+        """.utf8))
+        guard case .compactionUpdate(let nullPatch) = patch.update else {
+            Issue.record("expected compactionUpdate")
+            return
+        }
+        #expect(nullPatch.summaryWasProvided)
+        #expect(nullPatch.summaryWasNull)
+        #expect(nullPatch.errorWasProvided)
+        #expect(nullPatch.errorWasNull)
+
+        let chunk = try decode("session-update-compaction-summary-chunk")
+        guard case .compactionSummaryChunk(let summaryChunk) = chunk.params?.update else {
+            Issue.record("expected compactionSummaryChunk")
+            return
+        }
+        #expect(summaryChunk.compactionId == "standard-compact-1")
+        #expect(summaryChunk.content == .text("Kept decisions."))
+    }
+
+    @Test("initialize advertises compaction support")
+    func compactionCapability() throws {
+        let data = try JSONEncoder().encode(ACPInitializeParams(
+            protocolVersion: 1,
+            clientCapabilities: .init(
+                fs: .init(readTextFile: true, writeTextFile: true), terminal: true)))
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let capabilities = try #require(json["clientCapabilities"] as? [String: Any])
+        let session = try #require(capabilities["session"] as? [String: Any])
+        #expect(session["compaction"] as? [String: Any] != nil)
+    }
+
     private func decode(_ name: String) throws -> JSONRPCEnvelope<ACPSessionUpdateParams> {
         let bundle = Bundle(for: ACPSessionUpdateFixtureMarker.self)
         let url = try #require(bundle.url(forResource: name, withExtension: "json"))
         return try JSONDecoder().decode(JSONRPCEnvelope<ACPSessionUpdateParams>.self,
                                         from: try Data(contentsOf: url))
+    }
+
+    private func toolCallCompaction(
+        id: String,
+        status: String,
+        facts: String
+    ) throws -> ACPContextCompaction {
+        let json = """
+        { "sessionId": "s", "update": { "sessionUpdate": "tool_call", "toolCallId": "\(id)", "title": "Compact conversation", "status": "\(status)", "_meta": { "contextCompaction": { "version": 1, \(facts) } } } }
+        """
+        let params = try JSONDecoder().decode(ACPSessionUpdateParams.self, from: Data(json.utf8))
+        guard case .toolCall(let payload) = params.update,
+              let compaction = ACPContextCompaction(toolCall: .init(
+                toolCallId: payload.toolCallId, title: payload.title, kind: payload.kind,
+                status: payload.status, metadata: payload.metadata)) else {
+            throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "missing compaction"))
+        }
+        return compaction
     }
 }
 

--- a/AlasTests/ACP/Session/ACPMessageTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageTests.swift
@@ -108,6 +108,34 @@ struct ACPMessageTests {
         #expect(back == m)
     }
 
+    @Test("context compaction facts persist with a tool call")
+    func contextCompactionRoundtrip() throws {
+        let message = ACPMessage.toolCall(.init(
+            toolCallId: "context-compaction:compact-1",
+            title: "Compacting context",
+            kind: "context_compaction",
+            status: "completed",
+            metadata: AnyCodable([
+                "contextCompaction": [
+                    "version": 1,
+                    "trigger": "automatic",
+                    "preTokens": 128_000,
+                    "postTokens": 16_000,
+                    "durationMs": 950
+                ]
+            ])))
+
+        let payload = try ACPMessageCodec.encode(message)
+        guard case .toolCall(let restored) = try ACPMessageCodec.decode(kind: message.kind, payload: payload),
+              let compaction = ACPContextCompaction(toolCall: restored) else {
+            Issue.record("expected persisted context compaction")
+            return
+        }
+        #expect(compaction.tokensBefore == 128_000)
+        #expect(compaction.tokensAfter == 16_000)
+        #expect(compaction.durationMs == 950)
+    }
+
     @Test("legacy contentSummary decode keeps backward-compatible preview")
     func toolCallLegacyContentSummary() throws {
         let payload = """

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -5,6 +5,83 @@ import Testing
 @MainActor
 @Suite("ACPSession")
 struct ACPSessionTests {
+    @Test("compaction updates with the same ID replace one transcript row")
+    func compactionUpdatesMergeInPlace() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        session.apply(.compactionUpdate(.init(
+            compactionId: "compact-1", status: "in_progress")))
+        session.apply(.compactionUpdate(.init(
+            compactionId: "compact-1", status: "completed",
+            summary: [.text("Kept decisions.")])))
+
+        #expect(session.transcript.messages.count == 1)
+        guard case .toolCall(let toolCall) = session.transcript.messages[0],
+              let compaction = ACPContextCompaction(toolCall: toolCall) else {
+            Issue.record("expected a normalized compaction tool call")
+            return
+        }
+        #expect(compaction.id == "compact-1")
+        #expect(compaction.status == .completed)
+        #expect(toolCall.content == "Kept decisions.")
+    }
+
+    @Test("Codex compaction updates retain previously supplied facts")
+    func codexCompactionUpdatesMergeFacts() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        session.apply(.toolCall(.init(
+            toolCallId: "compact-1", title: "Compact conversation", kind: "think", status: "in_progress",
+            metadata: AnyCodable(["contextCompaction": ["version": 1, "trigger": "automatic", "preTokens": 100_000]]))))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "compact-1", status: "completed",
+            metadata: AnyCodable(["contextCompaction": ["version": 1, "postTokens": 12_000, "durationMs": 300]]))))
+
+        guard case .toolCall(let toolCall) = session.transcript.messages.first,
+              let compaction = ACPContextCompaction(toolCall: toolCall) else {
+            Issue.record("expected a normalized context compaction")
+            return
+        }
+        #expect(compaction.trigger == "automatic")
+        #expect(compaction.tokensBefore == 100_000)
+        #expect(compaction.tokensAfter == 12_000)
+        #expect(compaction.durationMs == 300)
+    }
+
+    @Test("compaction summary chunks append to the normalized row")
+    func compactionSummaryChunksAppend() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        session.apply(.compactionUpdate(.init(
+            compactionId: "compact-chunks", status: "in_progress")))
+        session.apply(.compactionSummaryChunk(.init(
+            compactionId: "compact-chunks", content: .text("Kept "))))
+        session.apply(.compactionSummaryChunk(.init(
+            compactionId: "compact-chunks", content: .text("decisions."))))
+
+        guard case .toolCall(let toolCall) = session.transcript.messages.first else {
+            Issue.record("expected a normalized compaction tool call")
+            return
+        }
+        #expect(toolCall.content == "Kept decisions.")
+    }
+
+    @Test("usage update remains authoritative over compaction counts")
+    func usageUpdateRemainsAuthoritative() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        session.apply(.compactionUpdate(.init(
+            compactionId: "compact-usage", status: "completed",
+            metadata: AnyCodable([
+                "preTokens": 99_000,
+                "postTokens": 12_000,
+                "durationMs": 400
+            ]))))
+        #expect(session.contextUsage == nil)
+
+        session.apply(.usageUpdate(.init(used: 3_000, size: 8_000, cost: nil)))
+        #expect(session.contextUsage == .init(used: 3_000, size: 8_000, cost: nil))
+    }
     @Test("replacement transcript preserves tool call content revision when content is unchanged")
     func replaceTranscriptPreservesToolCallContentRevisionForSameContent() {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/UI/ACPContextCompactionPresentationTests.swift
+++ b/AlasTests/ACP/UI/ACPContextCompactionPresentationTests.swift
@@ -1,0 +1,61 @@
+import Testing
+@testable import Alas
+
+@Suite("ACPContextCompaction presentation")
+struct ACPContextCompactionPresentationTests {
+    @Test("accepts documented version 1 facts and ignores unknown metadata")
+    func documentedFactsOnly() {
+        let compaction = ACPContextCompaction(toolCall: .init(
+            toolCallId: "context-compaction:compact-1",
+            title: "Compacting context",
+            kind: "context_compaction",
+            status: "completed",
+            metadata: AnyCodable([
+                "contextCompaction": [
+                    "version": 1,
+                    "trigger": "manual",
+                    "preTokens": 128_000,
+                    "postTokens": 16_000,
+                    "durationMs": 950,
+                    "unknown": "ignored"
+                ]
+            ])))
+
+        #expect(compaction?.status == .completed)
+        #expect(compaction?.trigger == "manual")
+        #expect(compaction?.tokensBefore == 128_000)
+        #expect(compaction?.tokensAfter == 16_000)
+        #expect(compaction?.durationMs == 950)
+        #expect(compaction?.label == "Context compacted")
+        #expect(compaction?.details == "manual · 128000 → 16000 tokens · 950 ms")
+    }
+
+    @Test("failed compactions retain their error without inventing counts")
+    func failedCompaction() {
+        let compaction = ACPContextCompaction(toolCall: .init(
+            toolCallId: "context-compaction:compact-failed",
+            title: "Compacting context",
+            kind: "context_compaction",
+            status: "failed",
+            metadata: AnyCodable([
+                "contextCompaction": [
+                    "version": 1,
+                    "error": "Context limit exceeded"
+                ]
+            ])))
+
+        #expect(compaction?.status == .failed)
+        #expect(compaction?.error == "Context limit exceeded")
+        #expect(compaction?.tokensBefore == nil)
+        #expect(compaction?.tokensAfter == nil)
+        #expect(compaction?.durationMs == nil)
+        #expect(compaction?.label == "Context compaction failed")
+    }
+
+    @Test("ordinary tool calls are not context compactions")
+    func ordinaryToolCall() {
+        #expect(ACPContextCompaction(toolCall: .init(
+            toolCallId: "run-1", title: "Run tests", kind: "execute", status: "completed"
+        )) == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- render Codex context compaction metadata as a dedicated transcript event
- normalize negotiated ACP compaction updates into the same presentation model
- cover decoding, merging, persistence, and usage accounting

Closes #1058

## Verification
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- `xcodebuild ... build-for-testing`\n- `git diff --check`\n\nThe local `xcodebuild test` action stalled in Xcode LaunchServices before test workers materialized; CI is the authoritative runtime test check.