### PR TITLE
feat: add repository import sources

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@
 		29418562DE5554B282C83D75 /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */; };
 		295EF629FAAA46FCD6802F4E /* ScrollEventCapturingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22E44126BAFC8F3B515BAC0 /* ScrollEventCapturingView.swift */; };
 		29806D50EECB300991471A7C /* AlasCLIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E57BC5EC8A465F26B3642 /* AlasCLIRequest.swift */; };
+		29B03005C017F3F40B4034B0 /* RepositoryImportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB12D651DACE6AED9923BAC3 /* RepositoryImportServiceTests.swift */; };
 		2A0E3B915DF645A8545D9B0B /* SpacesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B868809675C4110044C92E /* SpacesManager.swift */; };
 		2A18F8265F467BF33AD69159 /* ProjectGitWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */; };
 		2A19A7B4B392979989E25EC0 /* ACPDiffGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71D8A91D3A2BD4A522DD9AD /* ACPDiffGenerator.swift */; };
@@ -266,6 +267,7 @@
 		2B4CBD06D1568EBC1BD327E0 /* SemanticVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF2EE8A6AAA7F9B45DACC0C /* SemanticVersionTests.swift */; };
 		2B823A7361BB54D8D93D7C99 /* ACPMentionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */; };
 		2B85898841D3090D3C7E3169 /* RunScriptMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93ED8BA7A9EE46B37ED48EC /* RunScriptMetadataTests.swift */; };
+		2BC2E35EF1FA9E57037869B2 /* RepositoryImportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22A7BCA8F63051E6D842055 /* RepositoryImportService.swift */; };
 		2C35CA31DD223EC68FF917E9 /* DiffPaneDocumentCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B42075B231828DA553EA92 /* DiffPaneDocumentCache.swift */; };
 		2C4EDD06B2D26DCBB18DC2D1 /* SettingsBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A190D4B29B35C457AA9829F /* SettingsBinding.swift */; };
 		2C520D1FB289610CEB70BDB6 /* GitServiceDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */; };
@@ -2649,6 +2651,7 @@
 		B1615F1953C6FE9D1A30A1A2 /* ACPImageEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageEncoding.swift; sourceTree = "<group>"; };
 		B16BDCBFE4C1EB1C8EA6D4D5 /* RemoteDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteDevice.swift; sourceTree = "<group>"; };
 		B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRendererTests.swift; sourceTree = "<group>"; };
+		B22A7BCA8F63051E6D842055 /* RepositoryImportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryImportService.swift; sourceTree = "<group>"; };
 		B24ABE96ED3C62146A3CED62 /* EmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyState.swift; sourceTree = "<group>"; };
 		B24F24D2FFBBC49868AC84B3 /* ACPTranscriptScrollerPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollerPolicyTests.swift; sourceTree = "<group>"; };
 		B27595490B7D883CF5D9FFD5 /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
@@ -3117,6 +3120,7 @@
 		FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinitionTests.swift; sourceTree = "<group>"; };
 		FADFC82400385AD76A200A2B /* ACPSessionStoreDedupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreDedupTests.swift; sourceTree = "<group>"; };
 		FB02326DBD7A82431A33C50F /* DraftAmendPrefillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftAmendPrefillTests.swift; sourceTree = "<group>"; };
+		FB12D651DACE6AED9923BAC3 /* RepositoryImportServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryImportServiceTests.swift; sourceTree = "<group>"; };
 		FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServerCLITests.swift; sourceTree = "<group>"; };
 		FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerTests.swift; sourceTree = "<group>"; };
 		FB73E99357B77163006FA511 /* ACPManagedAdapterDescriptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPManagedAdapterDescriptorTests.swift; sourceTree = "<group>"; };
@@ -3632,6 +3636,7 @@
 				01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */,
 				220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */,
 				784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */,
+				FB12D651DACE6AED9923BAC3 /* RepositoryImportServiceTests.swift */,
 				CC958412AAB6B8788171F74A /* ReviewChangesLoaderTests.swift */,
 				CDAE8FBBADF986E1E6585941 /* ReviewChangesModelsTests.swift */,
 				F2C9F8BAEDB1D157E321A328 /* ReviewChangesScrollSpyTests.swift */,
@@ -3786,6 +3791,7 @@
 				D9C7B2268F3CE7A5FEDF8580 /* ProjectMCPServerEditorPolicy.swift */,
 				AFDDDF6CCDD6CE4A78AEF8F2 /* ProjectMCPServerManager.swift */,
 				3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */,
+				B22A7BCA8F63051E6D842055 /* RepositoryImportService.swift */,
 				0FA3C5D49DC1B6AB83479412 /* SSHHostPicker.swift */,
 				3790CACE965BC5005DA5A51B /* SSHHostSuggestions.swift */,
 				C2E05FF3EC7EAB497BA0FFE0 /* RepoSelector */,
