### PR TITLE
feat: copy diff filenames

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1549,6 +1549,7 @@
 		FCE78F165C46577F64D9B9AD /* CenterSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */; };
 		FCF61C2ECFE2CC61226F78D5 /* MermaidRenderCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93393A2C5EEEFFDB678FDA78 /* MermaidRenderCacheTests.swift */; };
 		FD4196C9F558CE954D94E060 /* RemoteTerminalScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C6579202DFD8E5FBF26DE5 /* RemoteTerminalScript.swift */; };
+		FD49944FD0777C90C98F990E /* CopyFeedbackStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ADF2AC196D39DF59097D4A /* CopyFeedbackStateTests.swift */; };
 		FD5AC98DEE4448EB95C49485 /* ACPUserInputFormStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A6CF0F6BDA59AAE1354EE7 /* ACPUserInputFormStateTests.swift */; };
 		FD5B6E7F566A9D0BACD19267 /* DiffInlineCommentModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729DDA22CA94FA0DC8810057 /* DiffInlineCommentModelTests.swift */; };
 		FD797B47C5EE0F82796A3733 /* LSPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028348C468E45161F567110A /* LSPInstallerTests.swift */; };
@@ -2765,6 +2766,7 @@
 		C5679CA959D40E1682A91F31 /* PendingReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingReview.swift; sourceTree = "<group>"; };
 		C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstaller.swift; sourceTree = "<group>"; };
 		C57B57158094E321BD68D224 /* AttachIssueDialogModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachIssueDialogModel.swift; sourceTree = "<group>"; };
+		C5ADF2AC196D39DF59097D4A /* CopyFeedbackStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyFeedbackStateTests.swift; sourceTree = "<group>"; };
 		C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcherTests.swift; sourceTree = "<group>"; };
 		C60A6B7CB83D842FEE2D801C /* ThreePaneSizingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneSizingTests.swift; sourceTree = "<group>"; };
 		C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTabView.swift; sourceTree = "<group>"; };
@@ -3456,6 +3458,7 @@
 				97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */,
 				C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */,
 				AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */,
+				C5ADF2AC196D39DF59097D4A /* CopyFeedbackStateTests.swift */,
 				BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */,
 				179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */,
 				40497B428C9395535DF6C146 /* DialogChromeLayoutTests.swift */,
@@ -7120,6 +7123,7 @@
 				5B02C8E213F6EA67BEB7E5BA /* ContentResultGroupViewTests.swift in Sources */,
 				2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */,
 				B6713CE9BFA38B7F1D089E5A /* CopilotInstallerTests.swift in Sources */,
