### PR TITLE
feat(gg): gg sync progress

### DIFF
--- a/Alas/Sources/Integrations/GG/GGConfigReader.swift
+++ b/Alas/Sources/Integrations/GG/GGConfigReader.swift
@@ -57,7 +57,9 @@ enum GGConfigReader {
             syncAutoRebase: effectiveDefaults?.syncAutoRebase
                 ?? GGEffectiveConfig.defaults.syncAutoRebase,
             syncBehindThreshold: effectiveDefaults?.syncBehindThreshold.flatMap { $0 >= 0 ? $0 : nil }
-                ?? GGEffectiveConfig.defaults.syncBehindThreshold
+                ?? GGEffectiveConfig.defaults.syncBehindThreshold,
+            syncAutoLint: effectiveDefaults?.syncAutoLint
+                ?? GGEffectiveConfig.defaults.syncAutoLint
         )
     }
 
@@ -90,16 +92,19 @@ enum GGConfigReader {
     private struct EffectiveDefaults: Decodable {
         var syncAutoRebase: Bool?
         var syncBehindThreshold: Int?
+        var syncAutoLint: Bool?
 
         private enum CodingKeys: String, CodingKey {
             case syncAutoRebase = "sync_auto_rebase"
             case syncBehindThreshold = "sync_behind_threshold"
+            case syncAutoLint = "sync_auto_lint"
         }
 
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             syncAutoRebase = try? container.decode(Bool.self, forKey: .syncAutoRebase)
             syncBehindThreshold = try? container.decode(Int.self, forKey: .syncBehindThreshold)
+            syncAutoLint = try? container.decode(Bool.self, forKey: .syncAutoLint)
         }
     }
 }

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -301,8 +301,13 @@ final class GGMutationCoordinator {
             )
             recordSummary(for: request, result: result)
             reconcilePausedState(after: request, error: nil)
-            releaseAction()
-            await refresh(after: request, result: result)
+            if request == .sync {
+                await refresh(after: request, result: result)
+                releaseAction()
+            } else {
+                releaseAction()
+                await refresh(after: request, result: result)
+            }
             if case .undo(let operationID) = request {
                 clearUndoCandidate(forOperationID: operationID)
             }

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -326,16 +326,26 @@ final class GGMutationCoordinator {
                 }
                 if actionState.lastError == nil { actionState.setError(error.userMessage) }
             }
-            releaseAction()
-            await refresh(after: request, result: .none)
+            if request == .sync {
+                await refresh(after: request, result: .none)
+                releaseAction()
+            } else {
+                releaseAction()
+                await refresh(after: request, result: .none)
+            }
             if toleratesMalformedRemoteOutput { return }
             throw error
         } catch {
             reconcilePausedState(after: request, error: error)
             if request == .sync { actionState.markSyncTerminalFailure() }
             actionState.setError(error.localizedDescription)
-            releaseAction()
-            await refresh(after: request, result: .none)
+            if request == .sync {
+                await refresh(after: request, result: .none)
+                releaseAction()
+            } else {
+                releaseAction()
+                await refresh(after: request, result: .none)
+            }
             throw error
         }
     }

