### PR TITLE
feat(diff): file and image review comments

### DIFF
--- a/Alas/Sources/App/ReviewCommentWireDTO.swift
+++ b/Alas/Sources/App/ReviewCommentWireDTO.swift
@@ -30,9 +30,12 @@ struct ReviewCommentWireDTO: Codable, Equatable {
     var id: String
     var sessionId: String
     var path: String
-    var startLine: Int
+    var anchorKind: String
+    var startLine: Int?
     var endLine: Int?
     var side: String
+    var xPercent: Double?
+    var yPercent: Double?
     var state: String
     var author: Author
     var body: String
@@ -43,7 +46,23 @@ struct ReviewCommentWireDTO: Codable, Equatable {
         id = comment.id
         sessionId = comment.sessionID.rawValue
         path = comment.path
-        startLine = comment.startLine
+        switch comment.anchor {
+        case .file:
+            anchorKind = "file"
+            startLine = nil
+            xPercent = nil
+            yPercent = nil
+        case .line(_, let line, _, _):
+            anchorKind = "line"
+            startLine = line
+            xPercent = nil
+            yPercent = nil
+        case .image(_, let x, let y):
+            anchorKind = "image"
+            startLine = nil
+            xPercent = x * 100
+            yPercent = y * 100
+        }
         endLine = comment.endLine
         side = comment.side.rawValue
         state = comment.state.rawValue

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -579,8 +579,8 @@ struct CommitReviewBody: View {
             draftCommentScrollCommand: draftCommentScrollCommand,
             draftCommentActions: effectiveDraftCommentActions,
             onSelectDraftComment: selectDraftComment,
-            onSaveDraftComment: { fileID, originalPath, anchor, body in
-                saveDraftComment(fileID: fileID, originalPath: originalPath, anchor: anchor, body: body)
+            onSaveDraftComment: { fileID, path, originalPath, anchor, body in
+                saveDraftComment(fileID: fileID, path: path, originalPath: originalPath, anchor: anchor, body: body)
             }
         )
         .accessibilityIdentifier("commit-review-body")
@@ -727,12 +727,13 @@ struct CommitReviewBody: View {
 
     private func saveDraftComment(
         fileID: DiffReviewFileID,
+        path: String,
         originalPath: String?,
-        anchor: DiffReviewLineAnchor,
+        anchor: ReviewDraftCommentAnchor,
         body: String
     ) {
         do {
-            try draftCommentController?.add(anchor: anchor, fileID: fileID, originalPath: originalPath, bodyMarkdown: body)
+            try draftCommentController?.add(anchor: anchor, path: path, fileID: fileID, originalPath: originalPath, bodyMarkdown: body)
         } catch {
             // The controller keeps the non-blocking error state for the review rail.
         }

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewPresentationState.swift
@@ -30,6 +30,7 @@ final class AppKitDiffReviewFileState: ObservableObject {
     let actionRelay = AppKitDiffReviewActionRelay()
     let hunkPresentationState = DiffPanePresentationState()
     @Published var pendingDraftAnchor: DiffReviewLineAnchor? { didSet { structuralDidChange.send() } }
+    @Published var pendingNonLineDraftAnchor: ReviewDraftCommentAnchor? { didSet { structuralDidChange.send() } }
     @Published var pendingDraftBody = ""
     @Published var draftComposerFocusRequestGeneration = 0 { didSet { structuralDidChange.send() } }
     @Published var quoteInsertionGeneration = 0 { didSet { structuralDidChange.send() } }
@@ -116,6 +117,7 @@ final class AppKitDiffReviewFileState: ObservableObject {
 
     func clearPendingDraft() {
         pendingDraftAnchor = nil
+        pendingNonLineDraftAnchor = nil
         pendingDraftBody = ""
     }
 
@@ -193,7 +195,7 @@ final class AppKitDiffReviewActionRelay {
     private var onSelectInlineFeedback: (DiffReviewInlineFeedback) -> Void = { _ in }
     private var draftCommentActions = ReviewDraftCommentActions()
     private var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
-    private var onSaveDraftComment: (DiffReviewLineAnchor, String) -> Void = { _, _ in }
+    private var onSaveDraftComment: (ReviewDraftCommentAnchor, String) -> Void = { _, _ in }
     private var onContextExpansionActivated: () -> Void = {}
     private var onReply: (DiffInlineCommentThread, String) -> Void = { _, _ in }
     private var onResolve: (DiffInlineCommentThread) -> Void = { _ in }
@@ -209,7 +211,7 @@ final class AppKitDiffReviewActionRelay {
         onSelectInlineFeedback: @escaping (DiffReviewInlineFeedback) -> Void,
         draftCommentActions: ReviewDraftCommentActions,
         onSelectDraftComment: @escaping (ReviewDraftComment) -> Void,
-        onSaveDraftComment: @escaping (DiffReviewLineAnchor, String) -> Void,
+        onSaveDraftComment: @escaping (ReviewDraftCommentAnchor, String) -> Void,
         onContextExpansionActivated: @escaping () -> Void,
         onReply: @escaping (DiffInlineCommentThread, String) -> Void,
         onResolve: @escaping (DiffInlineCommentThread) -> Void,
@@ -298,7 +300,7 @@ final class AppKitDiffReviewActionRelay {
     }
 
     func selectDraftComment(_ comment: ReviewDraftComment) { onSelectDraftComment(comment) }
-    func saveDraftComment(_ anchor: DiffReviewLineAnchor, body: String) { onSaveDraftComment(anchor, body) }
+    func saveDraftComment(_ anchor: ReviewDraftCommentAnchor, body: String) { onSaveDraftComment(anchor, body) }
     func contextExpansionActivated() { onContextExpansionActivated() }
     func reply(to thread: DiffInlineCommentThread, body: String) { onReply(thread, body) }
     func stageReply(to thread: DiffInlineCommentThread, body: String) { onStageReply(thread, body) }

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -151,7 +151,7 @@ struct AppKitDiffReviewRowInput {
         self.inlineFeedbackScrollTargetID = inlineFeedbackScrollTargetID
         self.focusedDraftCommentID = focusedDraftCommentID
         self.allowsDraftCommentCreation = allowsDraftCommentCreation
-        self.allowsNonLineDraftCommentCreation = allowsNonLineDraftCommentCreation
+        self.allowsNonLineDraftCommentCreation = allowsDraftCommentCreation && allowsNonLineDraftCommentCreation
         self.actionPresence = actionPresence
         self.lspContext = lspContext
         self.reviewFeedbackTarget = reviewFeedbackTarget
@@ -178,6 +178,7 @@ struct AppKitDiffReviewRowInput {
     }
 
     private func beginNonLineDraft(_ anchor: ReviewDraftCommentAnchor) {
+        guard allowsNonLineDraftCommentCreation else { return }
         state.pendingDraftAnchor = nil
         state.pendingNonLineDraftAnchor = anchor
         state.pendingDraftBody = ""
@@ -197,6 +198,10 @@ struct AppKitDiffReviewRowInput {
         let body = state.pendingDraftBody.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !body.isEmpty else { return }
         if let anchor = state.pendingNonLineDraftAnchor {
+            guard allowsNonLineDraftCommentCreation else {
+                clearPendingDraft()
+                return
+            }
             clearPendingDraft()
             state.actionRelay.saveDraftComment(anchor, body: body)
             return
@@ -382,7 +387,8 @@ enum AppKitDiffReviewRowPlanBuilder {
             append(&rows, id: headerID, input: input, signature: headerSignature(input), height: 45) {
                 AnyView(AppKitDiffReviewHeaderRowBody(input: input))
             }
-            if input.state.pendingNonLineDraftAnchor == .file {
+            if input.allowsNonLineDraftCommentCreation,
+               input.state.pendingNonLineDraftAnchor == .file {
                 appendComposer(scopeID: "file", input: input, rows: &rows)
             }
             if let contextLoadError = input.state.contextLoadError {
@@ -407,6 +413,9 @@ enum AppKitDiffReviewRowPlanBuilder {
             let isDeferred = (!input.automaticallyRendersDiff || !automaticallyRendersByAggregateBudget || individuallyDeferred)
                 && !input.state.showFullDiffOverride
             if isDeferred || (input.file.displayModel == nil && input.file.imageProvider == nil) {
+                if input.file.displayModel == nil && input.file.imageProvider == nil {
+                    appendFileAccessories(input, context: nil, rows: &rows, fallbacks: &fallbackByTargetID)
+                }
                 let placeholderID = AppKitDiffReviewRowID.placeholder(fileID: fileID)
                 placeholderByFileID[fileID] = placeholderID
                 append(
@@ -430,7 +439,8 @@ enum AppKitDiffReviewRowPlanBuilder {
                 append(&rows, id: imageID, input: input, signature: imageSignature(input), height: 360) {
                     AnyView(AppKitDiffReviewImageRowBody(input: input, loadsImage: true))
                 }
-                if case .image = input.state.pendingNonLineDraftAnchor {
+                if input.allowsNonLineDraftCommentCreation,
+                   case .image = input.state.pendingNonLineDraftAnchor {
                     appendComposer(scopeID: "image", input: input, rows: &rows)
                 }
                 for comment in ReviewDraftCommentPlacement.position(input.draftComments, in: []).image {
@@ -934,7 +944,11 @@ struct AppKitDiffReviewHeaderRowBody: View {
                 .font(.system(size: 11, weight: .medium, design: .monospaced))
             }
             if let pair = displayedImagePair {
-                ImageDiffControls(pair: pair, state: input.state.imageState.presentation)
+                ImageDiffControls(
+                    pair: pair,
+                    state: input.state.imageState.presentation,
+                    allowsModeSwitching: !input.allowsNonLineDraftCommentCreation
+                )
                     .background(DiffReviewAccessibilityMarker(
                         identifier: "diff-review-image-header-\(input.file.id.rawValue)",
                         label: "Image diff controls"
@@ -1264,26 +1278,29 @@ struct AppKitDiffReviewImageRowBody: View {
     }
 
     private func annotationPresentation(for pair: ImageDiffPair) -> ImageDiffAnnotationPresentation? {
+        Self.annotationPresentation(input: input, pair: pair)
+    }
+
+    @MainActor
+    static func annotationPresentation(
+        input: AppKitDiffReviewRowInput,
+        pair: ImageDiffPair
+    ) -> ImageDiffAnnotationPresentation? {
         guard input.allowsNonLineDraftCommentCreation else { return nil }
-        let side: DiffReviewInlineFeedbackSide = pair.kind == .deleted ? .old : .new
         let comments = ReviewDraftCommentPlacement.position(input.draftComments, in: []).image
-        let markers = comments.enumerated().compactMap { index, comment -> ImageDiffAnnotationMarker? in
-            guard case .image(let commentSide, let x, let y) = comment.anchor, commentSide == side else { return nil }
-            return .init(id: comment.id, number: index + 1, normalizedX: x, normalizedY: y)
-        }
-        let pendingPoint: CGPoint?
-        if case .image(let pendingSide, let x, let y) = input.state.pendingNonLineDraftAnchor,
-           pendingSide == side {
-            pendingPoint = CGPoint(x: x, y: y)
-        } else {
-            pendingPoint = nil
+        let markersBySide = Dictionary(grouping: comments.enumerated().compactMap { index, comment -> (DiffReviewInlineFeedbackSide, ImageDiffAnnotationMarker)? in
+            guard case .image(let side, let x, let y) = comment.anchor else { return nil }
+            return (side, .init(id: comment.id, number: index + 1, normalizedX: x, normalizedY: y))
+        }, by: \.0).mapValues { $0.map(\.1) }
+        var pendingPointBySide: [DiffReviewInlineFeedbackSide: CGPoint] = [:]
+        if case .image(let side, let x, let y) = input.state.pendingNonLineDraftAnchor {
+            pendingPointBySide[side] = CGPoint(x: x, y: y)
         }
         return ImageDiffAnnotationPresentation(
-            side: side,
-            markers: markers,
-            pendingPoint: pendingPoint,
+            markersBySide: markersBySide,
+            pendingPointBySide: pendingPointBySide,
             focusedMarkerID: input.state.hoveredDraftCommentID ?? input.focusedDraftCommentID,
-            onPointSelected: { input.beginImageDraft(side: side, point: $0) },
+            onPointSelected: { side, point in input.beginImageDraft(side: side, point: point) },
             onMarkerSelected: { id in
                 guard let comment = comments.first(where: { $0.id == id }) else { return }
                 input.state.actionRelay.selectDraftComment(comment)

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -755,10 +755,12 @@ enum AppKitDiffReviewRowPlanBuilder {
 
     private static func mapTargets(_ input: AppKitDiffReviewRowInput, to rowID: String, into fallbacks: inout [String: String]) {
         for item in input.inlineFeedback {
-            fallbacks[AppKitDiffReviewRowID.inlineFeedback(.targetID(feedbackID: item.id, fileID: input.file.id))] = rowID
+            let id = AppKitDiffReviewRowID.inlineFeedback(.targetID(feedbackID: item.id, fileID: input.file.id))
+            fallbacks[id] = fallbacks[id] ?? rowID
         }
         for comment in input.draftComments {
-            fallbacks[AppKitDiffReviewRowID.draftComment(.targetID(commentID: comment.id, fileID: input.file.id))] = rowID
+            let id = AppKitDiffReviewRowID.draftComment(.targetID(commentID: comment.id, fileID: input.file.id))
+            fallbacks[id] = fallbacks[id] ?? rowID
         }
     }
 

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -100,6 +100,7 @@ struct AppKitDiffReviewRowInput {
     var inlineFeedbackScrollTargetID: String?
     var focusedDraftCommentID: String?
     var allowsDraftCommentCreation = true
+    var allowsNonLineDraftCommentCreation = true
     var actionPresence = AppKitDiffReviewActionPresence()
     var lspContext: DiffPaneLSPContext?
     var reviewFeedbackTarget: ReviewFeedbackTarget?
@@ -124,6 +125,7 @@ struct AppKitDiffReviewRowInput {
         inlineFeedbackScrollTargetID: String? = nil,
         focusedDraftCommentID: String? = nil,
         allowsDraftCommentCreation: Bool = true,
+        allowsNonLineDraftCommentCreation: Bool = true,
         actionPresence: AppKitDiffReviewActionPresence = .init(),
         lspContext: DiffPaneLSPContext? = nil,
         reviewFeedbackTarget: ReviewFeedbackTarget? = nil,
@@ -149,6 +151,7 @@ struct AppKitDiffReviewRowInput {
         self.inlineFeedbackScrollTargetID = inlineFeedbackScrollTargetID
         self.focusedDraftCommentID = focusedDraftCommentID
         self.allowsDraftCommentCreation = allowsDraftCommentCreation
+        self.allowsNonLineDraftCommentCreation = allowsNonLineDraftCommentCreation
         self.actionPresence = actionPresence
         self.lspContext = lspContext
         self.reviewFeedbackTarget = reviewFeedbackTarget
@@ -160,6 +163,23 @@ struct AppKitDiffReviewRowInput {
 
     func beginPendingDraft(at anchor: DiffReviewLineAnchor) {
         state.pendingDraftAnchor = anchor
+        state.pendingNonLineDraftAnchor = nil
+        state.pendingDraftBody = ""
+        state.quoteInsertionGeneration = 0
+        state.draftComposerFocusRequestGeneration &+= 1
+    }
+
+    func beginFileDraft() {
+        beginNonLineDraft(.file)
+    }
+
+    func beginImageDraft(side: DiffReviewInlineFeedbackSide, point: CGPoint) {
+        beginNonLineDraft(.image(side: side, normalizedX: point.x, normalizedY: point.y))
+    }
+
+    private func beginNonLineDraft(_ anchor: ReviewDraftCommentAnchor) {
+        state.pendingDraftAnchor = nil
+        state.pendingNonLineDraftAnchor = anchor
         state.pendingDraftBody = ""
         state.quoteInsertionGeneration = 0
         state.draftComposerFocusRequestGeneration &+= 1
@@ -167,17 +187,23 @@ struct AppKitDiffReviewRowInput {
 
     func clearPendingDraft() {
         state.pendingDraftAnchor = nil
+        state.pendingNonLineDraftAnchor = nil
         state.pendingDraftBody = ""
         state.quoteInsertionGeneration = 0
         state.isDraftComposerFocused = false
     }
 
     func savePendingDraft() {
+        let body = state.pendingDraftBody.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !body.isEmpty else { return }
+        if let anchor = state.pendingNonLineDraftAnchor {
+            clearPendingDraft()
+            state.actionRelay.saveDraftComment(anchor, body: body)
+            return
+        }
         guard let anchor = state.pendingDraftAnchor else { return }
         let groups = currentDisplayGroups
         let canonicalAnchor = ReviewDraftCommentRowSegmentation.canonicalPendingAnchor(anchor, in: groups)
-        let body = state.pendingDraftBody.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !body.isEmpty else { return }
         let rowKeys = Set(groups.flatMap(ReviewDraftCommentPlacement.allRowKeys))
         guard rowKeys.contains(ReviewDraftCommentPlacement.RowKey(
             side: canonicalAnchor.side,
@@ -187,7 +213,15 @@ struct AppKitDiffReviewRowInput {
             return
         }
         clearPendingDraft()
-        state.actionRelay.saveDraftComment(canonicalAnchor, body: body)
+        state.actionRelay.saveDraftComment(
+            .line(
+                side: canonicalAnchor.side,
+                startLine: canonicalAnchor.line,
+                endLine: canonicalAnchor.endLine,
+                selectedText: canonicalAnchor.selectedText
+            ),
+            body: body
+        )
     }
 
     func loadContextAndExpand(
@@ -292,8 +326,10 @@ struct AppKitDiffReviewRowInput {
     private func activeHighlight(for candidate: DiffReviewActiveCommentCandidate) -> DiffReviewCommentHighlight? {
         switch candidate {
         case .draft(let id):
-            guard let comment = draftComments.first(where: { $0.id == id }), comment.state != .dismissed else { return nil }
-            return .init(path: comment.path, side: comment.side, lineRange: comment.normalizedLineRange)
+            guard let comment = draftComments.first(where: { $0.id == id }),
+                  comment.state != .dismissed,
+                  let lineRange = comment.normalizedLineRange else { return nil }
+            return .init(path: comment.path, side: comment.side, lineRange: lineRange)
         case .inlineFeedback(let id):
             guard let item = inlineFeedback.first(where: { $0.id == id }), let line = item.anchor.line else { return nil }
             return .init(path: item.anchor.path, side: item.anchor.side, line: line)
@@ -346,6 +382,9 @@ enum AppKitDiffReviewRowPlanBuilder {
             append(&rows, id: headerID, input: input, signature: headerSignature(input), height: 45) {
                 AnyView(AppKitDiffReviewHeaderRowBody(input: input))
             }
+            if input.state.pendingNonLineDraftAnchor == .file {
+                appendComposer(scopeID: "file", input: input, rows: &rows)
+            }
             if let contextLoadError = input.state.contextLoadError {
                 append(
                     &rows,
@@ -388,8 +427,14 @@ enum AppKitDiffReviewRowPlanBuilder {
                 appendFileAccessories(input, context: nil, rows: &rows, fallbacks: &fallbackByTargetID)
                 appendImageFeedback(input, rows: &rows)
                 let imageID = AppKitDiffReviewRowID.image(fileID: fileID)
-                append(&rows, id: imageID, input: input, signature: input.file.imageProvider?.id.hashValue ?? 0, height: 360) {
+                append(&rows, id: imageID, input: input, signature: imageSignature(input), height: 360) {
                     AnyView(AppKitDiffReviewImageRowBody(input: input, loadsImage: true))
+                }
+                if case .image = input.state.pendingNonLineDraftAnchor {
+                    appendComposer(scopeID: "image", input: input, rows: &rows)
+                }
+                for comment in ReviewDraftCommentPlacement.position(input.draftComments, in: []).image {
+                    appendDraft(comment, contextRows: nil, input: input, rows: &rows, fallbacks: &fallbackByTargetID)
                 }
                 mapTargetsDirectly(input, into: &fallbackByTargetID)
             } else if let context = renderContext(for: input) {
@@ -462,6 +507,24 @@ enum AppKitDiffReviewRowPlanBuilder {
         appendFeedback(feedback, scopeID: "file", contextRows: nil, input: input, rows: &rows, fallbacks: &fallbacks)
     }
 
+    private static func appendComposer(
+        scopeID: String,
+        input: AppKitDiffReviewRowInput,
+        rows: inout [AppKitDiffRowSpec],
+        contextRows: [DiffDisplayRow] = []
+    ) {
+        append(
+            &rows,
+            id: AppKitDiffReviewRowID.composer(fileID: input.file.id, segmentID: scopeID),
+            input: input,
+            signature: composerSignature(input.state),
+            height: 132,
+            retention: input.state.isDraftComposerFocused ? .pinned : .recyclable
+        ) {
+            AnyView(AppKitDiffReviewComposerRowBody(rows: contextRows, input: input))
+        }
+    }
+
     private static func appendTextRows(
         _ context: DiffReviewRenderContext,
         input: AppKitDiffReviewRowInput,
@@ -527,17 +590,7 @@ enum AppKitDiffReviewRowPlanBuilder {
                     appendDraft(comment, contextRows: segment.rows, input: input, rows: &rows, fallbacks: &fallbacks)
                 }
                 if segment.showsComposer {
-                    let composerID = AppKitDiffReviewRowID.composer(fileID: input.file.id, segmentID: segment.id)
-                    append(
-                        &rows,
-                        id: composerID,
-                        input: input,
-                        signature: composerSignature(input.state),
-                        height: 132,
-                        retention: input.state.isDraftComposerFocused ? .pinned : .recyclable
-                    ) {
-                        AnyView(AppKitDiffReviewComposerRowBody(rows: segment.rows, input: input))
-                    }
+                    appendComposer(scopeID: segment.id, input: input, rows: &rows, contextRows: segment.rows)
                 }
             }
         }
@@ -770,6 +823,18 @@ enum AppKitDiffReviewRowPlanBuilder {
         hasher.combine(input.file.summary.deletions)
         hasher.combine(input.showsSourceBadge)
         hasher.combine(input.file.summary.groupTitle)
+        hasher.combine(input.allowsDraftCommentCreation)
+        hasher.combine(input.allowsNonLineDraftCommentCreation)
+        return hasher.finalize()
+    }
+
+    private static func imageSignature(_ input: AppKitDiffReviewRowInput) -> Int {
+        var hasher = Hasher()
+        hasher.combine(input.file.imageProvider?.id)
+        hasher.combine(input.draftComments)
+        hasher.combine(input.state.pendingNonLineDraftAnchor)
+        hasher.combine(input.state.hoveredDraftCommentID)
+        hasher.combine(input.focusedDraftCommentID)
         return hasher.finalize()
     }
 
@@ -847,6 +912,17 @@ struct AppKitDiffReviewHeaderRowBody: View {
                     ))
             }
             Spacer(minLength: 12)
+            if input.allowsNonLineDraftCommentCreation {
+                Button("Comment", action: input.beginFileDraft)
+                    .buttonStyle(.plain)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(input.theme.color("fg-muted"))
+                    .padding(.horizontal, 8).frame(height: 24)
+                    .background(input.theme.color("bg-3"))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .accessibilityIdentifier("diff-review-comment-file-\(input.file.id.rawValue)")
+                    .help("Comment on this file")
+            }
             if shouldShowChangeSummary(
                 additions: input.file.summary.additions,
                 deletions: input.file.summary.deletions
@@ -1145,7 +1221,12 @@ struct AppKitDiffReviewImageRowBody: View {
                     ))
             }
             if let pair = input.state.imageState.pair ?? input.file.imageProvider.flatMap({ DiffReviewImagePairCache.shared.pair(for: $0.id) }) {
-                ImageDiffComparisonContent(pair: pair, state: input.state.imageState.presentation, boundedHeight: 360)
+                ImageDiffComparisonContent(
+                    pair: pair,
+                    state: input.state.imageState.presentation,
+                    boundedHeight: 360,
+                    annotation: annotationPresentation(for: pair)
+                )
                 if let message = failureMessage(in: pair) {
                     HStack(spacing: 10) {
                         Text(message).font(.system(size: 11)).foregroundColor(input.theme.color("warn"))
@@ -1180,6 +1261,34 @@ struct AppKitDiffReviewImageRowBody: View {
             }
             await input.state.imageState.load(provider: provider)
         }
+    }
+
+    private func annotationPresentation(for pair: ImageDiffPair) -> ImageDiffAnnotationPresentation? {
+        guard input.allowsNonLineDraftCommentCreation else { return nil }
+        let side: DiffReviewInlineFeedbackSide = pair.kind == .deleted ? .old : .new
+        let comments = ReviewDraftCommentPlacement.position(input.draftComments, in: []).image
+        let markers = comments.enumerated().compactMap { index, comment -> ImageDiffAnnotationMarker? in
+            guard case .image(let commentSide, let x, let y) = comment.anchor, commentSide == side else { return nil }
+            return .init(id: comment.id, number: index + 1, normalizedX: x, normalizedY: y)
+        }
+        let pendingPoint: CGPoint?
+        if case .image(let pendingSide, let x, let y) = input.state.pendingNonLineDraftAnchor,
+           pendingSide == side {
+            pendingPoint = CGPoint(x: x, y: y)
+        } else {
+            pendingPoint = nil
+        }
+        return ImageDiffAnnotationPresentation(
+            side: side,
+            markers: markers,
+            pendingPoint: pendingPoint,
+            focusedMarkerID: input.state.hoveredDraftCommentID ?? input.focusedDraftCommentID,
+            onPointSelected: { input.beginImageDraft(side: side, point: $0) },
+            onMarkerSelected: { id in
+                guard let comment = comments.first(where: { $0.id == id }) else { return }
+                input.state.actionRelay.selectDraftComment(comment)
+            }
+        )
     }
 
     private func failureMessage(in pair: ImageDiffPair) -> String? {
@@ -1329,6 +1438,7 @@ struct AppKitDiffReviewDraftCommentRowBody: View {
         ReviewDraftCommentCard(
             comment: comment, file: input.file.summary,
             isFocused: comment.id == input.focusedDraftCommentID,
+            markerNumber: markerNumber,
             actions: input.draftCommentActions ?? input.state.actionRelay.draftCommentActionsForRow,
             reviewFeedbackTarget: input.reviewFeedbackTarget ?? .init(
                 title: input.file.summary.path, repositoryPath: nil,
@@ -1348,6 +1458,12 @@ struct AppKitDiffReviewDraftCommentRowBody: View {
             editorState: input.state.bindingForDraftCommentEditor(comment.id)
         )
         .id(DiffReviewDraftCommentTargetID.targetID(commentID: comment.id, fileID: input.file.id))
+    }
+
+    private var markerNumber: Int? {
+        guard case .image = comment.anchor else { return nil }
+        return ReviewDraftCommentPlacement.position(input.draftComments, in: []).image
+            .firstIndex(where: { $0.id == comment.id }).map { $0 + 1 }
     }
 }
 
@@ -1492,13 +1608,15 @@ struct AppKitDiffReviewComposerRowBody: View {
                         .stroke(input.theme.color("accent").opacity(0.65), lineWidth: 0.75))
                     .accessibilityIdentifier("diff-review-draft-composer")
                 HStack {
-                    Button("Quote lines") { input.state.quoteInsertionGeneration &+= 1 }
-                        .buttonStyle(.plain).font(.system(size: 10, weight: .semibold))
-                        .foregroundColor(input.theme.color("fg-muted"))
-                        .padding(.horizontal, 8).frame(height: 24)
-                        .background(input.theme.color("bg-3"))
-                        .clipShape(RoundedRectangle(cornerRadius: 5))
-                        .accessibilityIdentifier("diff-review-draft-composer-quote")
+                    if input.state.pendingDraftAnchor != nil {
+                        Button("Quote lines") { input.state.quoteInsertionGeneration &+= 1 }
+                            .buttonStyle(.plain).font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(input.theme.color("fg-muted"))
+                            .padding(.horizontal, 8).frame(height: 24)
+                            .background(input.theme.color("bg-3"))
+                            .clipShape(RoundedRectangle(cornerRadius: 5))
+                            .accessibilityIdentifier("diff-review-draft-composer-quote")
+                    }
                     Spacer()
                     Button("Cancel", action: input.clearPendingDraft)
                         .buttonStyle(.plain).font(.system(size: 10, weight: .semibold))

--- a/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewFileSection.swift
@@ -25,6 +25,7 @@ struct DiffReviewContextStateSignature: Equatable {
 
 struct DiffReviewFilePresentationSignature: Equatable {
     let pendingDraftAnchor: DiffReviewLineAnchor?
+    let pendingNonLineDraftAnchor: ReviewDraftCommentAnchor?
     let pendingDraftBody: String
     let draftComposerFocusRequestGeneration: Int
     let quoteInsertionGeneration: Int
@@ -44,6 +45,7 @@ struct DiffReviewFilePresentationSignature: Equatable {
     @MainActor
     init(_ state: AppKitDiffReviewFileState) {
         pendingDraftAnchor = state.pendingDraftAnchor
+        pendingNonLineDraftAnchor = state.pendingNonLineDraftAnchor
         pendingDraftBody = state.pendingDraftBody
         draftComposerFocusRequestGeneration = state.draftComposerFocusRequestGeneration
         quoteInsertionGeneration = state.quoteInsertionGeneration
@@ -146,8 +148,9 @@ struct DiffReviewFileSection: View {
     var onSelectInlineFeedback: (DiffReviewInlineFeedback) -> Void = { _ in }
     var draftCommentActions = ReviewDraftCommentActions()
     var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
-    var onSaveDraftComment: (DiffReviewLineAnchor, String) -> Void = { _, _ in }
+    var onSaveDraftComment: (ReviewDraftCommentAnchor, String) -> Void = { _, _ in }
     var allowsDraftCommentCreation: Bool = true
+    var allowsNonLineDraftCommentCreation: Bool = true
     var onContextExpansionActivated: () -> Void = {}
     var reviewFeedbackTarget: ReviewFeedbackTarget?
     var threads: [DiffInlineCommentThread] = []
@@ -201,6 +204,7 @@ struct DiffReviewFileSection: View {
             focusedFeedbackID: focusedFeedbackID,
             focusedDraftCommentID: focusedDraftCommentID,
             allowsDraftCommentCreation: allowsDraftCommentCreation,
+            allowsNonLineDraftCommentCreation: allowsNonLineDraftCommentCreation,
             actionPresence: .init(
                 canOpenFile: file.openFile != nil,
                 canUnstageFile: file.stagedMutationActions?.unstageFile != nil,
@@ -235,12 +239,21 @@ struct DiffReviewFileSection: View {
         synchronizePresentationState()
         return VStack(spacing: 0) {
             header
+            if state.pendingNonLineDraftAnchor == .file {
+                AppKitDiffReviewComposerRowBody(rows: [], input: focusedRowInput)
+            }
             contextLoadErrorRow
             if file.imageProvider != nil {
                 fileLevelDraftCommentStack(renderContext: nil)
                 fileLevelInlineFeedbackStack(renderContext: nil)
                 imageProviderFeedbackStack
                 imageContent
+                if case .image = state.pendingNonLineDraftAnchor {
+                    AppKitDiffReviewComposerRowBody(rows: [], input: focusedRowInput)
+                }
+                fullWidthDraftCommentStack(
+                    ReviewDraftCommentPlacement.position(draftComments, in: []).image
+                )
             } else if shouldDeferRender {
                 renderBudgetPlaceholder
             } else {
@@ -815,12 +828,13 @@ struct DiffReviewFileSection: View {
 
     private func draftCommentHighlight(id: String) -> DiffReviewCommentHighlight? {
         guard let comment = draftComments.first(where: { $0.id == id }),
-              comment.state != .dismissed
+              comment.state != .dismissed,
+              let lineRange = comment.normalizedLineRange
         else { return nil }
         return DiffReviewCommentHighlight(
             path: comment.path,
             side: comment.side,
-            lineRange: comment.normalizedLineRange
+            lineRange: lineRange
         )
     }
 
@@ -856,7 +870,7 @@ struct DiffReviewFileSection: View {
 
     @ViewBuilder
     private func draftComposer(rows: [DiffDisplayRow]) -> some View {
-        if allowsDraftCommentCreation, let pendingDraftAnchor {
+        if allowsDraftCommentCreation, pendingDraftAnchor != nil {
             AppKitDiffReviewComposerRowBody(rows: rows, input: focusedRowInput)
         }
     }
@@ -1040,6 +1054,7 @@ struct EquatableDiffReviewFileSection: View, Equatable {
             && lhs.section.automaticallyRendersDiff == rhs.section.automaticallyRendersDiff
             && DiffPaneLSPContext.rendersEqual(lhs.section.lspContext, rhs.section.lspContext)
             && lhs.section.allowsDraftCommentCreation == rhs.section.allowsDraftCommentCreation
+            && lhs.section.allowsNonLineDraftCommentCreation == rhs.section.allowsNonLineDraftCommentCreation
             && lhs.section.reviewFeedbackTarget == rhs.section.reviewFeedbackTarget
             && lhs.section.threads == rhs.section.threads
             && lhs.section.annotations == rhs.section.annotations
@@ -1352,6 +1367,7 @@ enum ReviewDraftCommentPlacement {
 
     struct Result: Equatable {
         let fileLevel: [ReviewDraftComment]
+        let image: [ReviewDraftComment]
         let byRowAnchor: [RowKey: [ReviewDraftComment]]
         let groupIDByCommentID: [String: String]
     }
@@ -1363,11 +1379,20 @@ enum ReviewDraftCommentPlacement {
         let visibleKeys = Set(groups.flatMap(allRowKeys))
         let groupIDByKey = firstGroupIDByRowKey(in: groups)
         var fileLevel: [ReviewDraftComment] = []
+        var image: [ReviewDraftComment] = []
         var byRowAnchor: [RowKey: [ReviewDraftComment]] = [:]
         var groupIDByCommentID: [String: String] = [:]
 
         for comment in comments where comment.state != .dismissed {
-            let key = RowKey(side: comment.side, line: comment.normalizedLineRange.upperBound)
+            if case .image = comment.anchor {
+                image.append(comment)
+                continue
+            }
+            guard let lineRange = comment.normalizedLineRange else {
+                fileLevel.append(comment)
+                continue
+            }
+            let key = RowKey(side: comment.side, line: lineRange.upperBound)
             if visibleKeys.contains(key) {
                 byRowAnchor[key, default: []].append(comment)
                 if let groupID = groupIDByKey[key] {
@@ -1380,6 +1405,7 @@ enum ReviewDraftCommentPlacement {
 
         return Result(
             fileLevel: sorted(fileLevel),
+            image: sorted(image),
             byRowAnchor: byRowAnchor.mapValues(sorted),
             groupIDByCommentID: groupIDByCommentID
         )
@@ -1428,11 +1454,17 @@ enum ReviewDraftCommentPlacement {
             if lhs.path != rhs.path {
                 return lhs.path.localizedStandardCompare(rhs.path) == .orderedAscending
             }
-            if lhs.normalizedLineRange.lowerBound != rhs.normalizedLineRange.lowerBound {
-                return lhs.normalizedLineRange.lowerBound < rhs.normalizedLineRange.lowerBound
-            }
-            if lhs.normalizedLineRange.upperBound != rhs.normalizedLineRange.upperBound {
-                return lhs.normalizedLineRange.upperBound < rhs.normalizedLineRange.upperBound
+            if let lhsRange = lhs.normalizedLineRange, let rhsRange = rhs.normalizedLineRange {
+                if lhsRange.lowerBound != rhsRange.lowerBound {
+                    return lhsRange.lowerBound < rhsRange.lowerBound
+                }
+                if lhsRange.upperBound != rhsRange.upperBound {
+                    return lhsRange.upperBound < rhsRange.upperBound
+                }
+            } else if lhs.normalizedLineRange != nil {
+                return false
+            } else if rhs.normalizedLineRange != nil {
+                return true
             }
             if lhs.createdAt != rhs.createdAt {
                 return lhs.createdAt < rhs.createdAt
@@ -1908,6 +1940,7 @@ struct ReviewDraftCommentCard: View {
     let comment: ReviewDraftComment
     let file: DiffReviewFileSummary
     let isFocused: Bool
+    var markerNumber: Int? = nil
     let actions: ReviewDraftCommentActions
     let reviewFeedbackTarget: ReviewFeedbackTarget
     let onSelect: (ReviewDraftComment) -> Void
@@ -1966,6 +1999,12 @@ struct ReviewDraftCommentCard: View {
                     Text(draftLabel)
                         .font(.system(size: 10, weight: .semibold))
                         .foregroundColor(statusColor)
+
+                    if let markerNumber {
+                        Text("#\(markerNumber)")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(theme.color("accent"))
+                    }
 
                     Text(lineDescription)
                         .font(.system(size: 10))
@@ -2291,11 +2330,18 @@ struct ReviewDraftCommentCard: View {
     }
 
     private var lineDescription: String {
-        let range = comment.normalizedLineRange
-        if range.lowerBound == range.upperBound {
-            return "line \(range.lowerBound)"
+        switch comment.anchor {
+        case .file:
+            return "whole file"
+        case .image(let side, let x, let y):
+            return String(format: "%@ image at %.1f%%, %.1f%%", side.rawValue, x * 100, y * 100)
+        case .line(_, let startLine, let endLine, _):
+            let range = min(startLine, endLine ?? startLine)...max(startLine, endLine ?? startLine)
+            if range.lowerBound == range.upperBound {
+                return "line \(range.lowerBound)"
+            }
+            return "lines \(range.lowerBound)-\(range.upperBound)"
         }
-        return "lines \(range.lowerBound)-\(range.upperBound)"
     }
 
     private var draftLabel: String {

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -61,6 +61,7 @@ struct DiffReviewSurface: View {
     var showsRailDisplayControls: Bool = false
     var showsDraftSummaryRail: Bool = false
     var allowsDraftCommentCreation: Bool = true
+    var allowsNonLineDraftCommentCreation: Bool = true
     var lspContextForFile: (DiffReviewFileSectionModel) -> DiffPaneLSPContext? = { _ in nil }
     var inlineFeedbackByFileID: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:]
     var focusedFeedbackID: String? = nil
@@ -73,7 +74,7 @@ struct DiffReviewSurface: View {
     var draftCommentScrollCommand: DiffReviewDraftCommentScrollCommand? = nil
     var draftCommentActions = ReviewDraftCommentActions()
     var onSelectDraftComment: (ReviewDraftComment) -> Void = { _ in }
-    var onSaveDraftComment: (DiffReviewFileID, String?, DiffReviewLineAnchor, String) -> Void = { _, _, _, _ in }
+    var onSaveDraftComment: (DiffReviewFileID, String, String?, ReviewDraftCommentAnchor, String) -> Void = { _, _, _, _, _ in }
     var threads: [ReviewThread] = []
     var onReply: (DiffInlineCommentThread, String) -> Void = { _, _ in }
     var onResolve: (DiffInlineCommentThread) -> Void = { _ in }
@@ -115,6 +116,7 @@ struct DiffReviewSurface: View {
         showsRailDisplayControls: Bool = false,
         showsDraftSummaryRail: Bool = false,
         allowsDraftCommentCreation: Bool = true,
+        allowsNonLineDraftCommentCreation: Bool = true,
         lspContextForFile: @escaping (DiffReviewFileSectionModel) -> DiffPaneLSPContext? = { _ in nil },
         inlineFeedbackByFileID: [DiffReviewFileID: [DiffReviewInlineFeedback]] = [:],
         focusedFeedbackID: String? = nil,
@@ -127,7 +129,7 @@ struct DiffReviewSurface: View {
         draftCommentScrollCommand: DiffReviewDraftCommentScrollCommand? = nil,
         draftCommentActions: ReviewDraftCommentActions = ReviewDraftCommentActions(),
         onSelectDraftComment: @escaping (ReviewDraftComment) -> Void = { _ in },
-        onSaveDraftComment: @escaping (DiffReviewFileID, String?, DiffReviewLineAnchor, String) -> Void = { _, _, _, _ in },
+        onSaveDraftComment: @escaping (DiffReviewFileID, String, String?, ReviewDraftCommentAnchor, String) -> Void = { _, _, _, _, _ in },
         threads: [ReviewThread] = [],
         onReply: @escaping (DiffInlineCommentThread, String) -> Void = { _, _ in },
         onResolve: @escaping (DiffInlineCommentThread) -> Void = { _ in },
@@ -153,6 +155,7 @@ struct DiffReviewSurface: View {
         self.showsRailDisplayControls = showsRailDisplayControls
         self.showsDraftSummaryRail = showsDraftSummaryRail
         self.allowsDraftCommentCreation = allowsDraftCommentCreation
+        self.allowsNonLineDraftCommentCreation = allowsNonLineDraftCommentCreation
         self.lspContextForFile = lspContextForFile
         self.inlineFeedbackByFileID = inlineFeedbackByFileID
         self.focusedFeedbackID = focusedFeedbackID
@@ -386,7 +389,7 @@ struct DiffReviewSurface: View {
                 draftCommentActions: draftCommentActions,
                 onSelectDraftComment: onSelectDraftComment,
                 onSaveDraftComment: { anchor, body in
-                    onSaveDraftComment(file.id, file.summary.originalPath, anchor, body)
+                    onSaveDraftComment(file.id, file.summary.path, file.summary.originalPath, anchor, body)
                 },
                 onContextExpansionActivated: { contextExpandedFileIDs.insert(file.id) },
                 onReply: onReply,
@@ -434,6 +437,7 @@ struct DiffReviewSurface: View {
                 inlineFeedbackScrollTargetID: inlineFeedbackScrollTargetID(for: file.id),
                 focusedDraftCommentID: focusedDraftCommentID,
                 allowsDraftCommentCreation: allowsDraftCommentCreation,
+                allowsNonLineDraftCommentCreation: allowsNonLineDraftCommentCreation,
                 actionPresence: .init(
                     canOpenFile: file.openFile != nil,
                     canUnstageFile: file.stagedMutationActions?.unstageFile != nil,
@@ -482,9 +486,10 @@ struct DiffReviewSurface: View {
                 draftCommentActions: draftCommentActions,
                 onSelectDraftComment: onSelectDraftComment,
                 onSaveDraftComment: { anchor, body in
-                    onSaveDraftComment(file.id, file.summary.originalPath, anchor, body)
+                    onSaveDraftComment(file.id, file.summary.path, file.summary.originalPath, anchor, body)
                 },
                 allowsDraftCommentCreation: allowsDraftCommentCreation,
+                allowsNonLineDraftCommentCreation: allowsNonLineDraftCommentCreation,
                 onContextExpansionActivated: {
                     contextExpandedFileIDs.insert(file.id)
                 },

--- a/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewSurface.swift
@@ -155,7 +155,7 @@ struct DiffReviewSurface: View {
         self.showsRailDisplayControls = showsRailDisplayControls
         self.showsDraftSummaryRail = showsDraftSummaryRail
         self.allowsDraftCommentCreation = allowsDraftCommentCreation
-        self.allowsNonLineDraftCommentCreation = allowsNonLineDraftCommentCreation
+        self.allowsNonLineDraftCommentCreation = allowsDraftCommentCreation && allowsNonLineDraftCommentCreation
         self.lspContextForFile = lspContextForFile
         self.inlineFeedbackByFileID = inlineFeedbackByFileID
         self.focusedFeedbackID = focusedFeedbackID

--- a/Alas/Sources/Center/ImageDiff/ImageDiffPresentation.swift
+++ b/Alas/Sources/Center/ImageDiff/ImageDiffPresentation.swift
@@ -72,6 +72,7 @@ final class ImageDiffPresentationState {
 struct ImageDiffControls: View {
     let pair: ImageDiffPair
     @Bindable var state: ImageDiffPresentationState
+    var allowsModeSwitching = true
     @Environment(\.theme) private var theme
 
     var body: some View {
@@ -88,7 +89,9 @@ struct ImageDiffControls: View {
                     .clipShape(RoundedRectangle(cornerRadius: 3))
             }
             Spacer()
-            modeSwitcher
+            if allowsModeSwitching {
+                modeSwitcher
+            }
             if state.mode == .sideBySide {
                 resetButton
             }
@@ -181,7 +184,7 @@ struct ImageDiffComparisonContent: View {
 
     var body: some View {
         Group {
-            switch state.mode {
+            switch annotation == nil ? state.mode : .sideBySide {
             case .sideBySide:
                 ImageDiffSideBySideView(
                     before: pair.before,

--- a/Alas/Sources/Center/ImageDiff/ImageDiffPresentation.swift
+++ b/Alas/Sources/Center/ImageDiff/ImageDiffPresentation.swift
@@ -177,6 +177,7 @@ struct ImageDiffComparisonContent: View {
     let pair: ImageDiffPair
     @Bindable var state: ImageDiffPresentationState
     var boundedHeight: CGFloat? = nil
+    var annotation: ImageDiffAnnotationPresentation? = nil
 
     var body: some View {
         Group {
@@ -187,7 +188,8 @@ struct ImageDiffComparisonContent: View {
                     after: pair.after,
                     beforeLabel: "Before",
                     afterLabel: "After",
-                    transform: $state.transform
+                    transform: $state.transform,
+                    annotation: annotation
                 )
             case .overlay:
                 if let before = pair.beforeImage, let after = pair.afterImage {

--- a/Alas/Sources/Center/ImageDiff/ImageDiffSideBySideView.swift
+++ b/Alas/Sources/Center/ImageDiff/ImageDiffSideBySideView.swift
@@ -79,12 +79,19 @@ struct ImageDiffAnnotationMarker: Identifiable {
 }
 
 struct ImageDiffAnnotationPresentation {
-    let side: DiffReviewInlineFeedbackSide
-    let markers: [ImageDiffAnnotationMarker]
-    let pendingPoint: CGPoint?
+    let markersBySide: [DiffReviewInlineFeedbackSide: [ImageDiffAnnotationMarker]]
+    let pendingPointBySide: [DiffReviewInlineFeedbackSide: CGPoint]
     let focusedMarkerID: String?
-    let onPointSelected: (CGPoint) -> Void
+    let onPointSelected: (DiffReviewInlineFeedbackSide, CGPoint) -> Void
     let onMarkerSelected: (String) -> Void
+
+    func markers(for side: DiffReviewInlineFeedbackSide) -> [ImageDiffAnnotationMarker] {
+        markersBySide[side] ?? []
+    }
+
+    func pendingPoint(for side: DiffReviewInlineFeedbackSide) -> CGPoint? {
+        pendingPointBySide[side]
+    }
 }
 
 struct ImageDiffSideBySideView: View {
@@ -148,13 +155,13 @@ struct ImageDiffSideBySideView: View {
                 }
                 .contentShape(Rectangle())
                 .gesture(SpatialTapGesture().onEnded { value in
-                    guard annotation?.side == role, case .image(let image, _) = side,
+                    guard annotation != nil, case .image(let image, _) = side,
                           let point = geometry(imageSize: image.size, viewportSize: proxy.size)
                             .normalizedPoint(at: value.location) else { return }
-                    annotation?.onPointSelected(point)
+                    annotation?.onPointSelected(role, point)
                 })
-                if annotation?.side == role, case .image(let image, _) = side {
-                    markers(imageSize: image.size, viewportSize: proxy.size)
+                if annotation != nil, case .image(let image, _) = side {
+                    markers(side: role, imageSize: image.size, viewportSize: proxy.size)
                 }
             }
         }
@@ -173,9 +180,9 @@ struct ImageDiffSideBySideView: View {
     }
 
     @ViewBuilder
-    private func markers(imageSize: CGSize, viewportSize: CGSize) -> some View {
+    private func markers(side: DiffReviewInlineFeedbackSide, imageSize: CGSize, viewportSize: CGSize) -> some View {
         let geometry = geometry(imageSize: imageSize, viewportSize: viewportSize)
-        ForEach(annotation?.markers ?? []) { marker in
+        ForEach(annotation?.markers(for: side) ?? []) { marker in
             if let point = geometry.displayPoint(normalizedX: marker.normalizedX, normalizedY: marker.normalizedY) {
                 Button { annotation?.onMarkerSelected(marker.id) } label: {
                     Text("\(marker.number)")
@@ -191,7 +198,7 @@ struct ImageDiffSideBySideView: View {
                 .accessibilityLabel("Image comment \(marker.number)")
             }
         }
-        if let pending = annotation?.pendingPoint,
+        if let pending = annotation?.pendingPoint(for: side),
            let point = geometry.displayPoint(normalizedX: pending.x, normalizedY: pending.y) {
             Circle().fill(Color.accentColor).overlay(Circle().stroke(.white, lineWidth: 1))
                 .frame(width: 14, height: 14).position(point)

--- a/Alas/Sources/Center/ImageDiff/ImageDiffSideBySideView.swift
+++ b/Alas/Sources/Center/ImageDiff/ImageDiffSideBySideView.swift
@@ -154,12 +154,16 @@ struct ImageDiffSideBySideView: View {
                     }
                 }
                 .contentShape(Rectangle())
-                .gesture(SpatialTapGesture().onEnded { value in
-                    guard annotation != nil, case .image(let image, _) = side,
-                          let point = geometry(imageSize: image.size, viewportSize: proxy.size)
-                            .normalizedPoint(at: value.location) else { return }
-                    annotation?.onPointSelected(role, point)
-                })
+                .gesture(
+                    SpatialTapGesture(count: 2)
+                        .onEnded { _ in transform.reset() }
+                        .exclusively(before: SpatialTapGesture().onEnded { value in
+                            guard annotation != nil, case .image(let image, _) = side,
+                                  let point = geometry(imageSize: image.size, viewportSize: proxy.size)
+                                    .normalizedPoint(at: value.location) else { return }
+                            annotation?.onPointSelected(role, point)
+                        })
+                )
                 if annotation != nil, case .image(let image, _) = side {
                     markers(side: role, imageSize: image.size, viewportSize: proxy.size)
                 }

--- a/Alas/Sources/Center/ImageDiff/ImageDiffSideBySideView.swift
+++ b/Alas/Sources/Center/ImageDiff/ImageDiffSideBySideView.swift
@@ -32,12 +32,68 @@ struct ImageDiffTransform: Equatable {
     }
 }
 
+struct ImageDiffAnnotationGeometry {
+    let imageSize: CGSize
+    let viewportSize: CGSize
+    let transform: ImageDiffTransform
+
+    private var displayedFrame: CGRect? {
+        guard imageSize.width > 0, imageSize.height > 0,
+              viewportSize.width > 0, viewportSize.height > 0 else { return nil }
+        let fitScale = min(viewportSize.width / imageSize.width, viewportSize.height / imageSize.height)
+        let size = CGSize(
+            width: imageSize.width * fitScale * transform.scale,
+            height: imageSize.height * fitScale * transform.scale
+        )
+        return CGRect(
+            x: (viewportSize.width - size.width) / 2 + transform.offset.width,
+            y: (viewportSize.height - size.height) / 2 + transform.offset.height,
+            width: size.width,
+            height: size.height
+        )
+    }
+
+    func normalizedPoint(at point: CGPoint) -> CGPoint? {
+        guard let frame = displayedFrame, frame.contains(point) else { return nil }
+        return CGPoint(
+            x: (point.x - frame.minX) / frame.width,
+            y: (point.y - frame.minY) / frame.height
+        )
+    }
+
+    func displayPoint(normalizedX: Double, normalizedY: Double) -> CGPoint? {
+        guard let frame = displayedFrame,
+              (0...1).contains(normalizedX), (0...1).contains(normalizedY) else { return nil }
+        return CGPoint(
+            x: frame.minX + frame.width * normalizedX,
+            y: frame.minY + frame.height * normalizedY
+        )
+    }
+}
+
+struct ImageDiffAnnotationMarker: Identifiable {
+    let id: String
+    let number: Int
+    let normalizedX: Double
+    let normalizedY: Double
+}
+
+struct ImageDiffAnnotationPresentation {
+    let side: DiffReviewInlineFeedbackSide
+    let markers: [ImageDiffAnnotationMarker]
+    let pendingPoint: CGPoint?
+    let focusedMarkerID: String?
+    let onPointSelected: (CGPoint) -> Void
+    let onMarkerSelected: (String) -> Void
+}
+
 struct ImageDiffSideBySideView: View {
     let before: ImageDiffSide
     let after: ImageDiffSide
     let beforeLabel: String
     let afterLabel: String
     @Binding var transform: ImageDiffTransform
+    var annotation: ImageDiffAnnotationPresentation? = nil
     @Environment(\.theme) private var theme
     @GestureState private var dragTranslation: CGSize = .zero
 
@@ -45,9 +101,9 @@ struct ImageDiffSideBySideView: View {
         GeometryReader { proxy in
             let stackVertically = proxy.size.width < 600
             let panes = Group {
-                pane(side: before, label: beforeLabel, missingText: "No before")
+                pane(side: before, role: .old, label: beforeLabel, missingText: "No before")
                 divider(stack: stackVertically)
-                pane(side: after,  label: afterLabel,  missingText: "No after")
+                pane(side: after, role: .new, label: afterLabel, missingText: "No after")
             }
             if stackVertically {
                 VStack(spacing: 0) { panes }
@@ -62,30 +118,43 @@ struct ImageDiffSideBySideView: View {
                 }
             }
         )
-        .onTapGesture(count: 2) { transform.reset() }
         .simultaneousGesture(panGesture)
     }
 
     @ViewBuilder
-    private func pane(side: ImageDiffSide, label: String, missingText: String) -> some View {
-        ZStack {
-            ImageCheckerboardBackground()
-            switch side {
-            case .image(let image, _):
-                Image(nsImage: image)
-                    .resizable()
-                    .interpolation(.none)
-                    .aspectRatio(contentMode: .fit)
-                    .scaleEffect(transform.scale)
-                    .offset(
-                        Self.displayOffset(
-                            committed: transform.offset,
-                            translation: dragTranslation
-                        )
-                    )
-            case .missing, .failed:
-                if let message = Self.placeholderMessage(for: side, missingText: missingText) {
-                    placeholder(message)
+    private func pane(
+        side: ImageDiffSide,
+        role: DiffReviewInlineFeedbackSide,
+        label: String,
+        missingText: String
+    ) -> some View {
+        GeometryReader { proxy in
+            ZStack {
+                ZStack {
+                    ImageCheckerboardBackground()
+                    switch side {
+                    case .image(let image, _):
+                        Image(nsImage: image)
+                            .resizable()
+                            .interpolation(.none)
+                            .aspectRatio(contentMode: .fit)
+                            .scaleEffect(transform.scale)
+                            .offset(Self.displayOffset(committed: transform.offset, translation: dragTranslation))
+                    case .missing, .failed:
+                        if let message = Self.placeholderMessage(for: side, missingText: missingText) {
+                            placeholder(message)
+                        }
+                    }
+                }
+                .contentShape(Rectangle())
+                .gesture(SpatialTapGesture().onEnded { value in
+                    guard annotation?.side == role, case .image(let image, _) = side,
+                          let point = geometry(imageSize: image.size, viewportSize: proxy.size)
+                            .normalizedPoint(at: value.location) else { return }
+                    annotation?.onPointSelected(point)
+                })
+                if annotation?.side == role, case .image(let image, _) = side {
+                    markers(imageSize: image.size, viewportSize: proxy.size)
                 }
             }
         }
@@ -97,9 +166,48 @@ struct ImageDiffSideBySideView: View {
                 .background(.black.opacity(0.5))
                 .cornerRadius(3)
                 .padding(6)
+                .allowsHitTesting(false)
         }
         .clipped()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private func markers(imageSize: CGSize, viewportSize: CGSize) -> some View {
+        let geometry = geometry(imageSize: imageSize, viewportSize: viewportSize)
+        ForEach(annotation?.markers ?? []) { marker in
+            if let point = geometry.displayPoint(normalizedX: marker.normalizedX, normalizedY: marker.normalizedY) {
+                Button { annotation?.onMarkerSelected(marker.id) } label: {
+                    Text("\(marker.number)")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(.white)
+                        .frame(width: 22, height: 22)
+                        .background(annotation?.focusedMarkerID == marker.id ? Color.accentColor : Color.red)
+                        .clipShape(Circle())
+                        .overlay(Circle().stroke(.white, lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+                .position(point)
+                .accessibilityLabel("Image comment \(marker.number)")
+            }
+        }
+        if let pending = annotation?.pendingPoint,
+           let point = geometry.displayPoint(normalizedX: pending.x, normalizedY: pending.y) {
+            Circle().fill(Color.accentColor).overlay(Circle().stroke(.white, lineWidth: 1))
+                .frame(width: 14, height: 14).position(point)
+                .accessibilityLabel("New image comment")
+        }
+    }
+
+    private func geometry(imageSize: CGSize, viewportSize: CGSize) -> ImageDiffAnnotationGeometry {
+        ImageDiffAnnotationGeometry(
+            imageSize: imageSize,
+            viewportSize: viewportSize,
+            transform: .init(
+                scale: transform.scale,
+                offset: Self.displayOffset(committed: transform.offset, translation: dragTranslation)
+            )
+        )
     }
 
     static func placeholderMessage(for side: ImageDiffSide, missingText: String) -> String? {

--- a/Alas/Sources/Center/ImageDiff/ScrollEventCapturingView.swift
+++ b/Alas/Sources/Center/ImageDiff/ScrollEventCapturingView.swift
@@ -27,7 +27,29 @@ struct ScrollEventCapturingView: NSViewRepresentable {
 
     final class Backing: NSView {
         var onScroll: ((CGFloat, CGFloat, Bool) -> Void)?
+        private var eventMonitor: Any?
         override var acceptsFirstResponder: Bool { true }
+
+        override init(frame frameRect: NSRect) {
+            super.init(frame: frameRect)
+            installEventMonitor()
+        }
+
+        required init?(coder: NSCoder) {
+            super.init(coder: coder)
+            installEventMonitor()
+        }
+
+        deinit {
+            if let eventMonitor {
+                NSEvent.removeMonitor(eventMonitor)
+            }
+        }
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            nil
+        }
+
         override func scrollWheel(with event: NSEvent) {
             guard ScrollEventCapturingView.shouldCaptureScroll(
                 modifierFlags: event.modifierFlags
@@ -41,6 +63,18 @@ struct ScrollEventCapturingView: NSViewRepresentable {
                 event.scrollingDeltaY,
                 true
             )
+        }
+
+        private func installEventMonitor() {
+            eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
+                guard let self,
+                      event.window === self.window,
+                      bounds.contains(convert(event.locationInWindow, from: nil)),
+                      ScrollEventCapturingView.shouldCaptureScroll(modifierFlags: event.modifierFlags)
+                else { return event }
+                onScroll?(event.scrollingDeltaX, event.scrollingDeltaY, true)
+                return nil
+            }
         }
     }
 }

--- a/Alas/Sources/Center/Review/ReviewTabView.swift
+++ b/Alas/Sources/Center/Review/ReviewTabView.swift
@@ -383,18 +383,20 @@ struct ReviewTabView: View {
             codeFontFamily: appState.config.code.fontFamily,
             codeFontSize: CGFloat(appState.config.code.fontSize),
             showsSourceBadges: true,
+            allowsNonLineDraftCommentCreation: false,
             lspContextForFile: { file in
                 makeLSPContext(relativePath: file.summary.path)
             },
-            onSaveDraftComment: { _, _, anchor, body in
+            onSaveDraftComment: { _, path, _, anchor, body in
                 guard let pr = pendingReview else { return }
+                guard case .line(let side, let line, let endLine, _) = anchor else { return }
                 pr.stage(StagedComment(
                     id: UUID(),
                     threadID: nil,
-                    filePath: anchor.path,
-                    line: anchor.line,
-                    endLine: anchor.endLine,
-                    side: anchor.side,
+                    filePath: path,
+                    line: line,
+                    endLine: endLine,
+                    side: side,
                     body: body,
                     suggestion: nil
                 ))

--- a/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
+++ b/Alas/Sources/Center/ReviewChanges/ReviewChangesTabView.swift
@@ -526,12 +526,13 @@ struct ReviewChangesTabView: View {
 
     private func saveDraftComment(
         fileID: DiffReviewFileID,
+        path: String,
         originalPath: String?,
-        anchor: DiffReviewLineAnchor,
+        anchor: ReviewDraftCommentAnchor,
         body: String
     ) {
         do {
-            try draftCommentController?.add(anchor: anchor, fileID: fileID, originalPath: originalPath, bodyMarkdown: body)
+            try draftCommentController?.add(anchor: anchor, path: path, fileID: fileID, originalPath: originalPath, bodyMarkdown: body)
         } catch {
             // The controller keeps the non-blocking error state for the review rail.
         }

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -391,8 +391,8 @@ struct DraftReviewRequestTabView: View {
                 draftCommentScrollCommand: draftCommentScrollCommand,
                 draftCommentActions: draftCommentActions(),
                 onSelectDraftComment: selectDraftComment,
-                onSaveDraftComment: { fileID, originalPath, anchor, body in
-                    saveDraftComment(fileID: fileID, originalPath: originalPath, anchor: anchor, body: body)
+                onSaveDraftComment: { fileID, path, originalPath, anchor, body in
+                    saveDraftComment(fileID: fileID, path: path, originalPath: originalPath, anchor: anchor, body: body)
                 }
             )
         } else {
@@ -760,12 +760,13 @@ struct DraftReviewRequestTabView: View {
 
     private func saveDraftComment(
         fileID: DiffReviewFileID,
+        path: String,
         originalPath: String?,
-        anchor: DiffReviewLineAnchor,
+        anchor: ReviewDraftCommentAnchor,
         body: String
     ) {
         do {
-            try draftCommentController?.add(anchor: anchor, fileID: fileID, originalPath: originalPath, bodyMarkdown: body)
+            try draftCommentController?.add(anchor: anchor, path: path, fileID: fileID, originalPath: originalPath, bodyMarkdown: body)
         } catch {
             // The controller keeps the non-blocking error state for the review rail.
         }

--- a/Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ProviderReviewMutationController.swift
@@ -101,7 +101,10 @@ enum ProviderReviewPublishPlanner {
         if draft.state != .active {
             return "draft is \(draft.state.providerPublishDescription)."
         }
-        if draft.side == .unknown || draft.normalizedLineRange.lowerBound <= 0 {
+        guard let lineRange = draft.normalizedLineRange else {
+            return "missing line anchor."
+        }
+        if draft.side == .unknown || lineRange.lowerBound <= 0 {
             return "missing line anchor."
         }
         if draft.bodyMarkdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentController.swift
@@ -51,17 +51,35 @@ final class ReviewDraftCommentController {
         originalPath: String? = nil,
         bodyMarkdown: String
     ) throws {
+        try add(
+            anchor: .line(
+                side: anchor.side,
+                startLine: anchor.line,
+                endLine: anchor.endLine,
+                selectedText: anchor.selectedText
+            ),
+            path: anchor.path,
+            fileID: fileID,
+            originalPath: originalPath,
+            bodyMarkdown: bodyMarkdown
+        )
+    }
+
+    func add(
+        anchor: ReviewDraftCommentAnchor,
+        path: String,
+        fileID: DiffReviewFileID,
+        originalPath: String? = nil,
+        bodyMarkdown: String
+    ) throws {
         let timestamp = now()
         let comment = ReviewDraftComment(
             id: UUID().uuidString,
             sessionID: sessionID,
             fileID: fileID,
-            path: anchor.path,
+            path: path,
             originalPath: originalPath,
-            side: anchor.side,
-            startLine: anchor.line,
-            endLine: anchor.endLine,
-            selectedText: anchor.selectedText,
+            anchor: anchor,
             bodyMarkdown: bodyMarkdown,
             state: .active,
             createdAt: timestamp,

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftCommentStore.swift
@@ -102,11 +102,17 @@ struct ReviewDraftCommentStore {
         if lhs.path != rhs.path {
             return lhs.path.localizedStandardCompare(rhs.path) == .orderedAscending
         }
-        if lhs.normalizedLineRange.lowerBound != rhs.normalizedLineRange.lowerBound {
-            return lhs.normalizedLineRange.lowerBound < rhs.normalizedLineRange.lowerBound
-        }
-        if lhs.normalizedLineRange.upperBound != rhs.normalizedLineRange.upperBound {
-            return lhs.normalizedLineRange.upperBound < rhs.normalizedLineRange.upperBound
+        if let lhsRange = lhs.normalizedLineRange, let rhsRange = rhs.normalizedLineRange {
+            if lhsRange.lowerBound != rhsRange.lowerBound {
+                return lhsRange.lowerBound < rhsRange.lowerBound
+            }
+            if lhsRange.upperBound != rhsRange.upperBound {
+                return lhsRange.upperBound < rhsRange.upperBound
+            }
+        } else if lhs.normalizedLineRange != nil {
+            return false
+        } else if rhs.normalizedLineRange != nil {
+            return true
         }
         if lhs.createdAt != rhs.createdAt {
             return lhs.createdAt < rhs.createdAt

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftModels.swift
@@ -166,16 +166,41 @@ struct ReviewDraftProviderError: Codable, Equatable, Hashable, Sendable {
     let occurredAt: Date
 }
 
+enum ReviewDraftCommentAnchor: Codable, Equatable, Hashable, Sendable {
+    case file
+    case line(
+        side: DiffReviewInlineFeedbackSide,
+        startLine: Int,
+        endLine: Int?,
+        selectedText: String?
+    )
+    case image(
+        side: DiffReviewInlineFeedbackSide,
+        normalizedX: Double,
+        normalizedY: Double
+    )
+
+    var side: DiffReviewInlineFeedbackSide {
+        switch self {
+        case .file: .unknown
+        case .line(let side, _, _, _), .image(let side, _, _): side
+        }
+    }
+
+    var lineRange: ClosedRange<Int>? {
+        guard case .line(_, let startLine, let endLine, _) = self else { return nil }
+        let end = endLine ?? startLine
+        return min(startLine, end)...max(startLine, end)
+    }
+}
+
 struct ReviewDraftComment: Codable, Equatable, Hashable, Identifiable, Sendable {
     var id: String
     var sessionID: ReviewDraftSessionID
     var fileID: DiffReviewFileID
     var path: String
     var originalPath: String?
-    var side: DiffReviewInlineFeedbackSide
-    var startLine: Int
-    var endLine: Int?
-    var selectedText: String?
+    var anchor: ReviewDraftCommentAnchor
     var bodyMarkdown: String
     var state: ReviewDraftCommentState
     var createdAt: Date
@@ -186,12 +211,160 @@ struct ReviewDraftComment: Codable, Equatable, Hashable, Identifiable, Sendable 
     var replies: [ReviewCommentReply]? = nil
     var resolvedBy: ReviewDraftCommentAuthor? = nil
 
-    var normalizedLineRange: ClosedRange<Int> {
-        let end = endLine ?? startLine
-        return min(startLine, end)...max(startLine, end)
+    var side: DiffReviewInlineFeedbackSide { anchor.side }
+    var normalizedLineRange: ClosedRange<Int>? { anchor.lineRange }
+    var startLine: Int {
+        guard case .line(_, let startLine, _, _) = anchor else { return 0 }
+        return startLine
+    }
+    var endLine: Int? {
+        guard case .line(_, _, let endLine, _) = anchor else { return nil }
+        return endLine
+    }
+    var selectedText: String? {
+        get {
+            guard case .line(_, _, _, let selectedText) = anchor else { return nil }
+            return selectedText
+        }
+        set {
+            guard case .line(let side, let startLine, let endLine, _) = anchor else { return }
+            anchor = .line(side: side, startLine: startLine, endLine: endLine, selectedText: newValue)
+        }
     }
 
     var isActive: Bool { state == .active }
     var effectiveAuthor: ReviewDraftCommentAuthor { author ?? .user }
     var allReplies: [ReviewCommentReply] { replies ?? [] }
+
+    init(
+        id: String,
+        sessionID: ReviewDraftSessionID,
+        fileID: DiffReviewFileID,
+        path: String,
+        originalPath: String? = nil,
+        anchor: ReviewDraftCommentAnchor,
+        bodyMarkdown: String,
+        state: ReviewDraftCommentState,
+        createdAt: Date,
+        updatedAt: Date,
+        providerPublish: ReviewDraftProviderPublish? = nil,
+        providerError: ReviewDraftProviderError? = nil,
+        author: ReviewDraftCommentAuthor? = nil,
+        replies: [ReviewCommentReply]? = nil,
+        resolvedBy: ReviewDraftCommentAuthor? = nil
+    ) {
+        self.id = id
+        self.sessionID = sessionID
+        self.fileID = fileID
+        self.path = path
+        self.originalPath = originalPath
+        self.anchor = anchor
+        self.bodyMarkdown = bodyMarkdown
+        self.state = state
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.providerPublish = providerPublish
+        self.providerError = providerError
+        self.author = author
+        self.replies = replies
+        self.resolvedBy = resolvedBy
+    }
+
+    init(
+        id: String,
+        sessionID: ReviewDraftSessionID,
+        fileID: DiffReviewFileID,
+        path: String,
+        originalPath: String? = nil,
+        side: DiffReviewInlineFeedbackSide,
+        startLine: Int,
+        endLine: Int? = nil,
+        selectedText: String? = nil,
+        bodyMarkdown: String,
+        state: ReviewDraftCommentState,
+        createdAt: Date,
+        updatedAt: Date,
+        providerPublish: ReviewDraftProviderPublish? = nil,
+        providerError: ReviewDraftProviderError? = nil,
+        author: ReviewDraftCommentAuthor? = nil,
+        replies: [ReviewCommentReply]? = nil,
+        resolvedBy: ReviewDraftCommentAuthor? = nil
+    ) {
+        self.init(
+            id: id,
+            sessionID: sessionID,
+            fileID: fileID,
+            path: path,
+            originalPath: originalPath,
+            anchor: .line(
+                side: side,
+                startLine: startLine,
+                endLine: endLine,
+                selectedText: selectedText
+            ),
+            bodyMarkdown: bodyMarkdown,
+            state: state,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            providerPublish: providerPublish,
+            providerError: providerError,
+            author: author,
+            replies: replies,
+            resolvedBy: resolvedBy
+        )
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, sessionID, fileID, path, originalPath, anchor
+        case side, startLine, endLine, selectedText
+        case bodyMarkdown, state, createdAt, updatedAt
+        case providerPublish, providerError, author, replies, resolvedBy
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        sessionID = try container.decode(ReviewDraftSessionID.self, forKey: .sessionID)
+        fileID = try container.decode(DiffReviewFileID.self, forKey: .fileID)
+        path = try container.decode(String.self, forKey: .path)
+        originalPath = try container.decodeIfPresent(String.self, forKey: .originalPath)
+        if let decodedAnchor = try container.decodeIfPresent(ReviewDraftCommentAnchor.self, forKey: .anchor) {
+            anchor = decodedAnchor
+        } else {
+            anchor = .line(
+                side: try container.decode(DiffReviewInlineFeedbackSide.self, forKey: .side),
+                startLine: try container.decode(Int.self, forKey: .startLine),
+                endLine: try container.decodeIfPresent(Int.self, forKey: .endLine),
+                selectedText: try container.decodeIfPresent(String.self, forKey: .selectedText)
+            )
+        }
+        bodyMarkdown = try container.decode(String.self, forKey: .bodyMarkdown)
+        state = try container.decode(ReviewDraftCommentState.self, forKey: .state)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        providerPublish = try container.decodeIfPresent(ReviewDraftProviderPublish.self, forKey: .providerPublish)
+        providerError = try container.decodeIfPresent(ReviewDraftProviderError.self, forKey: .providerError)
+        author = try container.decodeIfPresent(ReviewDraftCommentAuthor.self, forKey: .author)
+        replies = try container.decodeIfPresent([ReviewCommentReply].self, forKey: .replies)
+        resolvedBy = try container.decodeIfPresent(ReviewDraftCommentAuthor.self, forKey: .resolvedBy)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(sessionID, forKey: .sessionID)
+        try container.encode(fileID, forKey: .fileID)
+        try container.encode(path, forKey: .path)
+        try container.encodeIfPresent(originalPath, forKey: .originalPath)
+        try container.encode(anchor, forKey: .anchor)
+        try container.encode(bodyMarkdown, forKey: .bodyMarkdown)
+        try container.encode(state, forKey: .state)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(updatedAt, forKey: .updatedAt)
+        try container.encodeIfPresent(providerPublish, forKey: .providerPublish)
+        try container.encodeIfPresent(providerError, forKey: .providerError)
+        try container.encodeIfPresent(author, forKey: .author)
+        try container.encodeIfPresent(replies, forKey: .replies)
+        try container.encodeIfPresent(resolvedBy, forKey: .resolvedBy)
+    }
 }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -721,11 +721,18 @@ struct ReviewDraftSummaryRail: View {
     }
 
     private func lineDescription(for comment: ReviewDraftComment) -> String {
-        let range = comment.normalizedLineRange
-        if range.lowerBound == range.upperBound {
-            return "\(sideLabel(for: comment.side)) line \(range.lowerBound)"
+        switch comment.anchor {
+        case .file:
+            return "Whole file"
+        case .image(let side, let x, let y):
+            return String(format: "%@ image · %.1f%%, %.1f%%", sideLabel(for: side), x * 100, y * 100)
+        case .line(let side, let startLine, let endLine, _):
+            let range = min(startLine, endLine ?? startLine)...max(startLine, endLine ?? startLine)
+            if range.lowerBound == range.upperBound {
+                return "\(sideLabel(for: side)) line \(range.lowerBound)"
+            }
+            return "\(sideLabel(for: side)) lines \(range.lowerBound)-\(range.upperBound)"
         }
-        return "\(sideLabel(for: comment.side)) lines \(range.lowerBound)-\(range.upperBound)"
     }
 
     private func accessibilityLabel(for comment: ReviewDraftComment) -> String {

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewFeedbackBundle.swift
@@ -53,7 +53,6 @@ struct ReviewFeedbackBundle: Equatable, Sendable {
         let sortedFiles = commentsByFile.keys.sorted()
         for fileContext in sortedFiles {
             guard let comments = commentsByFile[fileContext] else { continue }
-            let path = fileContext.path
             lines.append("")
             lines.append("## \(fileContext.heading)")
 
@@ -92,11 +91,17 @@ struct ReviewFeedbackBundle: Equatable, Sendable {
             if lhs.path != rhs.path {
                 return lhs.path.localizedStandardCompare(rhs.path) == .orderedAscending
             }
-            if lhs.normalizedLineRange.lowerBound != rhs.normalizedLineRange.lowerBound {
-                return lhs.normalizedLineRange.lowerBound < rhs.normalizedLineRange.lowerBound
-            }
-            if lhs.normalizedLineRange.upperBound != rhs.normalizedLineRange.upperBound {
-                return lhs.normalizedLineRange.upperBound < rhs.normalizedLineRange.upperBound
+            if let lhsRange = lhs.normalizedLineRange, let rhsRange = rhs.normalizedLineRange {
+                if lhsRange.lowerBound != rhsRange.lowerBound {
+                    return lhsRange.lowerBound < rhsRange.lowerBound
+                }
+                if lhsRange.upperBound != rhsRange.upperBound {
+                    return lhsRange.upperBound < rhsRange.upperBound
+                }
+            } else if lhs.normalizedLineRange != nil {
+                return false
+            } else if rhs.normalizedLineRange != nil {
+                return true
             }
             if lhs.createdAt != rhs.createdAt {
                 return lhs.createdAt < rhs.createdAt
@@ -133,11 +138,19 @@ private struct ReviewFeedbackFileContext: Hashable, Comparable {
     }
 
     func reference(for comment: ReviewDraftComment) -> String {
-        let line = ReviewFeedbackFileContext.lineDescription(for: comment)
-        guard shouldDisplayNamespace else {
-            return "\(path):\(line) (\(comment.side.rawValue))"
+        let suffix = shouldDisplayNamespace ? ", \(namespace)" : ""
+        switch comment.anchor {
+        case .file:
+            return "\(path) (whole file\(suffix))"
+        case .line(let side, _, _, _):
+            let line = ReviewFeedbackFileContext.lineDescription(for: comment)
+            return "\(path):\(line) (\(side.rawValue)\(suffix))"
+        case .image(let side, let x, let y):
+            return String(
+                format: "%@ (%@ image, %.1f%% from left, %.1f%% from top%@)",
+                path, side.rawValue, x * 100, y * 100, suffix
+            )
         }
-        return "\(path):\(line) (\(comment.side.rawValue), \(namespace))"
     }
 
     static func < (lhs: ReviewFeedbackFileContext, rhs: ReviewFeedbackFileContext) -> Bool {
@@ -153,7 +166,7 @@ private struct ReviewFeedbackFileContext: Hashable, Comparable {
     }
 
     private static func lineDescription(for comment: ReviewDraftComment) -> String {
-        let range = comment.normalizedLineRange
+        guard let range = comment.normalizedLineRange else { return "" }
         if range.lowerBound == range.upperBound {
             return "\(range.lowerBound)"
         }

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewSessionTabView.swift
@@ -1202,12 +1202,13 @@ struct ReviewSessionTabView: View {
 
     private func saveDraftComment(
         fileID: DiffReviewFileID,
+        path: String,
         originalPath: String?,
-        anchor: DiffReviewLineAnchor,
+        anchor: ReviewDraftCommentAnchor,
         body: String
     ) {
         do {
-            try draftCommentController?.add(anchor: anchor, fileID: fileID, originalPath: originalPath, bodyMarkdown: body)
+            try draftCommentController?.add(anchor: anchor, path: path, fileID: fileID, originalPath: originalPath, bodyMarkdown: body)
         } catch {
             // Draft comment save failures stay non-blocking; the controller keeps the error.
         }

--- a/Alas/Sources/Integrations/CodeHost/ProviderReviewActions.swift
+++ b/Alas/Sources/Integrations/CodeHost/ProviderReviewActions.swift
@@ -26,12 +26,14 @@ struct ProviderReviewDraftComment: Codable, Equatable, Identifiable, Sendable {
     let bodyMarkdown: String
 
     init?(localDraft: ReviewDraftComment) {
-        guard localDraft.state == .active, localDraft.providerPublish == nil else { return nil }
+        guard localDraft.state == .active,
+              localDraft.providerPublish == nil,
+              let lineRange = localDraft.normalizedLineRange else { return nil }
         self.localDraftID = localDraft.id
         self.path = localDraft.path
         self.originalPath = localDraft.originalPath
         self.side = localDraft.side
-        self.lineRange = localDraft.normalizedLineRange
+        self.lineRange = lineRange
         self.selectedText = localDraft.selectedText
         self.bodyMarkdown = localDraft.bodyMarkdown
     }

--- a/AlasCLI/crates/alas/src/mcp.rs
+++ b/AlasCLI/crates/alas/src/mcp.rs
@@ -239,7 +239,7 @@ pub fn tool_definitions() -> Vec<Value> {
         }),
         json!({
             "name": "review_comments",
-            "description": "List review comments from the user's Alas review pane for this worktree, as a JSON array. Each comment has an id, path, line range, side, state (active/resolved/dismissed), author, body, and replies. Defaults to active comments only.",
+            "description": "List review comments from the user's Alas review pane for this worktree, as a JSON array. Each comment has an id, path, anchor_kind (line/file/image), side, state (active/resolved/dismissed), author, body, and replies. Line anchors include start_line and optional end_line. Image anchors include x_percent and y_percent. Defaults to active comments only.",
             "inputSchema": {
                 "type": "object",
                 "properties": {

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -670,6 +670,22 @@ struct AlasCLICommandRouterTests {
         )
     }
 
+    @Test func reviewCommentWireDTODescribesNonLineAnchors() {
+        var fileComment = makeDraftComment(id: "file", worktreeID: "wt1")
+        fileComment.anchor = .file
+        var imageComment = makeDraftComment(id: "image", worktreeID: "wt1")
+        imageComment.anchor = .image(side: .new, normalizedX: 0.625, normalizedY: 0.25)
+
+        let file = ReviewCommentWireDTO(fileComment)
+        let image = ReviewCommentWireDTO(imageComment)
+
+        #expect(file.anchorKind == "file")
+        #expect(file.startLine == nil)
+        #expect(image.anchorKind == "image")
+        #expect(image.xPercent == 62.5)
+        #expect(image.yPercent == 25)
+    }
+
     private func makeReviewRouter(
         worktree: Worktree,
         store: ReviewDraftCommentStore,

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -66,6 +66,41 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(!ids.contains { $0.contains(":group:") || $0.contains(":segment:") })
     }
 
+    @Test func wholeFileComposerIsImmediatelyBelowHeader() {
+        let file = textFile()
+        let state = AppKitDiffReviewFileState()
+        state.pendingNonLineDraftAnchor = .file
+
+        let ids = AppKitDiffReviewRowPlanBuilder.build(inputs: [
+            .init(file: file, state: state, theme: theme),
+        ]).corePlan.rows.map(\.id)
+
+        #expect(ids.prefix(2) == [
+            AppKitDiffReviewRowID.header(fileID: file.id),
+            AppKitDiffReviewRowID.composer(fileID: file.id, segmentID: "file"),
+        ])
+    }
+
+    @Test func imageComposerAndCoordinateCardsAreBelowImage() throws {
+        let file = imageFile()
+        let state = AppKitDiffReviewFileState()
+        state.pendingNonLineDraftAnchor = .image(side: .new, normalizedX: 0.25, normalizedY: 0.75)
+        let comment = draftComment(
+            fileID: file.id,
+            anchor: .image(side: .new, normalizedX: 0.5, normalizedY: 0.5)
+        )
+
+        let ids = AppKitDiffReviewRowPlanBuilder.build(inputs: [
+            .init(file: file, draftComments: [comment], state: state, theme: theme),
+        ]).corePlan.rows.map(\.id)
+        let imageIndex = try #require(ids.firstIndex(of: AppKitDiffReviewRowID.image(fileID: file.id)))
+
+        #expect(Array(ids.dropFirst(imageIndex + 1).prefix(2)) == [
+            AppKitDiffReviewRowID.composer(fileID: file.id, segmentID: "image"),
+            AppKitDiffReviewRowID.draftComment(.targetID(commentID: comment.id, fileID: file.id)),
+        ])
+    }
+
     @Test func unavailableFilesEmitHeaderAndPlaceholder() {
         let file = placeholderFile()
         let input = AppKitDiffReviewRowInput(file: file, state: AppKitDiffReviewFileState(), theme: theme)
@@ -707,11 +742,15 @@ struct AppKitDiffReviewRowPlanTests {
         )
     }
 
-    private func draftComment(fileID: DiffReviewFileID) -> ReviewDraftComment {
+    private func draftComment(
+        fileID: DiffReviewFileID,
+        anchor: ReviewDraftCommentAnchor = .line(
+            side: .new, startLine: 1, endLine: nil, selectedText: "let new = 1"
+        )
+    ) -> ReviewDraftComment {
         .init(
             id: "draft", sessionID: .commit(worktreeID: "wt", repositoryPath: URL(fileURLWithPath: "/repo"), sha: "abc"),
-            fileID: fileID, path: fileID.path, originalPath: nil, side: .new,
-            startLine: 1, endLine: nil, selectedText: "let new = 1", bodyMarkdown: "Please revisit.",
+            fileID: fileID, path: fileID.path, originalPath: nil, anchor: anchor, bodyMarkdown: "Please revisit.",
             state: .active, createdAt: Date(timeIntervalSince1970: 1), updatedAt: Date(timeIntervalSince1970: 2)
         )
     }

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -81,6 +81,18 @@ struct AppKitDiffReviewRowPlanTests {
         ])
     }
 
+    @Test func nonLineDraftComposerFollowsDraftCreationGate() {
+        let file = textFile()
+        let state = AppKitDiffReviewFileState()
+        state.pendingNonLineDraftAnchor = .file
+
+        let ids = AppKitDiffReviewRowPlanBuilder.build(inputs: [
+            .init(file: file, state: state, theme: theme, allowsDraftCommentCreation: false),
+        ]).corePlan.rows.map(\.id)
+
+        #expect(!ids.contains(AppKitDiffReviewRowID.composer(fileID: file.id, segmentID: "file")))
+    }
+
     @Test func imageComposerAndCoordinateCardsAreBelowImage() throws {
         let file = imageFile()
         let state = AppKitDiffReviewFileState()
@@ -98,6 +110,53 @@ struct AppKitDiffReviewRowPlanTests {
         #expect(Array(ids.dropFirst(imageIndex + 1).prefix(2)) == [
             AppKitDiffReviewRowID.composer(fileID: file.id, segmentID: "image"),
             AppKitDiffReviewRowID.draftComment(.targetID(commentID: comment.id, fileID: file.id)),
+        ])
+    }
+
+    @Test func imageAnnotationPresentationIncludesOldAndNewSideMarkers() throws {
+        let file = imageFile()
+        let state = AppKitDiffReviewFileState()
+        let oldComment = draftComment(
+            id: "old-draft",
+            fileID: file.id,
+            anchor: .image(side: .old, normalizedX: 0.25, normalizedY: 0.75)
+        )
+        let newComment = draftComment(
+            id: "new-draft",
+            fileID: file.id,
+            anchor: .image(side: .new, normalizedX: 0.5, normalizedY: 0.5)
+        )
+        let pair = ImageDiffPair(
+            before: .image(NSImage(size: CGSize(width: 20, height: 20)), frameCount: 1),
+            after: .image(NSImage(size: CGSize(width: 20, height: 20)), frameCount: 1),
+            oldPath: file.summary.path,
+            kind: .modified
+        )
+        let input = AppKitDiffReviewRowInput(
+            file: file,
+            draftComments: [oldComment, newComment],
+            state: state,
+            theme: theme
+        )
+
+        let annotation = try #require(AppKitDiffReviewImageRowBody.annotationPresentation(input: input, pair: pair))
+
+        #expect(annotation.markers(for: .old).map(\.id) == ["old-draft"])
+        #expect(annotation.markers(for: .new).map(\.id) == ["new-draft"])
+    }
+
+    @Test func unavailableFilesShowWholeFileDraftsBeforePlaceholder() {
+        let file = placeholderFile()
+        let draft = draftComment(fileID: file.id, anchor: .file)
+
+        let ids = AppKitDiffReviewRowPlanBuilder.build(inputs: [
+            .init(file: file, draftComments: [draft], state: AppKitDiffReviewFileState(), theme: theme),
+        ]).corePlan.rows.map(\.id)
+
+        #expect(ids == [
+            AppKitDiffReviewRowID.header(fileID: file.id),
+            AppKitDiffReviewRowID.draftComment(.targetID(commentID: draft.id, fileID: file.id)),
+            AppKitDiffReviewRowID.placeholder(fileID: file.id),
         ])
     }
 
@@ -743,13 +802,14 @@ struct AppKitDiffReviewRowPlanTests {
     }
 
     private func draftComment(
+        id: String = "draft",
         fileID: DiffReviewFileID,
         anchor: ReviewDraftCommentAnchor = .line(
             side: .new, startLine: 1, endLine: nil, selectedText: "let new = 1"
         )
     ) -> ReviewDraftComment {
         .init(
-            id: "draft", sessionID: .commit(worktreeID: "wt", repositoryPath: URL(fileURLWithPath: "/repo"), sha: "abc"),
+            id: id, sessionID: .commit(worktreeID: "wt", repositoryPath: URL(fileURLWithPath: "/repo"), sha: "abc"),
             fileID: fileID, path: fileID.path, originalPath: nil, anchor: anchor, bodyMarkdown: "Please revisit.",
             state: .active, createdAt: Date(timeIntervalSince1970: 1), updatedAt: Date(timeIntervalSince1970: 2)
         )

--- a/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
+++ b/AlasTests/Center/DiffReview/AppKitDiffReviewRowPlanTests.swift
@@ -149,15 +149,18 @@ struct AppKitDiffReviewRowPlanTests {
         let file = placeholderFile()
         let draft = draftComment(fileID: file.id, anchor: .file)
 
-        let ids = AppKitDiffReviewRowPlanBuilder.build(inputs: [
+        let plan = AppKitDiffReviewRowPlanBuilder.build(inputs: [
             .init(file: file, draftComments: [draft], state: AppKitDiffReviewFileState(), theme: theme),
-        ]).corePlan.rows.map(\.id)
+        ])
+        let ids = plan.corePlan.rows.map(\.id)
 
         #expect(ids == [
             AppKitDiffReviewRowID.header(fileID: file.id),
             AppKitDiffReviewRowID.draftComment(.targetID(commentID: draft.id, fileID: file.id)),
             AppKitDiffReviewRowID.placeholder(fileID: file.id),
         ])
+        let draftID = AppKitDiffReviewRowID.draftComment(.targetID(commentID: draft.id, fileID: file.id))
+        #expect(plan.fallbackByTargetID[draftID] == draftID)
     }
 
     @Test func unavailableFilesEmitHeaderAndPlaceholder() {

--- a/AlasTests/DiffReviewSurfaceTests.swift
+++ b/AlasTests/DiffReviewSurfaceTests.swift
@@ -5274,7 +5274,7 @@ private final class AppKitPostedDraftHarnessModel {
         input(theme: theme).savePendingDraft()
     }
 
-    private func post(anchor: DiffReviewLineAnchor, body: String) {
+    private func post(anchor: ReviewDraftCommentAnchor, body: String) {
         comments = [ReviewDraftComment(
             id: "new-draft",
             sessionID: .commit(
@@ -5283,12 +5283,9 @@ private final class AppKitPostedDraftHarnessModel {
                 sha: "abc123"
             ),
             fileID: file.id,
-            path: anchor.path,
+            path: file.summary.path,
             originalPath: nil,
-            side: anchor.side,
-            startLine: anchor.line,
-            endLine: anchor.endLine,
-            selectedText: anchor.selectedText,
+            anchor: anchor,
             bodyMarkdown: body,
             state: .active,
             createdAt: Date(timeIntervalSince1970: 1),

--- a/AlasTests/ImageDiffSideBySideViewTests.swift
+++ b/AlasTests/ImageDiffSideBySideViewTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import CoreFoundation
 @testable import Alas
 
+@MainActor
 struct ImageDiffSideBySideViewTests {
     @Test func failedSideUsesFailureMessageAsItsPlaceholder() {
         let side = ImageDiffSide.failed(ImageDiffLoadFailure(message: "Could not decode image"))
@@ -53,6 +54,13 @@ struct ImageDiffSideBySideViewTests {
         #expect(
             ScrollEventCapturingView.shouldCaptureScroll(modifierFlags: [.command])
         )
+    }
+
+    @Test func scrollCaptureViewDoesNotBlockMouseHitTesting() {
+        let view = ScrollEventCapturingView.Backing()
+        view.frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+        #expect(view.hitTest(CGPoint(x: 50, y: 50)) == nil)
     }
 
     @Test func annotationGeometryMapsBetweenDisplayAndNormalizedCoordinates() throws {

--- a/AlasTests/ImageDiffSideBySideViewTests.swift
+++ b/AlasTests/ImageDiffSideBySideViewTests.swift
@@ -54,4 +54,30 @@ struct ImageDiffSideBySideViewTests {
             ScrollEventCapturingView.shouldCaptureScroll(modifierFlags: [.command])
         )
     }
+
+    @Test func annotationGeometryMapsBetweenDisplayAndNormalizedCoordinates() throws {
+        let geometry = ImageDiffAnnotationGeometry(
+            imageSize: CGSize(width: 400, height: 200),
+            viewportSize: CGSize(width: 300, height: 300),
+            transform: ImageDiffTransform(scale: 2, offset: CGSize(width: 10, height: -20))
+        )
+
+        let displayPoint = try #require(geometry.displayPoint(normalizedX: 0.75, normalizedY: 0.25))
+        #expect(displayPoint.x == 310)
+        #expect(displayPoint.y == 55)
+        let normalized = try #require(geometry.normalizedPoint(at: displayPoint))
+        #expect(abs(normalized.x - 0.75) < 0.0001)
+        #expect(abs(normalized.y - 0.25) < 0.0001)
+    }
+
+    @Test func annotationGeometryIgnoresClicksInLetterbox() {
+        let geometry = ImageDiffAnnotationGeometry(
+            imageSize: CGSize(width: 400, height: 200),
+            viewportSize: CGSize(width: 300, height: 300),
+            transform: ImageDiffTransform()
+        )
+
+        #expect(geometry.normalizedPoint(at: CGPoint(x: 150, y: 25)) == nil)
+        #expect(geometry.normalizedPoint(at: CGPoint(x: 150, y: 150)) != nil)
+    }
 }

--- a/AlasTests/ReviewDraftCommentStoreTests.swift
+++ b/AlasTests/ReviewDraftCommentStoreTests.swift
@@ -112,6 +112,35 @@ return value + other
         #expect(try store.load(sessionID: session).single?.originalPath == "Sources/OldApp.swift")
     }
 
+    @Test @MainActor func controllerPersistsFileAndImageAnchors() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("review-draft-comments.json")
+        let controller = ReviewDraftCommentController(
+            sessionID: .localChanges(
+                worktreeID: "wt",
+                worktreePath: URL(fileURLWithPath: "/repo"),
+                scope: .all
+            ),
+            store: ReviewDraftCommentStore(store: PersistenceStore(), url: url)
+        )
+        let fileID = DiffReviewFileID(namespace: "unstaged", path: "icon.png")
+
+        try controller.load()
+        try controller.add(anchor: .file, path: "icon.png", fileID: fileID, bodyMarkdown: "Whole file")
+        try controller.add(
+            anchor: .image(side: .new, normalizedX: 0.625, normalizedY: 0.25),
+            path: "icon.png",
+            fileID: fileID,
+            bodyMarkdown: "This pixel"
+        )
+
+        #expect(controller.comments.map(\.anchor) == [
+            .file,
+            .image(side: .new, normalizedX: 0.625, normalizedY: 0.25),
+        ])
+    }
+
     @Test func savesLoadsAndDeletesCommentsBySession() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/AlasTests/ReviewDraftModelsTests.swift
+++ b/AlasTests/ReviewDraftModelsTests.swift
@@ -90,8 +90,46 @@ struct ReviewDraftModelsTests {
         let comment = try JSONDecoder().decode(ReviewDraftComment.self, from: json)
 
         #expect(comment.id == "legacy")
+        #expect(comment.anchor == .line(
+            side: .new,
+            startLine: 8,
+            endLine: nil,
+            selectedText: "let value = 1"
+        ))
         #expect(comment.providerPublish == nil)
         #expect(comment.providerError == nil)
+    }
+
+    @Test func draftCommentRoundTripsFileAndImageAnchors() throws {
+        let anchors: [ReviewDraftCommentAnchor] = [
+            .file,
+            .image(side: .new, normalizedX: 0.625, normalizedY: 0.25),
+        ]
+
+        for (index, anchor) in anchors.enumerated() {
+            let comment = ReviewDraftComment(
+                id: "anchor-\(index)",
+                sessionID: .localChanges(
+                    worktreeID: "wt",
+                    worktreePath: URL(fileURLWithPath: "/repo"),
+                    scope: .all
+                ),
+                fileID: DiffReviewFileID(namespace: "unstaged", path: "image.png"),
+                path: "image.png",
+                originalPath: nil,
+                anchor: anchor,
+                bodyMarkdown: "Check this.",
+                state: .active,
+                createdAt: Date(timeIntervalSince1970: 1),
+                updatedAt: Date(timeIntervalSince1970: 2)
+            )
+
+            let data = try JSONEncoder().encode(comment)
+            let decoded = try JSONDecoder().decode(ReviewDraftComment.self, from: data)
+
+            #expect(decoded.anchor == anchor)
+            #expect(decoded.normalizedLineRange == nil)
+        }
     }
 
     @Test func draftCommentRoundTripsProviderPublishAndErrorMetadata() throws {

--- a/AlasTests/ReviewFeedbackBundleTests.swift
+++ b/AlasTests/ReviewFeedbackBundleTests.swift
@@ -89,6 +89,49 @@ struct ReviewFeedbackBundleTests {
         #expect(prompt.contains("This behavior regressed."))
     }
 
+    @Test func promptDescribesWholeFileAndImageAnchors() {
+        let session = ReviewDraftSessionID.localChanges(
+            worktreeID: "wt",
+            worktreePath: URL(fileURLWithPath: "/repo"),
+            scope: .all
+        )
+        let target = ReviewFeedbackTarget(
+            title: "Local changes",
+            repositoryPath: nil,
+            providerDescription: nil,
+            sourceDescription: "local changes"
+        )
+        let file = ReviewDraftComment(
+            id: "file",
+            sessionID: session,
+            fileID: DiffReviewFileID(namespace: "review", path: "README.md"),
+            path: "README.md",
+            originalPath: nil,
+            anchor: .file,
+            bodyMarkdown: "Clarify this file.",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 1)
+        )
+        let image = ReviewDraftComment(
+            id: "image",
+            sessionID: session,
+            fileID: DiffReviewFileID(namespace: "review", path: "icon.png"),
+            path: "icon.png",
+            originalPath: nil,
+            anchor: .image(side: .new, normalizedX: 0.625, normalizedY: 0.25),
+            bodyMarkdown: "Align this mark.",
+            state: .active,
+            createdAt: Date(timeIntervalSince1970: 2),
+            updatedAt: Date(timeIntervalSince1970: 2)
+        )
+
+        let prompt = ReviewFeedbackBundle(target: target, comments: [file, image]).promptMarkdown()
+
+        #expect(prompt.contains("`README.md (whole file)` [comment-id: file]"))
+        #expect(prompt.contains("`icon.png (new image, 62.5% from left, 25.0% from top)` [comment-id: image]"))
+    }
+
     @Test func promptDistinguishesSamePathCommentsFromDifferentNamespaces() {
         let session = ReviewDraftSessionID.localChanges(
             worktreeID: "wt",


### PR DESCRIPTION
## Summary

Enable local agent review workflows to capture feedback that does not map to a text line: whole-file comments and coordinate-anchored image comments. This preserves useful review context for visual and structural changes while keeping provider publication line-only.

## Changes

- Add typed file, line, and normalized image anchors to local draft comments.
- Add header-based whole-file composers and image click-to-comment markers with linked cards.
- Include non-line anchors in local agent prompts, persistence, and CLI wire data.

## Verification

- `xcodegen`
- macOS build
- Focused review-anchor, layout, image-geometry, persistence, prompt, and CLI tests

## Notes for reviewers

Provider publication intentionally remains unavailable for file/image anchors; they are local-agent review feedback in this iteration.