### PR TITLE
fix(gg): amend commit not working

### DIFF
--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -8,6 +8,7 @@ struct GGMutationContext {
     var refreshGitChanges: () async -> Void
     var refreshProviderReviews: () async -> Void
     var refreshProjectTopology: () async -> Void
+    var finishPendingStaging: () async -> Bool
     var worktreeExists: () -> Bool
     var invalidateInbox: () -> Void
     var selectWorktreeAtPath: (String) async -> Void
@@ -228,6 +229,11 @@ final class GGMutationCoordinator {
             }
         }
         defer { releaseAction() }
+
+        if request.requiresStagedChanges,
+           !(await context.finishPendingStaging()) {
+            throw GGMutationError.stagingFailed
+        }
 
         let isRecoveryRequest = request == .continueOperation || request == .abortOperation
         let snapshot: GGStackSnapshot?

--- a/Alas/Sources/Integrations/GG/GGMutationModels.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationModels.swift
@@ -61,6 +61,13 @@ enum GGMutationRequest: Equatable, Sendable {
         case .applySplit: .split
         }
     }
+
+    var requiresStagedChanges: Bool {
+        switch self {
+        case .amendCurrent, .absorbStaged: true
+        default: false
+        }
+    }
 }
 
 struct GGStackIdentity: Equatable, Sendable {
@@ -120,6 +127,7 @@ enum GGMutationError: Error, Equatable {
     case immutableTarget(reason: String)
     case pausedOperation
     case blockingGitOperation
+    case stagingFailed
 }
 
 extension GGMutationError: LocalizedError {
@@ -130,6 +138,7 @@ extension GGMutationError: LocalizedError {
         case .immutableTarget(let reason): reason
         case .pausedOperation: "Continue or abort the paused gg operation first."
         case .blockingGitOperation: "Finish the current Git operation first."
+        case .stagingFailed: "Staging failed. Fix the staging error and try again."
         }
     }
 }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -388,6 +388,9 @@ final class RightPaneState: GGSplitCommitServicing {
     private var stageMutationWorker: Task<Void, Never>? = nil
 
     @ObservationIgnored
+    private var pendingStageMutationsSucceeded = true
+
+    @ObservationIgnored
     private var lastReviewLoopRemoteRefreshAt: Date?
 
     @ObservationIgnored
@@ -462,6 +465,10 @@ final class RightPaneState: GGSplitCommitServicing {
                 refreshGitChanges: { [weak self] in await self?.refresh() },
                 refreshProviderReviews: { [weak self] in await self?.refresh(forceReviewLoopRemote: true) },
                 refreshProjectTopology: { [weak self] in await self?.refreshProjectTopologyAfterGGMutation?() },
+                finishPendingStaging: { [weak self] in
+                    guard let self else { return false }
+                    return await self.finishPendingStageMutations()
+                },
                 worktreeExists: { [weak self] in
                     guard let self else { return false }
                     return FileManager.default.fileExists(atPath: self.worktree.path.path)
@@ -2446,6 +2453,7 @@ final class RightPaneState: GGSplitCommitServicing {
             target: target
         ))
         guard stageMutationWorker == nil else { return }
+        pendingStageMutationsSucceeded = true
         stageMutationWorker = Task { @MainActor [weak self] in
             await self?.runStageMutationQueue()
         }
@@ -2465,12 +2473,20 @@ final class RightPaneState: GGSplitCommitServicing {
                 }
                 await refresh()
             } catch {
+                pendingStageMutationsSucceeded = false
                 pendingStageMutations.removeAll { $0.id == mutation.id }
                 sidebarError = (error as NSError).localizedDescription
                 await refresh()
             }
         }
         stageMutationWorker = nil