+				FD49944FD0777C90C98F990E /* CopyFeedbackStateTests.swift in Sources */,
 				42D8417781E790CA6AA49F7E /* CursorInstallerTests.swift in Sources */,
 				EC2C564EBA85B494489DF323 /* CursorModelVariantsTests.swift in Sources */,
 				25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */,

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -813,19 +813,27 @@ struct AppKitDiffReviewHeaderRowBody: View {
                 .font(.system(size: 12, weight: .semibold, design: .monospaced))
                 .foregroundColor(statusColor)
                 .frame(width: 16)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(input.file.summary.path)
-                    .font(CenterTypography.codeFont(family: input.codeFontFamily, size: input.codeFontSize))
-                    .foregroundColor(input.theme.color("fg"))
-                    .lineLimit(1).truncationMode(.middle)
-                if let originalPath = input.file.summary.originalPath {
-                    Text("from \(originalPath)")
-                        .font(.system(size: 10.5))
-                        .foregroundColor(input.theme.color("fg-faint"))
-                        .lineLimit(1)
-                        .truncationMode(.middle)
+            Button {
+                input.state.copyFeedback.copy(input.file.summary.path)
+            } label: {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(input.file.summary.path)
+                        .font(CenterTypography.codeFont(family: input.codeFontFamily, size: input.codeFontSize))
+                        .foregroundColor(input.theme.color("fg"))
+                        .lineLimit(1).truncationMode(.middle)
+                    if let originalPath = input.file.summary.originalPath {
+                        Text("from \(originalPath)")
+                            .font(.system(size: 10.5))
+                            .foregroundColor(input.theme.color("fg-faint"))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
                 }
             }
+            .buttonStyle(.plain)
+            .pointingHandCursor()
+            .help("Copy path")
+            .accessibilityLabel("Copy \(input.file.summary.path)")
             if input.showsSourceBadge, let title = input.file.summary.groupTitle {
                 Text(title.uppercased())
                     .font(.system(size: 9.5, weight: .semibold))

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -51,6 +51,7 @@ struct DiffTabView: View {
     @State private var reviewExpandedCollapsedRowIDs: Set<String> = []
     @State private var wrapLines = false
     @State private var showWhitespace = false
+    @StateObject private var copyFeedback = CopyFeedbackState()
     @StateObject private var renderContextCache = DiffTabRenderContextCache()
     @FocusState private var draftComposerFocused: Bool
 
@@ -156,6 +157,7 @@ struct DiffTabView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(theme.color("bg-1"))
+        .copyFeedbackOverlay(message: copyFeedback.message)
         .onChange(of: loadKey, initial: true) { _, _ in loadDraftCommentController() }
         .task(id: loadKey) {
             await load()
@@ -257,28 +259,38 @@ struct DiffTabView: View {
 
     private var header: some View {
         HStack(spacing: 12) {
-            Text((relativePath as NSString).lastPathComponent)
-                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize))
-                .foregroundColor(theme.color("fg"))
-            if compareWithHEAD {
-                Text("HEAD")
-                    .font(.system(size: 9.5, weight: .semibold))
-                    .padding(.horizontal, 5).padding(.vertical, 1)
-                    .background(theme.color("accent").opacity(0.16))
-                    .foregroundColor(theme.color("accent"))
-                    .clipShape(RoundedRectangle(cornerRadius: 3))
-            } else if staged {
-                Text("STAGED")
-                    .font(.system(size: 9.5, weight: .semibold))
-                    .padding(.horizontal, 5).padding(.vertical, 1)
-                    .background(theme.color("info").opacity(0.18))
-                    .foregroundColor(theme.color("info"))
-                    .clipShape(RoundedRectangle(cornerRadius: 3))
+            Button {
+                copyFeedback.copy(relativePath)
+            } label: {
+                HStack(spacing: 12) {
+                    Text((relativePath as NSString).lastPathComponent)
+                        .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize))
+                        .foregroundColor(theme.color("fg"))
+                    if compareWithHEAD {
+                        Text("HEAD")
+                            .font(.system(size: 9.5, weight: .semibold))
+                            .padding(.horizontal, 5).padding(.vertical, 1)
+                            .background(theme.color("accent").opacity(0.16))
+                            .foregroundColor(theme.color("accent"))
+                            .clipShape(RoundedRectangle(cornerRadius: 3))
+                    } else if staged {
+                        Text("STAGED")
+                            .font(.system(size: 9.5, weight: .semibold))
+                            .padding(.horizontal, 5).padding(.vertical, 1)
+                            .background(theme.color("info").opacity(0.18))
+                            .foregroundColor(theme.color("info"))
+                            .clipShape(RoundedRectangle(cornerRadius: 3))
+                    }
+                    Text("·").foregroundColor(theme.color("fg-faint"))
+                    Text((relativePath as NSString).deletingLastPathComponent)
+                        .font(.system(size: codeFontSize - 1.5))
+                        .foregroundColor(theme.color("fg-dim"))
+                }
             }
-            Text("·").foregroundColor(theme.color("fg-faint"))
-            Text((relativePath as NSString).deletingLastPathComponent)
-                .font(.system(size: codeFontSize - 1.5))
-                .foregroundColor(theme.color("fg-dim"))
+            .buttonStyle(.plain)
+            .pointingHandCursor()
+            .help("Copy path")
+            .accessibilityLabel("Copy \(relativePath)")
             Spacer()
             if shouldShowChangeSummary(additions: totalAdd, deletions: totalDel) {
                 HStack(spacing: 10) {

--- a/Alas/Sources/Center/ImageDiff/ImageDiffView.swift
+++ b/Alas/Sources/Center/ImageDiff/ImageDiffView.swift
@@ -9,6 +9,7 @@ struct ImageDiffView: View {
     let onRetry: (() -> Void)?
 
     @State private var presentation = ImageDiffPresentationState()
+    @StateObject private var copyFeedback = CopyFeedbackState()
     @Environment(\.theme) private var theme
 
     init(
@@ -31,6 +32,7 @@ struct ImageDiffView: View {
             content
         }
         .background(theme.color("bg-1"))
+        .copyFeedbackOverlay(message: copyFeedback.message)
         .onAppear {
             presentation.updateDisplayedPair(pair, identity: pairPresentationIdentity)
         }
@@ -51,22 +53,32 @@ struct ImageDiffView: View {
 
     private var header: some View {
         HStack(spacing: 10) {
-            Text((relativePath as NSString).lastPathComponent)
-                .font(.system(size: 12, design: .monospaced))
-                .foregroundColor(theme.color("fg"))
-            if let sourceBadge {
-                Text(sourceBadge)
-                    .font(.system(size: 9.5, weight: .semibold))
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 1)
-                    .background(theme.color("accent").opacity(0.16))
-                    .foregroundColor(theme.color("accent"))
-                    .clipShape(RoundedRectangle(cornerRadius: 3))
+            Button {
+                copyFeedback.copy(relativePath)
+            } label: {
+                HStack(spacing: 10) {
+                    Text((relativePath as NSString).lastPathComponent)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(theme.color("fg"))
+                    if let sourceBadge {
+                        Text(sourceBadge)
+                            .font(.system(size: 9.5, weight: .semibold))
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(theme.color("accent").opacity(0.16))
+                            .foregroundColor(theme.color("accent"))
+                            .clipShape(RoundedRectangle(cornerRadius: 3))
+                    }
+                    Text("·").foregroundColor(theme.color("fg-faint"))
+                    Text((relativePath as NSString).deletingLastPathComponent)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.color("fg-dim"))
+                }
             }
-            Text("·").foregroundColor(theme.color("fg-faint"))
-            Text((relativePath as NSString).deletingLastPathComponent)
-                .font(.system(size: 11))
-                .foregroundColor(theme.color("fg-dim"))
+            .buttonStyle(.plain)
+            .pointingHandCursor()
+            .help("Copy path")
+            .accessibilityLabel("Copy \(relativePath)")
             if pair.kind == .renamed, let old = pair.oldPath {
                 pathChangeChip(kind: "RENAMED", old: old, new: relativePath)
             }

--- a/Alas/Sources/UI/CopyFeedbackState.swift
+++ b/Alas/Sources/UI/CopyFeedbackState.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 @MainActor
@@ -33,6 +34,11 @@ final class CopyFeedbackState: ObservableObject {
                 self?.message = nil
             }
         }
+    }
+
+    func copy(_ text: String, to pasteboard: NSPasteboard = .general) {
+        Clipboard.copy(text, to: pasteboard)
+        show("Copied")
     }
 }
 

--- a/AlasTests/CopyFeedbackStateTests.swift
+++ b/AlasTests/CopyFeedbackStateTests.swift
@@ -1,0 +1,16 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+struct CopyFeedbackStateTests {
+    @Test func copyingWritesPathAndShowsFeedback() {
+        let pasteboard = NSPasteboard(name: .init("CopyFeedbackStateTests"))
+        let state = CopyFeedbackState()
+
+        state.copy("Alas/Sources/App.swift", to: pasteboard)
+
+        #expect(pasteboard.string(forType: .string) == "Alas/Sources/App.swift")
+        #expect(state.message == "Copied")
+    }
+}


### PR DESCRIPTION
## Summary

Make file paths in normal and review diff headers clickable so they copy the full repository-relative path and show the existing Copied feedback chip.

## Changes

- Reuse clipboard feedback state for path copying.
- Add accessible path buttons in both diff header variants.
- Cover the copy feedback state with a focused test.

## Verification

- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination "platform=macOS" -quiet build
- Focused CopyFeedbackStateTests pass

The full test suite was interrupted after unrelated existing failures in PairedPrimaryComposerSurfaceTests and RightPaneGGStackTests.