--- a/Alas/Sources/Integrations/GG/GGMutationModels.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationModels.swift
@@ -3,8 +3,13 @@ import Foundation
 struct GGEffectiveConfig: Equatable, Sendable {
     var syncAutoRebase: Bool
     var syncBehindThreshold: Int
+    var syncAutoLint: Bool = false
 
-    static let defaults = GGEffectiveConfig(syncAutoRebase: false, syncBehindThreshold: 1)
+    static let defaults = GGEffectiveConfig(
+        syncAutoRebase: false,
+        syncBehindThreshold: 1,
+        syncAutoLint: false
+    )
 }
 
 struct GGCapabilities: Equatable, Sendable {

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -442,13 +442,13 @@ struct GGStackReadinessModel: Equatable {
                 id: "prepare",
                 title: "Preparing stack",
                 detail: preparationDetails,
-                state: sawStart ? .complete : activeFailureState
+                state: sawStart || sawSummary ? .complete : activeFailureState
             ),
             GGSyncProgressPresentation.Step(
                 id: "commits",
                 title: "Syncing commits",
-                detail: sawStart ? (liveStatus ?? countStatus()) : "Waiting for stack preparation",
-                state: !sawStart ? .pending : (sawSummary ? .complete : activeFailureState)
+                detail: sawStart || sawSummary ? (liveStatus ?? countStatus()) : "Waiting for stack preparation",
+                state: sawSummary ? .complete : (sawStart ? activeFailureState : .pending)
             ),
             GGSyncProgressPresentation.Step(
                 id: "reviews",

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -421,7 +421,8 @@ struct GGStackReadinessModel: Equatable {
             }
         }
 
-        let terminalFailure = hasTerminalFailure || hasTerminalEventError || (sawSummary && hasEntryError)
+        let summaryEntryFailure = sawSummary && hasEntryError
+        let terminalFailure = hasTerminalFailure || hasTerminalEventError || summaryEntryFailure
         if sawSummary && isInFlight && !terminalFailure {
             liveStatus = "Refreshing Changes…"
         } else if !isInFlight || terminalFailure {
@@ -448,19 +449,21 @@ struct GGStackReadinessModel: Equatable {
                 id: "commits",
                 title: "Syncing commits",
                 detail: sawStart || sawSummary ? (liveStatus ?? countStatus()) : "Waiting for stack preparation",
-                state: sawSummary ? .complete : (sawStart ? activeFailureState : .pending)
+                state: summaryEntryFailure ? .failed : (sawSummary ? .complete :
+                    (sawStart ? activeFailureState : .pending))
             ),
             GGSyncProgressPresentation.Step(
                 id: "reviews",
                 title: "Updating pull requests",
                 detail: sawPREvent ? "Publishing review state" : "Waiting for pushed commits",
-                state: sawSummary ? .complete : (sawPREvent ? activeFailureState : .pending)
+                state: summaryEntryFailure ? .pending : (sawSummary ? .complete :
+                    (sawPREvent ? activeFailureState : .pending))
             ),
             GGSyncProgressPresentation.Step(
                 id: "refresh",
                 title: "Refreshing Changes",
                 detail: "Reloading Git and provider status",
-                state: sawSummary ? (isInFlight ? activeFailureState : .complete) : .pending
+                state: sawSummary && !terminalFailure ? (isInFlight ? .current : .complete) : .pending
             ),
         ]
         return GGSyncProgressPresentation(

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -1,6 +1,15 @@
 import Foundation
 
 struct GGSyncProgressPresentation: Equatable {
+    struct Step: Equatable, Identifiable {
+        enum State: Equatable { case pending, current, complete, failed }
+
+        let id: String
+        let title: String
+        let detail: String
+        let state: State
+    }
+
     struct Row: Equatable, Identifiable {
         let position: Int
         let text: String
@@ -9,6 +18,7 @@ struct GGSyncProgressPresentation: Equatable {
 
     let liveStatus: String?
     let showsSpinner: Bool
+    let steps: [Step]
     let rows: [Row]
 }
 
@@ -212,7 +222,10 @@ struct GGStackReadinessModel: Equatable {
                 ? makeSyncProgress(
                     events: action.syncProgress,
                     isInFlight: inFlight == .sync,
-                    hasTerminalFailure: action.syncHasTerminalFailure
+                    hasTerminalFailure: action.syncHasTerminalFailure,
+                    base: stack.base,
+                    behindBase: behind,
+                    effectiveConfig: effectiveConfig
                 )
                 : nil,
             isRetainedSyncFailure: isRetainedSyncFailure,
@@ -245,7 +258,10 @@ struct GGStackReadinessModel: Equatable {
                 ? makeSyncProgress(
                     events: action.syncProgress,
                     isInFlight: inFlight == .sync,
-                    hasTerminalFailure: action.syncHasTerminalFailure
+                    hasTerminalFailure: action.syncHasTerminalFailure,
+                    base: "base",
+                    behindBase: 0,
+                    effectiveConfig: .defaults
                 )
                 : nil,
             isRetainedSyncFailure: false,
@@ -290,17 +306,47 @@ struct GGStackReadinessModel: Equatable {
         var row: String?
     }
 
+    @MainActor
+    static func syncProgress(
+        action: GGStackActionState,
+        base: String,
+        behindBase: Int,
+        effectiveConfig: GGEffectiveConfig
+    ) -> GGSyncProgressPresentation? {
+        let isRetainedFailure = action.inFlightAction == nil
+            && action.lastError != nil
+            && !action.syncProgress.isEmpty
+        guard action.inFlightAction == .sync
+                || action.pausedOperation?.pausedBy == .sync
+                || isRetainedFailure
+        else { return nil }
+        return makeSyncProgress(
+            events: action.syncProgress,
+            isInFlight: action.inFlightAction == .sync,
+            hasTerminalFailure: action.syncHasTerminalFailure,
+            base: base,
+            behindBase: behindBase,
+            effectiveConfig: effectiveConfig
+        )
+    }
+
     private static func makeSyncProgress(
         events: [GGSyncEvent],
         isInFlight: Bool,
-        hasTerminalFailure: Bool
+        hasTerminalFailure: Bool,
+        base: String,
+        behindBase: Int,
+        effectiveConfig: GGEffectiveConfig
     ) -> GGSyncProgressPresentation {
         var entries: [Int: SyncEntryProgress] = [:]
         var completed: Set<Int> = []
         var totalEntries: Int?
-        var liveStatus: String? = events.isEmpty && isInFlight ? "Preparing sync…" : nil
+        var liveStatus: String? = events.isEmpty && isInFlight ? "Preparing stack…" : nil
         var sawSummary = false
         var hasTerminalEventError = false
+        var hasEntryError = false
+        var sawStart = false
+        var sawPREvent = false
 
         func titledStatus(_ verb: String, position: Int) -> String {
             guard let title = entries[position]?.title else { return "\(verb) [\(position)]…" }
@@ -319,6 +365,7 @@ struct GGStackReadinessModel: Equatable {
         for event in events {
             switch event {
             case .start(let total):
+                sawStart = true
                 totalEntries = total
                 liveStatus = "Syncing 0 of \(total) commit\(total == 1 ? "" : "s")…"
             case .entryStarted(let position, let title):
@@ -331,11 +378,13 @@ struct GGStackReadinessModel: Equatable {
                 entries[position, default: .init()].row = "[\(position)] Pushed"
                 liveStatus = titledStatus("Finishing", position: position)
             case .prCreated(let position, let number, _, _):
+                sawPREvent = true
                 let prefix = pushedPrefix(position: position)
                 entries[position, default: .init()].row = "[\(position)] \(prefix)PR #\(number) created"
                 completed.insert(position)
                 liveStatus = countStatus()
             case .prUpdated(let position, let number, let action):
+                sawPREvent = true
                 let result = switch action {
                 case "updated": " updated"
                 case "unchanged", "up_to_date": " up to date"
@@ -347,12 +396,14 @@ struct GGStackReadinessModel: Equatable {
                 completed.insert(position)
                 liveStatus = countStatus()
             case .prSkippedClosed(let position, let number):
+                sawPREvent = true
                 let prefix = pushedPrefix(position: position)
                 entries[position, default: .init()].row = "[\(position)] \(prefix)PR #\(number) already closed"
                 completed.insert(position)
                 liveStatus = countStatus()
             case .error(let position, let operation, _):
                 if let position {
+                    hasEntryError = true
                     var entry = entries[position, default: .init()]
                     entry.failedToPush = entry.failedToPush || operation == "push"
                     let failure = entry.failedToPush ? "Failed to push" : "Failed"
@@ -370,10 +421,52 @@ struct GGStackReadinessModel: Equatable {
             }
         }
 
-        if !isInFlight || hasTerminalFailure || hasTerminalEventError { liveStatus = nil }
+        let terminalFailure = hasTerminalFailure || hasTerminalEventError || (sawSummary && hasEntryError)
+        if sawSummary && isInFlight && !terminalFailure {
+            liveStatus = "Refreshing Changes…"
+        } else if !isInFlight || terminalFailure {
+            liveStatus = nil
+        }
+        let preparationDetails = [
+            "Checking base",
+            effectiveConfig.syncAutoRebase
+                && effectiveConfig.syncBehindThreshold > 0
+                && behindBase >= effectiveConfig.syncBehindThreshold
+                ? "Rebase onto \(base) if needed"
+                : nil,
+            effectiveConfig.syncAutoLint ? "Run configured lint" : nil,
+        ].compactMap { $0 }.joined(separator: " · ")
+        let activeFailureState: GGSyncProgressPresentation.Step.State = terminalFailure ? .failed : .current
+        let steps = [
+            GGSyncProgressPresentation.Step(
+                id: "prepare",
+                title: "Preparing stack",
+                detail: preparationDetails,
+                state: sawStart ? .complete : activeFailureState
+            ),
+            GGSyncProgressPresentation.Step(
+                id: "commits",
+                title: "Syncing commits",
+                detail: sawStart ? (liveStatus ?? countStatus()) : "Waiting for stack preparation",
+                state: !sawStart ? .pending : (sawSummary ? .complete : activeFailureState)
+            ),
+            GGSyncProgressPresentation.Step(
+                id: "reviews",
+                title: "Updating pull requests",
+                detail: sawPREvent ? "Publishing review state" : "Waiting for pushed commits",
+                state: sawSummary ? .complete : (sawPREvent ? activeFailureState : .pending)
+            ),
+            GGSyncProgressPresentation.Step(
+                id: "refresh",
+                title: "Refreshing Changes",
+                detail: "Reloading Git and provider status",
+                state: sawSummary ? (isInFlight ? activeFailureState : .complete) : .pending
+            ),
+        ]
         return GGSyncProgressPresentation(
             liveStatus: liveStatus,
-            showsSpinner: isInFlight && !sawSummary && !hasTerminalFailure && !hasTerminalEventError,
+            showsSpinner: isInFlight && !terminalFailure,
+            steps: steps,
             rows: entries.compactMap { position, entry in
                 entry.row.map { .init(position: position, text: $0) }
             }.sorted { $0.position < $1.position }

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -423,6 +423,7 @@ struct GGStackReadinessModel: Equatable {
 
         let summaryEntryFailure = sawSummary && hasEntryError
         let terminalFailure = hasTerminalFailure || hasTerminalEventError || summaryEntryFailure
+        let summaryFailure = sawSummary && terminalFailure
         if sawSummary && isInFlight && !terminalFailure {
             liveStatus = "Refreshing Changes…"
         } else if !isInFlight || terminalFailure {
@@ -438,6 +439,12 @@ struct GGStackReadinessModel: Equatable {
             effectiveConfig.syncAutoLint ? "Run configured lint" : nil,
         ].compactMap { $0 }.joined(separator: " · ")
         let activeFailureState: GGSyncProgressPresentation.Step.State = terminalFailure ? .failed : .current
+        let commitsDetail = summaryFailure ? "Sync failed" :
+            (sawSummary ? "Commit sync complete" :
+                (sawStart ? (liveStatus ?? countStatus()) : "Waiting for stack preparation"))
+        let reviewsDetail = summaryFailure ? "Not completed" :
+            (sawSummary ? "Pull request updates complete" :
+                (sawPREvent ? "Publishing review state" : "Waiting for pushed commits"))
         let steps = [
             GGSyncProgressPresentation.Step(
                 id: "prepare",
@@ -448,15 +455,15 @@ struct GGStackReadinessModel: Equatable {
             GGSyncProgressPresentation.Step(
                 id: "commits",
                 title: "Syncing commits",
-                detail: sawStart || sawSummary ? (liveStatus ?? countStatus()) : "Waiting for stack preparation",
-                state: summaryEntryFailure ? .failed : (sawSummary ? .complete :
+                detail: commitsDetail,
+                state: summaryFailure ? .failed : (sawSummary ? .complete :
                     (sawStart ? activeFailureState : .pending))
             ),
             GGSyncProgressPresentation.Step(
                 id: "reviews",
                 title: "Updating pull requests",
-                detail: sawPREvent ? "Publishing review state" : "Waiting for pushed commits",
-                state: summaryEntryFailure ? .pending : (sawSummary ? .complete :
+                detail: reviewsDetail,
+                state: summaryFailure ? .pending : (sawSummary ? .complete :
                     (sawPREvent ? activeFailureState : .pending))
             ),
             GGSyncProgressPresentation.Step(

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -63,6 +63,18 @@ struct GGStackReadinessProjection {
         return behindBase?.count
     }
 
+    static func effectiveBehindBase(
+        stack: GGStack,
+        selectedBaseBranch: String,
+        behindBase: GitService.BehindStatus?
+    ) -> Int {
+        liveBehindBaseOverride(
+            stack: stack,
+            selectedBaseBranch: selectedBaseBranch,
+            behindBase: behindBase
+        ) ?? stack.behindBase ?? 0
+    }
+
     static func hasBlockingGitOperation(
         mergeOperation: MergeOperation?,
         pausedGGOperation: GGPausedOperation?
@@ -464,8 +476,7 @@ struct GGStackReadinessModel: Equatable {
                 id: "reviews",
                 title: "Updating pull requests",
                 detail: reviewsDetail,
-                state: summaryFailure ? .pending : (sawSummary ? .complete :
-                    (sawPREvent ? activeFailureState : .pending))
+                state: summaryFailure ? .pending : (sawSummary ? .complete : .pending)
             ),
             GGSyncProgressPresentation.Step(
                 id: "refresh",

--- a/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
+++ b/Alas/Sources/Integrations/GG/GGStackReadinessModel.swift
@@ -438,7 +438,8 @@ struct GGStackReadinessModel: Equatable {
                 : nil,
             effectiveConfig.syncAutoLint ? "Run configured lint" : nil,
         ].compactMap { $0 }.joined(separator: " · ")
-        let activeFailureState: GGSyncProgressPresentation.Step.State = terminalFailure ? .failed : .current
+        let activeFailureState: GGSyncProgressPresentation.Step.State = terminalFailure ? .failed :
+            (isInFlight ? .current : .pending)
         let commitsDetail = summaryFailure ? "Sync failed" :
             (sawSummary ? "Commit sync complete" :
                 (sawStart ? (liveStatus ?? countStatus()) : "Waiting for stack preparation"))

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -12,6 +12,15 @@ enum ChangesPreparationCardText {
         let staged = stagedCount == 1 ? "1 staged" : "\(stagedCount) staged"
         return "\(staged) · +\(additions) −\(deletions)"
     }
+
+    static func syncStepState(_ state: GGSyncProgressPresentation.Step.State) -> String {
+        switch state {
+        case .pending: "Pending"
+        case .current: "In progress"
+        case .complete: "Complete"
+        case .failed: "Failed"
+        }
+    }
 }
 
 struct ChangesPreparationReconciliationPresentation: Equatable {
@@ -104,6 +113,7 @@ struct ChangesPreparationCard: View {
                 }
                 .frame(height: 20)
                 .accessibilityElement(children: .combine)
+                .accessibilityValue(ChangesPreparationCardText.syncStepState(step.state))
             }
         }
         .accessibilityIdentifier("changes-preparation-gg-sync-progress")

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -56,19 +56,19 @@ struct ChangesPreparationCard: View {
                             ggDestinationButton(action)
                         }
                     }
-                    if let error = model.mutationError {
-                        Text(error)
-                            .font(.system(size: 11))
-                            .foregroundStyle(theme.color("warn"))
-                            .fixedSize(horizontal: false, vertical: true)
-                            .accessibilityIdentifier("changes-preparation-gg-error")
-                    }
                 } else if model.draftAction != nil || !model.reviewRequestActions.isEmpty {
                     ViewThatFits(in: .horizontal) {
                         secondaryActionsHorizontal
                         secondaryActionsVertical
                     }
                 }
+            }
+            if let error = model.mutationError {
+                Text(error)
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.color("warn"))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("changes-preparation-gg-error")
             }
         }
         .padding(10)

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -41,29 +41,33 @@ struct ChangesPreparationCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 9) {
             header
-            if let reviewAction = model.reviewAction {
-                primaryReviewButton(reviewAction)
-            }
-            if let reconciliationAction = model.reconciliationAction {
-                ggReconciliationButton(reconciliationAction)
-            }
-            if !model.ggActions.isEmpty {
-                HStack(spacing: 6) {
-                    ForEach(model.ggActions, id: \.kind) { action in
-                        ggDestinationButton(action)
+            if let syncProgress = model.syncProgress {
+                syncProgressView(syncProgress)
+            } else {
+                if let reviewAction = model.reviewAction {
+                    primaryReviewButton(reviewAction)
+                }
+                if let reconciliationAction = model.reconciliationAction {
+                    ggReconciliationButton(reconciliationAction)
+                }
+                if !model.ggActions.isEmpty {
+                    HStack(spacing: 6) {
+                        ForEach(model.ggActions, id: \.kind) { action in
+                            ggDestinationButton(action)
+                        }
                     }
-                }
-                if let error = model.mutationError {
-                    Text(error)
-                        .font(.system(size: 11))
-                        .foregroundStyle(theme.color("warn"))
-                        .fixedSize(horizontal: false, vertical: true)
-                        .accessibilityIdentifier("changes-preparation-gg-error")
-                }
-            } else if model.draftAction != nil || !model.reviewRequestActions.isEmpty {
-                ViewThatFits(in: .horizontal) {
-                    secondaryActionsHorizontal
-                    secondaryActionsVertical
+                    if let error = model.mutationError {
+                        Text(error)
+                            .font(.system(size: 11))
+                            .foregroundStyle(theme.color("warn"))
+                            .fixedSize(horizontal: false, vertical: true)
+                            .accessibilityIdentifier("changes-preparation-gg-error")
+                    }
+                } else if model.draftAction != nil || !model.reviewRequestActions.isEmpty {
+                    ViewThatFits(in: .horizontal) {
+                        secondaryActionsHorizontal
+                        secondaryActionsVertical
+                    }
                 }
             }
         }
@@ -80,6 +84,47 @@ struct ChangesPreparationCard: View {
         .padding(.top, 8)
         .padding(.bottom, 6)
         .accessibilityIdentifier("changes-preparation-card")
+    }
+
+    private func syncProgressView(_ progress: GGSyncProgressPresentation) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(progress.steps) { step in
+                HStack(spacing: 7) {
+                    syncStepIcon(step.state)
+                        .frame(width: 12, height: 12)
+                        .accessibilityHidden(true)
+                    Text(step.title)
+                        .font(.system(size: 11, weight: step.state == .current ? .semibold : .regular))
+                        .foregroundStyle(theme.color(step.state == .pending ? "fg-faint" : "fg"))
+                    Spacer(minLength: 6)
+                    Text(step.detail)
+                        .font(.system(size: 9.5))
+                        .foregroundStyle(theme.color("fg-faint"))
+                        .lineLimit(1)
+                }
+                .frame(height: 20)
+                .accessibilityElement(children: .combine)
+            }
+        }
+        .accessibilityIdentifier("changes-preparation-gg-sync-progress")
+    }
+
+    @ViewBuilder
+    private func syncStepIcon(_ state: GGSyncProgressPresentation.Step.State) -> some View {
+        switch state {
+        case .pending:
+            Circle().stroke(theme.color("line"), lineWidth: 1).frame(width: 8, height: 8)
+        case .current:
+            Spinner(lineWidth: 1.4, duration: 0.8).frame(width: 10, height: 10)
+        case .complete:
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 10))
+                .foregroundStyle(theme.color("add"))
+        case .failed:
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 10))
+                .foregroundStyle(theme.color("warn"))
+        }
     }
 
     private var header: some View {

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -55,6 +55,7 @@ struct ChangesPreparationModel: Equatable {
     let draftAction: DraftAction?
     let reviewRequestActions: [ReviewRequestAction]
     let reconciliationAction: GGStackReadinessModel.Action?
+    let syncProgress: GGSyncProgressPresentation?
     let ggActions: [GGAction]
     let mutationError: String?
 
@@ -107,6 +108,7 @@ struct ChangesPreparationModel: Equatable {
         reviewAction = builtReviewAction
         draftAction = builtDraftAction
         reconciliationAction = nil
+        syncProgress = nil
         ggActions = []
         mutationError = nil
         let builtActions = Self.compactReviewRequestActions(from: readinessActions)
@@ -128,7 +130,8 @@ struct ChangesPreparationModel: Equatable {
         mutationDisabledReason: String? = nil,
         newCommitDisabledReason: String? = nil,
         mutationError: String? = nil,
-        reconciliationAction: GGStackReadinessModel.Action? = nil
+        reconciliationAction: GGStackReadinessModel.Action? = nil,
+        syncProgress: GGSyncProgressPresentation? = nil
     ) -> ChangesPreparationModel {
         let summary = ReviewChangesTriggerSummary.summary(for: changes)
         let stagedChanges = changes.filter { $0.stage == .staged }
@@ -146,6 +149,7 @@ struct ChangesPreparationModel: Equatable {
             newCommitDisabledReason: newCommitDisabledReason,
             mutationError: mutationError,
             reconciliationAction: reconciliationAction,
+            syncProgress: syncProgress,
             reviewSummary: summary
         )
     }
@@ -158,7 +162,8 @@ struct ChangesPreparationModel: Equatable {
         mutationDisabledReason: String? = nil,
         newCommitDisabledReason: String? = nil,
         mutationError: String? = nil,
-        reconciliationAction: GGStackReadinessModel.Action? = nil
+        reconciliationAction: GGStackReadinessModel.Action? = nil,
+        syncProgress: GGSyncProgressPresentation? = nil
     ) -> ChangesPreparationModel {
         let summary = staged.hasChanges
             ? ReviewChangesTriggerSummary(
@@ -176,6 +181,7 @@ struct ChangesPreparationModel: Equatable {
             newCommitDisabledReason: newCommitDisabledReason,
             mutationError: mutationError,
             reconciliationAction: reconciliationAction,
+            syncProgress: syncProgress,
             reviewSummary: summary
         )
     }
@@ -193,6 +199,7 @@ struct ChangesPreparationModel: Equatable {
         newCommitDisabledReason: String?,
         mutationError: String?,
         reconciliationAction: GGStackReadinessModel.Action?,
+        syncProgress: GGSyncProgressPresentation?,
         reviewSummary: ReviewChangesTriggerSummary?
     ) -> ChangesPreparationModel {
         let reviewAction = reviewSummary.map {
@@ -217,6 +224,7 @@ struct ChangesPreparationModel: Equatable {
         return ChangesPreparationModel(
             reviewAction: reviewAction,
             reconciliationAction: reconciliationAction,
+            syncProgress: syncProgress,
             mutationError: mutationError,
             ggActions: [
                 GGAction(
@@ -247,6 +255,7 @@ struct ChangesPreparationModel: Equatable {
     private init(
         reviewAction: ReviewAction?,
         reconciliationAction: GGStackReadinessModel.Action?,
+        syncProgress: GGSyncProgressPresentation?,
         mutationError: String?,
         ggActions: [GGAction]
     ) {
@@ -254,6 +263,7 @@ struct ChangesPreparationModel: Equatable {
         draftAction = nil
         reviewRequestActions = []
         self.reconciliationAction = reconciliationAction
+        self.syncProgress = syncProgress
         self.mutationError = mutationError
         self.ggActions = ggActions
     }

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -65,6 +65,7 @@ struct ChangesPreparationModel: Equatable {
         if !ggActions.isEmpty {
             return mutationError != nil
                 || reconciliationAction != nil
+                || syncProgress != nil
                 || reviewAction != nil
                 || ggAction(.newStackCommit)?.isEnabled == true
         }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -36,7 +36,13 @@ struct ChangesTabView: View {
                     currentHeadSHA: rps.currentHeadSHA
                 ),
                 mutationError: rps.ggActionState.lastError,
-                reconciliationAction: Self.reconciliationAction(from: ggReadinessModel)
+                reconciliationAction: Self.reconciliationAction(from: ggReadinessModel),
+                syncProgress: GGStackReadinessModel.syncProgress(
+                    action: rps.ggActionState,
+                    base: rps.ggStack?.base ?? rps.baseBranch,
+                    behindBase: rps.behindBase?.count ?? rps.ggStack?.behindBase ?? 0,
+                    effectiveConfig: rps.ggEffectiveConfig
+                )
             )
         }
         let readiness = ReviewReadinessModel(

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -40,7 +40,13 @@ struct ChangesTabView: View {
                 syncProgress: GGStackReadinessModel.syncProgress(
                     action: rps.ggActionState,
                     base: rps.ggStack?.base ?? rps.baseBranch,
-                    behindBase: rps.behindBase?.count ?? rps.ggStack?.behindBase ?? 0,
+                    behindBase: rps.ggStack.map {
+                        GGStackReadinessProjection.effectiveBehindBase(
+                            stack: $0,
+                            selectedBaseBranch: rps.baseBranch,
+                            behindBase: rps.behindBase
+                        )
+                    } ?? rps.behindBase?.count ?? 0,
                     effectiveConfig: rps.ggEffectiveConfig
                 )
             )

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -742,6 +742,10 @@ final class RightPaneState: GGSplitCommitServicing {
         baseCommits?.count ?? displayCommits.count
     }
 
+    nonisolated static func shouldScheduleGGStackRefresh(inFlightAction: GGStackActionKind?) -> Bool {
+        inFlightAction != .sync
+    }
+
     @discardableResult
     @MainActor
     func refresh(forceReviewLoopRemote: Bool = false) async -> Bool {
@@ -879,9 +883,11 @@ final class RightPaneState: GGSplitCommitServicing {
             if self.fileTree != mergedFileTree { self.fileTree = mergedFileTree }
             if self.commits != commits { self.commits = commits }
             self.ggStackSourceCommits = reviewLoopBaseResult?.commits ?? commits
-            ggStackRefreshTask?.cancel()
-            ggStackRefreshTask = Task { @MainActor [weak self] in
-                await self?.refreshGGStack(forceRemote: forceReviewLoopRemote)
+            if Self.shouldScheduleGGStackRefresh(inFlightAction: ggActionState.inFlightAction) {
+                ggStackRefreshTask?.cancel()
+                ggStackRefreshTask = Task { @MainActor [weak self] in
+                    await self?.refreshGGStack(forceRemote: forceReviewLoopRemote)
+                }
             }
             if self.comparisonRef != ref { self.comparisonRef = ref }
             let preferredCommitRemoteRef = ref ?? baseBranch

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -762,6 +762,13 @@ final class RightPaneState: GGSplitCommitServicing {
         refreshedCommitsKey == currentCommitsKey
     }
 
+    nonisolated static func shouldForceGGStackRefresh(
+        forceRemote: Bool,
+        deferredUntilSyncEnds: Bool
+    ) -> Bool {
+        forceRemote || deferredUntilSyncEnds
+    }
+
     @discardableResult
     @MainActor
     func refresh(forceReviewLoopRemote: Bool = false) async -> Bool {
@@ -902,10 +909,13 @@ final class RightPaneState: GGSplitCommitServicing {
             let ggStackSourceCommitsChanged = self.ggStackSourceCommits != nextGGStackSourceCommits
             self.ggStackSourceCommits = nextGGStackSourceCommits
             if Self.shouldScheduleGGStackRefresh(inFlightAction: ggActionState.inFlightAction) {
-                ggStackRefreshDeferredUntilSyncEnds = false
+                let forceGGStackRemote = Self.shouldForceGGStackRefresh(
+                    forceRemote: forceReviewLoopRemote,
+                    deferredUntilSyncEnds: ggStackRefreshDeferredUntilSyncEnds
+                )
                 ggStackRefreshTask?.cancel()
                 ggStackRefreshTask = Task { @MainActor [weak self] in
-                    await self?.refreshGGStack(forceRemote: forceReviewLoopRemote)
+                    await self?.refreshGGStack(forceRemote: forceGGStackRemote)
                 }
             } else if Self.shouldDeferGGStackRefresh(
                 inFlightAction: ggActionState.inFlightAction,
@@ -1295,7 +1305,6 @@ final class RightPaneState: GGSplitCommitServicing {
         guard ggStackRefreshDeferredUntilSyncEnds,
               ggActionState.inFlightAction != .sync
         else { return }
-        ggStackRefreshDeferredUntilSyncEnds = false
         ggStackRefreshTask?.cancel()
         ggStackRefreshTask = Task { @MainActor [weak self] in
             await self?.refreshGGStack(forceRemote: true)

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -193,6 +193,7 @@ final class RightPaneState: GGSplitCommitServicing {
     /// Off-critical-path gg stack load. Cancelled+restarted per refresh so a
     /// slow `gg ls --json` never blocks the Changes-pane snapshot.
     @ObservationIgnored private var ggStackRefreshTask: Task<Void, Never>? = nil
+    @ObservationIgnored private var ggStackRefreshDeferredUntilSyncEnds = false
     /// A refresh result may still arrive after its task was cancelled. Only
     /// the most recently started GG refresh may publish snapshot-derived
     /// stack state.
@@ -524,6 +525,7 @@ final class RightPaneState: GGSplitCommitServicing {
         remoteEventDebouncer.cancel()
         ggStackRefreshTask?.cancel()
         ggStackRefreshTask = nil
+        ggStackRefreshDeferredUntilSyncEnds = false
     }
 
     private func startRemoteHelperWatching() {
@@ -746,6 +748,13 @@ final class RightPaneState: GGSplitCommitServicing {
         inFlightAction != .sync
     }
 
+    nonisolated static func shouldDeferGGStackRefresh(
+        inFlightAction: GGStackActionKind?,
+        sourceCommitsChanged: Bool
+    ) -> Bool {
+        inFlightAction == .sync && sourceCommitsChanged
+    }
+
     @discardableResult
     @MainActor
     func refresh(forceReviewLoopRemote: Bool = false) async -> Bool {
@@ -882,12 +891,20 @@ final class RightPaneState: GGSplitCommitServicing {
             let mergedFileTree = Self.preservingLazyChildren(fresh: tree, previous: self.fileTree)
             if self.fileTree != mergedFileTree { self.fileTree = mergedFileTree }
             if self.commits != commits { self.commits = commits }
-            self.ggStackSourceCommits = reviewLoopBaseResult?.commits ?? commits
+            let nextGGStackSourceCommits = reviewLoopBaseResult?.commits ?? commits
+            let ggStackSourceCommitsChanged = self.ggStackSourceCommits != nextGGStackSourceCommits
+            self.ggStackSourceCommits = nextGGStackSourceCommits
             if Self.shouldScheduleGGStackRefresh(inFlightAction: ggActionState.inFlightAction) {
+                ggStackRefreshDeferredUntilSyncEnds = false
                 ggStackRefreshTask?.cancel()
                 ggStackRefreshTask = Task { @MainActor [weak self] in
                     await self?.refreshGGStack(forceRemote: forceReviewLoopRemote)
                 }
+            } else if Self.shouldDeferGGStackRefresh(
+                inFlightAction: ggActionState.inFlightAction,
+                sourceCommitsChanged: ggStackSourceCommitsChanged
+            ) {
+                ggStackRefreshDeferredUntilSyncEnds = true
             }
             if self.comparisonRef != ref { self.comparisonRef = ref }
             let preferredCommitRemoteRef = ref ?? baseBranch
@@ -1251,9 +1268,21 @@ final class RightPaneState: GGSplitCommitServicing {
     }
 
     func supersedeGGStackRefreshForSync() {
+        ggStackRefreshDeferredUntilSyncEnds = false
         ggStackRefreshGeneration &+= 1
         ggStackRefreshTask?.cancel()
         ggStackRefreshTask = nil
+    }
+
+    private func scheduleDeferredGGStackRefreshIfNeeded() {
+        guard ggStackRefreshDeferredUntilSyncEnds,
+              ggActionState.inFlightAction != .sync
+        else { return }
+        ggStackRefreshDeferredUntilSyncEnds = false
+        ggStackRefreshTask?.cancel()
+        ggStackRefreshTask = Task { @MainActor [weak self] in
+            await self?.refreshGGStack(forceRemote: true)
+        }
     }
 
     /// Re-run the gg gate immediately (e.g. after a Settings toggle) rather
@@ -1780,6 +1809,7 @@ final class RightPaneState: GGSplitCommitServicing {
         if request == .sync { supersedeGGStackRefreshForSync() }
         let actionGeneration = ggActionState.actionGeneration
         return Task { @MainActor in
+            defer { scheduleDeferredGGStackRefreshIfNeeded() }
             do {
                 try await operation.value
             } catch {
@@ -1794,6 +1824,7 @@ final class RightPaneState: GGSplitCommitServicing {
         if prepared.request == .sync { supersedeGGStackRefreshForSync() }
         let actionGeneration = ggActionState.actionGeneration
         return Task { @MainActor in
+            defer { scheduleDeferredGGStackRefreshIfNeeded() }
             do {
                 try await operation.value
             } catch {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -755,7 +755,7 @@ final class RightPaneState: GGSplitCommitServicing {
         inFlightAction == .sync && sourceCommitsChanged
     }
 
-    nonisolated static func shouldClearDeferredGGStackRefresh(
+    nonisolated static func shouldPublishGGStackRefresh(
         refreshedCommitsKey: String,
         currentCommitsKey: String
     ) -> Bool {
@@ -1131,7 +1131,11 @@ final class RightPaneState: GGSplitCommitServicing {
             // writing here would race it with a stale result.
             if Task.isCancelled { return }
             guard snapshotGeneration == snapshotInvalidationGeneration,
-                  refreshGeneration == ggStackRefreshGeneration
+                  refreshGeneration == ggStackRefreshGeneration,
+                  Self.shouldPublishGGStackRefresh(
+                      refreshedCommitsKey: key,
+                      currentCommitsKey: currentGGStackCommitsKey
+                  )
             else { return }
             let resolvedContext: GGWorktreeContext
             if branchContext.isActive {
@@ -1143,13 +1147,8 @@ final class RightPaneState: GGSplitCommitServicing {
             }
             if ggContext != resolvedContext { ggContext = resolvedContext }
             ggStackRemoteError = nil
-            if Self.shouldClearDeferredGGStackRefresh(
-                refreshedCommitsKey: key,
-                currentCommitsKey: currentGGStackCommitsKey
-            ) {
-                ggStackRefreshDeferredUntilSyncEnds = false
-            }
-            ggStackCommitsKey = currentGGStackCommitsKey
+            ggStackRefreshDeferredUntilSyncEnds = false
+            ggStackCommitsKey = key
             if ggStack != stack { ggStack = stack }
             ggStackDisplayCommits = displayCommits
             let stackIsEmpty = stack.map { $0.totalCommits == 0 || $0.entries.isEmpty } ?? true
@@ -1175,7 +1174,11 @@ final class RightPaneState: GGSplitCommitServicing {
             // so drop it and retry on the next refresh.
             if Task.isCancelled { return }
             guard snapshotGeneration == snapshotInvalidationGeneration,
-                  refreshGeneration == ggStackRefreshGeneration
+                  refreshGeneration == ggStackRefreshGeneration,
+                  Self.shouldPublishGGStackRefresh(
+                      refreshedCommitsKey: key,
+                      currentCommitsKey: currentGGStackCommitsKey
+                  )
             else { return }
             if keepsPreviousPresentation, key == currentGGStackCommitsKey {
                 ggStackRemoteError = (error as? GGServiceError)?.userMessage ?? error.localizedDescription

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1214,6 +1214,11 @@ final class RightPaneState: GGSplitCommitServicing {
     func invalidateGGPresentation(
         startingRefresh shouldRefresh: Bool
     ) -> Task<Void, Never>? {
+        // GG rewrites refs throughout sync. Keep the last coherent stack
+        // mounted until the coordinator performs its final refresh.
+        if ggActionState.inFlightAction == .sync, ggStackLoadState == .loaded {
+            return nil
+        }
         // Advance ownership before cancellation: a direct/untracked caller may
         // ignore cancellation, but its generation guard must still reject the
         // response after this presentation is invalidated.

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1223,9 +1223,6 @@ final class RightPaneState: GGSplitCommitServicing {
         // GG rewrites refs throughout sync. Keep the last coherent stack
         // mounted until the coordinator performs its final refresh.
         if ggActionState.inFlightAction == .sync, ggStackLoadState == .loaded {
-            ggStackRefreshGeneration &+= 1
-            ggStackRefreshTask?.cancel()
-            ggStackRefreshTask = nil
             return nil
         }
         // Advance ownership before cancellation: a direct/untracked caller may
@@ -1251,6 +1248,12 @@ final class RightPaneState: GGSplitCommitServicing {
         }
         ggStackRefreshTask = task
         return task
+    }
+
+    func supersedeGGStackRefreshForSync() {
+        ggStackRefreshGeneration &+= 1
+        ggStackRefreshTask?.cancel()
+        ggStackRefreshTask = nil
     }
 
     /// Re-run the gg gate immediately (e.g. after a Settings toggle) rather
@@ -1774,6 +1777,7 @@ final class RightPaneState: GGSplitCommitServicing {
             request,
             confirmedAgainst: identity
         ) else { return nil }
+        if request == .sync { supersedeGGStackRefreshForSync() }
         let actionGeneration = ggActionState.actionGeneration
         return Task { @MainActor in
             do {
@@ -1787,6 +1791,7 @@ final class RightPaneState: GGSplitCommitServicing {
     @discardableResult
     func runGGMutation(_ prepared: GGPreparedMutation) -> Task<Void, Never>? {
         guard let operation = ggMutationCoordinator.startApplying(prepared) else { return nil }
+        if prepared.request == .sync { supersedeGGStackRefreshForSync() }
         let actionGeneration = ggActionState.actionGeneration
         return Task { @MainActor in
             do {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -194,6 +194,7 @@ final class RightPaneState: GGSplitCommitServicing {
     /// slow `gg ls --json` never blocks the Changes-pane snapshot.
     @ObservationIgnored private var ggStackRefreshTask: Task<Void, Never>? = nil
     @ObservationIgnored var ggStackRefreshDeferredUntilSyncEnds = false
+    @ObservationIgnored private var ggStackRefreshDeferralGeneration: UInt = 0
     /// A refresh result may still arrive after its task was cancelled. Only
     /// the most recently started GG refresh may publish snapshot-derived
     /// stack state.
@@ -921,7 +922,7 @@ final class RightPaneState: GGSplitCommitServicing {
                 inFlightAction: ggActionState.inFlightAction,
                 refreshRequired: ggStackSourceCommitsChanged
             ) {
-                ggStackRefreshDeferredUntilSyncEnds = true
+                deferGGStackRefreshUntilSyncEnds()
             }
             if self.comparisonRef != ref { self.comparisonRef = ref }
             let preferredCommitRemoteRef = ref ?? baseBranch
@@ -1027,6 +1028,7 @@ final class RightPaneState: GGSplitCommitServicing {
         let snapshotGeneration = snapshotInvalidationGeneration
         ggStackRefreshGeneration &+= 1
         let refreshGeneration = ggStackRefreshGeneration
+        let deferralGeneration = ggStackRefreshDeferralGeneration
         let branchContext = ggContextProvider?(currentBranch) ?? .inactive(reason: .policyOff)
         if branchContext.isActive || !branchContext.permitsCurrentStackQuery || !ggContext.isActive {
             if ggContext != branchContext { ggContext = branchContext }
@@ -1157,7 +1159,9 @@ final class RightPaneState: GGSplitCommitServicing {
             }
             if ggContext != resolvedContext { ggContext = resolvedContext }
             ggStackRemoteError = nil
-            ggStackRefreshDeferredUntilSyncEnds = false
+            if deferralGeneration == ggStackRefreshDeferralGeneration {
+                ggStackRefreshDeferredUntilSyncEnds = false
+            }
             ggStackCommitsKey = key
             if ggStack != stack { ggStack = stack }
             ggStackDisplayCommits = displayCommits
@@ -1266,7 +1270,7 @@ final class RightPaneState: GGSplitCommitServicing {
         // GG rewrites refs throughout sync. Keep the last coherent stack
         // mounted until the coordinator performs its final refresh.
         if ggActionState.inFlightAction == .sync, ggStackLoadState == .loaded {
-            ggStackRefreshDeferredUntilSyncEnds = true
+            deferGGStackRefreshUntilSyncEnds()
             return nil
         }
         // Advance ownership before cancellation: a direct/untracked caller may
@@ -1299,6 +1303,11 @@ final class RightPaneState: GGSplitCommitServicing {
         ggStackRefreshGeneration &+= 1
         ggStackRefreshTask?.cancel()
         ggStackRefreshTask = nil
+    }
+
+    private func deferGGStackRefreshUntilSyncEnds() {
+        ggStackRefreshDeferralGeneration &+= 1
+        ggStackRefreshDeferredUntilSyncEnds = true
     }
 
     private func scheduleDeferredGGStackRefreshIfNeeded() {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -193,7 +193,7 @@ final class RightPaneState: GGSplitCommitServicing {
     /// Off-critical-path gg stack load. Cancelled+restarted per refresh so a
     /// slow `gg ls --json` never blocks the Changes-pane snapshot.
     @ObservationIgnored private var ggStackRefreshTask: Task<Void, Never>? = nil
-    @ObservationIgnored private var ggStackRefreshDeferredUntilSyncEnds = false
+    @ObservationIgnored var ggStackRefreshDeferredUntilSyncEnds = false
     /// A refresh result may still arrive after its task was cancelled. Only
     /// the most recently started GG refresh may publish snapshot-derived
     /// stack state.
@@ -750,9 +750,9 @@ final class RightPaneState: GGSplitCommitServicing {
 
     nonisolated static func shouldDeferGGStackRefresh(
         inFlightAction: GGStackActionKind?,
-        sourceCommitsChanged: Bool
+        refreshRequired: Bool
     ) -> Bool {
-        inFlightAction == .sync && sourceCommitsChanged
+        inFlightAction == .sync && refreshRequired
     }
 
     nonisolated static func shouldPublishGGStackRefresh(
@@ -909,7 +909,7 @@ final class RightPaneState: GGSplitCommitServicing {
                 }
             } else if Self.shouldDeferGGStackRefresh(
                 inFlightAction: ggActionState.inFlightAction,
-                sourceCommitsChanged: ggStackSourceCommitsChanged
+                refreshRequired: ggStackSourceCommitsChanged
             ) {
                 ggStackRefreshDeferredUntilSyncEnds = true
             }
@@ -1256,6 +1256,7 @@ final class RightPaneState: GGSplitCommitServicing {
         // GG rewrites refs throughout sync. Keep the last coherent stack
         // mounted until the coordinator performs its final refresh.
         if ggActionState.inFlightAction == .sync, ggStackLoadState == .loaded {
+            ggStackRefreshDeferredUntilSyncEnds = true
             return nil
         }
         // Advance ownership before cancellation: a direct/untracked caller may

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -755,6 +755,13 @@ final class RightPaneState: GGSplitCommitServicing {
         inFlightAction == .sync && sourceCommitsChanged
     }
 
+    nonisolated static func shouldClearDeferredGGStackRefresh(
+        refreshedCommitsKey: String,
+        currentCommitsKey: String
+    ) -> Bool {
+        refreshedCommitsKey == currentCommitsKey
+    }
+
     @discardableResult
     @MainActor
     func refresh(forceReviewLoopRemote: Bool = false) async -> Bool {
@@ -1136,6 +1143,12 @@ final class RightPaneState: GGSplitCommitServicing {
             }
             if ggContext != resolvedContext { ggContext = resolvedContext }
             ggStackRemoteError = nil
+            if Self.shouldClearDeferredGGStackRefresh(
+                refreshedCommitsKey: key,
+                currentCommitsKey: currentGGStackCommitsKey
+            ) {
+                ggStackRefreshDeferredUntilSyncEnds = false
+            }
             ggStackCommitsKey = currentGGStackCommitsKey
             if ggStack != stack { ggStack = stack }
             ggStackDisplayCommits = displayCommits

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1223,6 +1223,9 @@ final class RightPaneState: GGSplitCommitServicing {
         // GG rewrites refs throughout sync. Keep the last coherent stack
         // mounted until the coordinator performs its final refresh.
         if ggActionState.inFlightAction == .sync, ggStackLoadState == .loaded {
+            ggStackRefreshGeneration &+= 1
+            ggStackRefreshTask?.cancel()
+            ggStackRefreshTask = nil
             return nil
         }
         // Advance ownership before cancellation: a direct/untracked caller may

--- a/AlasTests/Integrations/GGConfigReaderTests.swift
+++ b/AlasTests/Integrations/GGConfigReaderTests.swift
@@ -72,13 +72,13 @@ struct GGConfigReaderTests {
     @Test func effectiveConfigReadsGlobalValues() throws {
         let repo = try makeRepo(configJSON: nil)
         let global = try makeGlobal(
-            configJSON: #"{"defaults":{"sync_auto_rebase":true,"sync_behind_threshold":4}}"#
+            configJSON: #"{"defaults":{"sync_auto_rebase":true,"sync_auto_lint":true,"sync_behind_threshold":4}}"#
         )
 
-        #expect(
-            GGConfigReader.effectiveConfig(repoPath: repo, globalConfigPath: global)
-                == GGEffectiveConfig(syncAutoRebase: true, syncBehindThreshold: 4)
-        )
+        let config = GGConfigReader.effectiveConfig(repoPath: repo, globalConfigPath: global)
+        #expect(config.syncAutoRebase)
+        #expect(config.syncBehindThreshold == 4)
+        #expect(config.syncAutoLint)
     }
 
     @Test func effectiveConfigLocalDefaultsReplaceGlobalDefaults() throws {

--- a/AlasTests/Integrations/GGMutationCoordinatorTests.swift
+++ b/AlasTests/Integrations/GGMutationCoordinatorTests.swift
@@ -729,8 +729,8 @@ struct GGMutationCoordinatorTests {
             stack: try #require(harness.stacks[0].stack),
             action: harness.actionState
         )
-        #expect(harness.coordinator.activeRequest == nil)
-        #expect(harness.actionState.inFlightAction == nil)
+        #expect(harness.coordinator.activeRequest == .sync)
+        #expect(harness.actionState.inFlightAction == .sync)
         #expect(harness.actionState.lastError == "sync failed")
         #expect(harness.actionState.syncHasTerminalFailure)
         #expect(model.syncProgress?.liveStatus == nil)
@@ -740,6 +740,8 @@ struct GGMutationCoordinatorTests {
         await #expect(throws: GGServiceError.commandFailed(stderr: "sync failed")) {
             try await task.value
         }
+        #expect(harness.coordinator.activeRequest == nil)
+        #expect(harness.actionState.inFlightAction == nil)
     }
 
     @Test func syncProtocolViolationsPropagateAndPublishError() async {

--- a/AlasTests/Integrations/GGMutationCoordinatorTests.swift
+++ b/AlasTests/Integrations/GGMutationCoordinatorTests.swift
@@ -677,7 +677,7 @@ struct GGMutationCoordinatorTests {
         #expect(harness.actionState.syncProgress.isEmpty)
     }
 
-    @Test func terminalSyncSummaryDoesNotRegressToPreparingDuringRefresh() async throws {
+    @Test func terminalSyncSummaryKeepsRefreshProgressVisibleUntilRefreshCompletes() async throws {
         let harness = GGMutationHarness(stacks: [stack(head: "a")])
         var refreshStarted = false
         var resumeRefresh: CheckedContinuation<Void, Never>?
@@ -695,15 +695,17 @@ struct GGMutationCoordinatorTests {
             stack: try #require(harness.stacks[0].stack),
             action: harness.actionState
         )
-        #expect(harness.coordinator.activeRequest == nil)
-        #expect(harness.actionState.inFlightAction == nil)
+        #expect(harness.coordinator.activeRequest == .sync)
+        #expect(harness.actionState.inFlightAction == .sync)
         #expect(harness.actionState.lastActionSummary == "Synced")
-        #expect(harness.actionState.syncProgress.isEmpty)
-        #expect(model.syncProgress == nil)
-        #expect(model.primaryActions.first(where: { $0.kind == .sync })?.isInFlight == false)
+        #expect(!harness.actionState.syncProgress.isEmpty)
+        #expect(model.syncProgress?.liveStatus == "Refreshing Changes…")
+        #expect(model.primaryActions.first(where: { $0.kind == .sync })?.isInFlight == true)
 
         resumeRefresh?.resume()
         try await task.value
+        #expect(harness.coordinator.activeRequest == nil)
+        #expect(harness.actionState.inFlightAction == nil)
         #expect(harness.actionState.syncProgress.isEmpty)
     }
 
@@ -767,7 +769,7 @@ struct GGMutationCoordinatorTests {
             stack: try #require(harness.stacks[0].stack),
             action: harness.actionState
         )
-        #expect(model.syncProgress?.liveStatus == "Preparing sync…")
+        #expect(model.syncProgress?.liveStatus == "Preparing stack…")
 
         try await waitUntil { !harness.service.requests.isEmpty }
         harness.service.resumeExecution()

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -490,6 +490,7 @@ struct GGStackReadinessModelTests {
         #expect(progress.rows == [.init(position: 1, text: "[1] Failed to push")])
         #expect(progress.liveStatus == nil)
         #expect(!progress.showsSpinner)
+        #expect(progress.steps.map(\.state) == [.complete, .failed, .pending, .pending])
     }
 
     @Test func pausedOnSyncKeepsProgressAndOffersContinueAbort() throws {

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -524,6 +524,19 @@ struct GGStackReadinessModelTests {
         #expect(progress.showsSpinner)
     }
 
+    @Test func summaryOnlySyncCompletesEveryPhaseBeforeRefresh() throws {
+        let action = GGStackActionState()
+        _ = action.beginAction(.sync)
+        action.appendSyncEvent(.summary)
+
+        let progress = try #require(GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .open)]),
+            action: action
+        ).syncProgress)
+
+        #expect(progress.steps.map(\.state) == [.complete, .complete, .complete, .current])
+    }
+
     @Test func idleFailedSyncRetainsProgressWhileLastErrorIsSet() throws {
         let action = GGStackActionState()
         _ = action.beginAction(.sync)

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -396,6 +396,20 @@ struct GGStackReadinessModelTests {
         )
     }
 
+    @Test func restoredPausedSyncDoesNotShowAnActivePhase() throws {
+        let action = GGStackActionState()
+        action.setPaused(GGPausedOperation(pausedBy: .sync))
+
+        let progress = try #require(GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .open)]),
+            action: action
+        ).syncProgress)
+
+        #expect(progress.liveStatus == nil)
+        #expect(progress.showsSpinner == false)
+        #expect(progress.steps.allSatisfy { $0.state == .pending })
+    }
+
     @Test func syncProgressUpdatesOneStableRowPerPosition() throws {
         let action = GGStackActionState()
         _ = action.beginAction(.sync)

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -536,6 +536,24 @@ struct GGStackReadinessModelTests {
         ).syncProgress)
 
         #expect(progress.steps.map(\.state) == [.complete, .complete, .complete, .current])
+        #expect(progress.steps[1].detail == "Commit sync complete")
+        #expect(progress.steps[2].detail == "Pull request updates complete")
+    }
+
+    @Test func postSummaryCommandFailureKeepsFailedSyncPhase() throws {
+        let action = GGStackActionState()
+        _ = action.beginAction(.sync)
+        action.appendSyncEvent(.summary)
+        action.markSyncTerminalFailure()
+        action.setError("sync exited unsuccessfully")
+        action.endAction(.sync)
+
+        let progress = try #require(GGStackReadinessModel.make(
+            stack: stack([entry(position: 1, prState: .open)]),
+            action: action
+        ).syncProgress)
+
+        #expect(progress.steps.map(\.state) == [.complete, .failed, .pending, .pending])
     }
 
     @Test func idleFailedSyncRetainsProgressWhileLastErrorIsSet() throws {

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -175,6 +175,11 @@ struct GGStackReadinessModelTests {
             selectedBaseBranch: "release",
             behindBase: behind
         ) == nil)
+        #expect(GGStackReadinessProjection.effectiveBehindBase(
+            stack: stack,
+            selectedBaseBranch: "release",
+            behindBase: behind
+        ) == 0)
     }
 
     @Test func blockingGitOperationDisablesStackMutations() {
@@ -430,6 +435,7 @@ struct GGStackReadinessModelTests {
             .init(position: 2, text: "[2] Pushed · PR #22 updated"),
         ])
         #expect(progress.liveStatus == "Syncing 2 of 2 commits…")
+        #expect(progress.steps.filter { $0.state == .current }.map(\.id) == ["commits"])
     }
 
     @Test func prUpdatedMapsKnownActionsAndUsesNeutralFallback() throws {

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -377,15 +377,23 @@ struct GGStackReadinessModelTests {
         _ = action.beginAction(.sync)
 
         let model = GGStackReadinessModel.make(
-            stack: stack([entry(position: 1, prState: .open)]),
-            action: action
+            stack: stack([entry(position: 1, prState: .open)], behind: 2),
+            action: action,
+            effectiveConfig: .init(syncAutoRebase: true, syncBehindThreshold: 1, syncAutoLint: true)
         )
 
-        #expect(model.syncProgress == GGSyncProgressPresentation(
-            liveStatus: "Preparing sync…",
-            showsSpinner: true,
-            rows: []
-        ))
+        #expect(model.syncProgress?.liveStatus == "Preparing stack…")
+        #expect(model.syncProgress?.showsSpinner == true)
+        #expect(model.syncProgress?.steps.map(\.title) == [
+            "Preparing stack",
+            "Syncing commits",
+            "Updating pull requests",
+            "Refreshing Changes",
+        ])
+        #expect(
+            model.syncProgress?.steps.first?.detail
+                == "Checking base · Rebase onto main if needed · Run configured lint"
+        )
     }
 
     @Test func syncProgressUpdatesOneStableRowPerPosition() throws {
@@ -504,7 +512,7 @@ struct GGStackReadinessModelTests {
         #expect(!progress.showsSpinner)
     }
 
-    @Test func terminalSummaryRemovesLiveStatus() throws {
+    @Test func terminalSummaryMovesToChangesRefresh() throws {
         let action = GGStackActionState()
         _ = action.beginAction(.sync)
         action.appendSyncEvent(.start(totalEntries: 1))
@@ -512,8 +520,8 @@ struct GGStackReadinessModelTests {
         action.appendSyncEvent(.summary)
         let model = GGStackReadinessModel.make(stack: stack([entry(position: 1, prState: .open)]), action: action)
         let progress = try #require(model.syncProgress)
-        #expect(progress.liveStatus == nil)
-        #expect(!progress.showsSpinner)
+        #expect(progress.liveStatus == "Refreshing Changes…")
+        #expect(progress.showsSpinner)
     }
 
     @Test func idleFailedSyncRetainsProgressWhileLastErrorIsSet() throws {

--- a/AlasTests/Right/ChangesPreparationModelTests.swift
+++ b/AlasTests/Right/ChangesPreparationModelTests.swift
@@ -3,6 +3,13 @@ import Testing
 @testable import Alas
 
 struct ChangesPreparationModelTests {
+    @Test func syncStepAccessibilityStatesAreExplicit() {
+        #expect(ChangesPreparationCardText.syncStepState(.pending) == "Pending")
+        #expect(ChangesPreparationCardText.syncStepState(.current) == "In progress")
+        #expect(ChangesPreparationCardText.syncStepState(.complete) == "Complete")
+        #expect(ChangesPreparationCardText.syncStepState(.failed) == "Failed")
+    }
+
     private typealias Action = ReviewReadinessModel.Action
     private let stagedOnlyCapabilities = GGCapabilities(
         structuredSplit: false,

--- a/AlasTests/Right/ChangesPreparationModelTests.swift
+++ b/AlasTests/Right/ChangesPreparationModelTests.swift
@@ -115,6 +115,22 @@ struct ChangesPreparationModelTests {
         #expect(model.isVisible)
     }
 
+    @Test func syncProgressKeepsEmptyGGPreparationVisible() {
+        let model = ChangesPreparationModel.makeGG(
+            staged: .zero,
+            hasDraft: false,
+            capabilities: stagedOnlyCapabilities,
+            syncProgress: GGSyncProgressPresentation(
+                liveStatus: "Refreshing Changes…",
+                showsSpinner: true,
+                steps: [],
+                rows: []
+            )
+        )
+
+        #expect(model.isVisible)
+    }
+
     @Test func emptyGGPreparationIsHiddenButKeepsStableDestinations() {
         let model = ChangesPreparationModel.makeGG(
             staged: .zero,

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -2203,6 +2203,31 @@ struct RightPaneGGStackTests {
         #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] == nil)
     }
 
+    @Test func headInvalidationKeepsLoadedStackVisibleDuringSync() {
+        let worktree = makeWorktree()
+        let state = makeState(worktree: worktree)
+        state.ggContext = .active(stackName: "feature")
+        state.ggStack = GGStack(
+            name: "feature",
+            base: "main",
+            totalCommits: 1,
+            syncedCommits: 0,
+            currentPosition: 1,
+            behindBase: nil,
+            entries: [GGStackEntry(position: 1, sha: "abc1234", title: "Change", isCurrent: true)]
+        )
+        state.ggStackLoadState = .loaded
+        state.ggStackCommitsKey = "feature|abc1234"
+        _ = state.ggActionState.beginAction(.sync)
+
+        let refresh = state.invalidateGGPresentation(startingRefresh: false)
+
+        #expect(refresh == nil)
+        #expect(state.ggStackLoadState == .loaded)
+        #expect(state.ggStack?.name == "feature")
+        #expect(state.ggStackCommitsKey == "feature|abc1234")
+    }
+
     @Test func activeHeadInvalidationReplacesInFlightColdDetachedRecovery() async throws {
         let worktree = makeWorktree()
         defer { GGStackSummaryStore.shared.summaries[worktree.path.path] = nil }

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -649,6 +649,15 @@ struct RightPaneGGStackErrorPresentationTests {
 }
 
 @MainActor
+struct RightPaneGGRefreshSchedulingTests {
+    @Test func watcherStackRefreshIsSuppressedOnlyDuringSync() {
+        #expect(!RightPaneState.shouldScheduleGGStackRefresh(inFlightAction: .sync))
+        #expect(RightPaneState.shouldScheduleGGStackRefresh(inFlightAction: .rebase))
+        #expect(RightPaneState.shouldScheduleGGStackRefresh(inFlightAction: nil))
+    }
+}
+
+@MainActor
 struct RightPaneGGStackTests {
     private struct MemoryStore: PersistenceStoreProtocol {
         var projectsFile: ProjectsFile?

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -382,7 +382,6 @@ private actor StaleMutationFailureRunner: GGCommandRunning {
         stderr: ""
     )
     private var stackReadCount = 0
-    private var syncCount = 0
     private var firstRefreshSuspended = false
     private var secondSyncSuspended = false
     private var firstRefreshWaiters: [CheckedContinuation<Void, Never>] = []
@@ -394,11 +393,10 @@ private actor StaleMutationFailureRunner: GGCommandRunning {
         if args == ["sync", "--help"] {
             return ProcessResult(exitCode: 0, stdout: "--jsonl", stderr: "")
         }
+        if args == ["restack", "--json"] {
+            return ProcessResult(exitCode: 1, stdout: "", stderr: "mutation A failed")
+        }
         if args == ["sync", "--json"] || args == ["sync", "--jsonl"] {
-            syncCount += 1
-            if syncCount == 1 {
-                return ProcessResult(exitCode: 1, stdout: "", stderr: "mutation A failed")
-            }
             return try await withCheckedThrowingContinuation { continuation in
                 secondSyncSuspended = true
                 secondSyncContinuation = continuation
@@ -2212,9 +2210,20 @@ struct RightPaneGGStackTests {
         #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] == nil)
     }
 
-    @Test func headInvalidationKeepsLoadedStackVisibleDuringSync() {
+    @Test func headInvalidationKeepsLoadedStackVisibleDuringSync() async {
         let worktree = makeWorktree()
         let state = makeState(worktree: worktree)
+        let staleSnapshot = GGStackModelsTests.fixture.replacingOccurrences(
+            of: "agent-inbox",
+            with: "stale-stack"
+        )
+        let runner = ControlledStackGGRunner(
+            stackResults: [("stale-stack", ProcessResult(exitCode: 0, stdout: staleSnapshot, stderr: ""))],
+            suspendedCalls: [1]
+        )
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "feature") }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
         state.ggContext = .active(stackName: "feature")
         state.ggStack = GGStack(
             name: "feature",
@@ -2226,7 +2235,10 @@ struct RightPaneGGStackTests {
             entries: [GGStackEntry(position: 1, sha: "abc1234", title: "Change", isCurrent: true)]
         )
         state.ggStackLoadState = .loaded
-        state.ggStackCommitsKey = "feature|abc1234"
+        state.ggStackCommitsKey = state.currentGGStackCommitsKey
+
+        let staleRefresh = Task { @MainActor in await state.refreshGGStack(forceRemote: true) }
+        await runner.waitUntilCall(1)
         _ = state.ggActionState.beginAction(.sync)
 
         let refresh = state.invalidateGGPresentation(startingRefresh: false)
@@ -2234,7 +2246,11 @@ struct RightPaneGGStackTests {
         #expect(refresh == nil)
         #expect(state.ggStackLoadState == .loaded)
         #expect(state.ggStack?.name == "feature")
-        #expect(state.ggStackCommitsKey == "feature|abc1234")
+        #expect(state.ggStackCommitsKey == state.currentGGStackCommitsKey)
+
+        await runner.complete(call: 1)
+        await staleRefresh.value
+        #expect(state.ggStack?.name == "feature")
     }
 
     @Test func activeHeadInvalidationReplacesInFlightColdDetachedRecovery() async throws {
@@ -2958,7 +2974,7 @@ struct RightPaneGGStackTests {
             commit(sha: String(repeating: "s", count: 40), stackShaped: true),
         ]
 
-        let mutationA = try #require(state.runGGMutation(.sync))
+        let mutationA = try #require(state.runGGMutation(.restack))
         await runner.waitUntilFirstRefreshSuspends()
 
         let mutationB = try #require(state.runGGMutation(.sync))

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -2217,9 +2217,16 @@ struct RightPaneGGStackTests {
             of: "agent-inbox",
             with: "stale-stack"
         )
+        let finalSnapshot = GGStackModelsTests.fixture.replacingOccurrences(
+            of: "agent-inbox",
+            with: "final-stack"
+        )
         let runner = ControlledStackGGRunner(
-            stackResults: [("stale-stack", ProcessResult(exitCode: 0, stdout: staleSnapshot, stderr: ""))],
-            suspendedCalls: [1]
+            stackResults: [
+                ("stale-stack", ProcessResult(exitCode: 0, stdout: staleSnapshot, stderr: "")),
+                ("final-stack", ProcessResult(exitCode: 0, stdout: finalSnapshot, stderr: "")),
+            ],
+            suspendedCalls: [1, 2]
         )
         state.ggService = GGService(runner: runner)
         state.ggContextProvider = { _ in .active(stackName: "feature") }
@@ -2240,6 +2247,7 @@ struct RightPaneGGStackTests {
         let staleRefresh = Task { @MainActor in await state.refreshGGStack(forceRemote: true) }
         await runner.waitUntilCall(1)
         _ = state.ggActionState.beginAction(.sync)
+        state.supersedeGGStackRefreshForSync()
 
         let refresh = state.invalidateGGPresentation(startingRefresh: false)
 
@@ -2251,6 +2259,13 @@ struct RightPaneGGStackTests {
         await runner.complete(call: 1)
         await staleRefresh.value
         #expect(state.ggStack?.name == "feature")
+
+        let finalRefresh = Task { @MainActor in await state.refreshGGStack(forceRemote: true) }
+        await runner.waitUntilCall(2)
+        _ = state.invalidateGGPresentation(startingRefresh: false)
+        await runner.complete(call: 2)
+        await finalRefresh.value
+        #expect(state.ggStack?.name == "final-stack")
     }
 
     @Test func activeHeadInvalidationReplacesInFlightColdDetachedRecovery() async throws {

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -669,12 +669,12 @@ struct RightPaneGGRefreshSchedulingTests {
         ))
     }
 
-    @Test func successfulRefreshClearsDeferralOnlyForItsCommitSnapshot() {
-        #expect(RightPaneState.shouldClearDeferredGGStackRefresh(
+    @Test func refreshPublishesOnlyForItsCommitSnapshot() {
+        #expect(RightPaneState.shouldPublishGGStackRefresh(
             refreshedCommitsKey: "main|abc",
             currentCommitsKey: "main|abc"
         ))
-        #expect(!RightPaneState.shouldClearDeferredGGStackRefresh(
+        #expect(!RightPaneState.shouldPublishGGStackRefresh(
             refreshedCommitsKey: "main|abc",
             currentCommitsKey: "main|def"
         ))
@@ -2506,6 +2506,34 @@ struct RightPaneGGStackTests {
         #expect(hydrationInvocation == 2)
         #expect(state.ggStackCommitsKey == nil)
         #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] == nil)
+    }
+
+    @Test func refreshDoesNotPublishAfterLiveCommitKeyChanges() async {
+        let worktree = makeWorktree()
+        let result = ProcessResult(
+            exitCode: 0,
+            stdout: GGStackModelsTests.fixture,
+            stderr: ""
+        )
+        let runner = DelayedStackGGRunner(staleResult: result, freshResult: result)
+        let state = makeState(worktree: worktree)
+        installFakeGGStackLoader(on: state)
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
+
+        let staleRefresh = Task { @MainActor in await state.refreshGGStack() }
+        while runner.callCount == 0 { await Task.yield() }
+        state.ggStackSourceCommits = [commit(sha: String(repeating: "b", count: 40), stackShaped: true)]
+        await staleRefresh.value
+
+        #expect(state.ggStack == nil)
+        #expect(state.ggStackCommitsKey == nil)
+
+        await state.refreshGGStack()
+        #expect(state.ggStack?.name == "agent-inbox")
+        #expect(state.ggStackCommitsKey == state.currentGGStackCommitsKey)
+        #expect(runner.callCount == 3)
     }
 
     @Test func cancelledFirstStackLoadBecomesRetryableFailure() async {

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -668,6 +668,17 @@ struct RightPaneGGRefreshSchedulingTests {
             sourceCommitsChanged: true
         ))
     }
+
+    @Test func successfulRefreshClearsDeferralOnlyForItsCommitSnapshot() {
+        #expect(RightPaneState.shouldClearDeferredGGStackRefresh(
+            refreshedCommitsKey: "main|abc",
+            currentCommitsKey: "main|abc"
+        ))
+        #expect(!RightPaneState.shouldClearDeferredGGStackRefresh(
+            refreshedCommitsKey: "main|abc",
+            currentCommitsKey: "main|def"
+        ))
+    }
 }
 
 @MainActor

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -654,18 +654,18 @@ struct RightPaneGGRefreshSchedulingTests {
         #expect(RightPaneState.shouldScheduleGGStackRefresh(inFlightAction: nil))
     }
 
-    @Test func changedCommitSnapshotDefersRefreshOnlyDuringSync() {
+    @Test func refreshWorkDefersOnlyDuringSync() {
         #expect(RightPaneState.shouldDeferGGStackRefresh(
             inFlightAction: .sync,
-            sourceCommitsChanged: true
+            refreshRequired: true
         ))
         #expect(!RightPaneState.shouldDeferGGStackRefresh(
             inFlightAction: .sync,
-            sourceCommitsChanged: false
+            refreshRequired: false
         ))
         #expect(!RightPaneState.shouldDeferGGStackRefresh(
             inFlightAction: .rebase,
-            sourceCommitsChanged: true
+            refreshRequired: true
         ))
     }
 
@@ -2255,6 +2255,13 @@ struct RightPaneGGStackTests {
             suspendedCalls: [1, 2]
         )
         state.ggService = GGService(runner: runner)
+        state.ggCapabilities = {
+            GGCapabilities(
+                structuredSplit: false,
+                keepCurrentUnstack: false,
+                localStackSnapshot: false
+            )
+        }
         state.ggContextProvider = { _ in .active(stackName: "feature") }
         state.ggStackSourceCommits = [commit(sha: String(repeating: "a", count: 40), stackShaped: true)]
         state.ggContext = .active(stackName: "feature")
@@ -2278,6 +2285,7 @@ struct RightPaneGGStackTests {
         let refresh = state.invalidateGGPresentation(startingRefresh: false)
 
         #expect(refresh == nil)
+        #expect(state.ggStackRefreshDeferredUntilSyncEnds)
         #expect(state.ggStackLoadState == .loaded)
         #expect(state.ggStack?.name == "feature")
         #expect(state.ggStackCommitsKey == state.currentGGStackCommitsKey)
@@ -2292,6 +2300,7 @@ struct RightPaneGGStackTests {
         await runner.complete(call: 2)
         await finalRefresh.value
         #expect(state.ggStack?.name == "final-stack")
+        #expect(!state.ggStackRefreshDeferredUntilSyncEnds)
     }
 
     @Test func activeHeadInvalidationReplacesInFlightColdDetachedRecovery() async throws {

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -679,6 +679,21 @@ struct RightPaneGGRefreshSchedulingTests {
             currentCommitsKey: "main|def"
         ))
     }
+
+    @Test func deferredRefreshForcesTheNextStackLoad() {
+        #expect(RightPaneState.shouldForceGGStackRefresh(
+            forceRemote: false,
+            deferredUntilSyncEnds: true
+        ))
+        #expect(RightPaneState.shouldForceGGStackRefresh(
+            forceRemote: true,
+            deferredUntilSyncEnds: false
+        ))
+        #expect(!RightPaneState.shouldForceGGStackRefresh(
+            forceRemote: false,
+            deferredUntilSyncEnds: false
+        ))
+    }
 }
 
 @MainActor

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -653,6 +653,21 @@ struct RightPaneGGRefreshSchedulingTests {
         #expect(RightPaneState.shouldScheduleGGStackRefresh(inFlightAction: .rebase))
         #expect(RightPaneState.shouldScheduleGGStackRefresh(inFlightAction: nil))
     }
+
+    @Test func changedCommitSnapshotDefersRefreshOnlyDuringSync() {
+        #expect(RightPaneState.shouldDeferGGStackRefresh(
+            inFlightAction: .sync,
+            sourceCommitsChanged: true
+        ))
+        #expect(!RightPaneState.shouldDeferGGStackRefresh(
+            inFlightAction: .sync,
+            sourceCommitsChanged: false
+        ))
+        #expect(!RightPaneState.shouldDeferGGStackRefresh(
+            inFlightAction: .rebase,
+            sourceCommitsChanged: true
+        ))
+    }
 }
 
 @MainActor

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -2266,6 +2266,7 @@ struct RightPaneGGStackTests {
             stackResults: [
                 ("stale-stack", ProcessResult(exitCode: 0, stdout: staleSnapshot, stderr: "")),
                 ("final-stack", ProcessResult(exitCode: 0, stdout: finalSnapshot, stderr: "")),
+                ("final-stack", ProcessResult(exitCode: 0, stdout: finalSnapshot, stderr: "")),
             ],
             suspendedCalls: [1, 2]
         )
@@ -2315,6 +2316,9 @@ struct RightPaneGGStackTests {
         await runner.complete(call: 2)
         await finalRefresh.value
         #expect(state.ggStack?.name == "final-stack")
+        #expect(state.ggStackRefreshDeferredUntilSyncEnds)
+
+        await state.refreshGGStack(forceRemote: true)
         #expect(!state.ggStackRefreshDeferredUntilSyncEnds)
     }
 


### PR DESCRIPTION
## Summary
`gg sync` rewrites refs several times, which caused the Changes tab to clear and reload throughout the operation. Keep the last coherent presentation mounted and show one stable progress checklist until the final refresh completes.

## Changes
- Replace Prepare actions during sync with preparation, commit sync, PR update, and Changes refresh phases.
- Include configured auto-rebase and lint work in the preparation detail.
- Ignore intermediate ref invalidations during sync and keep the mutation active through the final refresh.
- Cover progress transitions, config parsing, refresh lifetime, and presentation stability.

## Testing
- `xcodegen`
- macOS build
- Affected GG, coordinator, config, preparation, and right-pane tests