+    }
+
+    func finishPendingStageMutations() async -> Bool {
+        if let worker = stageMutationWorker {
+            await worker.value
+        }
+        return pendingStageMutationsSucceeded
     }
 
     func requestDiscardFile(path: String) {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -2486,6 +2486,7 @@ final class RightPaneState: GGSplitCommitServicing {
         if let worker = stageMutationWorker {
             await worker.value
         }
+        defer { pendingStageMutationsSucceeded = true }
         return pendingStageMutationsSucceeded
     }
 

--- a/AlasTests/Integrations/GGMutationCoordinatorTests.swift
+++ b/AlasTests/Integrations/GGMutationCoordinatorTests.swift
@@ -211,6 +211,7 @@ private final class GGMutationHarness {
     var selectedPaths: [String] = []
     var worktreeExists = true
     var currentBranch: String? = "feature"
+    var finishPendingStaging: () async -> Bool = { true }
     var onRefreshStack: (() async -> Void)?
     private(set) var coordinator: GGMutationCoordinator!
 
@@ -248,6 +249,7 @@ private final class GGMutationHarness {
                 refreshGitChanges: { [unowned self] in refreshes.append(.gitChanges) },
                 refreshProviderReviews: { [unowned self] in refreshes.append(.providerReviews) },
                 refreshProjectTopology: { [unowned self] in refreshes.append(.topology) },
+                finishPendingStaging: { [unowned self] in await finishPendingStaging() },
                 worktreeExists: { [unowned self] in
                     refreshes.append(.worktreeExistenceCheck)
                     return worktreeExists
@@ -288,6 +290,47 @@ private func stack(
 
 @MainActor
 struct GGMutationCoordinatorTests {
+    @Test func onlyStagedChangeMutationsWaitForStaging() {
+        #expect(GGMutationRequest.amendCurrent.requiresStagedChanges)
+        #expect(GGMutationRequest.absorbStaged.requiresStagedChanges)
+        #expect(!GGMutationRequest.sync.requiresStagedChanges)
+    }
+
+    @Test func amendWaitsForPendingStagingBeforeExecuting() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        let staging = FirstRefreshSuspension()
+        harness.finishPendingStaging = {
+            await staging.suspend()
+            return true
+        }
+
+        let task = try #require(
+            harness.coordinator.startApplying(.amendCurrent, confirmedAgainst: nil)
+        )
+        await staging.waitUntilSuspended()
+
+        #expect(harness.actionState.inFlightAction == .amendCurrent)
+        #expect(harness.loadCount == 0)
+        #expect(harness.service.requests.isEmpty)
+
+        await staging.resume()
+        try await task.value
+
+        #expect(harness.service.requests == [.amendCurrent])
+    }
+
+    @Test func failedStagingPreventsAmend() async {
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.finishPendingStaging = { false }
+
+        await #expect(throws: GGMutationError.stagingFailed) {
+            try await harness.coordinator.apply(.amendCurrent, confirmedAgainst: nil)
+        }
+
+        #expect(harness.loadCount == 0)
+        #expect(harness.service.requests.isEmpty)
+    }
+
     @Test func prepareLoadsFreshStackAndReturnsTypedDropConfirmation() async throws {
         let entries = [
             GGStackEntry(position: 1, sha: "a", title: "Drop", ggId: "change-1", prState: .open),

--- a/AlasTests/RightPaneOptimisticStageTests.swift
+++ b/AlasTests/RightPaneOptimisticStageTests.swift
@@ -66,6 +66,7 @@ struct RightPaneOptimisticStageTests {
         #expect(!(await state.finishPendingStageMutations()))
         #expect(state.sidebarError != nil)
         #expect(state.displayChanges.first { $0.path == "file.txt" }?.stage == .unstaged)
+        #expect(await state.finishPendingStageMutations())
     }
 
     private func makeRepo() async throws -> URL {

--- a/AlasTests/RightPaneOptimisticStageTests.swift
+++ b/AlasTests/RightPaneOptimisticStageTests.swift
@@ -15,9 +15,8 @@ struct RightPaneOptimisticStageTests {
         state.stageAll([unstaged])
         #expect(state.displayChanges.first { $0.path == "file.txt" }?.stage == .staged)
 
-        try await waitUntil {
-            state.changes.first { $0.path == "file.txt" }?.stage == .staged
-        }
+        #expect(await state.finishPendingStageMutations())
+        #expect(state.changes.first { $0.path == "file.txt" }?.stage == .staged)
         let staged = try #require(state.changes.first { $0.path == "file.txt" })
         state.unstageAll([staged])
         #expect(state.displayChanges.first { $0.path == "file.txt" }?.stage == .unstaged)
@@ -64,7 +63,8 @@ struct RightPaneOptimisticStageTests {
         state.stageAll([file])
         #expect(state.displayChanges.first { $0.path == "file.txt" }?.stage == .staged)
 
-        try await waitUntil { state.sidebarError != nil }
+        #expect(!(await state.finishPendingStageMutations()))
+        #expect(state.sidebarError != nil)
         #expect(state.displayChanges.first { $0.path == "file.txt" }?.stage == .unstaged)
     }
 

--- a/docs/superpowers/specs/2026-08-26-gg-amend-staging-race-design.md
+++ b/docs/superpowers/specs/2026-08-26-gg-amend-staging-race-design.md
@@ -1,0 +1,37 @@
+# GG Amend Staging Race Design
+
+## Problem
+
+Alas projects staging changes into the UI before the serialized Git staging
+queue has applied them to the index. This makes `Amend current` and `Absorb
+into stack` available while `git add` is still running. If either GG command
+starts first, it can read an empty or partial index and complete without the
+changes shown as staged in Alas.
+
+## Design
+
+Keep the optimistic staging UI. When a staged-change GG action is selected,
+reserve the action immediately so its controls become disabled, then await the
+existing staging worker before invoking GG. Apply this at the shared GG
+mutation boundary for both Amend and Absorb rather than in the button handler.
+
+If every queued staging mutation succeeds, execute the existing command
+unchanged. Amend remains `gg sc --staged-only`; Absorb remains `gg absorb -s`.
+If staging fails, stop before invoking GG and preserve the staging error for
+the user.
+
+## Testing
+
+Add one regression test that suspends staging, starts Amend, and verifies the
+GG executor has not run. After staging resumes successfully, verify Amend
+executes once. Cover the shared request classification so Absorb cannot regain
+the same race.
+
+Run the focused optimistic-staging and GG mutation tests, then the repository's
+required XcodeGen, build, and test commands.
+
+## Out of Scope
+
+- Replacing optimistic staging with disabled controls.
+- Adding a global queue for every Git and GG operation.
+- Changing GG commands, staging semantics, or the Changes layout.


### PR DESCRIPTION
## Summary

Fixes GG amend/absorb actions racing asynchronous staging. The action now waits for queued staging to finish, so it receives the staged index that the UI already shows.

## Changes

- Gate GG mutations that require staged changes behind the existing staging queue.
- Stop amend/absorb when staging fails and show a clear error instead of running against a partial index.
- Cover successful waiting and failed-staging behavior in GG coordinator and optimistic-staging tests.

## Verification

- `xcodegen`
- Focused GG and optimistic-staging tests: 77 passed.
- macOS build completed successfully.

## Notes for reviewers

- The full local test command was blocked by an unrelated stale Xcode test process; CI remains the final full-suite gate.