### PR TITLE
fix(acp): close live adapter sessions

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1220,6 +1220,7 @@
 		C8BF4593D35403A93FC05D50 /* ACPAdapterInstallCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C99F8D1A0A37DC4A6DBAEE /* ACPAdapterInstallCoordinator.swift */; };
 		C9004250BC974548165BE5B3 /* ACPSessionRecoveryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0616B1F0B84C45792C804E /* ACPSessionRecoveryIntegrationTests.swift */; };
 		C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */; };
+		C9588B240791A672B2529628 /* ACPSessionManagerDisposalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35A13D9B95A126987AD92885 /* ACPSessionManagerDisposalTests.swift */; };
 		C964306024B5EF69D7D4ED6D /* GGWorktreeContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C7BDB3BEEB5B23DCE7F2C0 /* GGWorktreeContext.swift */; };
 		C968F976028C3D9C6E17EC44 /* GGUndoMarkerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246A2AF26902AB36730A4F44 /* GGUndoMarkerStoreTests.swift */; };
 		C97F67F96D887D0A417F9FD3 /* BinaryPreviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E678D9C5E3D9D39BDD2AA51 /* BinaryPreviewTabView.swift */; };
@@ -1905,6 +1906,7 @@
 		35004DC60214F616FA84ED8B /* ReleaseInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseInfo.swift; sourceTree = "<group>"; };
 		3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchInputRow.swift; sourceTree = "<group>"; };
 		35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStoreTests.swift; sourceTree = "<group>"; };
+		35A13D9B95A126987AD92885 /* ACPSessionManagerDisposalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerDisposalTests.swift; sourceTree = "<group>"; };
 		35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationHelper.swift; sourceTree = "<group>"; };
 		35D6BBD77A210BB378E217FC /* GitRefNameInputFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRefNameInputFilterTests.swift; sourceTree = "<group>"; };
 		364213292935A05F3B52F51F /* Paths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paths.swift; sourceTree = "<group>"; };
@@ -4960,6 +4962,7 @@
 				1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */,
 				8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */,
 				F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */,
+				35A13D9B95A126987AD92885 /* ACPSessionManagerDisposalTests.swift */,
 				472917238C382A8125A84103 /* ACPSessionManagerHydrationTests.swift */,
 				069895A7C4E29B3275D8320E /* ACPSessionManagerRemoteRestoreTests.swift */,
 				6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */,
@@ -6939,6 +6942,7 @@
 				6C33DC3A21C3223832EA5D28 /* ACPSessionLeaseTests.swift in Sources */,
 				C51451EC8E103EB5FEF82EFE /* ACPSessionLifecycleTests.swift in Sources */,
 				9C78AF82EA26A9928865C5C6 /* ACPSessionManagerAttachRestoreTests.swift in Sources */,
