### PR TITLE
fix: avoid refreshing gg before commit dialogs

### DIFF
--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -94,6 +94,11 @@ final class GGMutationCoordinator {
         return try preflight(request, snapshot: snapshot)
     }
 
+    func prepare(_ request: GGMutationRequest, using snapshot: GGStackSnapshot) throws -> GGPreparedMutation {
+        guard activeRequest == nil else { throw GGMutationError.operationInFlight }
+        return try preflight(request, snapshot: snapshot)
+    }
+
     func prepareRestackPreview() async throws -> GGPreparedRestack {
         guard activeRequest == nil else { throw GGMutationError.operationInFlight }
         activeRequest = .restack

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -214,6 +214,11 @@ final class RightPaneState: GGSplitCommitServicing {
         ggStack != nil && ggStackCommitsKey != currentGGStackCommitsKey
     }
 
+    private var cachedGGStackSnapshot: GGStackSnapshot? {
+        guard !ggCommitSelectionIsStale, let ggStack else { return nil }
+        return GGStackSnapshot(version: GGStackSnapshot.supportedSchemaVersion, stack: ggStack)
+    }
+
     // Sync-nudge state. All fields are in-memory only; nothing is
     // persisted to AppConfig. Two independent conditions:
     //   - behindBase: HEAD is behind the trunk base (origin/main).
@@ -1472,14 +1477,15 @@ final class RightPaneState: GGSplitCommitServicing {
     @ObservationIgnored var requestGGSplitCommit: ((GGStackEntry) -> Void)? = nil
 
     func loadDescription(target: GGSplitCommitTarget) async throws -> GGSplitLoadedDescription {
-        let before = try await ggService.currentStackSnapshot(worktreePath: worktree.path.path)
-        guard let identity = before.identity else { throw GGMutationError.staleConfirmation }
+        guard let snapshot = cachedGGStackSnapshot,
+              let identity = snapshot.identity,
+              let entry = snapshot.stack?.entry(matchingCommitSHA: target.targetSHA),
+              target.targetGGID == nil || entry.ggId == target.targetGGID
+        else { throw GGMutationError.staleConfirmation }
         let description = try await ggService.describeSplit(
             worktreePath: worktree.path.path,
             target: target.commandTarget
         )
-        let after = try await ggService.currentStackSnapshot(worktreePath: worktree.path.path)
-        guard after.identity == identity else { throw GGMutationError.staleConfirmation }
         return GGSplitLoadedDescription(description: description, stackIdentity: identity)
     }
 
@@ -1496,24 +1502,25 @@ final class RightPaneState: GGSplitCommitServicing {
     }
 
     func requestGGDrop(_ entry: GGStackEntry) {
-        Task { @MainActor in
-            do {
-                let prepared = try await ggMutationCoordinator.prepare(.drop(target: entry.id))
-                guard case .drop(_, let descendants, let hasOpenReview) = prepared.confirmation else {
-                    throw GGMutationError.staleConfirmation
-                }
-                pendingGGDropPrepared = prepared
-                pendingGGDrop = GGDropPresentation(
-                    target: entry.id,
-                    title: entry.title,
-                    rewrittenDescendants: descendants,
-                    openReviewLabel: hasOpenReview
-                        ? (commitRemote?.kind.reviewRequestLabel ?? "review")
-                        : nil
-                )
-            } catch {
-                ggActionState.setError(GGErrorPresentation.message(for: error))
+        do {
+            guard let snapshot = cachedGGStackSnapshot else {
+                throw GGMutationError.staleConfirmation
             }
+            let prepared = try ggMutationCoordinator.prepare(.drop(target: entry.id), using: snapshot)
+            guard case .drop(_, let descendants, let hasOpenReview) = prepared.confirmation else {
+                throw GGMutationError.staleConfirmation
+            }
+            pendingGGDropPrepared = prepared
+            pendingGGDrop = GGDropPresentation(
+                target: entry.id,
+                title: entry.title,
+                rewrittenDescendants: descendants,
+                openReviewLabel: hasOpenReview
+                    ? (commitRemote?.kind.reviewRequestLabel ?? "review")
+                    : nil
+            )
+        } catch {
+            ggActionState.setError(GGErrorPresentation.message(for: error))
         }
     }
 
@@ -1526,7 +1533,23 @@ final class RightPaneState: GGSplitCommitServicing {
         guard let prepared = pendingGGDropPrepared else { return }
         pendingGGDrop = nil
         pendingGGDropPrepared = nil
-        runGGMutation(prepared)
+        guard let operation = ggMutationCoordinator.startApplying(prepared) else { return }
+        let actionGeneration = ggActionState.actionGeneration
+        Task { @MainActor in
+            do {
+                try await operation.value
+            } catch let error as GGMutationError {
+                switch error {
+                case .immutableTarget, .staleConfirmation:
+                    await refreshGGStack(forceRemote: true)
+                default:
+                    break
+                }
+                publishGGMutationPresentationError(error, forActionGeneration: actionGeneration)
+            } catch {
+                publishGGMutationPresentationError(error, forActionGeneration: actionGeneration)
+            }
+        }
     }
 
     func requestGGUnstack(_ entry: GGStackEntry) {

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -149,6 +149,25 @@ private final class ThrowingFakeGGRunner: GGCommandRunning, @unchecked Sendable 
     }
 }
 
+private final class SplitDescriptionGGRunner: GGCommandRunning, @unchecked Sendable {
+    private(set) var calls: [[String]] = []
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        calls.append(args)
+        if args == ["ls", "--json"] {
+            return ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        }
+        if args == ["split", "--describe", "--commit", "id-2", "--json"] {
+            return ProcessResult(
+                exitCode: 0,
+                stdout: #"{"version":1,"plan_token":"token","target":{"gg_id":"id-2","sha":"bbbbbbb","tree":"tree"},"hunks":[],"non_textual_files":[],"first_message":"First","remainder_message":"Remainder"}"#,
+                stderr: ""
+            )
+        }
+        return ProcessResult(exitCode: 1, stdout: "", stderr: "unexpected args: \(args)")
+    }
+}
+
 /// Delays the first stack read so a later refresh can publish a newer stack
 /// before the stale watcher result returns.
 private final class DelayedStackGGRunner: GGCommandRunning, @unchecked Sendable {
@@ -1006,20 +1025,122 @@ struct RightPaneGGStackTests {
         ))
     }
 
-    @Test func prepareFailurePresentsGGServiceUserMessage() async throws {
+    @Test func dropPresentationUsesLoadedStackWithoutRunningGG() async throws {
         let wt = makeWorktree()
         let state = makeState(worktree: wt)
-        state.ggService = GGService(runner: ThrowingFakeGGRunner())
-        let entry = try #require(try GGStackSnapshot.decode(
+        let runner = ThrowingFakeGGRunner()
+        state.ggService = GGService(runner: runner)
+        let stack = try #require(try GGStackSnapshot.decode(
             fromJSON: Data(GGStackModelsTests.fixture.utf8)
-        ).stack?.entries.first)
+        ).stack)
+        state.ggStack = stack
+        state.ggStackCommitsKey = state.currentGGStackCommitsKey
+        let entry = stack.entries[1]
 
         state.requestGGDrop(entry)
