### PR TITLE
fix(gg): prevent stack refresh blinking

### DIFF
--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1235,20 +1235,21 @@ final class RightPaneState: GGSplitCommitServicing {
     }
 
     /// Re-run the gg gate immediately (e.g. after a Settings toggle) rather
-    /// than waiting for the next watcher-driven refresh. Resets the
-    /// commits-key so the gate is fully re-evaluated even when commits are
-    /// unchanged, then reloads or clears stack state. Returns the
+    /// than waiting for the next watcher-driven refresh. Forces a fresh query
+    /// even when commits are unchanged while keeping a compatible loaded
+    /// stack visible, then reloads or clears stack state. Returns the
     /// underlying task so tests can await completion; production call
     /// sites ignore the return value.
     @MainActor
     @discardableResult
     func reevaluateGGGate() -> Task<Void, Never> {
         let remoteMetadata = ggStack
-        invalidateGGPresentation(startingRefresh: false)
+        ggStackRefreshGeneration &+= 1
+        ggStackRefreshTask?.cancel()
         ggStackRemoteMetadataCache = remoteMetadata
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
-            await self.refreshGGStack()
+            await self.refreshGGStack(forceRemote: true)
         }
         ggStackRefreshTask = task
         return task

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -2753,6 +2753,46 @@ struct RightPaneGGStackTests {
         await runner.releasePostSyncRead()
     }
 
+    @Test func reevaluatingGGGateKeepsCompatibleLoadedStackVisible() async throws {
+        let worktree = makeWorktree()
+        let result = ProcessResult(
+            exitCode: 0,
+            stdout: GGStackModelsTests.fixture,
+            stderr: ""
+        )
+        let runner = ControlledStackGGRunner(
+            stackResults: [("agent-inbox", result), ("agent-inbox", result)],
+            suspendedCalls: [2]
+        )
+        let state = makeState(worktree: worktree)
+        installFakeGGStackLoader(on: state)
+        state.ggService = GGService(runner: runner)
+        state.ggCapabilities = {
+            GGCapabilities(
+                structuredSplit: false,
+                keepCurrentUnstack: false,
+                localStackSnapshot: false
+            )
+        }
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.ggStackSourceCommits = [
+            commit(sha: String(repeating: "s", count: 40), stackShaped: true),
+        ]
+
+        await state.refreshGGStack()
+        let refresh = state.reevaluateGGGate()
+        for _ in 0..<500 where await runner.lsCallCount < 2 {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+
+        #expect(await runner.lsCallCount == 2)
+        #expect(state.ggStack?.name == "agent-inbox")
+        #expect(state.ggStackLoadState == .loaded)
+
+        await runner.complete(call: 2)
+        await refresh.value
+    }
+
     @Test func staleMutationFailureDoesNotOverwriteNewerActionState() async throws {
         let worktree = makeWorktree()
         let runner = StaleMutationFailureRunner()


### PR DESCRIPTION
## Summary

Syncing a GG stack briefly cleared the compatible loaded stack, which removed and reinserted the Changes "Prepare" section. Keep that presentation while the forced refresh runs.

## Changes

- Preserve a compatible GG stack during forced gate reevaluation.
- Cancel stale refreshes before starting the replacement refresh.
- Add a regression test that verifies the loaded stack remains visible.

## Where to start

- `Alas/Sources/Right/RightPaneState.swift` - GG refresh behavior
