### PR TITLE
feat(chat): Show ACP message timestamps and tool durations

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -601,6 +601,7 @@
 		604583AA3E3CE525933DA2AA /* EditorBufferExternalEditableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DEE18D06DCB7DE3C8C8D91A /* EditorBufferExternalEditableTests.swift */; };
 		604E881461FC839C4233B0AF /* LSPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D394D40BC9060833DD640A /* LSPInstaller.swift */; };
 		6094D26DB816FAD6FD9BE7F9 /* DiffReviewSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3B3FF5D7B8F892ED1972A8 /* DiffReviewSurface.swift */; };
+		6098FBC9DC3C6DF449F9B60B /* ACPMessageTimestampFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888C6244788973A640F4F138 /* ACPMessageTimestampFormatter.swift */; };
 		60F31F7C4A8A69EDE77363FB /* ReviewSessionModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8CA584A5F9F1BDE903E8D2 /* ReviewSessionModelsTests.swift */; };
 		610486A9FA350E77D1BF594B /* ACPTerminalTailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFD1CE53DE229626220B457 /* ACPTerminalTailView.swift */; };
 		6117C4AD7519BCD82EA0CF56 /* RightPaneTransitionalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */; };
@@ -803,6 +804,7 @@
 		84AFBFC844DF35AF5D37445B /* ACPGoalPillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA7FA6A8011D88FDFEE30A0 /* ACPGoalPillTests.swift */; };
 		84C505BF196A3BDA23C80235 /* LanguageServerConfigMasonPrefill.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */; };
 		84E96EB0EF4267784462B866 /* ACPComposerImageExtractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A637073E5D65DAA4E0CF6EA4 /* ACPComposerImageExtractTests.swift */; };
+		84F4596377F20F0133EB011C /* ACPMessageTimestampFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584AB9AD4F75DB8BB326B7D1 /* ACPMessageTimestampFormatterTests.swift */; };
 		850D54DB270088190BA20A13 /* DiffInlineCommentCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4526714086C04ED5B472C90 /* DiffInlineCommentCard.swift */; };
 		8510C6B68C2CF6664574C161 /* ACPSystemNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */; };
 		8514D39E901232E7C7343C26 /* FakeJSONRPCTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E340D23D2484C570F8E4B7F /* FakeJSONRPCTransport.swift */; };
@@ -2127,6 +2129,7 @@
 		57B7225443DF69C32D25338D /* SpacesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacesPane.swift; sourceTree = "<group>"; };
 		57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledFontRegistrar.swift; sourceTree = "<group>"; };
 		57E1A9B42D47CC0244C24F7B /* ACPElicitationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPElicitationTests.swift; sourceTree = "<group>"; };
+		584AB9AD4F75DB8BB326B7D1 /* ACPMessageTimestampFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageTimestampFormatterTests.swift; sourceTree = "<group>"; };
 		58BC051640BBB02A2EBF6E4F /* ReviewDraftCommentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentController.swift; sourceTree = "<group>"; };
 		596BB6B295D768E2C0D3BC85 /* FileSystemOpenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemOpenTests.swift; sourceTree = "<group>"; };
 		59C7BDB3BEEB5B23DCE7F2C0 /* GGWorktreeContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGWorktreeContext.swift; sourceTree = "<group>"; };
@@ -2411,6 +2414,7 @@
 		88379ACE40F42BE4A3257659 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		883981BBADF9816718091CE1 /* MergeScrollCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeScrollCoordinatorTests.swift; sourceTree = "<group>"; };
 		888112C4BC28BBC55C6804FA /* MermaidDiagramLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidDiagramLayoutTests.swift; sourceTree = "<group>"; };
+		888C6244788973A640F4F138 /* ACPMessageTimestampFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageTimestampFormatter.swift; sourceTree = "<group>"; };
 		88C6356C759B509DD81EDEBB /* ACPConfigOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConfigOption.swift; sourceTree = "<group>"; };
 		88DCE75EFAA8F6E576343CE5 /* RemoteTranscriptSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTranscriptSync.swift; sourceTree = "<group>"; };
 		89034A1968C6BC371826314D /* ACPSessionOrchestrationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionOrchestrationCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -4260,6 +4264,7 @@
 				8718406234B8C879B9D0CAB1 /* ACPMarkdownTextBareURLTests.swift */,
 				E64221361A2743CDAD692E64 /* ACPMCPStatusPolicyTests.swift */,
 				E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */,
+				584AB9AD4F75DB8BB326B7D1 /* ACPMessageTimestampFormatterTests.swift */,
 				D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */,
 				80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */,
 				44ACE3DEC81C465524111058 /* ACPQuestionPromptTests.swift */,
@@ -4674,6 +4679,7 @@
 				E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */,
 				29FCCD153F9C2AF78A7B2E47 /* ACPMessageGutter.swift */,
 				3F79A184C86BE6C6BF72EB57 /* ACPMessageList.swift */,
+				888C6244788973A640F4F138 /* ACPMessageTimestampFormatter.swift */,
 				CF80D59C3200AD3215D1E140 /* ACPNewChatEmptyStatePolicy.swift */,
 				7294C0B27241ADEB9A95347A /* ACPNewChatEmptyStateView.swift */,
 				0BCD93747BF71CB256038314 /* ACPPermissionPrompt.swift */,
@@ -6092,6 +6098,7 @@
 				94354D17B0FEF3F0046B452A /* ACPMessage.swift in Sources */,
 				CD70FE88F62533B4A2A281B4 /* ACPMessageGutter.swift in Sources */,
 				37DD3F3B818131973DAA2B9B /* ACPMessageList.swift in Sources */,
+				6098FBC9DC3C6DF449F9B60B /* ACPMessageTimestampFormatter.swift in Sources */,
 				9D4F9F5CE9FF51C33E32703C /* ACPMessageWire.swift in Sources */,
 				B8412B44C090B4AA6A892D25 /* ACPMessages.swift in Sources */,
 				552EBB79C20E7D939C7015A1 /* ACPMockClient.swift in Sources */,
@@ -6908,6 +6915,7 @@
 				26F83C65E75B5F44024FEF1F /* ACPMentionPickerTests.swift in Sources */,
 				9737C1A3CD708D28C62FD6A5 /* ACPMessageStableIdTests.swift in Sources */,
 				D10A8F47A537C1C8969752B1 /* ACPMessageTests.swift in Sources */,
