### PR TITLE
test: clean up test windows

### DIFF
--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerReconcilerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerReconcilerTests.swift
@@ -11,7 +11,8 @@ struct AppKitDiffScrollerReconcilerTests {
         scrollView: AppKitDiffScrollView,
         tiling: AppKitDiffTilingController,
         pool: AppKitDiffRowHostingPool,
-        reconciler: AppKitDiffScrollerReconciler
+        reconciler: AppKitDiffScrollerReconciler,
+        cleanup: TestWindowCleanup
     )
 
     private func makeStack() -> Stack {
@@ -26,7 +27,7 @@ struct AppKitDiffScrollerReconcilerTests {
         window.contentView = scrollView
         window.makeKeyAndOrderFront(nil)
         scrollView.layoutSubtreeIfNeeded()
-        return (window, scrollView, tiling, pool, reconciler)
+        return (window, scrollView, tiling, pool, reconciler, TestWindowCleanup(window))
     }
 
     private func spec(

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerStressTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerStressTests.swift
@@ -107,12 +107,14 @@ struct AppKitDiffScrollerStressTests {
         #expect(recycledAfterRelease)
     }
 
+    @MainActor
     private final class Stack {
         let window: NSWindow
         let scrollView: AppKitDiffScrollView
         let tiling: AppKitDiffTilingController
         let pool: AppKitDiffRowHostingPool
         let reconciler: AppKitDiffScrollerReconciler
+        private let cleanup: TestWindowCleanup
 
         init(
             window: NSWindow,
@@ -126,6 +128,7 @@ struct AppKitDiffScrollerStressTests {
             self.tiling = tiling
             self.pool = pool
             self.reconciler = reconciler
+            cleanup = TestWindowCleanup(window)
         }
     }
 

--- a/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/AppKitDiffScrollerTests.swift
@@ -9,7 +9,8 @@ struct AppKitDiffScrollerTests {
     private typealias Stack = (
         window: NSWindow,
         scrollView: AppKitDiffScrollView,
-        coordinator: AppKitDiffScroller.Coordinator
+        coordinator: AppKitDiffScroller.Coordinator,
+        cleanup: TestWindowCleanup
     )
 
     private func makeStack(
@@ -27,7 +28,7 @@ struct AppKitDiffScrollerTests {
         window.contentView = scrollView
         window.makeKeyAndOrderFront(nil)
         scrollView.layoutSubtreeIfNeeded()
-        return (window, scrollView, coordinator)
+        return (window, scrollView, coordinator, TestWindowCleanup(window))
     }
 
     private func plan(count: Int = 100) -> AppKitDiffRowPlan {

--- a/AlasTests/Center/Diff/Scroller/DiffPaneAppKitScrollerTests.swift
+++ b/AlasTests/Center/Diff/Scroller/DiffPaneAppKitScrollerTests.swift
@@ -102,7 +102,9 @@ struct DiffPaneAppKitScrollerTests {
         .environment(\.theme, theme())
     }
 
-    private func mount<Content: View>(_ content: Content) -> (NSWindow, NSHostingController<Content>) {
+    private func mount<Content: View>(
+        _ content: Content
+    ) -> (NSWindow, NSHostingController<Content>, TestWindowCleanup) {
         let controller = NSHostingController(rootView: content)
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 900, height: 480),
@@ -112,7 +114,7 @@ struct DiffPaneAppKitScrollerTests {
         window.contentView = controller.view
         window.makeKeyAndOrderFront(nil)
         controller.view.layoutSubtreeIfNeeded()
-        return (window, controller)
+        return (window, controller, TestWindowCleanup(window))
     }
 
     private func allSubviews(of view: NSView) -> [NSView] {

--- a/AlasTests/CommitMessageEditorViewTests.swift
+++ b/AlasTests/CommitMessageEditorViewTests.swift
@@ -3,6 +3,42 @@ import SwiftUI
 import AppKit
 @testable import Alas
 
+@MainActor
+final class TestWindowCleanup {
+    private let window: NSWindow
+
+    init(_ window: NSWindow) {
+        self.window = window
+    }
+
+    deinit {
+        MainActor.assumeIsolated {
+            window.orderOut(nil)
+        }
+    }
+}
+
+@MainActor
+@Suite(.serialized)
+struct TestWindowCleanupTests {
+    @Test func ordersWindowOutWhenReleased() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.makeKeyAndOrderFront(nil)
+        var cleanup: TestWindowCleanup? = TestWindowCleanup(window)
+
+        #expect(window.isVisible)
+        cleanup = nil
+
+        #expect(!window.isVisible)
+        _ = cleanup
+    }
+}
+
 @Suite(.serialized)
 @MainActor
 struct CommitMessageEditorViewTests {
@@ -84,6 +120,7 @@ struct CommitMessageEditorViewTests {
         let model = CommitComposerModel(subject: "subject", body: "body")
         let controller = NSHostingController(rootView: CommitComposerHarness(model: model, theme: currentTheme()))
         let window = attach(controller)
+        defer { window.orderOut(nil) }
         await drain(controller.view)
 
         let subject = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
@@ -102,14 +139,13 @@ struct CommitMessageEditorViewTests {
             body.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
         }
         #expect(model.body == "`body`")
-
-        window.orderOut(nil)
     }
 
     @Test func subjectKeepsFocusAcrossRepeatedTextUpdates() async throws {
         let model = CommitComposerModel(subject: "", body: "")
         let controller = NSHostingController(rootView: CommitComposerHarness(model: model, theme: currentTheme()))
         let window = attach(controller)
+        defer { window.orderOut(nil) }
         await drain(controller.view)
 
         let subject = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
@@ -125,8 +161,6 @@ struct CommitMessageEditorViewTests {
             #expect(window.firstResponder === editor)
         }
         #expect(model.subject == "abc")
-
-        window.orderOut(nil)
     }
 
     private func attach<Content: View>(_ controller: NSHostingController<Content>) -> NSWindow {

--- a/AlasTests/PairedAuthoredContentSurfaceTests.swift
+++ b/AlasTests/PairedAuthoredContentSurfaceTests.swift
@@ -11,12 +11,12 @@ struct PairedAuthoredContentSurfaceTests {
         let model = PromptDraftCapture(text: "prompt command")
         let controller = NSHostingController(rootView: PromptEditorHarness(model: model))
         let window = attach(controller)
+        defer { window.orderOut(nil) }
         await drain(controller.view)
 
         wrapSelection(in: try #require(textView(containing: "prompt command", in: controller.view)))
 
         #expect(model.text == "`prompt command`")
-        window.orderOut(nil)
     }
 
     @Test func terminalStartupScriptBindingWrapsSelectedCommand() async throws {
@@ -25,24 +25,24 @@ struct PairedAuthoredContentSurfaceTests {
         let controller = NSHostingController(rootView: TerminalPane(state: state)
             .environment(\.theme, try! ThemeStore().current))
         let window = attach(controller, height: 620)
+        defer { window.orderOut(nil) }
         await drain(controller.view)
 
         wrapSelection(in: try #require(textView(containing: "terminal command", in: controller.view)))
 
         #expect(state.config.terminal.startupScript == "`terminal command`")
-        window.orderOut(nil)
     }
 
     @Test func projectStartupScriptBindingWrapsSelectedCommandBeforeSave() async throws {
         let model = ProjectStartupScriptCapture(text: "project command")
         let controller = NSHostingController(rootView: ProjectStartupScriptHarness(model: model))
         let window = attach(controller)
+        defer { window.orderOut(nil) }
         await drain(controller.view)
 
         wrapSelection(in: try #require(textView(containing: "project command", in: controller.view)))
 
         #expect(model.text == "`project command`")
-        window.orderOut(nil)
     }
 
     private func attach<Content: View>(

--- a/AlasTests/PairedPrimaryComposerSurfaceTests.swift
+++ b/AlasTests/PairedPrimaryComposerSurfaceTests.swift
@@ -10,6 +10,7 @@ struct PairedPrimaryComposerSurfaceTests {
         let model = ReviewRequestComposerModel(title: "Review title", body: "Review body")
         let controller = NSHostingController(rootView: ReviewRequestComposerHarness(model: model, theme: try! ThemeStore().current))
         let window = attach(controller)
+        defer { window.orderOut(nil) }
         await drain(controller.view)
 
         let title = try #require(firstSubview(of: PairedTextFieldBackingView.self, in: controller.view))
@@ -28,8 +29,6 @@ struct PairedPrimaryComposerSurfaceTests {
             body.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
         }
         #expect(model.body == "`Review body`")
-
-        window.orderOut(nil)
     }
 
     @Test func ggSplitCardInvokesDraftChangeAfterPairedEdit() async throws {
@@ -56,6 +55,7 @@ struct PairedPrimaryComposerSurfaceTests {
         )
         .environment(\.theme, try! ThemeStore().current))
         let window = attach(controller)
+        defer { window.orderOut(nil) }
         await drain(controller.view)
         await drain(controller.view)
         draftChanges.removeAll()
@@ -72,7 +72,6 @@ struct PairedPrimaryComposerSurfaceTests {
 
         #expect(model.firstMessage == "`First commit`")
         #expect(draftChanges == ["`First commit`"])
-        window.orderOut(nil)
     }
 
     private func attach<Content: View>(_ controller: NSHostingController<Content>) -> NSWindow {

--- a/AlasTests/PairedReviewComposerSurfaceTests.swift
+++ b/AlasTests/PairedReviewComposerSurfaceTests.swift
@@ -26,6 +26,7 @@ struct PairedReviewComposerSurfaceTests {
             rootView: ReviewDraftComposerCaptureHarness(model: model, theme: try! ThemeStore().current)
         )
         let window = attach(controller)
+        defer { window.orderOut(nil) }
         await drain(controller.view)
 
         let composer = try #require(textView(containing: model.text, in: controller.view))
@@ -34,7 +35,6 @@ struct PairedReviewComposerSurfaceTests {
         await drain(controller.view)
 
         #expect(model.text == "before\n\n\(quote)\n\nafter")
-        window.orderOut(nil)
     }
 
     @Test func reviewDraftComposerWrapsSelectionAndRoutesKeyboardActions() async throws {
@@ -43,6 +43,7 @@ struct PairedReviewComposerSurfaceTests {
             rootView: ReviewDraftComposerCaptureHarness(model: model, theme: try! ThemeStore().current)
         )
         let window = attach(controller)
+        defer { window.orderOut(nil) }
         await drain(controller.view)
 
         let composer = try #require(textView(containing: model.text, in: controller.view) as? PairedDelimiterTextView)
@@ -56,14 +57,13 @@ struct PairedReviewComposerSurfaceTests {
         composer.keyDown(with: try keyEvent(characters: "\u{1b}", modifiers: []))
         #expect(model.saveCount == 1)
         #expect(model.cancelCount == 1)
-
-        window.orderOut(nil)
     }
 
     @Test func inlineReplyAndEditBindingsReceiveWrappedSelections() async throws {
         let model = InlineCommentCardCapture()
         let controller = NSHostingController(rootView: InlineCommentCardCaptureHarness(model: model))
         let window = attach(controller, height: 520)
+        defer { window.orderOut(nil) }
         await drain(controller.view)
 
         let replyEditor = try #require(textView(containing: "reply body", in: controller.view))
@@ -73,27 +73,25 @@ struct PairedReviewComposerSurfaceTests {
         let editEditor = try #require(textView(containing: "edit body", in: controller.view))
         wrapSelection(in: editEditor)
         #expect(model.editState.editDraft == "`edit body`")
-
-        window.orderOut(nil)
     }
 
     @Test func providerReplyBindingReceivesWrappedSelection() async throws {
         let model = ProviderReplyCapture()
         let controller = NSHostingController(rootView: ProviderReplyCaptureHarness(model: model))
         let window = attach(controller)
+        defer { window.orderOut(nil) }
         await drain(controller.view)
 
         let editor = try #require(textView(containing: "provider reply", in: controller.view))
         wrapSelection(in: editor)
         #expect(model.editorState.body == "`provider reply`")
-
-        window.orderOut(nil)
     }
 
     @Test func providerReplyEmptyEditorPreservesReplyLabelAndMinimumHeight() async throws {
         let model = ProviderReplyCapture(body: "")
         let controller = NSHostingController(rootView: ProviderReplyCaptureHarness(model: model))
         let window = attach(controller)
+        defer { window.orderOut(nil) }
         await drain(controller.view)
 
         let replyEditor = try #require(firstEditableTextView(in: controller.view))
@@ -101,7 +99,6 @@ struct PairedReviewComposerSurfaceTests {
 
         #expect(scrollView.frame.height >= 32)
         #expect(replyEditor.accessibilityPlaceholderValue() == "Reply")
-        window.orderOut(nil)
     }
 
     @Test func verdictSummaryEditorWrapsSelectedText() async throws {
@@ -112,6 +109,7 @@ struct PairedReviewComposerSurfaceTests {
             .environment(\.theme, try! ThemeStore().current)
         )
         let window = attach(controller, height: 420)
+        defer { window.orderOut(nil) }
         await drain(controller.view)
 
         let editor = try #require(firstEditableTextView(in: controller.view))
@@ -119,7 +117,6 @@ struct PairedReviewComposerSurfaceTests {
         wrapSelection(in: editor)
 
         #expect(editor.string == "`verdict summary`")
-        window.orderOut(nil)
     }
 
     @Test func verdictSummaryRequestChangesRequiresNonEmptySummary() {
@@ -134,6 +131,7 @@ struct PairedReviewComposerSurfaceTests {
         let model = ProviderPublishCapture()
         let controller = NSHostingController(rootView: ProviderPublishCaptureHarness(model: model))
         let window = attach(controller, height: 420)
+        defer { window.orderOut(nil) }
         await drain(controller.view)
 
         let editor = try #require(textView(containing: "publish summary", in: controller.view))
@@ -144,21 +142,19 @@ struct PairedReviewComposerSurfaceTests {
         model.isPublishing = true
         await drain(controller.view)
         #expect(!editor.isEditable)
-
-        window.orderOut(nil)
     }
 
     @Test func draftSummaryEditingBindingReceivesWrappedSelection() async throws {
         let capture = DraftSummaryEditCapture(body: "draft summary")
         let controller = NSHostingController(rootView: DraftSummaryEditCaptureHarness(capture: capture))
         let window = attach(controller, height: 240)
+        defer { window.orderOut(nil) }
         await drain(controller.view)
 
         let editor = try await waitForTextView(containing: "draft summary", in: controller.view)
         wrapSelection(in: editor)
 
         #expect(capture.body == "`draft summary`")
-        window.orderOut(nil)
     }
 
     private func attach<Content: View>(


### PR DESCRIPTION
## Summary

AppKit retains windows shown by tests, so window-heavy tests left visible ownerless windows in the test host. This change gives those windows deterministic teardown without weakening the focus assertions they need.

## Changes

- Keep an ownership token for reusable AppKit test-window stacks; it orders the window out when the stack is released.
- Use `defer` for focus-sensitive editor tests so assertion failures cannot leak their windows.
- Add a regression test that proves releasing the token hides the window.

## Verification

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- Targeted window-cleanup suites and isolated focus tests passed.\n- The full suite was interrupted after unrelated `RightPaneGGStackTests` failures and Xcode teardown stalled.