-        for _ in 0..<500 where state.ggActionState.lastError == nil {
+        await Task.yield()
+
+        #expect(state.pendingGGDrop?.target == "id-2")
+        #expect(state.pendingGGDrop?.rewrittenDescendants == 1)
+        #expect(runner.callCount == 0)
+    }
+
+    @Test func staleDropApplyRefreshesLoadedStack() async throws {
+        let state = makeState()
+        try FileManager.default.createDirectory(
+            at: state.worktree.path.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        let staleJSON = GGStackModelsTests.fixture.replacingOccurrences(
+            of: #""pr_state": "open""#,
+            with: #""pr_state": null"#
+        )
+        let runner = SequencedFakeGGRunner(results: [
+            ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: ""),
+        ])
+        state.ggService = GGService(runner: runner)
+        state.ggCapabilities = {
+            GGCapabilities(
+                structuredSplit: false,
+                keepCurrentUnstack: false,
+                localStackSnapshot: false
+            )
+        }
+        state.ggContext = .active(stackName: "agent-inbox")
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
+        let stack = try #require(try GGStackSnapshot.decode(fromJSON: Data(staleJSON.utf8)).stack)
+        state.ggStack = stack
+        state.ggStackCommitsKey = state.currentGGStackCommitsKey
+
+        state.requestGGDrop(stack.entries[1])
+        state.performGGDrop()
+        for _ in 0..<500 where runner.callCount < 2 || state.ggActionState.lastError == nil {
             try await Task.sleep(nanoseconds: 10_000_000)
         }
 
-        #expect(state.ggActionState.lastError == "boom")
+        #expect(runner.callCount == 2)
+        #expect(state.ggStack?.entries[1].prState == .open)
+        #expect(state.ggActionState.lastError == "The stack changed. Review the updated state and try again.")
+    }
+
+    @Test func immutableDropApplyRefreshesLoadedStack() async throws {
+        let state = makeState()
+        try FileManager.default.createDirectory(
+            at: state.worktree.path.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        let mergedJSON = GGStackModelsTests.fixture.replacingOccurrences(
+            of: #""pr_state": "open""#,
+            with: #""pr_state": "merged""#
+        )
+        let runner = SequencedFakeGGRunner(results: [
+            ProcessResult(exitCode: 0, stdout: mergedJSON, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: mergedJSON, stderr: ""),
+        ])
+        state.ggService = GGService(runner: runner)
+        state.ggCapabilities = {
+            GGCapabilities(
+                structuredSplit: false,
+                keepCurrentUnstack: false,
+                localStackSnapshot: false
+            )
+        }
+        state.ggContext = .active(stackName: "agent-inbox")
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
+        let stack = try #require(try GGStackSnapshot.decode(fromJSON: Data(GGStackModelsTests.fixture.utf8)).stack)
+        state.ggStack = stack
+        state.ggStackCommitsKey = state.currentGGStackCommitsKey
+
+        state.requestGGDrop(stack.entries[1])
+        state.performGGDrop()
+        for _ in 0..<500 where runner.callCount < 2 || state.ggActionState.lastError == nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(runner.callCount == 2)
+        #expect(state.ggStack?.entries[1].prState == .merged)
+        #expect(state.ggActionState.lastError == "Merged commits cannot be rewritten.")
+    }
+
+    @Test func splitDescriptionUsesLoadedStackWithoutRefreshingGG() async throws {
+        let state = makeState()
+        let runner = SplitDescriptionGGRunner()
+        state.ggService = GGService(runner: runner)
+        let snapshot = try GGStackSnapshot.decode(fromJSON: Data(GGStackModelsTests.fixture.utf8))
+        state.ggStack = snapshot.stack
+        state.ggStackCommitsKey = state.currentGGStackCommitsKey
+
+        let loaded = try await state.loadDescription(target: GGSplitCommitTarget(
+            worktreeId: state.worktree.id,
+            targetGGID: "id-2",
+            targetSHA: "bbbbbbb"
+        ))
+
+        #expect(runner.calls == [["split", "--describe", "--commit", "id-2", "--json"]])
+        #expect(loaded.stackIdentity == snapshot.identity)
     }
 
     @Test func applyPreflightFailurePresentsGGServiceUserMessage() async throws {


### PR DESCRIPTION
## Summary

Drop Commit and Split Commit now open from the GG stack already loaded in the UI instead of waiting on fresh `gg ls --json` refreshes before presentation. The actual mutation paths still reload and validate fresh stack state before rewriting anything.

## Changes

- Added a cached GG stack snapshot path for commit-dialog presentation when the loaded stack is current.
- Let drop preflight run synchronously from that loaded snapshot.
- Let split description validate the selected target from the loaded stack and only call `gg split --describe` before opening the editor.
- Added focused regression coverage for drop and split presentation without GG refresh calls.

## Verification

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:'AlasTests/RightPaneGGStackTests/dropPresentationUsesLoadedStackWithoutRunningGG()' -only-testing:'AlasTests/RightPaneGGStackTests/splitDescriptionUsesLoadedStackWithoutRefreshingGG()' test -quiet`