### PR TITLE
feat(acp): delete persisted agent sessions through session/delete

### DIFF
--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -143,6 +143,15 @@ final class ACPConnection: @unchecked Sendable {
         response.acknowledgeDurableConsumption()
     }
 
+    func deleteSession(sessionId: String) async throws {
+        let response = try await client.send(ACPRequest(
+            method: "session/delete",
+            params: ACPSessionDeleteParams(sessionId: sessionId)
+        ))
+        defer { response.acknowledgeDurableConsumption() }
+        _ = try JSONDecoder().decode(EmptyObject.self, from: response.body)
+    }
+
     func cancel(sessionId: String) async throws {
         // ACP defines `session/cancel` as a JSON-RPC NOTIFICATION
         // (no `id`, no reply). Sending it as a request and awaiting a

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -247,16 +247,24 @@ struct ACPInitializeResult: Codable, Equatable {
         let list: EmptyObject?
         let resume: EmptyObject?
         let fork: EmptyObject?
+        let delete: EmptyObject?
 
-        init(list: EmptyObject? = nil, resume: EmptyObject? = nil, fork: EmptyObject? = nil) {
+        init(
+            list: EmptyObject? = nil,
+            resume: EmptyObject? = nil,
+            fork: EmptyObject? = nil,
+            delete: EmptyObject? = nil
+        ) {
             self.list = list
             self.resume = resume
             self.fork = fork
+            self.delete = delete
         }
 
         var supportsList: Bool { list != nil }
         var supportsResume: Bool { resume != nil }
         var supportsFork: Bool { fork != nil }
+        var supportsDelete: Bool { delete != nil }
     }
     struct ACPPromptCapabilities: Codable, Equatable {
         let image: Bool
@@ -788,6 +796,12 @@ typealias ACPSessionForkParams = ACPSessionLoadParams
 // MARK: - session/close
 
 struct ACPSessionCloseParams: Codable, Equatable {
+    let sessionId: String
+}
+
+// MARK: - session/delete
+
+struct ACPSessionDeleteParams: Codable, Equatable {
     let sessionId: String
 }
 

--- a/Alas/Sources/ACP/Session/ACPSessionDiscovery.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionDiscovery.swift
@@ -5,6 +5,7 @@ struct ACPSessionDiscoveryCapabilities: Equatable {
     let canLoad: Bool
     let canResume: Bool
     let canFork: Bool
+    let canDelete: Bool
 
     var canOpenRemoteSession: Bool { canLoad || canResume }
 }
@@ -55,6 +56,7 @@ enum ACPSessionDiscoveryError: LocalizedError, Equatable {
     case noLaunchSpec(String)
     case setupRequired(String)
     case listingUnsupported
+    case deletionUnsupported
 
     var errorDescription: String? {
         switch self {
@@ -64,6 +66,8 @@ enum ACPSessionDiscoveryError: LocalizedError, Equatable {
             return reason
         case .listingUnsupported:
             return "This agent does not support session browsing."
+        case .deletionUnsupported:
+            return "This agent does not support deleting session history."
         }
     }
 }
@@ -142,6 +146,16 @@ final class ACPSessionDiscoveryHandle {
         return discovered
     }
 
+    func refresh() {
+        nextCursor = nil
+        hasLoadedPage = false
+    }
+
+    func deleteSession(remoteSessionId: String) async throws {
+        guard capabilities.canDelete else { throw ACPSessionDiscoveryError.deletionUnsupported }
+        try await connection.deleteSession(sessionId: remoteSessionId)
+    }
+
     func close() async {
         guard !closed else { return }
         closed = true
@@ -164,10 +178,75 @@ final class ACPSessionDiscoveryModel {
     private(set) var sessions: [ACPDiscoveredSession] = []
     private(set) var capabilities: ACPSessionDiscoveryCapabilities?
     private(set) var paginationError: String?
+    private(set) var deletingSessionIds: Set<String> = []
+    private(set) var remotelyDeletedSessionIds: Set<String> = []
     private var handle: ACPSessionDiscoveryHandle?
     private var stopped = false
+    private var replaceSessionsOnNextLoad = false
+    private var deletionActive = false
+    private var deletionQueue: [CheckedContinuation<Void, Never>] = []
+    private var deletionWaiters: [CheckedContinuation<Void, Never>] = []
 
     var canLoadMore: Bool { handle?.canLoadMore == true }
+
+    func deleteAgentHistory(
+        for session: ACPDiscoveredSession,
+        removeLocalHistory: Bool,
+        manager: ACPSessionManager
+    ) async throws {
+        guard capabilities?.canDelete == true, let handle else {
+            throw ACPSessionDiscoveryError.deletionUnsupported
+        }
+        guard await beginDeletion(session.remoteSessionId) else { return }
+        defer { finishDeletion(session.remoteSessionId) }
+
+        if !remotelyDeletedSessionIds.contains(session.remoteSessionId) {
+            try await manager.closeActiveSessionForDeletion(
+                localSessionId: session.localSessionId,
+                agentId: session.agentId,
+                remoteSessionId: session.remoteSessionId
+            )
+            try await handle.deleteSession(remoteSessionId: session.remoteSessionId)
+            remotelyDeletedSessionIds.insert(session.remoteSessionId)
+        }
+
+        try await refreshAfterDeletion()
+        if removeLocalHistory, let localSessionId = session.localSessionId {
+            do {
+                try await manager.deletePersistedSession(id: localSessionId)
+            } catch {
+                if !sessions.contains(where: { $0.remoteSessionId == session.remoteSessionId }) {
+                    sessions.append(session)
+                }
+                throw error
+            }
+        }
+    }
+
+    func removeLocalHistory(
+        for session: ACPDiscoveredSession,
+        manager: ACPSessionManager
+    ) async throws {
+        guard let localSessionId = session.localSessionId else { return }
+        guard await beginDeletion(session.remoteSessionId) else { return }
+        defer { finishDeletion(session.remoteSessionId) }
+        try await manager.deletePersistedSession(id: localSessionId)
+        try await refreshAfterDeletion()
+    }
+
+    private func refreshAfterDeletion() async throws {
+        guard let handle else { return }
+        let previous = sessions
+        handle.refresh()
+        replaceSessionsOnNextLoad = true
+        sessions = []
+        do {
+            try await loadMore()
+        } catch {
+            sessions = previous
+            throw error
+        }
+    }
 
     func start(manager: ACPSessionManager, agentId: String) async {
         guard phase == .idle, !stopped else { return }
@@ -193,6 +272,12 @@ final class ACPSessionDiscoveryModel {
         guard let handle else { return }
         do {
             let page = try await handle.loadNextPage()
+            if replaceSessionsOnNextLoad {
+                sessions = page
+                replaceSessionsOnNextLoad = false
+                paginationError = nil
+                return
+            }
             var known = Set(sessions.map(\.remoteSessionId))
             sessions.append(contentsOf: page.filter { known.insert($0.remoteSessionId).inserted })
             paginationError = nil
@@ -204,7 +289,32 @@ final class ACPSessionDiscoveryModel {
 
     func stop() async {
         stopped = true
+        if !deletingSessionIds.isEmpty {
+            await withCheckedContinuation { deletionWaiters.append($0) }
+        }
         await handle?.close()
         handle = nil
+    }
+
+    private func beginDeletion(_ remoteSessionId: String) async -> Bool {
+        guard deletingSessionIds.insert(remoteSessionId).inserted else { return false }
+        if deletionActive {
+            await withCheckedContinuation { deletionQueue.append($0) }
+        }
+        deletionActive = true
+        return true
+    }
+
+    private func finishDeletion(_ remoteSessionId: String) {
+        deletingSessionIds.remove(remoteSessionId)
+        if !deletionQueue.isEmpty {
+            deletionQueue.removeFirst().resume()
+        } else {
+            deletionActive = false
+        }
+        guard deletingSessionIds.isEmpty else { return }
+        let waiters = deletionWaiters
+        deletionWaiters = []
+        waiters.forEach { $0.resume() }
     }
 }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1073,6 +1073,32 @@ final class ACPSessionManager: ObservableObject {
     }
 
     func deleteSession(id: ACPSession.ID) {
+        forgetSession(id: id)
+        enqueuePersistence { persistence in
+            try await persistence.deleteSession(id: id)
+        }
+    }
+
+    func deletePersistedSession(id: ACPSession.ID) async throws {
+        await detach(sessionId: id)
+        try await persistence.deleteSession(id: id)
+        forgetSession(id: id)
+    }
+
+    func closeActiveSessionForDeletion(
+        localSessionId: ACPSession.ID?,
+        agentId: String,
+        remoteSessionId: String
+    ) async throws {
+        let localSessionId = localSessionId ?? runners.keys.first {
+            sessions[$0]?.agentId == agentId && sessions[$0]?.remoteSessionId == remoteSessionId
+        }
+        guard let localSessionId, let runner = runners[localSessionId] else { return }
+        try await runner.connection.closeSession(sessionId: remoteSessionId)
+        await detach(sessionId: localSessionId)
+    }
+
+    private func forgetSession(id: ACPSession.ID) {
         killRemoteHelperACPProcIfPossible(sessionId: id)
         onSessionEnded?(id)
         autoReconnectTasks.removeValue(forKey: id)?.cancel()
@@ -1089,9 +1115,6 @@ final class ACPSessionManager: ObservableObject {
         pendingMode.removeValue(forKey: id)
         persistedRows.removeValue(forKey: id)
         recent.removeAll { $0.id == id }
-        enqueuePersistence { persistence in
-            try await persistence.deleteSession(id: id)
-        }
     }
 
     /// Increment the UI refcount for `id`. No-op if the session isn't
@@ -1718,7 +1741,8 @@ final class ACPSessionManager: ObservableObject {
                 capabilities: .init(
                     canLoad: initialized.loadSession,
                     canResume: initialized.sessionCapabilities.supportsResume,
-                    canFork: initialized.sessionCapabilities.supportsFork
+                    canFork: initialized.sessionCapabilities.supportsFork,
+                    canDelete: initialized.sessionCapabilities.supportsDelete
                 )
             )
         } catch {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1081,7 +1081,22 @@ final class ACPSessionManager: ObservableObject {
 
     func deletePersistedSession(id: ACPSession.ID) async throws {
         await detach(sessionId: id)
-        try await persistence.deleteSession(id: id)
+        let previous = persistenceTail
+        let persistence = persistence
+        persistenceGeneration += 1
+        let deletion = Task { @MainActor [weak self] in
+            await previous?.value
+            do {
+                try await persistence.deleteSession(id: id)
+            } catch {
+                self?.persistenceError = error.localizedDescription
+                throw error
+            }
+        }
+        persistenceTail = Task { @MainActor in
+            _ = try? await deletion.value
+        }
+        try await deletion.value
         forgetSession(id: id)
     }
 

--- a/Alas/Sources/Agents/AgentLauncherDialog.swift
+++ b/Alas/Sources/Agents/AgentLauncherDialog.swift
@@ -580,6 +580,7 @@ struct AgentLauncherDialog: View {
                     )
                 }
             } catch {
+                guard self.discoveryModel === discoveryModel else { return }
                 deletionError = error.localizedDescription
             }
         }

--- a/Alas/Sources/Agents/AgentLauncherDialog.swift
+++ b/Alas/Sources/Agents/AgentLauncherDialog.swift
@@ -9,6 +9,8 @@ struct AgentLauncherDialog: View {
     @State private var discoveryModel: ACPSessionDiscoveryModel?
     @State private var selectedSessionIndex = 0
     @State private var loadingMore = false
+    @State private var deletionRequest: ACPSessionDeletionRequest?
+    @State private var deletionError: String?
 
     var body: some View {
         Group {
@@ -65,6 +67,33 @@ struct AgentLauncherDialog: View {
         .onChange(of: appState.agentLauncher.openTick) { _, _ in
             resetSessionBrowser()
             requestInputFocus()
+        }
+        .confirmationDialog(
+            deletionRequest?.title ?? "Delete session history?",
+            isPresented: Binding(
+                get: { deletionRequest != nil },
+                set: { if !$0 { deletionRequest = nil } }
+            ),
+            presenting: deletionRequest
+        ) { request in
+            switch request.kind {
+            case .localOnly:
+                Button("Remove from Alas", role: .destructive) {
+                    performDeletion(request)
+                }
+            case .agentHistory:
+                Button("Delete agent-side history", role: .destructive) {
+                    performDeletion(request)
+                }
+                if request.session.localSessionId != nil {
+                    Button("Delete agent-side history and remove from Alas", role: .destructive) {
+                        performDeletion(request, removeLocalHistory: true)
+                    }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { request in
+            Text(request.message)
         }
     }
 
@@ -283,6 +312,28 @@ struct AgentLauncherDialog: View {
                         isEnabled: canOpen,
                         onTap: { openDiscoveredSession(item) }
                     )
+                    .contextMenu {
+                        if item.localSessionId != nil {
+                            Button("Remove from Alas…", role: .destructive) {
+                                deletionRequest = .init(
+                                    kind: .localOnly,
+                                    agentName: agent.displayName,
+                                    session: item
+                                )
+                            }
+                        }
+                        if capabilities?.canDelete == true,
+                           discoveryModel?.remotelyDeletedSessionIds.contains(item.remoteSessionId) != true {
+                            Button("Delete agent-side history…", role: .destructive) {
+                                deletionRequest = .init(
+                                    kind: .agentHistory,
+                                    agentName: agent.displayName,
+                                    session: item
+                                )
+                            }
+                        }
+                    }
+                    .disabled(discoveryModel?.deletingSessionIds.contains(item.remoteSessionId) == true)
                     .onHover { hovering in
                         if hovering { selectedSessionIndex = index + 1 }
                     }
@@ -307,6 +358,9 @@ struct AgentLauncherDialog: View {
             }
             if let paginationError = discoveryModel?.paginationError {
                 launcherStatusRow(paginationError)
+            }
+            if let deletionError {
+                launcherStatusRow(deletionError)
             }
         }
     }
@@ -503,6 +557,34 @@ struct AgentLauncherDialog: View {
         }
     }
 
+    private func performDeletion(
+        _ request: ACPSessionDeletionRequest,
+        removeLocalHistory: Bool = false
+    ) {
+        guard let worktree = selectedWorktree(),
+              let manager = appState.acpManager(for: worktree),
+              let discoveryModel
+        else { return }
+        deletionRequest = nil
+        deletionError = nil
+        Task {
+            do {
+                switch request.kind {
+                case .localOnly:
+                    try await discoveryModel.removeLocalHistory(for: request.session, manager: manager)
+                case .agentHistory:
+                    try await discoveryModel.deleteAgentHistory(
+                        for: request.session,
+                        removeLocalHistory: removeLocalHistory,
+                        manager: manager
+                    )
+                }
+            } catch {
+                deletionError = error.localizedDescription
+            }
+        }
+    }
+
     private func backToAgents() {
         resetSessionBrowser()
         appState.agentLauncher.query = ""
@@ -521,6 +603,8 @@ struct AgentLauncherDialog: View {
         chatAgent = nil
         selectedSessionIndex = 0
         loadingMore = false
+        deletionRequest = nil
+        deletionError = nil
         Task { await prior?.stop() }
     }
 
@@ -531,6 +615,37 @@ struct AgentLauncherDialog: View {
             DispatchQueue.main.async {
                 inputFocused = true
             }
+        }
+    }
+}
+
+struct ACPSessionDeletionRequest: Identifiable {
+    enum Kind { case localOnly, agentHistory }
+
+    let kind: Kind
+    let agentName: String
+    let session: ACPDiscoveredSession
+
+    var id: String { "\(session.remoteSessionId)-\(kind)" }
+
+    var title: String {
+        switch kind {
+        case .localOnly:
+            return "Remove \(agentName) session “\(session.title)” from Alas?"
+        case .agentHistory:
+            return "Delete \(agentName) history for “\(session.title)”?"
+        }
+    }
+
+    var message: String {
+        switch kind {
+        case .localOnly:
+            return "Only Alas’s local record will be removed. The session remains in \(agentName)’s history."
+        case .agentHistory:
+            let localCopy = session.localSessionId == nil
+                ? ""
+                : " Choosing only agent-side history keeps Alas’s local record."
+            return "This asks \(agentName) to delete session “\(session.title)”. The adapter controls whether deletion is soft or permanent, and no undo is available.\(localCopy)"
         }
     }
 }

--- a/AlasTests/ACP/Protocol/ACPConnectionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConnectionTests.swift
@@ -4,6 +4,29 @@ import Testing
 
 @Suite("ACPConnection")
 struct ACPConnectionTests {
+    @Test("deleteSession sends session/delete with the wire id and accepts an empty result")
+    func deleteSessionRPC() async throws {
+        let mock = ACPMockClient()
+        mock.script(method: "session/delete") { _ in Data("{}".utf8) }
+        let connection = ACPConnection(client: mock)
+
+        try await connection.deleteSession(sessionId: "remote-42")
+
+        let request = try #require(mock.sent.last)
+        #expect(request.method == "session/delete")
+        #expect(request.params as? ACPSessionDeleteParams == .init(sessionId: "remote-42"))
+    }
+
+    @Test("deleteSession accepts an unknown session")
+    func deleteUnknownSession() async throws {
+        let mock = ACPMockClient()
+        mock.script(method: "session/delete") { _ in Data("{}".utf8) }
+
+        try await ACPConnection(client: mock).deleteSession(sessionId: "already-missing")
+
+        #expect(mock.sent.map(\.method) == ["session/delete"])
+    }
+
     @Test("initialize + new session populates sessionId, models, modes")
     func newSession() async throws {
         let mock = ACPMockClient()

--- a/AlasTests/ACP/Protocol/ACPInitializeTests.swift
+++ b/AlasTests/ACP/Protocol/ACPInitializeTests.swift
@@ -150,6 +150,22 @@ struct ACPInitializeTests {
         #expect(result.agentCapabilities?.promptCapabilities?.embeddedContext == true)
     }
 
+    @Test("decodes absent and present session delete capability")
+    func decodeSessionDeleteCapability() throws {
+        let absent = try JSONDecoder().decode(ACPInitializeResult.self, from: Data("""
+        { "protocolVersion": 1, "agentCapabilities": { "sessionCapabilities": {} } }
+        """.utf8))
+        #expect(absent.agentCapabilities?.sessionCapabilities.supportsDelete == false)
+
+        let present = try JSONDecoder().decode(ACPInitializeResult.self, from: Data("""
+        {
+          "protocolVersion": 1,
+          "agentCapabilities": { "sessionCapabilities": { "delete": {} } }
+        }
+        """.utf8))
+        #expect(present.agentCapabilities?.sessionCapabilities.supportsDelete == true)
+    }
+
     @Test("decodes absent, supported, and extended provider capabilities")
     func decodeProviderCapabilities() throws {
         let absent = try JSONDecoder().decode(ACPInitializeResult.self, from: Data("""

--- a/AlasTests/ACP/Session/ACPSessionDiscoveryTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionDiscoveryTests.swift
@@ -97,6 +97,20 @@ struct ACPSessionDiscoveryTests {
     }
 
     @MainActor
+    @Test("local deletion runs after already queued session upserts")
+    func localDeletionRunsLastOnPersistenceQueue() async throws {
+        let store = try temporaryStore()
+        let manager = manager(store: store, client: ACPMockClient())
+        let session = manager.createSession(id: "local-1", agentId: "claude")
+        manager.renameSession(id: session.id, title: "Queued rename", source: .manual)
+
+        try await manager.deletePersistedSession(id: session.id)
+        await manager.flushPersistence()
+
+        #expect(try store.loadSession(id: session.id) == nil)
+    }
+
+    @MainActor
     @Test("duplicate deletion is ignored while the first request is in flight")
     func duplicateDeletionIsIgnored() async throws {
         let client = discoveryClient(deleteCapability: true)

--- a/AlasTests/ACP/Session/ACPSessionDiscoveryTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionDiscoveryTests.swift
@@ -4,6 +4,371 @@ import Testing
 
 @Suite("ACP session discovery")
 struct ACPSessionDiscoveryTests {
+    @MainActor
+    @Test("unsupported discovery never sends session/delete")
+    func unsupportedDeletionIsGated() async throws {
+        let store = try temporaryStore()
+        let client = discoveryClient(deleteCapability: false)
+        let manager = manager(store: store, client: client)
+        let model = ACPSessionDiscoveryModel()
+        await model.start(manager: manager, agentId: "claude")
+        let session = try #require(model.sessions.first)
+
+        await #expect(throws: ACPSessionDiscoveryError.deletionUnsupported) {
+            try await model.deleteAgentHistory(for: session, removeLocalHistory: false, manager: manager)
+        }
+        #expect(!client.sent.contains { $0.method == "session/delete" })
+    }
+
+    @MainActor
+    @Test("remote deletion uses the discovered wire id and refreshes discovery")
+    func remoteDeletionRefreshes() async throws {
+        let store = try temporaryStore()
+        let client = discoveryClient(deleteCapability: true)
+        let manager = manager(store: store, client: client)
+        let model = ACPSessionDiscoveryModel()
+        await model.start(manager: manager, agentId: "claude")
+        let session = try #require(model.sessions.first)
+
+        try await model.deleteAgentHistory(for: session, removeLocalHistory: false, manager: manager)
+
+        #expect(client.sent.map(\.method).filter { $0 == "session/delete" }.count == 1)
+        let request = try #require(client.sent.first { $0.method == "session/delete" })
+        #expect(request.params as? ACPSessionDeleteParams == .init(sessionId: "remote-listed"))
+        #expect(client.sent.map(\.method).filter { $0 == "session/list" }.count == 2)
+        #expect(model.sessions.isEmpty)
+    }
+
+    @MainActor
+    @Test("remote deletion failure preserves local and discovered history")
+    func remoteDeletionFailurePreservesHistory() async throws {
+        let store = try temporaryStore()
+        try store.upsertSession(row(
+            id: "local-1", remoteSessionId: "remote-listed", title: "Local", origin: .alasCreated
+        ))
+        let client = discoveryClient(deleteCapability: true, deletionError: TestError.failed)
+        let manager = manager(store: store, client: client)
+        let model = ACPSessionDiscoveryModel()
+        await model.start(manager: manager, agentId: "claude")
+        let session = try #require(model.sessions.first)
+
+        await #expect(throws: TestError.failed) {
+            try await model.deleteAgentHistory(for: session, removeLocalHistory: true, manager: manager)
+        }
+
+        #expect(model.sessions == [session])
+        #expect(try store.loadSession(id: "local-1") != nil)
+        #expect(client.sent.map(\.method).filter { $0 == "session/list" }.count == 1)
+    }
+
+    @MainActor
+    @Test("local cleanup can be retried after remote deletion without another destructive request")
+    func localCleanupRetryDoesNotRepeatRemoteDeletion() async throws {
+        let store = try temporaryStore()
+        try store.upsertSession(row(
+            id: "local-1", remoteSessionId: "remote-listed", title: "Local", origin: .alasCreated
+        ))
+        try store.db.exec("""
+        CREATE TRIGGER fail_session_delete
+        BEFORE DELETE ON sessions
+        BEGIN
+          SELECT RAISE(ABORT, 'forced local cleanup failure');
+        END
+        """)
+        let client = discoveryClient(deleteCapability: true)
+        let manager = manager(store: store, client: client)
+        let model = ACPSessionDiscoveryModel()
+        await model.start(manager: manager, agentId: "claude")
+        let session = try #require(model.sessions.first)
+
+        await #expect(throws: (any Error).self) {
+            try await model.deleteAgentHistory(for: session, removeLocalHistory: true, manager: manager)
+        }
+        #expect(model.sessions == [session])
+        #expect(try store.loadSession(id: "local-1") != nil)
+        #expect(client.sent.map(\.method).filter { $0 == "session/delete" }.count == 1)
+
+        try store.db.exec("DROP TRIGGER fail_session_delete")
+        try await model.removeLocalHistory(for: session, manager: manager)
+
+        #expect(try store.loadSession(id: "local-1") == nil)
+        #expect(client.sent.map(\.method).filter { $0 == "session/delete" }.count == 1)
+        #expect(model.sessions.isEmpty)
+    }
+
+    @MainActor
+    @Test("duplicate deletion is ignored while the first request is in flight")
+    func duplicateDeletionIsIgnored() async throws {
+        let client = discoveryClient(deleteCapability: true)
+        let started = AsyncStream<Void>.makeStream()
+        let release = AsyncStream<Void>.makeStream()
+        client.scriptAsync(method: "session/delete") { _ in
+            started.continuation.yield()
+            for await _ in release.stream { break }
+            return Data("{}".utf8)
+        }
+        let store = try temporaryStore()
+        let manager = manager(store: store, client: client)
+        let model = ACPSessionDiscoveryModel()
+        await model.start(manager: manager, agentId: "claude")
+        let session = try #require(model.sessions.first)
+
+        let first = Task {
+            try await model.deleteAgentHistory(for: session, removeLocalHistory: false, manager: manager)
+        }
+        for await _ in started.stream { break }
+        #expect(model.deletingSessionIds == ["remote-listed"])
+
+        try await model.deleteAgentHistory(for: session, removeLocalHistory: false, manager: manager)
+        #expect(client.sent.map(\.method).filter { $0 == "session/delete" }.count == 1)
+
+        release.continuation.yield()
+        try await first.value
+        #expect(model.deletingSessionIds.isEmpty)
+    }
+
+    @MainActor
+    @Test("concurrent deletions serialize their discovery refreshes")
+    func concurrentDeletionsSerializeRefreshes() async throws {
+        let client = discoveryClient(deleteCapability: true)
+        var deleted: Set<String> = []
+        let firstDeleteStarted = AsyncStream<Void>.makeStream()
+        let releaseFirstDelete = AsyncStream<Void>.makeStream()
+        client.script(method: "session/list") { _ in
+            try JSONEncoder().encode(ACPSessionListResult(sessions: ["first", "second", "third"]
+                .filter { !deleted.contains($0) }
+                .map { .init(sessionId: $0, cwd: "/tmp/wt", title: $0) }))
+        }
+        client.scriptAsync(method: "session/delete") { request in
+            let id = try #require(request.params as? ACPSessionDeleteParams).sessionId
+            if id == "first" {
+                firstDeleteStarted.continuation.yield()
+                for await _ in releaseFirstDelete.stream { break }
+            }
+            deleted.insert(id)
+            return Data("{}".utf8)
+        }
+        let store = try temporaryStore()
+        let manager = manager(store: store, client: client)
+        let model = ACPSessionDiscoveryModel()
+        await model.start(manager: manager, agentId: "claude")
+        let first = try #require(model.sessions.first { $0.remoteSessionId == "first" })
+        let second = try #require(model.sessions.first { $0.remoteSessionId == "second" })
+        let third = try #require(model.sessions.first { $0.remoteSessionId == "third" })
+
+        let firstDeletion = Task {
+            try await model.deleteAgentHistory(for: first, removeLocalHistory: false, manager: manager)
+        }
+        for await _ in firstDeleteStarted.stream { break }
+        let secondDeletion = Task {
+            try await model.deleteAgentHistory(for: second, removeLocalHistory: false, manager: manager)
+        }
+        let thirdDeletion = Task {
+            try await model.deleteAgentHistory(for: third, removeLocalHistory: false, manager: manager)
+        }
+        await Task.yield()
+        #expect(client.sent.map(\.method).filter { $0 == "session/delete" }.count == 1)
+
+        releaseFirstDelete.continuation.yield()
+        try await firstDeletion.value
+        try await secondDeletion.value
+        try await thirdDeletion.value
+
+        #expect(client.sent.map(\.method).filter { $0 == "session/delete" }.count == 3)
+        #expect(model.sessions.isEmpty)
+    }
+
+    @MainActor
+    @Test("stopping discovery waits for an in-flight deletion")
+    func stopWaitsForDeletion() async throws {
+        let client = discoveryClient(deleteCapability: true)
+        let started = AsyncStream<Void>.makeStream()
+        let release = AsyncStream<Void>.makeStream()
+        client.scriptAsync(method: "session/delete") { _ in
+            started.continuation.yield()
+            for await _ in release.stream { break }
+            return Data("{}".utf8)
+        }
+        let store = try temporaryStore()
+        let manager = manager(store: store, client: client)
+        let model = ACPSessionDiscoveryModel()
+        await model.start(manager: manager, agentId: "claude")
+        let session = try #require(model.sessions.first)
+
+        let deletion = Task {
+            try await model.deleteAgentHistory(for: session, removeLocalHistory: false, manager: manager)
+        }
+        for await _ in started.stream { break }
+        let stop = Task { await model.stop() }
+        await Task.yield()
+        #expect(client.shutdownCount == 0)
+
+        release.continuation.yield()
+        try await deletion.value
+        await stop.value
+        #expect(client.sent.map(\.method).filter { $0 == "session/delete" }.count == 1)
+        #expect(client.shutdownCount == 1)
+    }
+
+    @MainActor
+    @Test("retry after a post-delete list failure replaces the stale row")
+    func refreshRetryReplacesStaleRow() async throws {
+        let client = discoveryClient(deleteCapability: true)
+        var listCall = 0
+        client.script(method: "session/list") { _ in
+            listCall += 1
+            if listCall == 2 { throw TestError.failed }
+            return try JSONEncoder().encode(ACPSessionListResult(
+                sessions: listCall == 1
+                    ? [.init(sessionId: "remote-listed", cwd: "/tmp/wt", title: "Listed")]
+                    : []
+            ))
+        }
+        let store = try temporaryStore()
+        let manager = manager(store: store, client: client)
+        let model = ACPSessionDiscoveryModel()
+        await model.start(manager: manager, agentId: "claude")
+        let session = try #require(model.sessions.first)
+
+        await #expect(throws: TestError.failed) {
+            try await model.deleteAgentHistory(for: session, removeLocalHistory: false, manager: manager)
+        }
+        #expect(model.sessions == [session])
+
+        try await model.loadMore()
+        #expect(model.sessions.isEmpty)
+        #expect(client.sent.map(\.method).filter { $0 == "session/delete" }.count == 1)
+    }
+
+    @MainActor
+    @Test("active adapter session is closed before agent history is deleted")
+    func activeSessionClosesBeforeDeletion() async throws {
+        let store = try temporaryStore()
+        try store.upsertSession(row(
+            id: "local-1", remoteSessionId: "remote-listed", title: "Local", origin: .agentImported
+        ))
+        let client = discoveryClient(deleteCapability: true)
+        client.script(method: "initialize") { _ in
+            try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: .init(
+                    loadSession: true,
+                    sessionCapabilities: .init(list: .init(), delete: .init())
+                ),
+                authMethods: []
+            ))
+        }
+        client.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-listed",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+        client.script(method: "session/close") { _ in Data("{}".utf8) }
+        let manager = manager(store: store, client: client)
+        let local = try #require(manager.placeholderSession(id: "local-1"))
+        await manager.attach(to: local.id, freshlyCreated: false)
+        let model = ACPSessionDiscoveryModel()
+        await model.start(manager: manager, agentId: "claude")
+        let listed = try #require(model.sessions.first)
+        let discovered = ACPDiscoveredSession(
+            worktreeId: listed.worktreeId,
+            agentId: listed.agentId,
+            remoteSessionId: listed.remoteSessionId,
+            cwd: listed.cwd,
+            title: listed.title,
+            updatedAt: listed.updatedAt,
+            additionalDirectories: listed.additionalDirectories,
+            localSessionId: nil
+        )
+
+        try await model.deleteAgentHistory(
+            for: discovered,
+            removeLocalHistory: false,
+            manager: manager
+        )
+
+        let methods = client.sent.map(\.method)
+        let closeIndex = try #require(methods.firstIndex(of: "session/close"))
+        let deleteIndex = try #require(methods.firstIndex(of: "session/delete"))
+        #expect(closeIndex < deleteIndex)
+        #expect(manager.runners[local.id] == nil)
+    }
+
+    @MainActor
+    @Test("active deletion fallback scopes a shared wire id by agent")
+    func activeDeletionFallbackScopesAgent() async throws {
+        let store = try temporaryStore()
+        try store.upsertSession(row(
+            id: "claude-local",
+            remoteSessionId: "shared-remote",
+            title: "Claude",
+            origin: .agentImported,
+            agentId: "claude"
+        ))
+        try store.upsertSession(row(
+            id: "pi-local",
+            remoteSessionId: "shared-remote",
+            title: "Pi",
+            origin: .agentImported,
+            agentId: "pi"
+        ))
+        let claudeClient = activeSessionClient(remoteSessionId: "shared-remote")
+        let piClient = activeSessionClient(remoteSessionId: "shared-remote")
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { spec, _, _ in
+                ACPConnection(client: spec.agentID == "pi" ? piClient : claudeClient)
+            }
+        )
+        let claude = try #require(manager.placeholderSession(id: "claude-local"))
+        let pi = try #require(manager.placeholderSession(id: "pi-local"))
+        await manager.attach(to: claude.id, freshlyCreated: false)
+        await manager.attach(to: pi.id, freshlyCreated: false)
+
+        try await manager.closeActiveSessionForDeletion(
+            localSessionId: nil,
+            agentId: "pi",
+            remoteSessionId: "shared-remote"
+        )
+
+        #expect(!claudeClient.sent.contains { $0.method == "session/close" })
+        #expect(piClient.sent.contains { $0.method == "session/close" })
+        #expect(manager.runners[claude.id] != nil)
+        #expect(manager.runners[pi.id] == nil)
+        await manager.detach(sessionId: claude.id)
+    }
+
+    @Test("deletion confirmations name the agent and session and explain retention semantics")
+    func deletionConfirmationCopy() {
+        let session = ACPDiscoveredSession(
+            worktreeId: "wt",
+            agentId: "pi",
+            remoteSessionId: "remote-listed",
+            cwd: "/tmp/wt",
+            title: "Fix parser",
+            updatedAt: nil,
+            additionalDirectories: [],
+            localSessionId: "local-1"
+        )
+        let remote = ACPSessionDeletionRequest(kind: .agentHistory, agentName: "Pi", session: session)
+        #expect(remote.title.contains("Pi"))
+        #expect(remote.title.contains("Fix parser"))
+        #expect(remote.message.contains("soft or permanent"))
+        #expect(remote.message.contains("no undo"))
+
+        let local = ACPSessionDeletionRequest(kind: .localOnly, agentName: "Pi", session: session)
+        #expect(local.message.contains("Only Alas’s local record"))
+        #expect(local.message.contains("remains in Pi’s history"))
+    }
+
     @Test("restore policy prefers resume locally and strict load for imported sessions")
     func restorePolicy() {
         #expect(ACPSessionRestorePolicy.operation(
@@ -82,6 +447,7 @@ struct ACPSessionDiscoveryTests {
         #expect(client.shutdownCount == 0)
         await model.stop()
         #expect(client.shutdownCount == 1)
+        #expect(!client.sent.contains { $0.method == "session/delete" })
     }
 
     @Test("store scopes remote identity by agent and preserves origin")
@@ -154,6 +520,64 @@ struct ACPSessionDiscoveryTests {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("acp-discovery-\(UUID().uuidString).sqlite")
         return try ACPSessionStore(path: url.path)
+    }
+
+    private enum TestError: Error { case failed }
+
+    private func discoveryClient(
+        deleteCapability: Bool,
+        deletionError: Error? = nil
+    ) -> ACPMockClient {
+        let client = ACPMockClient()
+        client.script(method: "initialize") { _ in
+            try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: .init(
+                    sessionCapabilities: .init(
+                        list: .init(),
+                        delete: deleteCapability ? .init() : nil
+                    )
+                ),
+                authMethods: []
+            ))
+        }
+        var listed = false
+        client.script(method: "session/list") { _ in
+            defer { listed = true }
+            return try JSONEncoder().encode(ACPSessionListResult(
+                sessions: listed ? [] : [.init(
+                    sessionId: "remote-listed", cwd: "/tmp/wt", title: "Listed"
+                )]
+            ))
+        }
+        client.script(method: "session/delete") { _ in
+            if let deletionError { throw deletionError }
+            return Data("{}".utf8)
+        }
+        return client
+    }
+
+    private func activeSessionClient(remoteSessionId: String) -> ACPMockClient {
+        let client = ACPMockClient()
+        client.script(method: "initialize") { _ in
+            try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: .init(loadSession: true),
+                authMethods: []
+            ))
+        }
+        client.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: remoteSessionId,
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+        client.script(method: "session/close") { _ in Data("{}".utf8) }
+        return client
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- decode the stable ACP session deletion capability and send typed session/delete requests
- add explicitly confirmed agent-history and local-history deletion actions to session discovery
- preserve retryable local state across remote, persistence, refresh, and concurrent deletion failures
- close matching live adapter sessions before remote deletion

## Testing
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- focused ACP protocol and discovery tests
- full suite attempted; unrelated RightPaneGGStackTests fail locally and Xcode stalls during finalization

Closes #1059