+				C9588B240791A672B2529628 /* ACPSessionManagerDisposalTests.swift in Sources */,
 				D204CCA2E2FE480D2C502186 /* ACPSessionManagerHydrationTests.swift in Sources */,
 				D28EE6309DBB51EFEDCEAC18 /* ACPSessionManagerLeaseTests.swift in Sources */,
 				6C70755431CFBA41420A2F47 /* ACPSessionManagerRemoteRestoreTests.swift in Sources */,

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -248,23 +248,27 @@ struct ACPInitializeResult: Codable, Equatable {
         let resume: EmptyObject?
         let fork: EmptyObject?
         let delete: EmptyObject?
+        let close: EmptyObject?
 
         init(
             list: EmptyObject? = nil,
             resume: EmptyObject? = nil,
             fork: EmptyObject? = nil,
-            delete: EmptyObject? = nil
+            delete: EmptyObject? = nil,
+            close: EmptyObject? = nil
         ) {
             self.list = list
             self.resume = resume
             self.fork = fork
             self.delete = delete
+            self.close = close
         }
 
         var supportsList: Bool { list != nil }
         var supportsResume: Bool { resume != nil }
         var supportsFork: Bool { fork != nil }
         var supportsDelete: Bool { delete != nil }
+        var supportsClose: Bool { close != nil }
     }
     struct ACPPromptCapabilities: Codable, Equatable {
         let image: Bool

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -141,6 +141,7 @@ final class ACPSessionManager: ObservableObject {
     private(set) var runners: [ACPSession.ID: ACPSessionRunner] = [:]
     private var elicitationCoordinators: [ACPSession.ID: ACPElicitationCoordinator] = [:]
     private var autoReconnectTasks: [ACPSession.ID: Task<Void, Never>] = [:]
+    private var disposalTasks: [ACPSession.ID: Task<Void, Error>] = [:]
     /// Per-session attach counter. The built-in MCP registration grace timer
     /// captures the epoch at attach and only writes the row if it still matches,
     /// so a timer from a superseded attach can never clobber the current state.
@@ -1072,15 +1073,12 @@ final class ACPSessionManager: ObservableObject {
         pendingMode.removeValue(forKey: id)
     }
 
-    func deleteSession(id: ACPSession.ID) {
-        forgetSession(id: id)
-        enqueuePersistence { persistence in
-            try await persistence.deleteSession(id: id)
-        }
+    func deleteSession(id: ACPSession.ID) async throws {
+        try await deletePersistedSession(id: id)
     }
 
     func deletePersistedSession(id: ACPSession.ID) async throws {
-        await detach(sessionId: id)
+        try await disposeSession(id: id)
         let previous = persistenceTail
         let persistence = persistence
         persistenceGeneration += 1
@@ -1108,9 +1106,10 @@ final class ACPSessionManager: ObservableObject {
         let localSessionId = localSessionId ?? runners.keys.first {
             sessions[$0]?.agentId == agentId && sessions[$0]?.remoteSessionId == remoteSessionId
         }
-        guard let localSessionId, let runner = runners[localSessionId] else { return }
-        try await runner.connection.closeSession(sessionId: remoteSessionId)
-        await detach(sessionId: localSessionId)
+        guard let localSessionId,
+              runners[localSessionId] != nil || disposalTasks[localSessionId] != nil
+        else { return }
+        try await disposeSession(id: localSessionId)
     }
 
     private func forgetSession(id: ACPSession.ID) {
@@ -1971,7 +1970,8 @@ final class ACPSessionManager: ObservableObject {
     private func releaseReplayedForkCompletionForTranscriptFallback(
         targetSessionID: ACPSession.ID,
         sourceRemoteSessionID: String,
-        connection: ACPConnection
+        connection: ACPConnection,
+        sessionCapabilities: ACPInitializeResult.ACPAgentSessionCapabilities
     ) async {
         guard let brokerClient = connection.client as? ACPBrokerClient else { return }
         let operationKey = Self.brokerStartupOperationKey(
@@ -1991,7 +1991,11 @@ final class ACPSessionManager: ObservableObject {
                from: result.data
            ),
            !forked.sessionId.isEmpty {
-            try? await connection.closeSession(sessionId: forked.sessionId)
+            try? await closeRemoteSession(
+                id: forked.sessionId,
+                using: connection,
+                sessionCapabilities: sessionCapabilities
+            )
         }
         replayed.acknowledgeDurableConsumption()
     }
@@ -2000,12 +2004,14 @@ final class ACPSessionManager: ObservableObject {
         targetSessionID: ACPSession.ID,
         sourceRemoteSessionID: String,
         connection: ACPConnection,
+        sessionCapabilities: ACPInitializeResult.ACPAgentSessionCapabilities,
         wireMCPServers: [ACPMCPServer]
     ) async throws -> ACPSessionNewResult {
         await releaseReplayedForkCompletionForTranscriptFallback(
             targetSessionID: targetSessionID,
             sourceRemoteSessionID: sourceRemoteSessionID,
-            connection: connection
+            connection: connection,
+            sessionCapabilities: sessionCapabilities
         )
         do {
             let result = try await connection.newSession(
@@ -2019,14 +2025,16 @@ final class ACPSessionManager: ObservableObject {
             await releaseReplayedForkCompletionForTranscriptFallback(
                 targetSessionID: targetSessionID,
                 sourceRemoteSessionID: sourceRemoteSessionID,
-                connection: connection
+                connection: connection,
+                sessionCapabilities: sessionCapabilities
             )
             return result
         } catch {
             await releaseReplayedForkCompletionForTranscriptFallback(
                 targetSessionID: targetSessionID,
                 sourceRemoteSessionID: sourceRemoteSessionID,
-                connection: connection
+                connection: connection,
+                sessionCapabilities: sessionCapabilities
             )
             throw error
         }
@@ -2129,7 +2137,8 @@ final class ACPSessionManager: ObservableObject {
                 await releaseReplayedForkCompletionForTranscriptFallback(
                     targetSessionID: session.id,
                     sourceRemoteSessionID: sourceRemoteSessionID,
-                    connection: connection
+                    connection: connection,
+                    sessionCapabilities: initialized.sessionCapabilities
                 )
                 let fallbackError: any Error
                 if let terminalError = durableReplay?.outcome.error {
@@ -2144,6 +2153,7 @@ final class ACPSessionManager: ObservableObject {
                     targetSessionID: session.id,
                     sourceRemoteSessionID: sourceRemoteSessionID,
                     connection: connection,
+                    sessionCapabilities: initialized.sessionCapabilities,
                     wireMCPServers: wireMCPServers
                 )
                 return (fallback, true)
@@ -2156,7 +2166,11 @@ final class ACPSessionManager: ObservableObject {
                     remoteSessionID: result.sessionId
                 )
             } catch {
-                try? await connection.closeSession(sessionId: result.sessionId)
+                try? await closeRemoteSession(
+                    id: result.sessionId,
+                    using: connection,
+                    sessionCapabilities: initialized.sessionCapabilities
+                )
                 let transcriptFinalized: Bool
                 do {
                     try await persistence.finalizeFork(
@@ -2209,6 +2223,7 @@ final class ACPSessionManager: ObservableObject {
                 targetSessionID: session.id,
                 sourceRemoteSessionID: sourceRemoteSessionID,
                 connection: connection,
+                sessionCapabilities: initialized.sessionCapabilities,
                 wireMCPServers: wireMCPServers
             )
             return (result, true)
@@ -2351,6 +2366,20 @@ final class ACPSessionManager: ObservableObject {
 // MARK: - Writer lease + heartbeat
 
 extension ACPSessionManager {
+    private enum BoundedOperationOutcome {
+        case succeeded
+        case failed(any Error)
+        case timedOut
+    }
+
+    private enum SessionDisposalError: LocalizedError {
+        case timedOut
+
+        var errorDescription: String? {
+            "Timed out while closing the adapter session."
+        }
+    }
+
     /// Seconds after which a lease whose owner stopped heart-beating is
     /// considered abandoned and reclaimable.
     static let leaseStaleAfter: Int64 = 15
@@ -4216,14 +4245,83 @@ extension ACPSessionManager {
         await runner.connection.shutdown()
     }
 
+    func disposeSession(id: ACPSession.ID) async throws {
+        if let task = disposalTasks[id] {
+            try await task.value
+            return
+        }
+        let task = Task<Void, Error> { @MainActor [weak self] in
+            guard let self else { return }
+            try await self.tearDownSession(sessionId: id, closeRemote: true)
+        }
+        disposalTasks[id] = task
+        defer { disposalTasks.removeValue(forKey: id) }
+        try await task.value
+    }
+
     func detach(sessionId: ACPSession.ID) async {
+        try? await tearDownSession(sessionId: sessionId, closeRemote: false)
+    }
+
+    private func closeRemoteSession(
+        id: String,
+        using connection: ACPConnection,
+        sessionCapabilities: ACPInitializeResult.ACPAgentSessionCapabilities?
+    ) async throws {
+        guard sessionCapabilities?.supportsClose == true else { return }
+        let outcome = await runBounded(timeout: .seconds(2)) {
+            try await connection.closeSession(sessionId: id)
+        }
+        switch outcome {
+        case .succeeded:
+            return
+        case .failed(let error):
+            throw error
+        case .timedOut:
+            throw SessionDisposalError.timedOut
+        }
+    }
+
+    private func runBounded(
+        timeout: Duration,
+        operation: @escaping () async throws -> Void
+    ) async -> BoundedOperationOutcome {
+        let (stream, continuation) = AsyncStream<BoundedOperationOutcome>.makeStream()
+        let operationTask = Task {
+            do {
+                try await operation()
+                continuation.yield(.succeeded)
+            } catch {
+                continuation.yield(.failed(error))
+            }
+        }
+        let timeoutTask = Task {
+            do {
+                try await Task.sleep(for: timeout)
+                continuation.yield(.timedOut)
+            } catch {}
+        }
+        var iterator = stream.makeAsyncIterator()
+        let outcome = await iterator.next() ?? .timedOut
+        continuation.finish()
+        operationTask.cancel()
+        timeoutTask.cancel()
+        return outcome
+    }
+
+    private func tearDownSession(sessionId: ACPSession.ID, closeRemote: Bool) async throws {
+        autoReconnectTasks.removeValue(forKey: sessionId)?.cancel()
+        let session = sessions[sessionId]
+        let shouldCloseRemote = closeRemote && session?.agentState != .disconnected
+        let remoteSessionId = session?.remoteSessionId
+        let sessionCapabilities = session?.sessionCapabilities
         // Reset transient session state SYNCHRONOUSLY before any await.
         // The steer task is unstructured and can resume during the
         // `connection.shutdown()` await below — if `agentState` is still
         // `.ready` at that point, its post-`userCancel` liveness
         // check passes and it dispatches `sendNow` against a connection
         // being torn down. Flipping the state here closes that window.
-        if let session = sessions[sessionId] {
+        if let session {
             // .idle (user-initiated teardown), not .disconnected — the latter
             // is reserved for the runner's unexpected stream-end branch.
             session.agentState = .idle
@@ -4238,6 +4336,7 @@ extension ACPSessionManager {
             // full app restart reloads from SQLite.
             session.restoreQueue(session.queue)
         }
+        var closeError: (any Error)?
         if let runner = runners.removeValue(forKey: sessionId) {
             // Invalidate the in-flight prompt BEFORE shutting down the
             // connection. The unstructured `sendNow` task survives stop()
@@ -4248,19 +4347,44 @@ extension ACPSessionManager {
             runner.invalidateActivePrompt()
             runner.stop()
             await runner.flushPersistence()
-            await runner.connection.shutdown()
+            if shouldCloseRemote, let remoteSessionId, !remoteSessionId.isEmpty {
+                do {
+                    try await closeRemoteSession(
+                        id: remoteSessionId,
+                        using: runner.connection,
+                        sessionCapabilities: sessionCapabilities
+                    )
+                } catch {
+                    closeError = error
+                }
+            }
+            if closeRemote {
+                let shutdownOutcome = await runBounded(timeout: .seconds(2)) {
+                    await runner.connection.shutdown()
+                }
+                if case .timedOut = shutdownOutcome, closeError == nil {
+                    closeError = SessionDisposalError.timedOut
+                }
+            } else {
+                await runner.connection.shutdown()
+            }
         }
         elicitationCoordinators.removeValue(forKey: sessionId)?.stop()
         stopHeartbeat(sessionId: sessionId)
         stopWriterWatch(sessionId: sessionId)
         await releaseWriterLease(sessionId: sessionId)
         endMirroring(sessionId: sessionId)
-        // SwiftUI's `.onDisappear` retain release for a closing tab can
-        // arrive BEFORE this async detach starts, so the release runs while
-        // agentState is still `.ready` and short-circuits eviction. Re-check
-        // now that state is `.idle` so a closed-while-attached session
-        // doesn't keep its transcript + caches resident indefinitely.
-        evictIfIdle(id: sessionId)
+        if closeRemote {
+            closeSession(id: sessionId)
+        } else {
+            // SwiftUI's `.onDisappear` retain release for a closing tab can
+            // arrive BEFORE this async detach starts, so the release runs while
+            // agentState is still `.ready` and short-circuits eviction. Re-check
+            // now that state is `.idle` so a closed-while-attached session
+            // doesn't keep its transcript + caches resident indefinitely.
+            evictIfIdle(id: sessionId)
+        }
+        if let closeError { throw closeError }
     }
 }
 

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -447,6 +447,7 @@ final class ACPSessionManager: ObservableObject {
     /// release the lease after `connection.shutdown` — preserving the
     /// correct shutdown order (connection down before lease freed).
     private var attachingSessions: Set<ACPSession.ID> = []
+    private var disposingAttachments: Set<ACPSession.ID> = []
     private struct AttachingConnection {
         let connection: ACPConnection
         var remoteSessionId: String?
@@ -1113,7 +1114,8 @@ final class ACPSessionManager: ObservableObject {
             sessions[$0]?.agentId == agentId && sessions[$0]?.remoteSessionId == remoteSessionId
         }
         guard let localSessionId,
-              runners[localSessionId] != nil || disposalTasks[localSessionId] != nil
+              runners[localSessionId] != nil || attachingSessions.contains(localSessionId)
+                || disposalTasks[localSessionId] != nil
         else { return }
         try await disposeSession(id: localSessionId)
     }
@@ -2973,6 +2975,7 @@ extension ACPSessionManager {
         var attachSucceeded = false
         defer {
             attachingSessions.remove(sessionId)
+            disposingAttachments.remove(sessionId)
             if !attachSucceeded {
                 stopHeartbeat(sessionId: sessionId)
                 stopWriterWatch(sessionId: sessionId)
@@ -3036,6 +3039,10 @@ extension ACPSessionManager {
             return
         }
         let setup = await evaluateSetup(for: spec)
+        guard sessions[sessionId] === session, !disposingAttachments.contains(sessionId), !isDisposed else {
+            await releaseWriterLease(sessionId: sessionId)
+            return
+        }
         guard case .ready = setup else {
             do {
                 try await downgradeNegotiatingForkToTranscript(session: session)
@@ -3136,6 +3143,11 @@ extension ACPSessionManager {
                 attachingConnections[sessionId] = nil
             }
         }
+        guard sessions[sessionId] === session, !disposingAttachments.contains(sessionId), !isDisposed else {
+            await connection.shutdown()
+            await releaseWriterLease(sessionId: sessionId)
+            return
+        }
         // Collect a short tail of stderr so we can surface it when the
         // agent rejects initialize / new for protocol or auth reasons.
         let stderrBuffer = StderrBuffer()
@@ -3177,6 +3189,11 @@ extension ACPSessionManager {
                     method: "initialize"
                 )
             )
+            guard sessions[sessionId] === session, !disposingAttachments.contains(sessionId), !isDisposed else {
+                await connection.shutdown()
+                await releaseWriterLease(sessionId: sessionId)
+                return
+            }
             if var attaching = attachingConnections[sessionId], attaching.connection === connection {
                 attaching.sessionCapabilities = initialized.sessionCapabilities
                 attachingConnections[sessionId] = attaching
@@ -3653,6 +3670,16 @@ extension ACPSessionManager {
                     session.contextRecoveryStatus = .sendingTranscript
                 }
             }
+            if disposingAttachments.contains(sessionId) || sessions[sessionId] !== session || isDisposed {
+                try? await closeRemoteSession(
+                    id: result.sessionId,
+                    using: connection,
+                    sessionCapabilities: initialized.sessionCapabilities
+                )
+                await connection.shutdown()
+                await releaseWriterLease(sessionId: sessionId)
+                return
+            }
             if var attaching = attachingConnections[sessionId], attaching.connection === connection {
                 attaching.remoteSessionId = result.sessionId
                 attachingConnections[sessionId] = attaching
@@ -3741,9 +3768,15 @@ extension ACPSessionManager {
                 shouldAbortAttach = !(await confirmedWriterLease(for: sessionId))
             }
             if shouldAbortAttach {
-                if isDisposed {
+                if attachingConnections[sessionId]?.connection === connection,
+                   (isDisposed || disposingAttachments.contains(sessionId)) {
+                    try? await closeRemoteSession(
+                        id: result.sessionId,
+                        using: connection,
+                        sessionCapabilities: initialized.sessionCapabilities
+                    )
                     await connection.shutdown()
-                } else {
+                } else if attachingConnections[sessionId]?.connection === connection {
                     await connection.detach()
                 }
                 startedRunner?.stop()
@@ -4282,6 +4315,13 @@ extension ACPSessionManager {
         try await task.value
     }
 
+    func disposeAllLiveSessions() async {
+        let ids = Set(runners.keys).union(attachingSessions)
+        for id in ids {
+            try? await disposeSession(id: id)
+        }
+    }
+
     func detach(sessionId: ACPSession.ID) async {
         try? await tearDownSession(sessionId: sessionId, closeRemote: false)
     }
@@ -4338,6 +4378,9 @@ extension ACPSessionManager {
         let shouldCloseRemote = closeRemote && session?.agentState != .disconnected
         let remoteSessionId = session?.remoteSessionId
         let sessionCapabilities = session?.sessionCapabilities
+        if attachingSessions.contains(sessionId) {
+            disposingAttachments.insert(sessionId)
+        }
         let attaching = attachingConnections.removeValue(forKey: sessionId)
         // Reset transient session state SYNCHRONOUSLY before any await.
         // The steer task is unstructured and can resume during the

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -447,6 +447,12 @@ final class ACPSessionManager: ObservableObject {
     /// release the lease after `connection.shutdown` — preserving the
     /// correct shutdown order (connection down before lease freed).
     private var attachingSessions: Set<ACPSession.ID> = []
+    private struct AttachingConnection {
+        let connection: ACPConnection
+        var remoteSessionId: String?
+        var sessionCapabilities: ACPInitializeResult.ACPAgentSessionCapabilities?
+    }
+    private var attachingConnections: [ACPSession.ID: AttachingConnection] = [:]
     private var delegatedMessageWatchTokens: [ACPSession.ID: Int32] = [:]
 
     init(worktreeId: String, worktreePath: String, store: ACPSessionStore? = nil,
@@ -3124,6 +3130,12 @@ extension ACPSessionManager {
         // `cliEnvActive` / `cliParentSessionId` are consumed below, once we
         // know whether this attach created a fresh remote session (the
         // preamble is only sent once, on first prompt).
+        attachingConnections[sessionId] = .init(connection: connection)
+        defer {
+            if attachingConnections[sessionId]?.connection === connection {
+                attachingConnections[sessionId] = nil
+            }
+        }
         // Collect a short tail of stderr so we can surface it when the
         // agent rejects initialize / new for protocol or auth reasons.
         let stderrBuffer = StderrBuffer()
@@ -3165,6 +3177,10 @@ extension ACPSessionManager {
                     method: "initialize"
                 )
             )
+            if var attaching = attachingConnections[sessionId], attaching.connection === connection {
+                attaching.sessionCapabilities = initialized.sessionCapabilities
+                attachingConnections[sessionId] = attaching
+            }
             session.promptCapabilities = initialized.promptCapabilities
             session.sessionCapabilities = initialized.sessionCapabilities
             session.authMethods = initialized.authMethods
@@ -3637,6 +3653,10 @@ extension ACPSessionManager {
                     session.contextRecoveryStatus = .sendingTranscript
                 }
             }
+            if var attaching = attachingConnections[sessionId], attaching.connection === connection {
+                attaching.remoteSessionId = result.sessionId
+                attachingConnections[sessionId] = attaching
+            }
             let providers: [ACPProviderInfo] = if initialized.providerCapabilities != nil {
                 (try? await connection.listProviders()) ?? []
             } else {
@@ -3760,6 +3780,9 @@ extension ACPSessionManager {
             let localModelAfterRemoteIdPersist = session.currentModel
             connection.acknowledgeDurableSessionResponses()
             startRunnerIfNeeded()
+            if attachingConnections[sessionId]?.connection === connection {
+                attachingConnections[sessionId] = nil
+            }
             runners[sessionId] = runner
             keepElicitationCoordinator = true
             attachSucceeded = true
@@ -4315,6 +4338,7 @@ extension ACPSessionManager {
         let shouldCloseRemote = closeRemote && session?.agentState != .disconnected
         let remoteSessionId = session?.remoteSessionId
         let sessionCapabilities = session?.sessionCapabilities
+        let attaching = attachingConnections.removeValue(forKey: sessionId)
         // Reset transient session state SYNCHRONOUSLY before any await.
         // The steer task is unstructured and can resume during the
         // `connection.shutdown()` await below — if `agentState` is still
@@ -4367,6 +4391,28 @@ extension ACPSessionManager {
                 }
             } else {
                 await runner.connection.shutdown()
+            }
+        } else if let attaching {
+            if shouldCloseRemote, let remoteSessionId = attaching.remoteSessionId, !remoteSessionId.isEmpty {
+                do {
+                    try await closeRemoteSession(
+                        id: remoteSessionId,
+                        using: attaching.connection,
+                        sessionCapabilities: attaching.sessionCapabilities
+                    )
+                } catch {
+                    closeError = error
+                }
+            }
+            if closeRemote {
+                let shutdownOutcome = await runBounded(timeout: .seconds(2)) {
+                    await attaching.connection.shutdown()
+                }
+                if case .timedOut = shutdownOutcome, closeError == nil {
+                    closeError = SessionDisposalError.timedOut
+                }
+            } else {
+                await attaching.connection.detach()
             }
         }
         elicitationCoordinators.removeValue(forKey: sessionId)?.stop()

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4496,7 +4496,7 @@ final class AppState {
         invalidateFollowRevisionRequests(for: allTabs.filter { closedSet.contains($0.id) })
     }
 
-    /// Detach a single ACP session's runner and remove it from the
+    /// Dispose a single ACP session's runner and remove it from the
     /// worktree's manager. Different from `disposeACPManager`, which
     /// tears down the whole worktree's manager — this leaves the
     /// manager (and any sibling sessions) running.
@@ -4507,11 +4507,11 @@ final class AppState {
         // (other tabs may share it), so the global flush from
         // disposeACPManager wouldn't fire here.
         manager.flushPendingDraftWrite(forSession: sessionId)
-        // Call detach unconditionally — a session can hold a writer lease
+        // Dispose unconditionally — a session can hold a writer lease
         // + heartbeat + writer-watch before its runner is registered (the
         // "attach window"). If we returned early when no runner was present,
         // closing the tab during that window would leak all of those
-        // resources. detach is idempotent: releaseWriterLease is owner-
+        // resources. Disposal is idempotent: releaseWriterLease is owner-
         // scoped, and endMirroring / stopHeartbeat / stopWriterWatch are
         // all no-ops when not active.
         if let runner = manager.runners[sessionId] {
@@ -4522,7 +4522,15 @@ final class AppState {
             if let acpDetachRunner {
                 await acpDetachRunner(manager, sessionId)
             } else {
-                await manager.detach(sessionId: sessionId)
+                do {
+                    try await manager.disposeSession(id: sessionId)
+                } catch {
+                    Self.logger.error("Failed to close ACP session: \(String(describing: error), privacy: .public)")
+                    showFileActionError(
+                        title: "Close Session Failed",
+                        message: error.localizedDescription
+                    )
+                }
             }
         }
         pendingACPDetachTasks[worktreeId, default: [:]][sessionId] = PendingACPDetach(id: pendingID, task: task)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6386,7 +6386,7 @@ final class AppState {
         manager.shutdownBackgroundTasks()
         Task { @MainActor in
             await manager.flushAllPersistence()
-            for sid in sessionIds { await manager.detach(sessionId: sid) }
+            await manager.disposeAllLiveSessions()
             // Release any leases this manager still owns AFTER all runner
             // connections are shut down (detach above). A freed lease must
             // not be claimable while an old agent process is still alive.

--- a/AlasTests/ACP/Protocol/ACPInitializeTests.swift
+++ b/AlasTests/ACP/Protocol/ACPInitializeTests.swift
@@ -166,6 +166,22 @@ struct ACPInitializeTests {
         #expect(present.agentCapabilities?.sessionCapabilities.supportsDelete == true)
     }
 
+    @Test("decodes absent and present session close capability")
+    func decodeSessionCloseCapability() throws {
+        let absent = try JSONDecoder().decode(ACPInitializeResult.self, from: Data("""
+        { "protocolVersion": 1, "agentCapabilities": { "sessionCapabilities": {} } }
+        """.utf8))
+        #expect(absent.agentCapabilities?.sessionCapabilities.supportsClose == false)
+
+        let present = try JSONDecoder().decode(ACPInitializeResult.self, from: Data("""
+        {
+          "protocolVersion": 1,
+          "agentCapabilities": { "sessionCapabilities": { "close": {} } }
+        }
+        """.utf8))
+        #expect(present.agentCapabilities?.sessionCapabilities.supportsClose == true)
+    }
+
     @Test("decodes absent, supported, and extended provider capabilities")
     func decodeProviderCapabilities() throws {
         let absent = try JSONDecoder().decode(ACPInitializeResult.self, from: Data("""

--- a/AlasTests/ACP/Session/ACPSessionDiscoveryTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionDiscoveryTests.swift
@@ -267,7 +267,7 @@ struct ACPSessionDiscoveryTests {
                 protocolVersion: 1,
                 agentCapabilities: .init(
                     loadSession: true,
-                    sessionCapabilities: .init(list: .init(), delete: .init())
+                    sessionCapabilities: .init(list: .init(), delete: .init(), close: .init())
                 ),
                 authMethods: []
             ))
@@ -576,7 +576,10 @@ struct ACPSessionDiscoveryTests {
         client.script(method: "initialize") { _ in
             try JSONEncoder().encode(ACPInitializeResult(
                 protocolVersion: 1,
-                agentCapabilities: .init(loadSession: true),
+                agentCapabilities: .init(
+                    loadSession: true,
+                    sessionCapabilities: .init(close: .init())
+                ),
                 authMethods: []
             ))
         }

--- a/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
@@ -595,7 +595,7 @@ struct ACPSessionForkAttachTests {
         try installFinalizeFailure(mechanism: .nativeACP, store: store)
         let client = durableMockClient()
         let acknowledgements = ForkAcknowledgementRecorder()
-        scriptInitialize(client, supportsFork: true)
+        scriptInitialize(client, supportsFork: true, supportsClose: true)
         client.scriptResponse(method: "session/fork") { _ in
             ACPResponse(
                 body: try JSONEncoder().encode(ACPSessionNewResult(
@@ -643,6 +643,26 @@ struct ACPSessionForkAttachTests {
         #expect(fork.mechanism == .transcriptTransfer)
         #expect(fork.contextDeliveryPending == true)
         #expect(acknowledgements.values == ["close", "fork"])
+    }
+
+    @Test("native finalization failure does not close an orphan when close is unsupported")
+    func nativeFinalizationFailureSkipsUnsupportedOrphanClose() async throws {
+        let store = try seededForkStore()
+        try installFinalizeFailure(mechanism: .nativeACP, store: store)
+        let client = durableMockClient()
+        scriptInitialize(client, supportsFork: true)
+        scriptSessionResult(client, method: "session/fork", sessionId: "orphaned-remote")
+        let manager = try await makeManagerWithAttachedSource(
+            store: store,
+            targetClient: client
+        )
+        let target = try await hydratedTarget(manager)
+
+        await manager.attach(to: target.id, freshlyCreated: true)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/fork"])
+        #expect(target.forkRecord?.phase == .ready)
+        #expect(target.forkRecord?.mechanism == .transcriptTransfer)
     }
 
     @Test("broker pre-send failure durably falls back to transcript transfer")
@@ -960,6 +980,7 @@ struct ACPSessionForkAttachTests {
     private func scriptInitialize(
         _ client: ACPMockClient,
         supportsFork: Bool,
+        supportsClose: Bool = false,
         authMethods: [ACPInitializeResult.ACPAuthMethod] = []
     ) {
         client.script(method: "initialize") { _ in
@@ -967,7 +988,8 @@ struct ACPSessionForkAttachTests {
                 protocolVersion: 1,
                 agentCapabilities: .init(
                     sessionCapabilities: .init(
-                        fork: supportsFork ? .init() : nil
+                        fork: supportsFork ? .init() : nil,
+                        close: supportsClose ? .init() : nil
                     )
                 ),
                 authMethods: authMethods
@@ -1537,7 +1559,8 @@ private actor ForkReplayBrokerService: ACPBrokerServicing {
                 "protocolVersion": .number(1),
                 "agentCapabilities": .object([
                     "sessionCapabilities": .object([
-                        "fork": .object([:])
+                        "fork": .object([:]),
+                        "close": .object([:])
                     ])
                 ]),
                 "authMethods": .array([])

--- a/AlasTests/ACP/Session/ACPSessionManagerDisposalTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerDisposalTests.swift
@@ -151,6 +151,62 @@ struct ACPSessionManagerDisposalTests {
         #expect(try store.loadSession(id: session.id) == nil)
     }
 
+    @Test("disposing while attach waits for providers closes the created remote session")
+    func disposalClosesRemoteSessionBeforeRunnerRegistration() async throws {
+        let client = ACPMockClient()
+        let providersStarted = AsyncStream<Void>.makeStream()
+        let releaseProviders = AsyncStream<Void>.makeStream()
+        client.script(method: "initialize") { _ in
+            try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: .init(
+                    sessionCapabilities: .init(close: .init()),
+                    providerCapabilities: .init()
+                ),
+                authMethods: []
+            ))
+        }
+        client.script(method: "session/new") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+        client.scriptAsync(method: "providers/list") { _ in
+            providersStarted.continuation.yield()
+            for await _ in releaseProviders.stream { break }
+            return Data("{\"providers\":[]}".utf8)
+        }
+        client.script(method: "session/close") { _ in Data("{}".utf8) }
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-disposal-attach-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: path.path)
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in ACPConnection(client: client) }
+        )
+        let session = manager.createSession(agentId: "claude")
+        let attach = Task { @MainActor in
+            await manager.attach(to: session.id, freshlyCreated: true)
+        }
+        for await _ in providersStarted.stream { break }
+
+        try await manager.disposeSession(id: session.id)
+        releaseProviders.continuation.yield()
+        await attach.value
+
+        #expect(client.sent.map(\.method).filter { $0 == "session/close" }.count == 1)
+        #expect(client.shutdownCount >= 1)
+        #expect(manager.runners[session.id] == nil)
+    }
+
     private func attachedManager(
         client: ACPMockClient,
         supportsClose: Bool,

--- a/AlasTests/ACP/Session/ACPSessionManagerDisposalTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerDisposalTests.swift
@@ -207,6 +207,52 @@ struct ACPSessionManagerDisposalTests {
         #expect(manager.runners[session.id] == nil)
     }
 
+    @Test("disposing while session creation is in flight closes its late result")
+    func disposalClosesLateRemoteSessionResult() async throws {
+        let client = ACPMockClient()
+        let newStarted = AsyncStream<Void>.makeStream()
+        let releaseNew = AsyncStream<Void>.makeStream()
+        client.script(method: "initialize") { _ in
+            try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: .init(sessionCapabilities: .init(close: .init())),
+                authMethods: []
+            ))
+        }
+        client.scriptAsync(method: "session/new") { _ in
+            newStarted.continuation.yield()
+            for await _ in releaseNew.stream { break }
+            return try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+        client.script(method: "session/close") { _ in Data("{}".utf8) }
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-disposal-late-new-\(UUID()).sqlite")
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: try ACPSessionStore(path: path.path),
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in ACPConnection(client: client) }
+        )
+        let session = manager.createSession(agentId: "claude")
+        let attach = Task { @MainActor in await manager.attach(to: session.id, freshlyCreated: true) }
+        for await _ in newStarted.stream { break }
+
+        try await manager.disposeSession(id: session.id)
+        releaseNew.continuation.yield()
+        await attach.value
+
+        #expect(client.sent.map(\.method).filter { $0 == "session/close" }.count == 1)
+        #expect(manager.runners[session.id] == nil)
+    }
+
     private func attachedManager(
         client: ACPMockClient,
         supportsClose: Bool,

--- a/AlasTests/ACP/Session/ACPSessionManagerDisposalTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerDisposalTests.swift
@@ -1,0 +1,211 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPSessionManager disposal")
+struct ACPSessionManagerDisposalTests {
+    private enum TestError: Error { case closeFailed }
+
+    @Test("supported attached disposal closes once and keeps the persisted session resumable")
+    func supportedDisposalClosesAndPreservesPersistence() async throws {
+        let client = ACPMockClient()
+        let resumeClient = ACPMockClient()
+        client.script(method: "session/close") { _ in Data("{}".utf8) }
+        let (manager, store, session) = try await attachedManager(
+            client: client,
+            supportsClose: true,
+            resumeClient: resumeClient
+        )
+
+        try await manager.disposeSession(id: session.id)
+        await manager.flushPersistence()
+
+        #expect(client.sent.map(\.method).filter { $0 == "session/close" }.count == 1)
+        #expect(manager.runners[session.id] == nil)
+        #expect(try store.loadSession(id: session.id)?.remoteSessionId == "remote")
+
+        let restored = try #require(manager.placeholderSession(id: session.id))
+        await manager.attach(to: restored.id, freshlyCreated: false)
+        #expect(resumeClient.sent.contains { $0.method == "session/resume" })
+        #expect(manager.runners[restored.id] != nil)
+        await manager.detach(sessionId: restored.id)
+    }
+
+    @Test("unsupported and disconnected sessions do not close remotely")
+    func unsupportedAndDisconnectedSessionsDoNotClose() async throws {
+        let unsupportedClient = ACPMockClient()
+        let (unsupportedManager, _, unsupportedSession) = try await attachedManager(
+            client: unsupportedClient,
+            supportsClose: false
+        )
+        try await unsupportedManager.disposeSession(id: unsupportedSession.id)
+
+        let disconnectedClient = ACPMockClient()
+        let (disconnectedManager, _, disconnectedSession) = try await attachedManager(
+            client: disconnectedClient,
+            supportsClose: true
+        )
+        disconnectedSession.agentState = .disconnected
+        try await disconnectedManager.disposeSession(id: disconnectedSession.id)
+
+        #expect(!unsupportedClient.sent.contains { $0.method == "session/close" })
+        #expect(!disconnectedClient.sent.contains { $0.method == "session/close" })
+    }
+
+    @Test("duplicate disposal sends at most one close")
+    func duplicateDisposalClosesOnce() async throws {
+        let client = ACPMockClient()
+        let closeStarted = AsyncStream<Void>.makeStream()
+        let releaseClose = AsyncStream<Void>.makeStream()
+        client.scriptAsync(method: "session/close") { _ in
+            closeStarted.continuation.yield()
+            for await _ in releaseClose.stream { break }
+            return Data("{}".utf8)
+        }
+        let (manager, _, session) = try await attachedManager(client: client, supportsClose: true)
+
+        let first = Task { @MainActor in try await manager.disposeSession(id: session.id) }
+        for await _ in closeStarted.stream { break }
+        let second = Task { @MainActor in try await manager.disposeSession(id: session.id) }
+        await Task.yield()
+        releaseClose.continuation.yield()
+        try await first.value
+        try await second.value
+
+        #expect(client.sent.map(\.method).filter { $0 == "session/close" }.count == 1)
+    }
+
+    @Test("failed close still removes the runner and shuts down the connection")
+    func failedCloseStillTearsDown() async throws {
+        let client = ACPMockClient()
+        client.script(method: "session/close") { _ in throw TestError.closeFailed }
+        let (manager, _, session) = try await attachedManager(client: client, supportsClose: true)
+
+        await #expect(throws: TestError.closeFailed) {
+            try await manager.disposeSession(id: session.id)
+        }
+
+        #expect(manager.runners[session.id] == nil)
+        #expect(client.shutdownCount == 1)
+    }
+
+    @Test("unresponsive close times out and still tears down")
+    func unresponsiveCloseTimesOutAndTearsDown() async throws {
+        let client = ACPMockClient()
+        client.scriptAsync(method: "session/close") { _ in
+            try await Task.sleep(for: .seconds(3))
+            return Data("{}".utf8)
+        }
+        let (manager, _, session) = try await attachedManager(client: client, supportsClose: true)
+
+        await #expect(throws: (any Error).self) {
+            try await manager.disposeSession(id: session.id)
+        }
+
+        #expect(manager.runners[session.id] == nil)
+        #expect(client.shutdownCount == 1)
+    }
+
+    @Test("view release and local cache eviction never close a session")
+    func viewReleaseAndCacheEvictionDoNotClose() async throws {
+        let client = ACPMockClient()
+        let (manager, _, session) = try await attachedManager(client: client, supportsClose: true)
+
+        manager.retainSession(id: session.id)
+        manager.releaseSession(id: session.id)
+        #expect(manager.runners[session.id] != nil)
+        #expect(!client.sent.contains { $0.method == "session/close" })
+
+        await manager.detach(sessionId: session.id)
+        #expect(manager.liveSession(for: session.id) == nil)
+        #expect(!client.sent.contains { $0.method == "session/close" })
+    }
+
+    @Test("delete preparation uses disposal before deleting agent history")
+    func deletePreparationUsesDisposal() async throws {
+        let client = ACPMockClient()
+        client.script(method: "session/close") { _ in Data("{}".utf8) }
+        let (manager, _, session) = try await attachedManager(client: client, supportsClose: true)
+
+        try await manager.closeActiveSessionForDeletion(
+            localSessionId: session.id,
+            agentId: session.agentId,
+            remoteSessionId: "remote"
+        )
+
+        #expect(client.sent.map(\.method).filter { $0 == "session/close" }.count == 1)
+        #expect(manager.runners[session.id] == nil)
+    }
+
+    @Test("local history deletion disposes an attached session")
+    func localHistoryDeletionUsesDisposal() async throws {
+        let client = ACPMockClient()
+        client.script(method: "session/close") { _ in Data("{}".utf8) }
+        let (manager, store, session) = try await attachedManager(client: client, supportsClose: true)
+
+        try await manager.deleteSession(id: session.id)
+
+        #expect(client.sent.map(\.method).filter { $0 == "session/close" }.count == 1)
+        #expect(manager.runners[session.id] == nil)
+        #expect(try store.loadSession(id: session.id) == nil)
+    }
+
+    private func attachedManager(
+        client: ACPMockClient,
+        supportsClose: Bool,
+        resumeClient: ACPMockClient? = nil
+    ) async throws -> (ACPSessionManager, ACPSessionStore, ACPSession) {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("acp-disposal-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: path.path)
+        let clients = resumeClient.map { [client, $0] } ?? [client]
+        for client in clients {
+            client.script(method: "initialize") { _ in
+                try JSONEncoder().encode(ACPInitializeResult(
+                    protocolVersion: 1,
+                    agentCapabilities: .init(sessionCapabilities: .init(
+                        resume: supportsClose ? .init() : nil,
+                        close: supportsClose ? .init() : nil
+                    )),
+                    authMethods: []
+                ))
+            }
+            client.script(method: "session/new") { _ in
+                try JSONEncoder().encode(ACPSessionNewResult(
+                    sessionId: "remote",
+                    availableModels: [],
+                    availableModes: [],
+                    currentModel: nil,
+                    currentMode: nil,
+                    promptSuggestions: []
+                ))
+            }
+            client.script(method: "session/resume") { _ in
+                try JSONEncoder().encode(ACPSessionNewResult(
+                    sessionId: "remote",
+                    availableModels: [],
+                    availableModes: [],
+                    currentModel: nil,
+                    currentMode: nil,
+                    promptSuggestions: []
+                ))
+            }
+        }
+        var connectionIndex = 0
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in
+                defer { connectionIndex += 1 }
+                return ACPConnection(client: clients[min(connectionIndex, clients.count - 1)])
+            }
+        )
+        let session = manager.createSession(agentId: "claude")
+        await manager.attach(to: session.id, freshlyCreated: true)
+        _ = try #require(manager.runners[session.id])
+        return (manager, store, session)
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionManagerRetentionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerRetentionTests.swift
@@ -54,7 +54,7 @@ struct ACPSessionManagerRetentionTests {
     }
 
     @Test("onSessionEnded fires on deleteSession but not closeSession")
-    func onSessionEndedFiresOnDeleteOnly() {
+    func onSessionEndedFiresOnDeleteOnly() async throws {
         let path = NSTemporaryDirectory() + "ended-\(UUID()).sqlite"
         let store = try! ACPSessionStore(path: path)
         var ended: [ACPSession.ID] = []
@@ -65,7 +65,7 @@ struct ACPSessionManagerRetentionTests {
         mgr.closeSession(id: closed)
         #expect(ended.isEmpty)
         let deleted = mgr.createSession(agentId: "claude").id
-        mgr.deleteSession(id: deleted)
+        try await mgr.deleteSession(id: deleted)
         #expect(ended == [deleted])
     }
 


### PR DESCRIPTION
## Summary
- Decode ACP session close capability and centralize adapter-session disposal.
- Close supported live sessions for permanent tab close and before deletion while keeping persisted history resumable.
- Reuse the close operation for native-fork cleanup and add lifecycle regressions.

Closes #1056

## Verification
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- Focused ACP, discovery, retention, and closed-tab suites\n\nThe prior full local suite run reached unrelated RightPaneGGStack failures and an Xcode runner hang; CI is the authoritative full-suite check.