+				84F4596377F20F0133EB011C /* ACPMessageTimestampFormatterTests.swift in Sources */,
 				BC4B8B193F020CBEA02B01A6 /* ACPMessageWireTests.swift in Sources */,
 				395276FB3018E0B9E68A7D81 /* ACPMockClientTests.swift in Sources */,
 				FB51C37DBD897B3A690DCDC3 /* ACPNewChatEmptyStateTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -197,6 +197,16 @@ enum ACPMessage: Equatable {
         /// `ACPTerminalTailView` per id, in addition to whatever text
         /// content the agent emitted.
         var terminalIds: [String]
+        /// Local observation times for the active part of a tool invocation.
+        /// They are intentionally optional because an adapter can first report
+        /// a call after it has already reached a terminal state.
+        var executionStartedAt: Date?
+        var executionFinishedAt: Date?
+
+        var executionDuration: TimeInterval? {
+            guard let executionStartedAt, let executionFinishedAt else { return nil }
+            return max(0, executionFinishedAt.timeIntervalSince(executionStartedAt))
+        }
 
         /// Set when `content` has been truncated to save memory. The full
         /// content is still in SQLite (`ACPSessionStore.loadMessages`) and
@@ -296,7 +306,8 @@ enum ACPMessage: Equatable {
              contentLanguage: String? = nil, rawInput: String? = nil,
              rawOutput: String? = nil, metadata: AnyCodable? = nil,
              assets: [ToolCallAsset] = [],
-             locations: [String]? = nil, terminalIds: [String] = [])
+             locations: [String]? = nil, terminalIds: [String] = [],
+             executionStartedAt: Date? = nil, executionFinishedAt: Date? = nil)
         {
             self.toolCallId = toolCallId
             self.title = title
@@ -311,6 +322,8 @@ enum ACPMessage: Equatable {
             self.assets = assets
             self.locations = locations ?? []
             self.terminalIds = terminalIds
+            self.executionStartedAt = executionStartedAt
+            self.executionFinishedAt = executionFinishedAt
         }
 
         // Backwards-compatible decoder: older messages persisted only a
@@ -319,7 +332,7 @@ enum ACPMessage: Equatable {
         enum CodingKeys: String, CodingKey {
             case toolCallId, title, kind, status, content, preview,
                  contentSummary, contentLanguage, rawInput, rawOutput, metadata,
-                 assets, locations, terminalIds
+                 assets, locations, terminalIds, executionStartedAt, executionFinishedAt
         }
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -337,6 +350,8 @@ enum ACPMessage: Equatable {
             assets = (try? c.decode([ToolCallAsset].self, forKey: .assets)) ?? []
             locations = (try? c.decode([String].self, forKey: .locations)) ?? []
             terminalIds = (try? c.decode([String].self, forKey: .terminalIds)) ?? []
+            executionStartedAt = try? c.decode(Date.self, forKey: .executionStartedAt)
+            executionFinishedAt = try? c.decode(Date.self, forKey: .executionFinishedAt)
         }
         func encode(to encoder: Encoder) throws {
             var c = encoder.container(keyedBy: CodingKeys.self)
@@ -353,6 +368,8 @@ enum ACPMessage: Equatable {
             try c.encode(assets, forKey: .assets)
             try c.encode(locations, forKey: .locations)
             try c.encode(terminalIds, forKey: .terminalIds)
+            try c.encodeIfPresent(executionStartedAt, forKey: .executionStartedAt)
+            try c.encodeIfPresent(executionFinishedAt, forKey: .executionFinishedAt)
         }
 
         // Manual Equatable/Hashable: `isContentTruncated` is an in-memory-only
@@ -373,6 +390,8 @@ enum ACPMessage: Equatable {
                 && lhs.assets == rhs.assets
                 && lhs.locations == rhs.locations
                 && lhs.terminalIds == rhs.terminalIds
+                && lhs.executionStartedAt == rhs.executionStartedAt
+                && lhs.executionFinishedAt == rhs.executionFinishedAt
         }
 
         func hash(into hasher: inout Hasher) {
@@ -389,6 +408,8 @@ enum ACPMessage: Equatable {
             hasher.combine(assets)
             hasher.combine(locations)
             hasher.combine(terminalIds)
+            hasher.combine(executionStartedAt)
+            hasher.combine(executionFinishedAt)
         }
 
         mutating func replaceContent(_ newContent: String) {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -389,7 +389,11 @@ final class ACPSession: ObservableObject, Identifiable {
     /// `.plan` or `.toolCallUpdate` can mutate a message anywhere in the
     /// transcript, not just the trailing row.
     @discardableResult
-    func apply(_ update: ACPSessionUpdate, tracksRetryStatus: Bool = true) -> Set<Int> {
+    func apply(
+        _ update: ACPSessionUpdate,
+        tracksRetryStatus: Bool = true,
+        at timestamp: Date = Date()
+    ) -> Set<Int> {
         if tracksRetryStatus {
             switch update {
             case .agentMessageChunk, .agentThoughtChunk, .toolCall, .toolCallUpdate, .plan:
@@ -515,7 +519,9 @@ final class ACPSession: ObservableObject, Identifiable {
                 metadata: payload.metadata,
                 assets: Self.mergeAssets(Self.extractAssets(items), rawOutputAssets),
                 locations: payload.locations?.map(\.path) ?? [],
-                terminalIds: terminalIds)))
+                terminalIds: terminalIds,
+                executionStartedAt: payload.status == "in_progress" ? timestamp : nil)),
+                createdAt: timestamp)
             didAppendTranscriptMessage()
             transcript.completedOutputBoundaryMessageIds.removeAll()
             applyToolCallMetadata(payload.metadata)
@@ -524,6 +530,13 @@ final class ACPSession: ObservableObject, Identifiable {
             clearRestoredContextRecoveryStatus()
             let touched = updateToolCall(id: u.toolCallId) { tc in
                 Self.applyToolCallUpdateFields(u, to: &tc)
+                if tc.status == "in_progress", tc.executionStartedAt == nil {
+                    tc.executionStartedAt = timestamp
+                }
+                if Self.isFinalStatus(tc.status), tc.executionStartedAt != nil,
+                   tc.executionFinishedAt == nil {
+                    tc.executionFinishedAt = timestamp
+                }
             }
             if touched != nil {
                 applyToolCallMetadata(u.metadata)
@@ -1325,9 +1338,14 @@ final class ACPSession: ObservableObject, Identifiable {
         transcript.completedOutputBoundaryMessageIds.removeAll()
     }
 
-    func replaceTranscriptMessages(_ messages: [ACPMessage], messageIndexOffset: Int = 0) {
+    func replaceTranscriptMessages(
+        _ messages: [ACPMessage],
+        createdAts: [Date]? = nil,
+        messageIndexOffset: Int = 0
+    ) {
         transcript.replaceMessages(
             with: messagesPreservingToolCallContentRevisions(messages),
+            createdAts: createdAts,
             messageIndexOffset: messageIndexOffset
         )
     }
@@ -1360,9 +1378,9 @@ final class ACPSession: ObservableObject, Identifiable {
     /// forward by `older.count` so the visible tail window stays anchored to
     /// the same messages. Used by the post-hydration backfill that prepends
     /// pre-tail messages after the UI has already painted the tail.
-    func prependTranscriptMessages(_ older: [ACPMessage]) {
+    func prependTranscriptMessages(_ older: [ACPMessage], createdAts: [Date]? = nil) {
         guard !older.isEmpty else { return }
-        transcript.prependMessages(older)
+        transcript.prependMessages(older, createdAts: createdAts)
         // Keep the visible window anchored to the tail the user is already
         // looking at while trimming newly-hidden historical tool output.
         transcript.shiftVisibleHeadAfterPrepending(older.count)

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1592,12 +1592,15 @@ final class ACPSession: ObservableObject, Identifiable {
     /// status reflects reality (the agent isn't coming back to finish
     /// these). Returns the indices of mutated messages so callers can
     /// persist them.
-    func cancelInFlightToolCalls() -> [Int] {
+    func cancelInFlightToolCalls(at timestamp: Date = Date()) -> [Int] {
         var changed: [Int] = []
         for i in transcript.messages.indices {
             if case .toolCall(var tc) = transcript.messages[i],
                tc.status == "in_progress" || tc.status == "pending" {
                 tc.status = "canceled"
+                if tc.executionStartedAt != nil, tc.executionFinishedAt == nil {
+                    tc.executionFinishedAt = timestamp
+                }
                 transcript.replaceMessage(at: i, with: .toolCall(tc))
                 changed.append(i)
             }

--- a/Alas/Sources/ACP/Session/ACPSessionHydrator.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionHydrator.swift
@@ -53,11 +53,14 @@ actor ACPSessionHydrator {
         let queue = (try? store.loadQueue(sessionId: sessionId)) ?? []
         var staleSubmittedDraft = false
         var sawRecordedSubmittedDraft = false
-        var wire: [ACPMessageWire] = []
-        wire.reserveCapacity(stored.count)
+        var messages: [ACPHydratedMessage] = []
+        messages.reserveCapacity(stored.count)
         for m in stored {
             if let w = try? ACPMessageWire.decode(kind: m.kind, payload: m.payload, decoder: decoder) {
-                wire.append(w)
+                messages.append(.init(
+                    wire: w,
+                    createdAt: Date(timeIntervalSince1970: TimeInterval(m.createdAt))
+                ))
                 if storedDraft != nil,
                    sawRecordedSubmittedDraft,
                    w.isAgentSideProgress {
@@ -92,7 +95,7 @@ actor ACPSessionHydrator {
 
         return HydrationResult(
             row: row,
-            wireMessages: wire,
+            messages: messages,
             queue: queue,
             draft: draft,
             forkRecord: forkRecord,
@@ -105,11 +108,13 @@ actor ACPSessionHydrator {
 /// `StreamingText`, a `@MainActor` class).
 struct HydrationResult: Sendable {
     let row: ACPSessionRow
-    let wireMessages: [ACPMessageWire]
+    let messages: [ACPHydratedMessage]
     let queue: [QueuedPrompt]
     let draft: ACPComposerDraft?
     let forkRecord: ACPSessionForkRecord?
     let recent: [ACPSessionRow]
+
+    var wireMessages: [ACPMessageWire] { messages.map(\.wire) }
 
     func replacingRowLastOpenedAt(_ lastOpenedAt: Int64) -> HydrationResult {
         HydrationResult(
@@ -126,7 +131,7 @@ struct HydrationResult: Sendable {
                 createdAt: row.createdAt, updatedAt: row.updatedAt,
                 lastOpenedAt: lastOpenedAt,
                 archived: row.archived),
-            wireMessages: wireMessages,
+            messages: messages,
             queue: queue,
             draft: draft,
             forkRecord: forkRecord,
@@ -136,10 +141,15 @@ struct HydrationResult: Sendable {
     func replacingRecent(_ recent: [ACPSessionRow]) -> HydrationResult {
         HydrationResult(
             row: row,
-            wireMessages: wireMessages,
+            messages: messages,
             queue: queue,
             draft: draft,
             forkRecord: forkRecord,
             recent: recent)
     }
+}
+
+struct ACPHydratedMessage: Sendable {
+    let wire: ACPMessageWire
+    let createdAt: Date
 }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -412,7 +412,7 @@ final class ACPSessionManager: ObservableObject {
     /// tail-only paint applied by `applyHydration`. Tracked so tests (and
     /// teardown) can wait for it; production UI does not.
     private var inFlightBackfills: [ACPSession.ID: Task<Void, Never>] = [:]
-    private var pendingBackfillOlderWires: [ACPSession.ID: [ACPMessageWire]] = [:]
+    private var pendingBackfillOlderMessages: [ACPSession.ID: [ACPHydratedMessage]] = [:]
 
     /// Per-session UI refcount. When this drops to zero AND the session is
     /// not `attached`, the cached `ACPSession` is evicted from `sessions`.
@@ -869,8 +869,8 @@ final class ACPSessionManager: ObservableObject {
         // later prepends the older entries, `visibleHead` is shifted by
         // the prepended count so the same tail messages stay on screen
         // without a layout jump.
-        let wires = result.wireMessages
-        let tailStart = replaceTranscriptWithTail(wires, in: session, markCompletedBoundary: true)
+        let messages = result.messages
+        let tailStart = replaceTranscriptWithTail(messages, in: session, markCompletedBoundary: true)
         applyRememberedTranscriptScrollWindow(to: session, messageIndexOffset: tailStart)
         session.restoreQueue(result.queue)
         // The composer is rendered (and focused) the moment the placeholder
@@ -921,7 +921,7 @@ final class ACPSessionManager: ObservableObject {
         // we captured before the user typed it.
         session.hydrationState = .ready
         self.recent = result.recent
-        scheduleBackfillIfNeeded(olderWires: Array(wires.prefix(tailStart)),
+        scheduleBackfillIfNeeded(olderMessages: Array(messages.prefix(tailStart)),
                                  sessionId: session.id, session: session)
     }
 
@@ -930,20 +930,27 @@ final class ACPSessionManager: ObservableObject {
     /// any surrounding session state.
     @discardableResult
     private func replaceTranscriptWithTail(
-        _ wires: [ACPMessageWire],
+        _ messages: [ACPHydratedMessage],
         in session: ACPSession,
         markCompletedBoundary: Bool
     ) -> Int {
-        let total = wires.count
+        let total = messages.count
         let tailWindow = ACPTranscript.tailWindow
         let tailStart = max(0, total - tailWindow)
 
         var tail: [ACPMessage] = []
+        var tailCreatedAts: [Date] = []
         tail.reserveCapacity(total - tailStart)
+        tailCreatedAts.reserveCapacity(total - tailStart)
         for i in tailStart..<total {
-            tail.append(wires[i].toMessage())
+            tail.append(messages[i].wire.toMessage())
+            tailCreatedAts.append(messages[i].createdAt)
         }
-        session.replaceTranscriptMessages(tail, messageIndexOffset: tailStart)
+        session.replaceTranscriptMessages(
+            tail,
+            createdAts: tailCreatedAts,
+            messageIndexOffset: tailStart
+        )
         session.transcript.visibleHead = 0
         if markCompletedBoundary {
             // Seed completedOutputBoundaryMessageIds from loaded history so
@@ -982,26 +989,26 @@ final class ACPSessionManager: ObservableObject {
     /// the same instance: the user closed-then-reopened the tab and the
     /// fresh placeholder will run its own hydration.
     private func scheduleBackfillIfNeeded(
-        olderWires: [ACPMessageWire],
+        olderMessages: [ACPHydratedMessage],
         sessionId: ACPSession.ID,
         session: ACPSession
     ) {
         if let existing = inFlightBackfills[sessionId], !existing.isCancelled {
-            if olderWires.isEmpty {
+            if olderMessages.isEmpty {
                 existing.cancel()
                 inFlightBackfills[sessionId] = nil
-                pendingBackfillOlderWires[sessionId] = nil
+                pendingBackfillOlderMessages[sessionId] = nil
                 session.transcript.isBackfillingOlderMessages = false
             } else {
-                pendingBackfillOlderWires[sessionId] = olderWires
+                pendingBackfillOlderMessages[sessionId] = olderMessages
                 session.transcript.isBackfillingOlderMessages = true
             }
             return
         }
 
         inFlightBackfills[sessionId] = nil
-        pendingBackfillOlderWires[sessionId] = nil
-        guard !olderWires.isEmpty else { return }
+        pendingBackfillOlderMessages[sessionId] = nil
+        guard !olderMessages.isEmpty else { return }
         session.transcript.isBackfillingOlderMessages = true
 
         // Capture a stable handle the task body can compare against the
@@ -1028,16 +1035,19 @@ final class ACPSessionManager: ObservableObject {
             guard !Task.isCancelled else { return }
 
             var older: [ACPMessage] = []
-            older.reserveCapacity(olderWires.count)
+            older.reserveCapacity(olderMessages.count)
+            var olderCreatedAts: [Date] = []
+            olderCreatedAts.reserveCapacity(olderMessages.count)
             let batchSize = 100
             var index = 0
-            while index < olderWires.count {
-                let end = min(index + batchSize, olderWires.count)
+            while index < olderMessages.count {
+                let end = min(index + batchSize, olderMessages.count)
                 for i in index..<end {
-                    older.append(olderWires[i].toMessage())
+                    older.append(olderMessages[i].wire.toMessage())
+                    olderCreatedAts.append(olderMessages[i].createdAt)
                 }
                 index = end
-                if index < olderWires.count {
+                if index < olderMessages.count {
                     await Task.yield()
                     if Task.isCancelled { return }
                 }
@@ -1047,15 +1057,15 @@ final class ACPSessionManager: ObservableObject {
                   self.inFlightBackfills[sessionId] == me,
                   self.sessions[sessionId] === session
             else { return }
-            if let newerWires = self.pendingBackfillOlderWires.removeValue(forKey: sessionId) {
+            if let newerMessages = self.pendingBackfillOlderMessages.removeValue(forKey: sessionId) {
                 self.inFlightBackfills[sessionId] = nil
                 self.scheduleBackfillIfNeeded(
-                    olderWires: newerWires,
+                    olderMessages: newerMessages,
                     sessionId: sessionId,
                     session: session)
                 return
             }
-            session.prependTranscriptMessages(older)
+            session.prependTranscriptMessages(older, createdAts: olderCreatedAts)
             self.applyRememberedTranscriptScrollWindow(to: session)
         }
         handle.task = task
@@ -1070,7 +1080,7 @@ final class ACPSessionManager: ObservableObject {
         flushPendingDraftWrite(for: id)
         inFlightBackfills[id]?.cancel()
         inFlightBackfills[id] = nil
-        pendingBackfillOlderWires[id] = nil
+        pendingBackfillOlderMessages[id] = nil
         sessions[id]?.transcript.resetMarkdownCaches()
         sessions[id] = nil
         sessionRefCounts.removeValue(forKey: id)
@@ -1127,7 +1137,7 @@ final class ACPSessionManager: ObservableObject {
         cancelPendingDraftWrite(for: id)
         inFlightBackfills[id]?.cancel()
         inFlightBackfills[id] = nil
-        pendingBackfillOlderWires[id] = nil
+        pendingBackfillOlderMessages[id] = nil
         sessions[id]?.transcript.resetMarkdownCaches()
         sessions[id] = nil
         sessionRefCounts.removeValue(forKey: id)
@@ -1247,7 +1257,7 @@ final class ACPSessionManager: ObservableObject {
         flushPendingDraftWrite(for: id)
         inFlightBackfills[id]?.cancel()
         inFlightBackfills[id] = nil
-        pendingBackfillOlderWires[id] = nil
+        pendingBackfillOlderMessages[id] = nil
         // Stop any active mirror poll/subscription so the 2.5s poll task
         // doesn't keep waking after a mirrored tab closes. Idempotent —
         // no-op for writer sessions.
@@ -2886,12 +2896,12 @@ extension ACPSessionManager {
         session.restoreQueue(result.queue)
         guard !result.wireMessages.isEmpty else { return }
         let tailStart = replaceTranscriptWithTail(
-            result.wireMessages,
+            result.messages,
             in: session,
             markCompletedBoundary: false)
         applyRememberedTranscriptScrollWindow(to: session, messageIndexOffset: tailStart)
         scheduleBackfillIfNeeded(
-            olderWires: Array(result.wireMessages.prefix(tailStart)),
+            olderMessages: Array(result.messages.prefix(tailStart)),
             sessionId: sessionId,
             session: session)
     }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -2275,7 +2275,6 @@ extension ACPSessionRunner {
 
     private func persistStreamingPersistSnapshots() {
         guard !pendingStreamingPersistSnapshots.isEmpty else { return }
-        let now = Int64(Date().timeIntervalSince1970)
         let snapshots = pendingStreamingPersistSnapshots
         for i in snapshots.keys.sorted() {
             guard let snapshot = snapshots[i] else { continue }
@@ -2296,7 +2295,7 @@ extension ACPSessionRunner {
                     kind: snapshot.kind,
                     seq: Int64(i),
                     payload: snapshot.payload,
-                    createdAt: now
+                    createdAt: createdAt(forMessageAt: i)
                 )
                 enqueuePersistence { persistence in
                     _ = try await persistence.insertMessageIfMissing(row)
@@ -2332,7 +2331,6 @@ extension ACPSessionRunner {
             return true
         }
         let messages = session.transcript.messages
-        let now = Int64(Date().timeIntervalSince1970)
         var rows: [ACPStoredMessage] = []
         for i in indices.sorted() {
             guard i >= 0, i < messages.count else { continue }
@@ -2345,7 +2343,7 @@ extension ACPSessionRunner {
                 kind: m.kind,
                 seq: Int64(i),
                 payload: payload,
-                createdAt: now
+                createdAt: createdAt(forMessageAt: i)
             ))
         }
         let fence = requiresLease ? leaseFenceProvider() : nil
@@ -2370,6 +2368,11 @@ extension ACPSessionRunner {
 
     private func messageForPersistence(_ message: ACPMessage) -> ACPMessage {
         message
+    }
+
+    private func createdAt(forMessageAt index: Int) -> Int64 {
+        Int64(session.transcript.createdAt(forMessageAt: index)?.timeIntervalSince1970
+            ?? Date().timeIntervalSince1970)
     }
 
     private func commitPersistedMessageRows(_ rows: [ACPStoredMessage]) {
@@ -2411,7 +2414,6 @@ extension ACPSessionRunner {
             return
         }
 
-        let now = Int64(Date().timeIntervalSince1970)
         var rows: [ACPStoredMessage] = []
         for i in lowerBound..<messages.count {
             let m = messages[i]
@@ -2423,7 +2425,7 @@ extension ACPSessionRunner {
                 kind: m.kind,
                 seq: Int64(i),
                 payload: payload,
-                createdAt: now
+                createdAt: createdAt(forMessageAt: i)
             ))
         }
         let fence = leaseFenceProvider()

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -10,6 +10,7 @@ import Combine
 final class ACPTranscript: ObservableObject {
     @Published var messages: [ACPMessage] = [] {
         didSet {
+            synchronizeMessageCreatedAts()
             messagesGeneration &+= 1
             updatePlanCaches(for: pendingMessagesMutation)
             updateMessageIndexCaches(for: pendingMessagesMutation)
@@ -117,6 +118,7 @@ final class ACPTranscript: ObservableObject {
 
     private var markdownCaches: [String: ACPMarkdownBlockCache] = [:]
     private var stableIdCache: [ACPMessage.StableIdentityKey: String] = [:]
+    private var messageCreatedAts: [String: Date] = [:]
 
     func stableId(for message: ACPMessage) -> String {
         let key = message.stableIdentityKey
@@ -168,27 +170,73 @@ final class ACPTranscript: ObservableObject {
         return latestPlanMessageIndex
     }
 
-    func appendMessage(_ message: ACPMessage) {
+    func createdAt(forStableId stableId: String) -> Date? {
+        messageCreatedAts[stableId]
+    }
+
+    func createdAt(forMessageAt index: Int) -> Date? {
+        guard messages.indices.contains(index) else { return nil }
+        return createdAt(forStableId: stableId(for: messages[index]))
+    }
+
+    func appendMessage(_ message: ACPMessage, createdAt: Date = Date()) {
+        messageCreatedAts[stableId(for: message)] = createdAt
         pendingMessagesMutation = .append(message)
         messages.append(message)
     }
 
     func replaceMessage(at index: Int, with message: ACPMessage) {
         let old = messages[index]
+        let oldStableId = stableId(for: old)
+        let newStableId = stableId(for: message)
+        if oldStableId != newStableId {
+            messageCreatedAts[newStableId] = messageCreatedAts[oldStableId] ?? Date()
+            messageCreatedAts.removeValue(forKey: oldStableId)
+        }
         pendingMessagesMutation = .replace(index: index, old: old, new: message)
         messages[index] = message
     }
 
-    func replaceMessages(with newMessages: [ACPMessage], messageIndexOffset: Int = 0) {
+    func replaceMessages(
+        with newMessages: [ACPMessage],
+        createdAts: [Date]? = nil,
+        messageIndexOffset: Int = 0
+    ) {
+        let previousCreatedAts = messageCreatedAts
+        messageCreatedAts.removeAll(keepingCapacity: true)
+        for (index, message) in newMessages.enumerated() {
+            let stableId = stableId(for: message)
+            let createdAt = createdAts?.indices.contains(index) == true
+                ? createdAts![index]
+                : previousCreatedAts[stableId] ?? Date()
+            messageCreatedAts[stableId] = createdAt
+        }
         self.messageIndexOffset = max(0, messageIndexOffset)
         messages = newMessages
     }
 
-    func prependMessages(_ older: [ACPMessage]) {
+    func prependMessages(_ older: [ACPMessage], createdAts: [Date]? = nil) {
         guard !older.isEmpty else { return }
+        for (index, message) in older.enumerated() {
+            let createdAt = createdAts?.indices.contains(index) == true
+                ? createdAts![index]
+                : Date()
+            messageCreatedAts[stableId(for: message)] = createdAt
+        }
         messageIndexOffset = max(0, messageIndexOffset - older.count)
         pendingMessagesMutation = .prepend(count: older.count)
         messages.insert(contentsOf: older, at: 0)
+    }
+
+    private func synchronizeMessageCreatedAts() {
+        let stableIds = Set(messages.map { stableId(for: $0) })
+        messageCreatedAts = messageCreatedAts.filter { stableIds.contains($0.key) }
+        for message in messages {
+            let stableId = stableId(for: message)
+            if messageCreatedAts[stableId] == nil {
+                messageCreatedAts[stableId] = Date()
+            }
+        }
     }
 
     func globalIndex(forLocalIndex index: Int) -> Int? {

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -10,10 +10,15 @@ import Combine
 final class ACPTranscript: ObservableObject {
     @Published var messages: [ACPMessage] = [] {
         didSet {
-            synchronizeMessageCreatedAts()
+            let mutation = pendingMessagesMutation
+            // Incremental mutation helpers maintain timestamps directly. Only
+            // direct or wholesale assignments need to reconcile the map.
+            if mutation == nil {
+                synchronizeMessageCreatedAts()
+            }
             messagesGeneration &+= 1
-            updatePlanCaches(for: pendingMessagesMutation)
-            updateMessageIndexCaches(for: pendingMessagesMutation)
+            updatePlanCaches(for: mutation)
+            updateMessageIndexCaches(for: mutation)
             pendingMessagesMutation = nil
             recordMessagesDiff(old: oldValue)
         }

--- a/Alas/Sources/ACP/UI/ACPMessageGutter.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageGutter.swift
@@ -35,6 +35,8 @@ struct ACPMessageGutter<Content: View>: View {
     /// a reference to the live buffer so copy reads the latest text without a
     /// per-row closure recreated on every list evaluation.
     let copySource: CopySource
+    let messageCreatedAt: Date?
+    let showsInlineTimestamp: Bool
     let forkBoundary: ACPForkMessageBoundary?
     let forkTargets: [ACPSessionForkTarget]
     let onQuote: (String) -> Void
@@ -47,7 +49,7 @@ struct ACPMessageGutter<Content: View>: View {
     var body: some View {
         content
             .overlay(alignment: .topTrailing) {
-                dotsMenu
+                actions
                     // Keep the menu label mounted at all times and toggle
                     // visibility via opacity/hit-testing rather than inserting
                     // and removing the view. Removing the label while its menu
@@ -62,7 +64,7 @@ struct ACPMessageGutter<Content: View>: View {
                     // lane reserved by the container; this relies on no ancestor
                     // applying `clipped()` (SwiftUI does not clip overlays by
                     // default), which also keeps the button hit-testable.
-                    .offset(x: ACPMessageGutterLayout.laneWidth - 8, y: -2)
+                    .offset(x: actionsOffsetX, y: -2)
                     // The button sits in the lane, outside `content`'s hover
                     // region, so it must keep itself alive while hovered —
                     // otherwise pointing at it past the hide delay would fade
@@ -76,9 +78,42 @@ struct ACPMessageGutter<Content: View>: View {
             }
     }
 
+    @ViewBuilder private var actions: some View {
+        if showsInlineTimestamp, messageCreatedAt != nil {
+            VStack(alignment: .leading, spacing: ACPMessageGutterLayout.timestampVerticalSpacing) {
+                dotsMenu
+                timestamp
+            }
+            .frame(width: ACPMessageGutterLayout.timestampWidth, alignment: .leading)
+        } else {
+            dotsMenu
+        }
+    }
+
+    private var actionsOffsetX: CGFloat {
+        let expandedWidth = showsInlineTimestamp && messageCreatedAt != nil
+            ? ACPMessageGutterLayout.timestampWidth - ACPMessageGutterLayout.menuWidth
+            : 0
+        return ACPMessageGutterLayout.laneWidth - 8 + expandedWidth
+    }
+
+    @ViewBuilder private var timestamp: some View {
+        if let messageCreatedAt {
+            Text(ACPMessageTimestampFormatter.string(for: messageCreatedAt))
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundStyle(theme.color("fg-faint"))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 4)
+                .background(theme.color("bg-3").opacity(0.92))
+                .clipShape(Capsule())
+                .accessibilityHidden(true)
+        }
+    }
+
     private var dotsMenu: some View {
         ACPMessageActionsButton(
             copySource: copySource,
+            timestampText: messageCreatedAt.map { ACPMessageTimestampFormatter.string(for: $0) },
             forkBoundary: forkBoundary,
             forkTargets: forkTargets,
             onQuote: onQuote,
@@ -99,6 +134,7 @@ struct ACPMessageGutter<Content: View>: View {
 
 private struct ACPMessageActionsButton: NSViewRepresentable {
     let copySource: ACPMessageCopySource
+    let timestampText: String?
     let forkBoundary: ACPForkMessageBoundary?
     let forkTargets: [ACPSessionForkTarget]
     let onQuote: (String) -> Void
@@ -108,6 +144,7 @@ private struct ACPMessageActionsButton: NSViewRepresentable {
     func makeCoordinator() -> Coordinator {
         Coordinator(
             copySource: copySource,
+            timestampText: timestampText,
             forkBoundary: forkBoundary,
             forkTargets: forkTargets,
             onQuote: onQuote,
@@ -125,6 +162,7 @@ private struct ACPMessageActionsButton: NSViewRepresentable {
 
     func updateNSView(_ button: NSButton, context: Context) {
         context.coordinator.copySource = copySource
+        context.coordinator.timestampText = timestampText
         context.coordinator.forkBoundary = forkBoundary
         context.coordinator.forkTargets = forkTargets
         context.coordinator.onQuote = onQuote
@@ -135,6 +173,7 @@ private struct ACPMessageActionsButton: NSViewRepresentable {
     @MainActor
     final class Coordinator: NSObject {
         var copySource: ACPMessageCopySource
+        var timestampText: String?
         var forkBoundary: ACPForkMessageBoundary?
         var forkTargets: [ACPSessionForkTarget]
         var onQuote: (String) -> Void
@@ -142,12 +181,14 @@ private struct ACPMessageActionsButton: NSViewRepresentable {
 
         init(
             copySource: ACPMessageCopySource,
+            timestampText: String?,
             forkBoundary: ACPForkMessageBoundary?,
             forkTargets: [ACPSessionForkTarget],
             onQuote: @escaping (String) -> Void,
             onFork: @escaping (ACPForkMessageBoundary, String) -> Void
         ) {
             self.copySource = copySource
+            self.timestampText = timestampText
             self.forkBoundary = forkBoundary
             self.forkTargets = forkTargets
             self.onQuote = onQuote
@@ -156,6 +197,12 @@ private struct ACPMessageActionsButton: NSViewRepresentable {
 
         @objc func showMenu(_ sender: NSButton) {
             let menu = NSMenu()
+            if let timestampText {
+                let timestampItem = NSMenuItem(title: timestampText, action: nil, keyEquivalent: "")
+                timestampItem.isEnabled = false
+                menu.addItem(timestampItem)
+                menu.addItem(.separator())
+            }
             let copyItem = NSMenuItem(
                 title: "Copy message",
                 action: #selector(copyMessage(_:)),
@@ -261,4 +308,8 @@ enum ACPMessageGutterLayout {
     /// Width of each reserved side lane. The left lane stays empty (reads as
     /// padding); the right lane hosts the "…" on hover.
     static let laneWidth: CGFloat = 32
+    static let menuWidth: CGFloat = 19
+    static let inlineTimestampMinimumContentWidth: CGFloat = 520
+    static let timestampVerticalSpacing: CGFloat = 4
+    static let timestampWidth: CGFloat = 128
 }

--- a/Alas/Sources/ACP/UI/ACPMessageGutter.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageGutter.swift
@@ -312,4 +312,5 @@ enum ACPMessageGutterLayout {
     static let inlineTimestampMinimumContentWidth: CGFloat = 520
     static let timestampVerticalSpacing: CGFloat = 4
     static let timestampWidth: CGFloat = 128
+    static let inlineTimestampTrailingExtent: CGFloat = laneWidth - 8 + timestampWidth - menuWidth
 }

--- a/Alas/Sources/ACP/UI/ACPMessageTimestampFormatter.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageTimestampFormatter.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum ACPMessageTimestampFormatter {
+    static func string(
+        for date: Date,
+        relativeTo now: Date = Date(),
+        calendar: Calendar = .current,
+        locale: Locale = .current
+    ) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.calendar = calendar
+        formatter.timeZone = calendar.timeZone
+        if calendar.isDate(date, inSameDayAs: now) {
+            formatter.dateFormat = "HH:mm"
+        } else if calendar.component(.year, from: date) == calendar.component(.year, from: now) {
+            formatter.dateFormat = "d MMM, HH:mm"
+        } else {
+            formatter.dateFormat = "d MMM yyyy, HH:mm"
+        }
+        return formatter.string(from: date)
+    }
+}
+
+enum ACPToolCallDurationFormatter {
+    static func string(for duration: TimeInterval, locale: Locale = .current) -> String {
+        let seconds = max(0, duration)
+        let fractionDigits = seconds < 10 ? 1 : 0
+        let formatter = NumberFormatter()
+        formatter.locale = locale
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = fractionDigits
+        let value = formatter.string(from: seconds as NSNumber) ?? "0"
+        return "\(value)s"
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -7,6 +7,7 @@ import AppKit
 /// renders an animated spinner instead of a static glyph.
 struct ACPToolCallCard: View {
     let toolCall: ACPMessage.ToolCall
+    let messageCreatedAt: Date?
     var trustedImageRoot: URL? = nil
     /// Closure that returns the full persisted `content` for the tool call
     /// whose in-memory `content` was truncated when its row left the render
@@ -19,16 +20,19 @@ struct ACPToolCallCard: View {
     @State private var expandedContent: String? = nil
     @State private var expandedSyntax = ACPToolCallSyntaxCache()
     @State private var loadingContentToolCallId: String? = nil
+    @State private var isHovering = false
     @Environment(\.theme) private var theme
     @Environment(\.acpTerminalHost) private var terminalHost
 
     init(
         toolCall: ACPMessage.ToolCall,
+        messageCreatedAt: Date? = nil,
         trustedImageRoot: URL? = nil,
         loadFullContent: ((String) async -> String?)? = nil,
         initiallyExpanded: Bool = false
     ) {
         self.toolCall = toolCall
+        self.messageCreatedAt = messageCreatedAt
         self.trustedImageRoot = trustedImageRoot
         self.loadFullContent = loadFullContent
         _expanded = State(initialValue: initiallyExpanded)
@@ -73,6 +77,20 @@ struct ACPToolCallCard: View {
                             .truncationMode(.middle)
                     }
                     Spacer(minLength: 6)
+                    if isHovering, let messageCreatedAt {
+                        Text(ACPMessageTimestampFormatter.string(for: messageCreatedAt))
+                            .font(.system(size: 10, weight: .medium, design: .monospaced))
+                            .foregroundStyle(theme.color("fg-faint"))
+                            .lineLimit(1)
+                    }
+                    if let duration = toolCall.executionDuration {
+                        Text(ACPToolCallDurationFormatter.string(for: duration))
+                            .font(.system(size: 10, weight: .medium, design: .monospaced))
+                            .foregroundStyle(theme.color("fg-faint"))
+                            .lineLimit(1)
+                            .accessibilityLabel("Tool duration")
+                            .accessibilityValue(ACPToolCallDurationFormatter.string(for: duration))
+                    }
                     statusIndicator
                     Image(systemName: "chevron.down")
                         .font(.system(size: 9))
@@ -105,6 +123,7 @@ struct ACPToolCallCard: View {
         .onChange(of: toolCall.contentRevision) { _, _ in
             expandedSyntax.clear()
         }
+        .onHover { isHovering = $0 }
     }
 
     /// What to draw inside the expanded card. Prefers the just-fetched

--- a/Alas/Sources/ACP/UI/ACPTranscriptRowContent.swift
+++ b/Alas/Sources/ACP/UI/ACPTranscriptRowContent.swift
@@ -17,6 +17,7 @@ struct ACPTranscriptRowContent: View, Equatable {
     let messageCreatedAt: Date?
     let messagePhase: ACPMessagePhase?
     let contentMaxWidth: CGFloat
+    var availableRowContentWidth: CGFloat?
     let typography: ACPChatTypography
     let trustedImageRoot: URL?
     // Excluded from equality — reference-stable for the session's lifetime
@@ -58,7 +59,9 @@ struct ACPTranscriptRowContent: View, Equatable {
             stableId: lhs.stableId, message: lhs.message,
             messageCreatedAt: lhs.messageCreatedAt,
             messagePhase: lhs.messagePhase,
-            contentMaxWidth: lhs.contentMaxWidth, typography: lhs.typography,
+            contentMaxWidth: lhs.contentMaxWidth,
+            availableRowContentWidth: lhs.availableRowContentWidth ?? lhs.contentMaxWidth,
+            typography: lhs.typography,
             trustedImageRoot: lhs.trustedImageRoot,
             isForkEligible: lhs.isForkEligible, forkTargets: lhs.forkTargets
         )
@@ -66,7 +69,9 @@ struct ACPTranscriptRowContent: View, Equatable {
             stableId: rhs.stableId, message: rhs.message,
             messageCreatedAt: rhs.messageCreatedAt,
             messagePhase: rhs.messagePhase,
-            contentMaxWidth: rhs.contentMaxWidth, typography: rhs.typography,
+            contentMaxWidth: rhs.contentMaxWidth,
+            availableRowContentWidth: rhs.availableRowContentWidth ?? rhs.contentMaxWidth,
+            typography: rhs.typography,
             trustedImageRoot: rhs.trustedImageRoot,
             isForkEligible: rhs.isForkEligible, forkTargets: rhs.forkTargets
         )
@@ -80,6 +85,7 @@ struct ACPTranscriptRowContent: View, Equatable {
         messageCreatedAt: Date? = nil,
         messagePhase: ACPMessagePhase? = nil,
         contentMaxWidth: CGFloat,
+        availableRowContentWidth: CGFloat? = nil,
         typography: ACPChatTypography,
         trustedImageRoot: URL?,
         isForkEligible: Bool = false,
@@ -90,6 +96,7 @@ struct ACPTranscriptRowContent: View, Equatable {
             messageCreatedAt: messageCreatedAt,
             messagePhase: messagePhase ?? presentationPhase(of: message),
             contentMaxWidth: contentMaxWidth,
+            availableRowContentWidth: availableRowContentWidth ?? contentMaxWidth,
             typography: typography, trustedImageRoot: trustedImageRoot,
             isForkEligible: isForkEligible, forkTargets: forkTargets
         )
@@ -101,6 +108,7 @@ struct ACPTranscriptRowContent: View, Equatable {
         let messageCreatedAt: Date?
         let messagePhase: ACPMessagePhase?
         let contentMaxWidth: CGFloat
+        let availableRowContentWidth: CGFloat
         let typography: ACPChatTypography
         let trustedImageRoot: URL?
         let isForkEligible: Bool
@@ -112,13 +120,19 @@ struct ACPTranscriptRowContent: View, Equatable {
         return buffer.phase
     }
 
+    static func showsInlineTimestamp(availableRowContentWidth: CGFloat) -> Bool {
+        availableRowContentWidth >= ACPMessageGutterLayout.inlineTimestampMinimumContentWidth
+    }
+
     var body: some View {
         switch message {
         case .user(_, _, let text, let attachments, let delegatedSource):
             ACPMessageGutter(
                 copySource: .text(text),
                 messageCreatedAt: messageCreatedAt,
-                showsInlineTimestamp: contentMaxWidth >= ACPMessageGutterLayout.inlineTimestampMinimumContentWidth,
+                showsInlineTimestamp: Self.showsInlineTimestamp(
+                    availableRowContentWidth: availableRowContentWidth ?? contentMaxWidth
+                ),
                 forkBoundary: forkBoundary(kind: .user),
                 forkTargets: forkTargets,
                 onQuote: onQuote,
@@ -136,7 +150,9 @@ struct ACPTranscriptRowContent: View, Equatable {
             ACPMessageGutter(
                 copySource: .streaming(buf),
                 messageCreatedAt: messageCreatedAt,
-                showsInlineTimestamp: contentMaxWidth >= ACPMessageGutterLayout.inlineTimestampMinimumContentWidth,
+                showsInlineTimestamp: Self.showsInlineTimestamp(
+                    availableRowContentWidth: availableRowContentWidth ?? contentMaxWidth
+                ),
                 forkBoundary: forkBoundary(kind: .agent),
                 forkTargets: forkTargets,
                 onQuote: onQuote,

--- a/Alas/Sources/ACP/UI/ACPTranscriptRowContent.swift
+++ b/Alas/Sources/ACP/UI/ACPTranscriptRowContent.swift
@@ -14,6 +14,7 @@ struct ACPTranscriptRowContent: View, Equatable {
     let stableId: String
     let messageIndex: Int
     let message: ACPMessage
+    let messageCreatedAt: Date?
     let messagePhase: ACPMessagePhase?
     let contentMaxWidth: CGFloat
     let typography: ACPChatTypography
@@ -55,6 +56,7 @@ struct ACPTranscriptRowContent: View, Equatable {
         guard lhs.messagePhase == rhs.messagePhase else { return false }
         return equalityKey(
             stableId: lhs.stableId, message: lhs.message,
+            messageCreatedAt: lhs.messageCreatedAt,
             messagePhase: lhs.messagePhase,
             contentMaxWidth: lhs.contentMaxWidth, typography: lhs.typography,
             trustedImageRoot: lhs.trustedImageRoot,
@@ -62,6 +64,7 @@ struct ACPTranscriptRowContent: View, Equatable {
         )
         == equalityKey(
             stableId: rhs.stableId, message: rhs.message,
+            messageCreatedAt: rhs.messageCreatedAt,
             messagePhase: rhs.messagePhase,
             contentMaxWidth: rhs.contentMaxWidth, typography: rhs.typography,
             trustedImageRoot: rhs.trustedImageRoot,
@@ -74,6 +77,7 @@ struct ACPTranscriptRowContent: View, Equatable {
     static func equalityKey(
         stableId: String,
         message: ACPMessage,
+        messageCreatedAt: Date? = nil,
         messagePhase: ACPMessagePhase? = nil,
         contentMaxWidth: CGFloat,
         typography: ACPChatTypography,
@@ -83,6 +87,7 @@ struct ACPTranscriptRowContent: View, Equatable {
     ) -> EqualityKey {
         EqualityKey(
             stableId: stableId, message: message,
+            messageCreatedAt: messageCreatedAt,
             messagePhase: messagePhase ?? presentationPhase(of: message),
             contentMaxWidth: contentMaxWidth,
             typography: typography, trustedImageRoot: trustedImageRoot,
@@ -93,6 +98,7 @@ struct ACPTranscriptRowContent: View, Equatable {
     struct EqualityKey: Equatable {
         let stableId: String
         let message: ACPMessage
+        let messageCreatedAt: Date?
         let messagePhase: ACPMessagePhase?
         let contentMaxWidth: CGFloat
         let typography: ACPChatTypography
@@ -111,6 +117,8 @@ struct ACPTranscriptRowContent: View, Equatable {
         case .user(_, _, let text, let attachments, let delegatedSource):
             ACPMessageGutter(
                 copySource: .text(text),
+                messageCreatedAt: messageCreatedAt,
+                showsInlineTimestamp: contentMaxWidth >= ACPMessageGutterLayout.inlineTimestampMinimumContentWidth,
                 forkBoundary: forkBoundary(kind: .user),
                 forkTargets: forkTargets,
                 onQuote: onQuote,
@@ -127,6 +135,8 @@ struct ACPTranscriptRowContent: View, Equatable {
         case .agent(_, _, let buf):
             ACPMessageGutter(
                 copySource: .streaming(buf),
+                messageCreatedAt: messageCreatedAt,
+                showsInlineTimestamp: contentMaxWidth >= ACPMessageGutterLayout.inlineTimestampMinimumContentWidth,
                 forkBoundary: forkBoundary(kind: .agent),
                 forkTargets: forkTargets,
                 onQuote: onQuote,
@@ -151,6 +161,7 @@ struct ACPTranscriptRowContent: View, Equatable {
             } else {
                 ACPToolCallCard(
                     toolCall: tc,
+                    messageCreatedAt: messageCreatedAt,
                     trustedImageRoot: trustedImageRoot,
                     loadFullContent: tc.isContentTruncated ? onLoadFullToolCallContent : nil)
                     .environment(\.acpTerminalHost, session.terminalHost)

--- a/Alas/Sources/ACP/UI/ACPTranscriptRowContent.swift
+++ b/Alas/Sources/ACP/UI/ACPTranscriptRowContent.swift
@@ -18,6 +18,7 @@ struct ACPTranscriptRowContent: View, Equatable {
     let messagePhase: ACPMessagePhase?
     let contentMaxWidth: CGFloat
     var availableRowContentWidth: CGFloat?
+    var availableTrailingGutterWidth: CGFloat?
     let typography: ACPChatTypography
     let trustedImageRoot: URL?
     // Excluded from equality — reference-stable for the session's lifetime
@@ -61,6 +62,7 @@ struct ACPTranscriptRowContent: View, Equatable {
             messagePhase: lhs.messagePhase,
             contentMaxWidth: lhs.contentMaxWidth,
             availableRowContentWidth: lhs.availableRowContentWidth ?? lhs.contentMaxWidth,
+            availableTrailingGutterWidth: lhs.availableTrailingGutterWidth ?? .infinity,
             typography: lhs.typography,
             trustedImageRoot: lhs.trustedImageRoot,
             isForkEligible: lhs.isForkEligible, forkTargets: lhs.forkTargets
@@ -71,6 +73,7 @@ struct ACPTranscriptRowContent: View, Equatable {
             messagePhase: rhs.messagePhase,
             contentMaxWidth: rhs.contentMaxWidth,
             availableRowContentWidth: rhs.availableRowContentWidth ?? rhs.contentMaxWidth,
+            availableTrailingGutterWidth: rhs.availableTrailingGutterWidth ?? .infinity,
             typography: rhs.typography,
             trustedImageRoot: rhs.trustedImageRoot,
             isForkEligible: rhs.isForkEligible, forkTargets: rhs.forkTargets
@@ -86,6 +89,7 @@ struct ACPTranscriptRowContent: View, Equatable {
         messagePhase: ACPMessagePhase? = nil,
         contentMaxWidth: CGFloat,
         availableRowContentWidth: CGFloat? = nil,
+        availableTrailingGutterWidth: CGFloat? = nil,
         typography: ACPChatTypography,
         trustedImageRoot: URL?,
         isForkEligible: Bool = false,
@@ -97,6 +101,7 @@ struct ACPTranscriptRowContent: View, Equatable {
             messagePhase: messagePhase ?? presentationPhase(of: message),
             contentMaxWidth: contentMaxWidth,
             availableRowContentWidth: availableRowContentWidth ?? contentMaxWidth,
+            availableTrailingGutterWidth: availableTrailingGutterWidth ?? .infinity,
             typography: typography, trustedImageRoot: trustedImageRoot,
             isForkEligible: isForkEligible, forkTargets: forkTargets
         )
@@ -109,6 +114,7 @@ struct ACPTranscriptRowContent: View, Equatable {
         let messagePhase: ACPMessagePhase?
         let contentMaxWidth: CGFloat
         let availableRowContentWidth: CGFloat
+        let availableTrailingGutterWidth: CGFloat
         let typography: ACPChatTypography
         let trustedImageRoot: URL?
         let isForkEligible: Bool
@@ -120,8 +126,12 @@ struct ACPTranscriptRowContent: View, Equatable {
         return buffer.phase
     }
 
-    static func showsInlineTimestamp(availableRowContentWidth: CGFloat) -> Bool {
+    static func showsInlineTimestamp(
+        availableRowContentWidth: CGFloat,
+        availableTrailingGutterWidth: CGFloat
+    ) -> Bool {
         availableRowContentWidth >= ACPMessageGutterLayout.inlineTimestampMinimumContentWidth
+            && availableTrailingGutterWidth >= ACPMessageGutterLayout.inlineTimestampTrailingExtent
     }
 
     var body: some View {
@@ -131,7 +141,8 @@ struct ACPTranscriptRowContent: View, Equatable {
                 copySource: .text(text),
                 messageCreatedAt: messageCreatedAt,
                 showsInlineTimestamp: Self.showsInlineTimestamp(
-                    availableRowContentWidth: availableRowContentWidth ?? contentMaxWidth
+                    availableRowContentWidth: availableRowContentWidth ?? contentMaxWidth,
+                    availableTrailingGutterWidth: availableTrailingGutterWidth ?? .infinity
                 ),
                 forkBoundary: forkBoundary(kind: .user),
                 forkTargets: forkTargets,
@@ -151,7 +162,8 @@ struct ACPTranscriptRowContent: View, Equatable {
                 copySource: .streaming(buf),
                 messageCreatedAt: messageCreatedAt,
                 showsInlineTimestamp: Self.showsInlineTimestamp(
-                    availableRowContentWidth: availableRowContentWidth ?? contentMaxWidth
+                    availableRowContentWidth: availableRowContentWidth ?? contentMaxWidth,
+                    availableTrailingGutterWidth: availableTrailingGutterWidth ?? .infinity
                 ),
                 forkBoundary: forkBoundary(kind: .agent),
                 forkTargets: forkTargets,

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -361,9 +361,11 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             )
             for row in rows where transcript.messages.indices.contains(row.index) {
                 let message = transcript.messages[row.index]
+                let messageCreatedAt = transcript.createdAt(forStableId: row.stableId)
                 let messagePhase = ACPTranscriptRowContent.presentationPhase(of: message)
                 let rowToken = token(ACPTranscriptRowContent.equalityKey(
                     stableId: row.stableId, message: message,
+                    messageCreatedAt: messageCreatedAt,
                     messagePhase: messagePhase,
                     contentMaxWidth: host.contentMaxWidth, typography: host.typography,
                     trustedImageRoot: host.trustedImageRoot,
@@ -397,6 +399,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 stableId: row.stableId,
                 messageIndex: row.index,
                 message: message,
+                messageCreatedAt: host.transcript.createdAt(forStableId: row.stableId),
                 messagePhase: ACPTranscriptRowContent.presentationPhase(of: message),
                 contentMaxWidth: host.contentMaxWidth,
                 typography: host.typography,

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -245,13 +245,20 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             // "already applied" memo would leave the transcript permanently
             // empty once a real width does arrive.
             guard let reconciler, let scroller else { return }
-            let specs = Self.rowSpecs(host: host)
+            let contentWidth = scroller.contentView.bounds.width
+            let specs = Self.rowSpecs(
+                host: host,
+                availableRowContentWidth: Self.availableRowContentWidth(
+                    contentViewWidth: contentWidth,
+                    contentMaxWidth: host.contentMaxWidth
+                )
+            )
             hasNonSyntheticRow = specs.contains {
                 !$0.id.hasPrefix(ACPTranscriptScrollerReconciler.syntheticIdPrefix)
             }
             reconciler.apply(
                 specs: specs,
-                contentWidth: scroller.contentView.bounds.width,
+                contentWidth: contentWidth,
                 followsTail: host.session.followsTranscriptTail
             )
             // This update carries whatever `visibleHead` currently is, so a
@@ -334,9 +341,13 @@ struct ACPTranscriptScroller: NSViewRepresentable {
 
         /// Message rows from the render window + synthetic tail rows, in the
         /// same order the legacy VStack rendered them.
-        static func rowSpecs(host: ACPTranscriptScroller) -> [ACPTranscriptRowSpec] {
+        static func rowSpecs(
+            host: ACPTranscriptScroller,
+            availableRowContentWidth: CGFloat? = nil
+        ) -> [ACPTranscriptRowSpec] {
             let transcript = host.transcript
             var specs: [ACPTranscriptRowSpec] = []
+            let availableRowContentWidth = availableRowContentWidth ?? host.contentMaxWidth
 
             if transcript.isBackfillingOlderMessages || transcript.visibleHead > 0 {
                 specs.append(ACPTranscriptRowSpec(
@@ -367,7 +378,9 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                     stableId: row.stableId, message: message,
                     messageCreatedAt: messageCreatedAt,
                     messagePhase: messagePhase,
-                    contentMaxWidth: host.contentMaxWidth, typography: host.typography,
+                    contentMaxWidth: host.contentMaxWidth,
+                    availableRowContentWidth: availableRowContentWidth,
+                    typography: host.typography,
                     trustedImageRoot: host.trustedImageRoot,
                     isForkEligible: host.session.canForkMessage(at: row.index),
                     forkTargets: host.forkTargets
@@ -375,7 +388,16 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 specs.append(ACPTranscriptRowSpec(
                     id: row.stableId,
                     equalityToken: rowToken,
-                    build: { wrapRow(host: host) { Self.messageRow(host: host, row: row, message: message) } }
+                    build: {
+                        wrapRow(host: host) {
+                            Self.messageRow(
+                                host: host,
+                                row: row,
+                                message: message,
+                                availableRowContentWidth: availableRowContentWidth
+                            )
+                        }
+                    }
                 ))
                 // Fork divider follows its boundary row, as in the legacy list.
                 if let fork = host.session.forkRecord,
@@ -393,7 +415,8 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         static func messageRow(
             host: ACPTranscriptScroller,
             row: ACPTranscriptVisibleRow,
-            message: ACPMessage
+            message: ACPMessage,
+            availableRowContentWidth: CGFloat? = nil
         ) -> some View {
             ACPTranscriptRowContent(
                 stableId: row.stableId,
@@ -402,6 +425,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 messageCreatedAt: host.transcript.createdAt(forStableId: row.stableId),
                 messagePhase: ACPTranscriptRowContent.presentationPhase(of: message),
                 contentMaxWidth: host.contentMaxWidth,
+                availableRowContentWidth: availableRowContentWidth ?? host.contentMaxWidth,
                 typography: host.typography,
                 trustedImageRoot: host.trustedImageRoot,
                 transcript: host.transcript,
@@ -416,6 +440,14 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             // Column framing (max width / horizontal padding / centering)
             // is applied uniformly to every row by `wrapRow`, not here —
             // see its doc comment.
+        }
+
+        static func availableRowContentWidth(
+            contentViewWidth: CGFloat,
+            contentMaxWidth: CGFloat
+        ) -> CGFloat {
+            let horizontalPadding = 2 * (28 + ACPMessageGutterLayout.laneWidth)
+            return max(0, min(contentMaxWidth, contentViewWidth - horizontalPadding))
         }
 
         /// Beyond `fork` (and theme/contentMaxWidth folded by

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -251,6 +251,10 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 availableRowContentWidth: Self.availableRowContentWidth(
                     contentViewWidth: contentWidth,
                     contentMaxWidth: host.contentMaxWidth
+                ),
+                availableTrailingGutterWidth: Self.availableTrailingGutterWidth(
+                    contentViewWidth: contentWidth,
+                    contentMaxWidth: host.contentMaxWidth
                 )
             )
             hasNonSyntheticRow = specs.contains {
@@ -343,11 +347,13 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         /// same order the legacy VStack rendered them.
         static func rowSpecs(
             host: ACPTranscriptScroller,
-            availableRowContentWidth: CGFloat? = nil
+            availableRowContentWidth: CGFloat? = nil,
+            availableTrailingGutterWidth: CGFloat? = nil
         ) -> [ACPTranscriptRowSpec] {
             let transcript = host.transcript
             var specs: [ACPTranscriptRowSpec] = []
             let availableRowContentWidth = availableRowContentWidth ?? host.contentMaxWidth
+            let availableTrailingGutterWidth = availableTrailingGutterWidth ?? .infinity
 
             if transcript.isBackfillingOlderMessages || transcript.visibleHead > 0 {
                 specs.append(ACPTranscriptRowSpec(
@@ -380,6 +386,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                     messagePhase: messagePhase,
                     contentMaxWidth: host.contentMaxWidth,
                     availableRowContentWidth: availableRowContentWidth,
+                    availableTrailingGutterWidth: availableTrailingGutterWidth,
                     typography: host.typography,
                     trustedImageRoot: host.trustedImageRoot,
                     isForkEligible: host.session.canForkMessage(at: row.index),
@@ -394,7 +401,8 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                                 host: host,
                                 row: row,
                                 message: message,
-                                availableRowContentWidth: availableRowContentWidth
+                                availableRowContentWidth: availableRowContentWidth,
+                                availableTrailingGutterWidth: availableTrailingGutterWidth
                             )
                         }
                     }
@@ -416,7 +424,8 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             host: ACPTranscriptScroller,
             row: ACPTranscriptVisibleRow,
             message: ACPMessage,
-            availableRowContentWidth: CGFloat? = nil
+            availableRowContentWidth: CGFloat? = nil,
+            availableTrailingGutterWidth: CGFloat? = nil
         ) -> some View {
             ACPTranscriptRowContent(
                 stableId: row.stableId,
@@ -426,6 +435,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 messagePhase: ACPTranscriptRowContent.presentationPhase(of: message),
                 contentMaxWidth: host.contentMaxWidth,
                 availableRowContentWidth: availableRowContentWidth ?? host.contentMaxWidth,
+                availableTrailingGutterWidth: availableTrailingGutterWidth ?? .infinity,
                 typography: host.typography,
                 trustedImageRoot: host.trustedImageRoot,
                 transcript: host.transcript,
@@ -446,8 +456,25 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             contentViewWidth: CGFloat,
             contentMaxWidth: CGFloat
         ) -> CGFloat {
-            let horizontalPadding = 2 * (28 + ACPMessageGutterLayout.laneWidth)
+            let horizontalPadding = 2 * rowHorizontalPadding
             return max(0, min(contentMaxWidth, contentViewWidth - horizontalPadding))
+        }
+
+        static func availableTrailingGutterWidth(
+            contentViewWidth: CGFloat,
+            contentMaxWidth: CGFloat
+        ) -> CGFloat {
+            let rowContentWidth = availableRowContentWidth(
+                contentViewWidth: contentViewWidth,
+                contentMaxWidth: contentMaxWidth
+            )
+            let centeredRowWidth = rowContentWidth + 2 * rowHorizontalPadding
+            let trailingCenteringMargin = max(0, contentViewWidth - centeredRowWidth) / 2
+            return rowHorizontalPadding + trailingCenteringMargin
+        }
+
+        private static var rowHorizontalPadding: CGFloat {
+            28 + ACPMessageGutterLayout.laneWidth
         }
 
         /// Beyond `fork` (and theme/contentMaxWidth folded by

--- a/AlasTests/ACP/Session/ACPSessionHydratorTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionHydratorTests.swift
@@ -52,6 +52,11 @@ struct ACPSessionHydratorTests {
         #expect(result.row.currentModel == "sonnet")
         #expect(result.row.autoRun == true)
         #expect(result.wireMessages.count == 3)
+        #expect(result.messages.map(\.createdAt) == [
+            Date(timeIntervalSince1970: 0),
+            Date(timeIntervalSince1970: 1),
+            Date(timeIntervalSince1970: 2)
+        ])
         #expect(result.queue.count == 1)
         #expect(result.draft != nil)
         #expect(result.recent.contains(where: { $0.id == "s" }))

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1710,6 +1710,27 @@ struct ACPSessionTests {
         #expect(abs((toolCall.executionDuration ?? 0) - 2.4) < 0.0001)
     }
 
+    @Test("canceling an active tool stops its duration")
+    func cancelingToolCallStopsExecutionDuration() {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let startedAt = Date(timeIntervalSince1970: 100)
+        let canceledAt = Date(timeIntervalSince1970: 102.4)
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-cancel", title: "Run", kind: "execute", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil
+        )), at: startedAt)
+
+        _ = session.cancelInFlightToolCalls(at: canceledAt)
+
+        guard case .toolCall(let toolCall) = session.transcript.messages.first else {
+            Issue.record("expected tool call")
+            return
+        }
+        #expect(toolCall.status == "canceled")
+        #expect(toolCall.executionFinishedAt == canceledAt)
+        #expect(abs((toolCall.executionDuration ?? 0) - 2.4) < 0.0001)
+    }
+
     @Test("initial toolCall preserves raw input metadata")
     func toolCallPreservesRawInput() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1687,6 +1687,29 @@ struct ACPSessionTests {
         } else { Issue.record("expected toolCall message") }
     }
 
+    @Test("tool duration starts with active execution and stops at completion")
+    func toolCallExecutionDuration() {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let startedAt = Date(timeIntervalSince1970: 100)
+        let finishedAt = Date(timeIntervalSince1970: 102.4)
+
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-duration", title: "Run", kind: "execute", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil
+        )), at: startedAt)
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-duration", status: "completed", content: nil, rawOutput: nil
+        )), at: finishedAt)
+
+        guard case .toolCall(let toolCall) = session.transcript.messages.first else {
+            Issue.record("expected tool call")
+            return
+        }
+        #expect(toolCall.executionStartedAt == startedAt)
+        #expect(toolCall.executionFinishedAt == finishedAt)
+        #expect(abs((toolCall.executionDuration ?? 0) - 2.4) < 0.0001)
+    }
+
     @Test("initial toolCall preserves raw input metadata")
     func toolCallPreservesRawInput() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/UI/ACPMessageTimestampFormatterTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageTimestampFormatterTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACP message timestamp formatting")
+struct ACPMessageTimestampFormatterTests {
+    @Test("uses time today, month and day this year, and year for older dates")
+    func adaptiveTimestamp() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let locale = Locale(identifier: "en_GB")
+        func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int, _ minute: Int) -> Date {
+            calendar.date(from: DateComponents(
+                year: year, month: month, day: day, hour: hour, minute: minute
+            ))!
+        }
+        let now = date(2026, 8, 29, 15, 30)
+
+        #expect(ACPMessageTimestampFormatter.string(
+            for: date(2026, 8, 29, 14, 42),
+            relativeTo: now, calendar: calendar, locale: locale
+        ) == "14:42")
+        #expect(ACPMessageTimestampFormatter.string(
+            for: date(2026, 8, 26, 15, 42),
+            relativeTo: now, calendar: calendar, locale: locale
+        ) == "26 Aug, 15:42")
+        #expect(ACPMessageTimestampFormatter.string(
+            for: date(2025, 8, 26, 15, 42),
+            relativeTo: now, calendar: calendar, locale: locale
+        ) == "26 Aug 2025, 15:42")
+    }
+
+    @Test("tool duration keeps sub-ten-second precision")
+    func toolDuration() {
+        let locale = Locale(identifier: "en_US")
+        #expect(ACPToolCallDurationFormatter.string(for: 2.4, locale: locale) == "2.4s")
+        #expect(ACPToolCallDurationFormatter.string(for: 42, locale: locale) == "42s")
+    }
+
+    @Test("places the hover timestamp below the message actions button")
+    func hoverTimestampPlacement() {
+        #expect(ACPMessageGutterLayout.timestampVerticalSpacing == 4)
+    }
+
+    @Test("reserves enough width for a timestamp below the message actions button")
+    func hoverTimestampWidth() {
+        #expect(ACPMessageGutterLayout.timestampWidth == 128)
+    }
+}

--- a/AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift
@@ -47,6 +47,7 @@ struct ACPTranscriptRowContentTests {
                 stableId: message.stableId,
                 messageIndex: 0,
                 message: message,
+                messageCreatedAt: nil,
                 messagePhase: ACPTranscriptRowContent.presentationPhase(of: message),
                 contentMaxWidth: 800,
                 typography: .default,
@@ -107,6 +108,7 @@ struct ACPTranscriptRowContentTests {
                 stableId: message.stableId,
                 messageIndex: 0,
                 message: message,
+                messageCreatedAt: nil,
                 messagePhase: ACPTranscriptRowContent.presentationPhase(of: message),
                 contentMaxWidth: 800,
                 typography: .default,
@@ -140,6 +142,21 @@ struct ACPTranscriptRowContentTests {
         let b = ACPTranscriptRowContent.equalityKey(
             stableId: "s1", message: msg, contentMaxWidth: 640,
             typography: .default, trustedImageRoot: nil)
+        #expect(a != b)
+    }
+
+    @Test("equality detects a message timestamp change")
+    @MainActor
+    func rowContentEqualityDetectsTimestampChange() {
+        let message = ACPMessage.systemNotice(id: UUID(), text: "hello")
+        let a = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: message,
+            messageCreatedAt: Date(timeIntervalSince1970: 1),
+            contentMaxWidth: 800, typography: .default, trustedImageRoot: nil)
+        let b = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: message,
+            messageCreatedAt: Date(timeIntervalSince1970: 2),
+            contentMaxWidth: 800, typography: .default, trustedImageRoot: nil)
         #expect(a != b)
     }
 

--- a/AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift
@@ -145,6 +145,30 @@ struct ACPTranscriptRowContentTests {
         #expect(a != b)
     }
 
+    @Test("equality detects available row width changes independently from content max width")
+    @MainActor
+    func rowContentEqualityDetectsAvailableRowWidthChange() {
+        let msg = ACPMessage.user(id: UUID(), text: "hello", attachments: [])
+        let a = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msg,
+            messageCreatedAt: Date(timeIntervalSince1970: 1),
+            contentMaxWidth: 720,
+            availableRowContentWidth: 720,
+            typography: .default,
+            trustedImageRoot: nil)
+        let b = ACPTranscriptRowContent.equalityKey(
+            stableId: "s1", message: msg,
+            messageCreatedAt: Date(timeIntervalSince1970: 1),
+            contentMaxWidth: 720,
+            availableRowContentWidth: 280,
+            typography: .default,
+            trustedImageRoot: nil)
+
+        #expect(a != b)
+        #expect(ACPTranscriptRowContent.showsInlineTimestamp(availableRowContentWidth: 720))
+        #expect(!ACPTranscriptRowContent.showsInlineTimestamp(availableRowContentWidth: 280))
+    }
+
     @Test("equality detects a message timestamp change")
     @MainActor
     func rowContentEqualityDetectsTimestampChange() {

--- a/AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptRowContentTests.swift
@@ -165,8 +165,18 @@ struct ACPTranscriptRowContentTests {
             trustedImageRoot: nil)
 
         #expect(a != b)
-        #expect(ACPTranscriptRowContent.showsInlineTimestamp(availableRowContentWidth: 720))
-        #expect(!ACPTranscriptRowContent.showsInlineTimestamp(availableRowContentWidth: 280))
+        #expect(ACPTranscriptRowContent.showsInlineTimestamp(
+            availableRowContentWidth: 720,
+            availableTrailingGutterWidth: 180
+        ))
+        #expect(!ACPTranscriptRowContent.showsInlineTimestamp(
+            availableRowContentWidth: 280,
+            availableTrailingGutterWidth: 180
+        ))
+        #expect(!ACPTranscriptRowContent.showsInlineTimestamp(
+            availableRowContentWidth: 720,
+            availableTrailingGutterWidth: 60
+        ))
     }
 
     @Test("equality detects a message timestamp change")

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -51,6 +51,41 @@ struct ACPTranscriptScrollerRowSpecsTests {
         .systemNotice(id: UUID(), text: "hello")
     }
 
+    @Test("available row width subtracts row padding before timestamp policy")
+    func availableRowWidthSubtractsRowPadding() {
+        #expect(ACPTranscriptScroller.Coordinator.availableRowContentWidth(
+            contentViewWidth: 400,
+            contentMaxWidth: 720
+        ) == 280)
+        #expect(!ACPTranscriptRowContent.showsInlineTimestamp(availableRowContentWidth: 280))
+
+        #expect(ACPTranscriptScroller.Coordinator.availableRowContentWidth(
+            contentViewWidth: 840,
+            contentMaxWidth: 720
+        ) == 720)
+        #expect(ACPTranscriptRowContent.showsInlineTimestamp(availableRowContentWidth: 720))
+    }
+
+    @Test("message row token changes when available row width changes")
+    func messageRowTokenChangesOnAvailableRowWidth() throws {
+        let host = makeHost(contentMaxWidth: 720)
+        let message = ACPMessage.user(id: UUID(), text: "hello", attachments: [])
+        host.transcript.messages = [message]
+        host.transcript.visibleHead = 0
+        host.transcript.visibleTail = nil
+
+        let narrowToken = try #require(ACPTranscriptScroller.Coordinator.rowSpecs(
+            host: host,
+            availableRowContentWidth: 280
+        ).first { $0.id == message.stableId }?.equalityToken)
+        let wideToken = try #require(ACPTranscriptScroller.Coordinator.rowSpecs(
+            host: host,
+            availableRowContentWidth: 720
+        ).first { $0.id == message.stableId }?.equalityToken)
+
+        #expect(!narrowToken.isEqual(to: wideToken))
+    }
+
     @Test("plain transcript: message rows followed by the composer spacer, no head sentinel")
     func plainTranscriptIdList() {
         let host = makeHost()

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -51,19 +51,48 @@ struct ACPTranscriptScrollerRowSpecsTests {
         .systemNotice(id: UUID(), text: "hello")
     }
 
-    @Test("available row width subtracts row padding before timestamp policy")
-    func availableRowWidthSubtractsRowPadding() {
+    @Test("timestamp policy uses row width and trailing gutter")
+    func timestampPolicyUsesRowWidthAndTrailingGutter() {
         #expect(ACPTranscriptScroller.Coordinator.availableRowContentWidth(
             contentViewWidth: 400,
             contentMaxWidth: 720
         ) == 280)
-        #expect(!ACPTranscriptRowContent.showsInlineTimestamp(availableRowContentWidth: 280))
+        #expect(ACPTranscriptScroller.Coordinator.availableTrailingGutterWidth(
+            contentViewWidth: 400,
+            contentMaxWidth: 720
+        ) == 60)
+        #expect(!ACPTranscriptRowContent.showsInlineTimestamp(
+            availableRowContentWidth: 280,
+            availableTrailingGutterWidth: 60
+        ))
 
+        let clippedWidth: CGFloat = 640
         #expect(ACPTranscriptScroller.Coordinator.availableRowContentWidth(
-            contentViewWidth: 840,
+            contentViewWidth: clippedWidth,
+            contentMaxWidth: 720
+        ) == 520)
+        #expect(ACPTranscriptScroller.Coordinator.availableTrailingGutterWidth(
+            contentViewWidth: clippedWidth,
+            contentMaxWidth: 720
+        ) == 60)
+        #expect(!ACPTranscriptRowContent.showsInlineTimestamp(
+            availableRowContentWidth: 520,
+            availableTrailingGutterWidth: 60
+        ))
+
+        let fittingWidth: CGFloat = 1_080
+        #expect(ACPTranscriptScroller.Coordinator.availableRowContentWidth(
+            contentViewWidth: fittingWidth,
             contentMaxWidth: 720
         ) == 720)
-        #expect(ACPTranscriptRowContent.showsInlineTimestamp(availableRowContentWidth: 720))
+        #expect(ACPTranscriptScroller.Coordinator.availableTrailingGutterWidth(
+            contentViewWidth: fittingWidth,
+            contentMaxWidth: 720
+        ) == 180)
+        #expect(ACPTranscriptRowContent.showsInlineTimestamp(
+            availableRowContentWidth: 720,
+            availableTrailingGutterWidth: 180
+        ))
     }
 
     @Test("message row token changes when available row width changes")
@@ -76,11 +105,13 @@ struct ACPTranscriptScrollerRowSpecsTests {
 
         let narrowToken = try #require(ACPTranscriptScroller.Coordinator.rowSpecs(
             host: host,
-            availableRowContentWidth: 280
+            availableRowContentWidth: 280,
+            availableTrailingGutterWidth: 60
         ).first { $0.id == message.stableId }?.equalityToken)
         let wideToken = try #require(ACPTranscriptScroller.Coordinator.rowSpecs(
             host: host,
-            availableRowContentWidth: 720
+            availableRowContentWidth: 720,
+            availableTrailingGutterWidth: 180
         ).first { $0.id == message.stableId }?.equalityToken)
 
         #expect(!narrowToken.isEqual(to: wideToken))


### PR DESCRIPTION
## Summary
- show compact sent/received timestamps in ACP transcript hover actions
- keep timestamps available in narrow-row action menus
- show final tool execution duration after completion
- preserve message creation times through hydration and persistence

## Testing
- rtk xcodegen
- rtk swiftformat Alas/Sources/ACP AlasTests/ACP
- isolated macOS build
- 180 focused ACP tests