@@ -6688,6 +6694,7 @@
 				E3158A4D8FBD36D06D421D28 /* RepoSelectorRecents.swift in Sources */,
 				2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */,
 				1B387AAB575A42ED1AFB5D46 /* RepoSelectorRowView.swift in Sources */,
+				2BC2E35EF1FA9E57037869B2 /* RepositoryImportService.swift in Sources */,
 				111516874CEE27D789DF61E9 /* ReviewChangesFileSection.swift in Sources */,
 				520F19A37512D2FA0D10EB63 /* ReviewChangesLoader.swift in Sources */,
 				6EA7BCF9318AC459144B47FB /* ReviewChangesModels.swift in Sources */,
@@ -7423,6 +7430,7 @@
 				133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */,
 				737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */,
 				35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */,
+				29B03005C017F3F40B4034B0 /* RepositoryImportServiceTests.swift in Sources */,
 				A9D16AD457FE772237B7A710 /* ReviewChangesLoaderTests.swift in Sources */,
 				13928612F39D3D86ED3313AC /* ReviewChangesModelsTests.swift in Sources */,
 				B13C57CF7090C966143A6840 /* ReviewChangesScrollSpyTests.swift in Sources */,

--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -70,7 +70,22 @@ private struct ProjectDialog: View {
     @State private var path: String = ""
     private enum ProjectLocation: String, CaseIterable {
         case local = "Local"
-        case remoteSSH = "Remote (SSH)"
+        case github = "GitHub"
+        case gitlab = "GitLab"
+        case gitURL = "Git URL"
+        case remoteSSH = "SSH"
+
+        var repositoryHost: RepositoryHost? {
+            switch self {
+            case .github: .github
+            case .gitlab: .gitlab
+            default: nil
+            }
+        }
+
+        var clonesRepository: Bool {
+            self == .github || self == .gitlab || self == .gitURL
+        }
     }
     @State private var location: ProjectLocation = .local
     @State private var sshHost: String = ""
@@ -103,6 +118,16 @@ private struct ProjectDialog: View {
     @State private var sshSetupSurface: AlasGhostty.SurfaceView?
     @State private var sshSetupStatus: SSHSetupStatus = .connecting
     @State private var sshSetupAttemptID = UUID()
+    @State private var gitRemote = ""
+    @State private var cloneRootPath = ""
+    @State private var repositoryCatalogs: [RepositoryHost: [RemoteRepository]] = [:]
+    @State private var displayedRepositories: [RemoteRepository] = []
+    @State private var selectedRepository: RemoteRepository?
+    @State private var repositorySearch = ""
+    @State private var repositoryCatalogLoading = false
+    @State private var catalogErrorMessage: String?
+    @State private var catalogTask: Task<Void, Never>?
+    @State private var cloneTask: Task<Void, Never>?
 
     private let palette = [
         "#5fb7c4", "#c89d6f", "#9789c7", "#7fb978", "#d77b88",
@@ -139,43 +164,10 @@ private struct ProjectDialog: View {
                         Seg(value: $location, options: ProjectLocation.allCases.map { ($0, $0.rawValue) })
                     }
                 }
-                DialogField(label: location == .remoteSSH ? "Remote repository path" : "Repository path") {
+                DialogField(label: locationFieldLabel) {
                     switch mode {
                     case .add:
-                        if location == .local {
-                            HStack(spacing: 6) {
-                                AlasField(text: $path, placeholder: "/path/to/repo", monospaced: true)
-                                AlasButton(title: "Choose…", action: choose)
-                            }
-                        } else {
-                            VStack(alignment: .leading, spacing: 6) {
-                                HStack(spacing: 6) {
-                                    AlasField(text: $sshHost, placeholder: "devbox or user@host", monospaced: true)
-                                    Button(action: { showHostPicker.toggle() }) {
-                                        Image(systemName: "list.bullet")
-                                            .font(.system(size: 12, weight: .semibold))
-                                            .foregroundColor(theme.color("fg-dim"))
-                                            .frame(width: 30, height: 28)
-                                            .background(theme.color("bg-2"))
-                                            .overlay(RoundedRectangle(cornerRadius: 6)
-                                                .strokeBorder(theme.color("line"), lineWidth: 0.5))
-                                            .clipShape(RoundedRectangle(cornerRadius: 6))
-                                    }
-                                    .buttonStyle(.plain)
-                                    .help("Choose a host from ~/.ssh/config")
-                                    .accessibilityLabel("Choose SSH host")
-                                    .popover(isPresented: $showHostPicker, arrowEdge: .bottom) {
-                                        SSHHostPicker(
-                                            host: $sshHost,
-                                            hosts: sshHosts,
-                                            isLoading: sshHostsLoading,
-                                            isPresented: $showHostPicker
-                                        )
-                                    }
-                                }
-                                AlasField(text: $path, placeholder: "/home/me/repo", monospaced: true)
-                            }
-                        }
+                        addLocationFields
                     case .edit:
                         readOnlyPath
                     }
@@ -201,7 +193,7 @@ private struct ProjectDialog: View {
             cancelTitle: "Cancel",
             confirmTitle: confirmTitle,
             confirmStyle: .primary,
-            onCancel: { presented = false },
+            onCancel: cancel,
             onConfirm: confirm,
             confirmEnabled: confirmEnabled
         )
@@ -229,6 +221,19 @@ private struct ProjectDialog: View {
         .onChange(of: location) { _, _ in
             sshConnectionIssue = nil
             errorMessage = nil
+            catalogErrorMessage = nil
+            selectedRepository = nil
+            repositorySearch = ""
+            displayedRepositories = []
+            loadRepositoryCatalogIfNeeded()
+        }
+        .onChange(of: repositorySearch) { _, _ in
+            refreshDisplayedRepositories()
+        }
+        .onChange(of: gitRemote) { _, remote in
+            if let suggested = RepositoryImportService.repositoryName(from: remote), name.isEmpty {
+                name = suggested
+            }
         }
         .sheet(isPresented: $mcpManagerPresented) {
             ProjectMCPServerManager(servers: $mcpServers)
@@ -259,9 +264,159 @@ private struct ProjectDialog: View {
         }
     }
 
+    private var locationFieldLabel: String {
+        switch mode {
+        case .edit: "Repository path"
+        case .add:
+            switch location {
+            case .local: "Repository path"
+            case .github, .gitlab: "Repository"
+            case .gitURL: "Git remote"
+            case .remoteSSH: "Remote repository path"
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var addLocationFields: some View {
+        switch location {
+        case .local:
+            HStack(spacing: 6) {
+                AlasField(text: $path, placeholder: "/path/to/repo", monospaced: true)
+                AlasButton(title: "Choose…", action: choose)
+            }
+        case .github, .gitlab:
+            VStack(alignment: .leading, spacing: 8) {
+                AlasField(text: $repositorySearch, placeholder: "Search repositories")
+                repositoryCatalog
+                cloneFolderField
+            }
+        case .gitURL:
+            VStack(alignment: .leading, spacing: 8) {
+                AlasField(text: $gitRemote, placeholder: "https://host/team/repo.git or git@host:team/repo.git", monospaced: true)
+                cloneFolderField
+            }
+        case .remoteSSH:
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    AlasField(text: $sshHost, placeholder: "devbox or user@host", monospaced: true)
+                    Button(action: { showHostPicker.toggle() }) {
+                        Image(systemName: "list.bullet")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(theme.color("fg-dim"))
+                            .frame(width: 30, height: 28)
+                            .background(theme.color("bg-2"))
+                            .overlay(RoundedRectangle(cornerRadius: 6)
+                                .strokeBorder(theme.color("line"), lineWidth: 0.5))
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                    }
+                    .buttonStyle(.plain)
+                    .help("Choose a host from ~/.ssh/config")
+                    .accessibilityLabel("Choose SSH host")
+                    .popover(isPresented: $showHostPicker, arrowEdge: .bottom) {
+                        SSHHostPicker(
+                            host: $sshHost,
+                            hosts: sshHosts,
+                            isLoading: sshHostsLoading,
+                            isPresented: $showHostPicker
+                        )
+                    }
+                }
+                AlasField(text: $path, placeholder: "/home/me/repo", monospaced: true)
+            }
+        }
+    }
+
+    private var repositoryCatalog: some View {
+        Group {
+            if repositoryCatalogLoading {
+                HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text("Loading repositories…")
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.color("fg-muted"))
+                }
+                .frame(maxWidth: .infinity, minHeight: 90, alignment: .center)
+            } else if let catalogErrorMessage {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(catalogErrorMessage)
+                        .font(.system(size: 11))
+                        .foregroundColor(.red)
+                        .textSelection(.enabled)
+                    AlasButton(title: "Retry", action: { loadRepositoryCatalog(force: true) })
+                }
+                .frame(maxWidth: .infinity, minHeight: 90, alignment: .leading)
+            } else if displayedRepositories.isEmpty {
+                Text(repositorySearch.isEmpty ? "No repositories found." : "No matching repositories.")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-muted"))
+                    .frame(maxWidth: .infinity, minHeight: 90, alignment: .center)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 2) {
+                        ForEach(displayedRepositories) { repository in
+                            repositoryRow(repository)
+                        }
+                    }
+                }
+                .frame(height: 150)
+            }
+        }
+        .padding(6)
+        .background(theme.color("bg-1"))
+        .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line"), lineWidth: 0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func repositoryRow(_ repository: RemoteRepository) -> some View {
+        let selected = selectedRepository?.id == repository.id
+        return Button {
+            selectedRepository = repository
+            name = repository.name
+        } label: {
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(repository.fullName)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.color("fg"))
+                    Text([repository.visibility, repository.isArchived ? "Archived" : nil].compactMap { $0 }.joined(separator: " · "))
+                        .font(.system(size: 10.5))
+                        .foregroundColor(theme.color("fg-muted"))
+                }
+                Spacer()
+                if selected {
+                    Image(systemName: "checkmark")
+                        .foregroundColor(theme.color("accent"))
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(selected ? theme.color("bg-3") : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: 5))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(repository.fullName), \(repository.visibility)\(repository.isArchived ? ", archived" : "")")
+        .accessibilityAddTraits(selected ? .isSelected : [])
+    }
+
+    private var cloneFolderField: some View {
+        HStack(spacing: 6) {
+            Text("Clone into")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-muted"))
+            AlasField(text: $cloneRootPath, placeholder: "Choose on first clone", monospaced: true)
+            AlasButton(title: "Choose…", action: chooseCloneFolder)
+        }
+    }
+
     private var confirmTitle: String {
         switch mode {
-        case .add: isValidating ? "Adding…" : "Add project"
+        case .add:
+            if location.clonesRepository {
+                isValidating ? "Cloning…" : "Clone and add"
+            } else {
+                isValidating ? "Adding…" : "Add project"
+            }
         case .edit: "Save changes"
         }
     }
