### PR TITLE
fix(sidebar): hide removal actions for main worktrees

### DIFF
--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -246,6 +246,8 @@ struct RootView: View {
             DeleteFailedWorktreeView(
                 worktree: wt,
                 message: message,
+                allowsRemovalActions: state.projects.first(where: { $0.id == wt.projectId })
+                    .map { !state.projectsManager.isMain(wt, in: $0) } ?? false,
                 onRetry: { state.deleteWorktree(wt) },
                 onArchive: { state.archiveWorktree(wt) },
                 onCopyError: {

--- a/Alas/Sources/Center/DeleteFailedWorktreeView.swift
+++ b/Alas/Sources/Center/DeleteFailedWorktreeView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct DeleteFailedWorktreeView: View {
     let worktree: Worktree
     let message: String
+    let allowsRemovalActions: Bool
     let onRetry: () -> Void
     let onArchive: () -> Void
     let onCopyError: () -> Void
@@ -34,8 +35,10 @@ struct DeleteFailedWorktreeView: View {
                 .padding(.horizontal, 24)
             HStack(spacing: 10) {
                 AlasButton(title: "Copy Error", icon: "doc.on.doc", style: .normal, action: onCopyError)
-                AlasButton(title: "Archive", icon: "archivebox", style: .normal, action: onArchive)
-                AlasButton(title: "Retry Delete", icon: "arrow.clockwise", style: .primary, action: onRetry)
+                if allowsRemovalActions {
+                    AlasButton(title: "Archive", icon: "archivebox", style: .normal, action: onArchive)
+                    AlasButton(title: "Retry Delete", icon: "arrow.clockwise", style: .primary, action: onRetry)
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -274,8 +274,10 @@ struct WorktreeRowView: View {
                 }
                 Button("Copy Path", action: onCopyPath)
             } else if case .deleteFailed = operationState {
-                Button("Retry Delete", action: onRetryDelete)
-                Button("Archive", action: onArchive)
+                if Self.showsRemovalActions(isMain: isMain) {
+                    Button("Retry Delete", action: onRetryDelete)
+                    Button("Archive", action: onArchive)
+                }
                 Divider()
                 if let errorMessage {
                     Button("Copy Error") { onCopyError(errorMessage) }

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -87,6 +87,10 @@ struct WorktreeRowView: View {
         "fg-faint"
     }
 
+    static func showsRemovalActions(isMain: Bool) -> Bool {
+        !isMain
+    }
+
     private static func stackSummaryText(merged: Int, total: Int) -> String {
         "gg stack · \(merged) of \(total) commit\(total == 1 ? "" : "s") merged"
     }
@@ -308,10 +312,12 @@ struct WorktreeRowView: View {
                     }
                     Divider()
                 }
-                Button("Archive", action: onArchive)
-                Button("Delete Worktree…", role: .destructive, action: onDelete)
-                if showKeepBranchOption {
-                    Button("Delete Worktree, Keep Branch…", role: .destructive, action: onDeleteKeepBranch)
+                if Self.showsRemovalActions(isMain: isMain) {
+                    Button("Archive", action: onArchive)
+                    Button("Delete Worktree…", role: .destructive, action: onDelete)
+                    if showKeepBranchOption {
+                        Button("Delete Worktree, Keep Branch…", role: .destructive, action: onDeleteKeepBranch)
+                    }
                 }
             }
         }

--- a/AlasTests/WorktreeRowHeightTests.swift
+++ b/AlasTests/WorktreeRowHeightTests.swift
@@ -6,6 +6,11 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct WorktreeRowHeightTests {
+    @Test func mainWorktreeDoesNotShowRemovalActions() {
+        #expect(!WorktreeRowView.showsRemovalActions(isMain: true))
+        #expect(WorktreeRowView.showsRemovalActions(isMain: false))
+    }
+
     @Test func ggModeMenuUsesStackedDiffsName() {
         #expect(WorktreeRowView.ggModeMenuTitle == "Stacked Diffs Mode")
     }


### PR DESCRIPTION
## Summary

The primary checkout is a protected worktree, but its context menu exposed archive and deletion actions. Hide those actions while leaving feature-worktree actions unchanged.

## Changes

- Gate archive and delete menu actions on the main-worktree flag.
- Add a focused regression test for the visibility rule.

## Validation

- `swiftc -parse Alas/Sources/Sidebar/WorktreeRowView.swift AlasTests/WorktreeRowHeightTests.swift`
- `xcodebuild` could not compile locally because this linked worktree is missing `.build/ghostty/GhosttyKit.xcframework`.