### PR TITLE
fix(worktrees): show stacked diff modes

### DIFF
--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -50,7 +50,6 @@ struct WorktreeRowView: View {
     struct GGModeMenuItem: Equatable, Identifiable {
         let mode: GGWorktreeMode
         let title: String
-        let isSelected: Bool
 
         var id: GGWorktreeMode { mode }
     }
@@ -59,18 +58,15 @@ struct WorktreeRowView: View {
         [
             GGModeMenuItem(
                 mode: .inherit,
-                title: "Inherit repository default",
-                isSelected: selectedMode == .inherit
+                title: selectedMode == .inherit ? "✓ Inherit repository default" : "Inherit repository default"
             ),
             GGModeMenuItem(
                 mode: .on,
-                title: "On",
-                isSelected: selectedMode == .on
+                title: selectedMode == .on ? "✓ On" : "On"
             ),
             GGModeMenuItem(
                 mode: .off,
-                title: "Off",
-                isSelected: selectedMode == .off
+                title: selectedMode == .off ? "✓ Off" : "Off"
             )
         ]
     }
@@ -293,13 +289,10 @@ struct WorktreeRowView: View {
                 if ggMenuModel.isVisible {
                     Menu(Self.ggModeMenuTitle) {
                         ForEach(Self.ggModeMenuItems(selectedMode: ggMenuModel.selectedMode)) { item in
-                            Toggle(item.title, isOn: Binding(
-                                get: { item.isSelected },
-                                set: { isOn in
-                                    guard isOn, item.mode != ggMenuModel.selectedMode else { return }
-                                    onSetGGWorktreeMode(item.mode)
-                                }
-                            ))
+                            Button(item.title) {
+                                guard item.mode != ggMenuModel.selectedMode else { return }
+                                onSetGGWorktreeMode(item.mode)
+                            }
                         }
                     }
                     if let explanation = ggMenuModel.inactiveExplanation {

--- a/AlasTests/GGWorktreeMenuModelTests.swift
+++ b/AlasTests/GGWorktreeMenuModelTests.swift
@@ -99,12 +99,11 @@ struct GGWorktreeMenuModelTests {
         #expect(model.showsStatusIndicator)
     }
 
-    @Test func ggModeMenuItemsExposeStableLabelsAndSelectionState() {
+    @Test func ggModeMenuItemsMarkTheSelectedMode() {
         let items = WorktreeRowView.ggModeMenuItems(selectedMode: .on)
 
         #expect(items.map(\.mode) == [.inherit, .on, .off])
-        #expect(items.map(\.title) == ["Inherit repository default", "On", "Off"])
-        #expect(items.map(\.isSelected) == [false, true, false])
+        #expect(items.map(\.title) == ["Inherit repository default", "✓ On", "Off"])
     }
 
     private func menuModel(


### PR DESCRIPTION
## Summary

The worktree context menu showed an empty Stacked Diffs Mode submenu because nested SwiftUI toggles did not render there on macOS.

## Changes

- Replace the nested toggles with ordinary selectable menu buttons.
- Mark the active Inherit, On, or Off option with a checkmark.
- Cover the selected menu label with a focused test.

## Verification

- `xcodegen`
- Focused `GGWorktreeMenuModelTests` passes.
- Full macOS build passes.
- Full test suite was interrupted after 15 minutes because xcodebuild was waiting with no active test host.