@@ -269,9 +424,17 @@ private struct ProjectDialog: View {
     private var confirmEnabled: Bool {
         switch mode {
         case .add:
-            let hasLocation = location == .local
-                ? !path.isEmpty
-                : !sshHost.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && path.hasPrefix("/")
+            let hasLocation: Bool
+            switch location {
+            case .local:
+                hasLocation = !path.isEmpty
+            case .github, .gitlab:
+                hasLocation = selectedRepository != nil
+            case .gitURL:
+                hasLocation = RepositoryImportService.repositoryName(from: gitRemote) != nil
+            case .remoteSSH:
+                hasLocation = !sshHost.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && path.hasPrefix("/")
+            }
             return hasLocation && !name.isEmpty && !isValidating
         case .edit:
             return !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -548,7 +711,7 @@ private struct ProjectDialog: View {
     private func populateInitialValues() {
         switch mode {
         case .add:
-            break
+            cloneRootPath = state.config.repositoryCloneRootPath
         case .edit(let project):
             path = project.path
             name = project.name
@@ -574,6 +737,24 @@ private struct ProjectDialog: View {
         if panel.runModal() == .OK, let url = panel.url {
             path = url.path
         }
+    }
+
+    private func chooseCloneFolder() {
+        _ = pickCloneFolder()
+    }
+
+    private func pickCloneFolder() -> URL? {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        guard panel.runModal() == .OK, let url = panel.url else { return nil }
+        cloneRootPath = url.path
+        if state.config.repositoryCloneRootPath.isEmpty {
+            state.config.repositoryCloneRootPath = url.path
+            state.saveConfig()
+        }
+        return url
     }
 
     private func chooseProjectIconImage() {
@@ -620,6 +801,53 @@ private struct ProjectDialog: View {
             sshHosts = parsed
             sshHostsLoading = false
         }
+    }
+
+    private func loadRepositoryCatalogIfNeeded() {
+        guard let host = location.repositoryHost else { return }
+        if let repositories = repositoryCatalogs[host] {
+            showCachedRepositoryCatalog(repositories)
+        } else {
+            loadRepositoryCatalog(force: false)
+        }
+    }
+
+    private func loadRepositoryCatalog(force: Bool) {
+        guard let host = location.repositoryHost else { return }
+        if !force, let repositories = repositoryCatalogs[host] {
+            showCachedRepositoryCatalog(repositories)
+            return
+        }
+        catalogTask?.cancel()
+        repositoryCatalogLoading = true
+        catalogErrorMessage = nil
+        catalogTask = Task {
+            do {
+                let repositories = try await RepositoryImportService().repositories(for: host)
+                guard !Task.isCancelled, location.repositoryHost == host else { return }
+                repositoryCatalogs[host] = repositories
+                displayedRepositories = RepositoryImportService.filter(repositories, query: repositorySearch)
+            } catch {
+                guard !Task.isCancelled, location.repositoryHost == host else { return }
+                catalogErrorMessage = error.localizedDescription
+            }
+            if location.repositoryHost == host {
+                repositoryCatalogLoading = false
+            }
+        }
+    }
+
+    private func showCachedRepositoryCatalog(_ repositories: [RemoteRepository]) {
+        catalogTask?.cancel()
+        catalogTask = nil
+        repositoryCatalogLoading = false
+        catalogErrorMessage = nil
+        displayedRepositories = RepositoryImportService.filter(repositories, query: repositorySearch)
+    }
+
+    private func refreshDisplayedRepositories() {
+        guard let host = location.repositoryHost, let repositories = repositoryCatalogs[host] else { return }
+        displayedRepositories = RepositoryImportService.filter(repositories, query: repositorySearch)
     }
 
     private func existingProjectIdForIconStorage() -> String {
@@ -693,12 +921,24 @@ private struct ProjectDialog: View {
     private func confirm() {
         switch mode {
         case .add:
+            if location.clonesRepository && cloneRootPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                guard pickCloneFolder() != nil else { return }
+            }
+            if location.clonesRepository && state.config.repositoryCloneRootPath.isEmpty {
+                state.config.repositoryCloneRootPath = cloneRootPath
+                state.saveConfig()
+            }
             isValidating = true
             errorMessage = nil
             sshConnectionIssue = nil
-            Task {
-                await addProject(afterInteractiveSetup: false)
+            cloneTask = Task {
+                if location.clonesRepository {
+                    await cloneAndAddProject()
+                } else {
+                    await addProject(afterInteractiveSetup: false)
+                }
                 isValidating = false
+                cloneTask = nil
             }
         case .edit(let project):
             // Preserve fields the dialog doesn't yet edit (the worktree
@@ -722,6 +962,57 @@ private struct ProjectDialog: View {
             )
             presented = false
         }
+    }
+
+    private func cloneAndAddProject() async {
+        let source: RepositoryCloneSource
+        let repositoryName: String
+        switch location {
+        case .github:
+            guard let repository = selectedRepository else { return }
+            source = .github(repository.fullName)
+            repositoryName = repository.name
+        case .gitlab:
+            guard let repository = selectedRepository else { return }
+            source = .gitlab(repository.fullName)
+            repositoryName = repository.name
+        case .gitURL:
+            guard let derivedName = RepositoryImportService.repositoryName(from: gitRemote) else { return }
+            source = .gitURL(gitRemote.trimmingCharacters(in: .whitespacesAndNewlines))
+            repositoryName = derivedName
+        case .local, .remoteSSH:
+            return
+        }
+
+        let expandedRoot = NSString(string: cloneRootPath).expandingTildeInPath
+        let destination = URL(fileURLWithPath: expandedRoot, isDirectory: true)
+            .appendingPathComponent(repositoryName, isDirectory: true)
+        do {
+            try await RepositoryImportService().clone(source, to: destination)
+            if Task.isCancelled { return }
+            path = destination.path
+            do {
+                try await state.addProject(
+                    path: destination,
+                    displayName: name,
+                    icon: draftIcon,
+                    id: pendingProjectId
+                )
+                presented = false
+            } catch {
+                errorMessage = "Cloned to \(destination.path), but Alas couldn't add the project: \(error.localizedDescription)"
+            }
+        } catch {
+            if !Task.isCancelled {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func cancel() {
+        catalogTask?.cancel()
+        cloneTask?.cancel()
+        presented = false
     }
 
     private func addProject(afterInteractiveSetup: Bool) async {

--- a/Alas/Sources/Dialogs/RepositoryImportService.swift
+++ b/Alas/Sources/Dialogs/RepositoryImportService.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+enum RepositoryHost: String, Equatable, Sendable {
+    case github
+    case gitlab
+
+    var displayName: String { self == .github ? "GitHub" : "GitLab" }
+    var cli: String { self == .github ? "gh" : "glab" }
+    var hostname: String { self == .github ? "github.com" : "gitlab.com" }
+}
+
+struct RemoteRepository: Equatable, Identifiable, Sendable {
+    let host: RepositoryHost
+    let fullName: String
+    let name: String
+    let visibility: String
+    let isArchived: Bool
+
+    var id: String { "\(host.rawValue):\(fullName)" }
+}
+
+enum RepositoryCloneSource: Equatable, Sendable {
+    case github(String)
+    case gitlab(String)
+    case gitURL(String)
+}
+
+struct RepositoryCloneInvocation: Equatable, Sendable {
+    let executable: String
+    let arguments: [String]
+}
+
+enum RepositoryImportError: LocalizedError, Equatable {
+    case cliMissing(RepositoryHost)
+    case unauthenticated(RepositoryHost)
+    case destinationExists(String)
+    case commandFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .cliMissing(let host):
+            "`\(host.cli)` is not installed. Run `brew install \(host.cli)`, then retry."
+        case .unauthenticated(let host):
+            "\(host.displayName) authentication is required. Run `\(host.cli) auth login --hostname \(host.hostname)`, then retry."
+        case .destinationExists(let path):
+            "A file or folder already exists at \(path). Choose another clone folder."
+        case .commandFailed(let detail):
+            detail.isEmpty ? "The repository command failed." : detail
+        }
+    }
+}
+
+struct RepositoryImportService {
+    typealias Runner = @Sendable (String, [String], TimeInterval) async throws -> ProcessResult
+
+    private let run: Runner
+
+    init(run: @escaping Runner = { executable, arguments, timeout in
+        try await RepositoryImportService.runProcess(executable: executable, arguments: arguments, timeout: timeout)
+    }) {
+        self.run = run
+    }
+
+    static func parseGitHubRepositories(_ output: String) throws -> [RemoteRepository] {
+        let decoder = JSONDecoder()
+        let data = Data(output.utf8)
+        let values: [GitHubRepository]
+        if let pages = try? decoder.decode([[GitHubRepository]].self, from: data) {
+            values = pages.flatMap { $0 }
+        } else {
+            values = try decoder.decode([GitHubRepository].self, from: data)
+        }
+        return values.map {
+            RemoteRepository(
+                host: .github,
+                fullName: $0.fullName,
+                name: $0.name,
+                visibility: $0.isPrivate ? "Private" : "Public",
+                isArchived: $0.archived
+            )
+        }
+    }
+
+    static func parseGitLabRepositories(_ output: String) throws -> [RemoteRepository] {
+        try JSONDecoder().decode([GitLabRepository].self, from: Data(output.utf8)).map {
+            RemoteRepository(
+                host: .gitlab,
+                fullName: $0.fullName,
+                name: $0.name,
+                visibility: $0.visibility.capitalized,
+                isArchived: $0.archived
+            )
+        }
+    }
+
+    static func filter(_ repositories: [RemoteRepository], query: String) -> [RemoteRepository] {
+        let query = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return repositories }
+        return repositories.filter { $0.fullName.localizedCaseInsensitiveContains(query) }
+    }
+
+    static func repositoryName(from remote: String) -> String? {
+        var value = remote.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return nil }
+        if let marker = value.firstIndex(where: { $0 == "?" || $0 == "#" }) {
+            value = String(value[..<marker])
+        }
+        value = value.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard let component = value.split(whereSeparator: { $0 == "/" || $0 == ":" }).last else { return nil }
+        let name = component.hasSuffix(".git") ? component.dropLast(4) : component[...]
+        return name.isEmpty ? nil : String(name)
+    }
+
+    static func cloneInvocation(for source: RepositoryCloneSource, destination: URL) -> RepositoryCloneInvocation {
+        switch source {
+        case .github(let repository):
+            RepositoryCloneInvocation(executable: "gh", arguments: ["repo", "clone", repository, destination.path])
+        case .gitlab(let repository):
+            RepositoryCloneInvocation(executable: "glab", arguments: ["repo", "clone", repository, destination.path])
+        case .gitURL(let remote):
+            RepositoryCloneInvocation(executable: "git", arguments: ["clone", "--", remote, destination.path])
+        }
+    }
+
+    func repositories(for host: RepositoryHost) async throws -> [RemoteRepository] {
+        let version = try await run(host.cli, ["--version"], 30)
+        guard version.exitCode == 0 else { throw RepositoryImportError.cliMissing(host) }
+        let auth = try await run(host.cli, ["auth", "status", "--hostname", host.hostname], 30)
+        guard auth.exitCode == 0 else { throw RepositoryImportError.unauthenticated(host) }
+
+        let result: ProcessResult
+        switch host {
+        case .github:
+            result = try await run("gh", [
+                "api", "user/repos", "-X", "GET", "-f", "per_page=100",
+                "-f", "affiliation=owner,collaborator,organization_member",
+                "-f", "sort=updated", "--paginate", "--slurp",
+            ], 120)
+        case .gitlab:
+            result = try await run("glab", [
+                "api", "projects?membership=true&simple=true&per_page=100&order_by=last_activity_at&sort=desc",
+                "--paginate", "--output", "json",
+            ], 120)
+        }
+        guard result.exitCode == 0 else {
+            throw RepositoryImportError.commandFailed(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        return try host == .github
+            ? Self.parseGitHubRepositories(result.stdout)
+            : Self.parseGitLabRepositories(result.stdout)
+    }
+
+    func clone(_ source: RepositoryCloneSource, to destination: URL) async throws {
+        let fileManager = FileManager.default
+        guard !fileManager.fileExists(atPath: destination.path) else {
+            throw RepositoryImportError.destinationExists(destination.path)
+        }
+        let staging = destination
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(destination.lastPathComponent).clone-\(UUID().uuidString)", isDirectory: true)
+        let invocation = Self.cloneInvocation(for: source, destination: staging)
+        do {
+            let result = try await run(invocation.executable, invocation.arguments, 1_800)
+            guard result.exitCode == 0 else {
+                throw RepositoryImportError.commandFailed(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
+            }
+            guard !fileManager.fileExists(atPath: destination.path) else {
+                throw RepositoryImportError.destinationExists(destination.path)
+            }
+            try fileManager.moveItem(at: staging, to: destination)
+        } catch {
+            try? fileManager.removeItem(at: staging)
+            throw error
+        }
+    }
+
+    private static func runProcess(
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval
+    ) async throws -> ProcessResult {
+        var environment = Process.gitEnv()
+        environment["GIT_TERMINAL_PROMPT"] = "0"
+        return try await Process.run(
+            "/usr/bin/env",
+            args: [executable] + arguments,
+            env: environment,
+            timeout: timeout
+        )
+    }
+}
+
+private struct GitHubRepository: Decodable {
+    let fullName: String
+    let name: String
+    let isPrivate: Bool
+    let archived: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case fullName = "full_name"
+        case name
+        case isPrivate = "private"
+        case archived
+    }
+}
+
+private struct GitLabRepository: Decodable {
+    let fullName: String
+    let name: String
+    let visibility: String
+    let archived: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case fullName = "path_with_namespace"
+        case name = "path"
+        case visibility
+        case archived
+    }
+}

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -47,6 +47,7 @@ struct AppConfig: Codable, Equatable {
     var collapsedProjectIds: [String] = []
     var sidebarChromeOverrides: [String: SidebarChromeOverride] = [:]
     var shortcutOverrides: [String: ShortcutBinding?] = [:]
+    var repositoryCloneRootPath: String = ""
 
     struct Remote: Codable, Equatable {
         var enabled: Bool = false
@@ -582,7 +583,8 @@ extension AppConfig {
              recentProjectIds, recentWorktreeIdsByProject, recentWorktreeRefs,
              collapsedProjectIds,
              sidebarChromeOverrides,
-             shortcutOverrides
+             shortcutOverrides,
+             repositoryCloneRootPath
     }
 
     // Custom decode tolerates older config files that predate `code`.
@@ -821,6 +823,8 @@ extension AppConfig {
             (try? c.decode([String: SidebarChromeOverride].self, forKey: .sidebarChromeOverrides)) ?? [:]
         shortcutOverrides =
             (try? c.decode([String: ShortcutBinding?].self, forKey: .shortcutOverrides)) ?? [:]
+        repositoryCloneRootPath =
+            (try? c.decode(String.self, forKey: .repositoryCloneRootPath)) ?? ""
         migrateLegacyFindAndReplaceShortcutOverride()
         migrateLegacyAgentLauncherShortcutOverrides()
         removeShortcutOverridesCollidingWithReservedBindings()

--- a/Alas/Sources/Settings/GeneralPane.swift
+++ b/Alas/Sources/Settings/GeneralPane.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct GeneralPane: View {
@@ -20,8 +21,36 @@ struct GeneralPane: View {
                         AlasToggle(on: state.bind(\.general.autoUpdate))
                     }
                 }
+
+                SettingsGroup(title: "Repositories") {
+                    SettingsRow(
+                        name: "Default clone folder",
+                        desc: "Used when cloning repositories from GitHub, GitLab, or a Git URL."
+                    ) {
+                        HStack(spacing: 6) {
+                            AlasField(
+                                text: state.bind(\.repositoryCloneRootPath),
+                                placeholder: "Choose on first clone",
+                                monospaced: true
+                            )
+                            .frame(width: 220)
+                            AlasButton(title: "Choose…", action: chooseCloneFolder)
+                        }
+                    }
+                }
             }
             .padding(.horizontal, 32).padding(.vertical, 24)
+        }
+    }
+
+    private func chooseCloneFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url {
+            state.config.repositoryCloneRootPath = url.path
+            state.saveConfig()
         }
     }
 }

--- a/AlasTests/AppConfigCodeInstallTests.swift
+++ b/AlasTests/AppConfigCodeInstallTests.swift
@@ -15,6 +15,16 @@ struct AppConfigCodeInstallTests {
         #expect(AppConfig.defaults.code.showLineNumbers)
     }
 
+    @Test("clone folder round trips")
+    func cloneFolderRoundTrip() throws {
+        var config = AppConfig.defaults
+        config.repositoryCloneRootPath = "/tmp/repositories"
+
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: JSONEncoder().encode(config))
+
+        #expect(decoded.repositoryCloneRootPath == "/tmp/repositories")
+    }
+
     @Test("legacy config without these keys decodes with empty defaults")
     func legacyDecode() throws {
         // Minimal config omitting dismissedInstallNudges and userDefinedRecipes
@@ -52,6 +62,7 @@ struct AppConfigCodeInstallTests {
         let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
         #expect(cfg.code.dismissedInstallNudges == [])
         #expect(cfg.code.userDefinedRecipes == [:])
+        #expect(cfg.repositoryCloneRootPath == "")
     }
 
     @Test("legacy code config without showLineNumbers decodes as enabled")

--- a/AlasTests/RepositoryImportServiceTests.swift
+++ b/AlasTests/RepositoryImportServiceTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Repository import")
+struct RepositoryImportServiceTests {
+    @Test("GitHub catalog flattens paginated account repositories")
+    func parsesGitHubCatalog() throws {
+        let json = #"[[{"full_name":"team/private-repo","name":"private-repo","private":true,"archived":false}],[{"full_name":"me/archive","name":"archive","private":false,"archived":true}]]"#
+
+        let repositories = try RepositoryImportService.parseGitHubRepositories(json)
+
+        #expect(repositories == [
+            RemoteRepository(
+                host: .github,
+                fullName: "team/private-repo",
+                name: "private-repo",
+                visibility: "Private",
+                isArchived: false
+            ),
+            RemoteRepository(
+                host: .github,
+                fullName: "me/archive",
+                name: "archive",
+                visibility: "Public",
+                isArchived: true
+            ),
+        ])
+    }
+
+    @Test("GitLab catalog decodes account repositories")
+    func parsesGitLabCatalog() throws {
+        let json = #"[{"path_with_namespace":"group/tool","path":"tool","visibility":"private","archived":false}]"#
+
+        #expect(try RepositoryImportService.parseGitLabRepositories(json) == [
+            RemoteRepository(
+                host: .gitlab,
+                fullName: "group/tool",
+                name: "tool",
+                visibility: "Private",
+                isArchived: false
+            ),
+        ])
+    }
+
+    @Test("Repository search ignores case")
+    func filtersCatalog() {
+        let repositories = [
+            RemoteRepository(host: .github, fullName: "team/Alpha", name: "Alpha", visibility: "Private", isArchived: false),
+            RemoteRepository(host: .github, fullName: "me/beta", name: "beta", visibility: "Public", isArchived: false),
+        ]
+
+        #expect(RepositoryImportService.filter(repositories, query: "TEAM") == [repositories[0]])
+        #expect(RepositoryImportService.filter(repositories, query: "  ") == repositories)
+    }
+
+    @Test("Repository name supports URL and SCP remotes")
+    func derivesRepositoryName() {
+        #expect(RepositoryImportService.repositoryName(from: "https://codeberg.org/team/tool.git") == "tool")
+        #expect(RepositoryImportService.repositoryName(from: "git@codeberg.org:team/widget.git") == "widget")
+        #expect(RepositoryImportService.repositoryName(from: "") == nil)
+    }
+
+    @Test("Clone commands preserve each source's authentication")
+    func buildsCloneCommands() {
+        let destination = URL(fileURLWithPath: "/tmp/tool")
+
+        #expect(RepositoryImportService.cloneInvocation(for: .github("team/tool"), destination: destination)
+            == RepositoryCloneInvocation(executable: "gh", arguments: ["repo", "clone", "team/tool", "/tmp/tool"]))
+        #expect(RepositoryImportService.cloneInvocation(for: .gitlab("group/tool"), destination: destination)
+            == RepositoryCloneInvocation(executable: "glab", arguments: ["repo", "clone", "group/tool", "/tmp/tool"]))
+        #expect(RepositoryImportService.cloneInvocation(for: .gitURL("git@example.com:team/tool.git"), destination: destination)
+            == RepositoryCloneInvocation(executable: "git", arguments: ["clone", "--", "git@example.com:team/tool.git", "/tmp/tool"]))
+    }
+
+    @Test("Failed clone preserves a destination created by another process")
+    func failedCloneCleanup() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let destination = root.appendingPathComponent("tool")
+        let marker = destination.appendingPathComponent("README.md")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let service = RepositoryImportService { _, arguments, _ in
+            let cloneTarget = URL(fileURLWithPath: arguments.last ?? "")
+            try FileManager.default.createDirectory(at: cloneTarget, withIntermediateDirectories: true)
+            try "partial".write(
+                to: cloneTarget.appendingPathComponent("partial.txt"),
+                atomically: true,
+                encoding: .utf8
+            )
+            try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+            try "keep".write(to: marker, atomically: true, encoding: .utf8)
+            return ProcessResult(exitCode: 1, stdout: "", stderr: "clone failed")
+        }
+
+        await #expect(throws: RepositoryImportError.self) {
+            try await service.clone(.gitURL("https://example.com/team/tool.git"), to: destination)
+        }
+        #expect(try String(contentsOf: marker, encoding: .utf8) == "keep")
+        let leftovers = try FileManager.default.contentsOfDirectory(atPath: root.path)
+            .filter { $0.hasPrefix(".tool.clone-") }
+        #expect(leftovers.isEmpty)
+    }
+
+    @Test("Generic Git source clones a local repository")
+    func clonesLocalRepository() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let remote = root.appendingPathComponent("remote.git")
+        let destination = root.appendingPathComponent("checkout")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let initialized = try await Process.git(["init", "--bare", remote.path])
+        #expect(initialized.exitCode == 0)
+
+        try await RepositoryImportService().clone(.gitURL(remote.path), to: destination)
+
+        let checked = try await Process.git(["rev-parse", "--is-inside-work-tree"], cwd: destination)
+        #expect(checked.exitCode == 0)
+        #expect(checked.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "true")
+    }
+
+    @Test("CLI errors include setup commands")
+    func setupErrors() {
+        #expect(RepositoryImportError.cliMissing(.github).localizedDescription.contains("brew install gh"))
+        #expect(RepositoryImportError.unauthenticated(.gitlab).localizedDescription.contains("glab auth login --hostname gitlab.com"))
+    }
+}


### PR DESCRIPTION
## Summary
- add Local, GitHub, GitLab, Git URL, and SSH source modes to the new project dialog
- clone GitHub/GitLab repos through their CLIs and generic remotes through git
- persist a default clone folder and add focused import/config coverage

## Testing
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RepositoryImportServiceTests -only-testing:AlasTests/AppConfigCodeInstallTests -quiet test
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test: interrupted after reproducing existing unrelated suite failures; result bundle: /Users/nacho.lopez/Library/Developer/Xcode/DerivedData/Alas-efsgrmgltpaqgfbllybxegkpdcog/Logs/Test/Test-Alas-2026.08.31_15-59-54-+0200.xcresult