### PR TITLE
fix(editor): restore editor tab view state

### DIFF
--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -278,6 +278,8 @@ final class CodeEditorCoordinator {
             appState.tabs.ensureExternalLSPOpen(tabId: tabId)
         }
 
+        restoreViewStateIfNeeded(for: buffer, tabId: tabId, revealLine: revealLine, revealCharacter: revealCharacter)
+
         applyRevealIfNeeded(
             tabId: tabId,
             line: revealLine,
@@ -338,6 +340,7 @@ final class CodeEditorCoordinator {
         }
 
         if pathChanged {
+            saveViewState()
             clearRevealHighlight()
             hoverHighlight?.cancelAndClear()
             completion?.cancelAndDismiss()
@@ -425,6 +428,17 @@ final class CodeEditorCoordinator {
             runHighlight(theme: theme)
         }
 
+        if pathChanged, let buffer {
+            restoreViewStateIfNeeded(
+                for: buffer,
+                tabId: tabId,
+                revealLine: revealLine,
+                revealCharacter: revealCharacter,
+                deferred: false,
+                resetScrollWhenMissing: true
+            )
+        }
+
         applyRevealIfNeeded(
             tabId: tabId,
             line: revealLine,
@@ -504,8 +518,68 @@ final class CodeEditorCoordinator {
         }
     }
 
+    private func saveViewState() {
+        guard let textView, let buffer, let currentTabId else { return }
+        buffer.viewStates[currentTabId] = (
+            textView.selectedRanges,
+            textView.enclosingScrollView?.contentView.bounds.origin ?? .zero
+        )
+    }
+
+    private func restoreViewStateIfNeeded(
+        for buffer: EditorBuffer,
+        tabId: TabID,
+        revealLine: Int?,
+        revealCharacter: Int?,
+        deferred: Bool = true,
+        resetScrollWhenMissing: Bool = false
+    ) {
+        guard revealLine == nil || revealCharacter == nil,
+              let textView else { return }
+        guard let viewState = buffer.viewStates[tabId] else {
+            if resetScrollWhenMissing {
+                scroll(textView, to: .zero)
+            }
+            return
+        }
+        if deferred {
+            DispatchQueue.main.async { [weak self, weak textView, weak buffer] in
+                self?.applyViewState(viewState, for: buffer, textView: textView, tabId: tabId)
+            }
+        } else {
+            applyViewState(viewState, for: buffer, textView: textView, tabId: tabId)
+        }
+    }
+
+    private func applyViewState(
+        _ viewState: (selectedRanges: [NSValue], scrollOrigin: NSPoint),
+        for buffer: EditorBuffer?,
+        textView: CodeTextView?,
+        tabId: TabID
+    ) {
+        guard let textView, let buffer,
+              self.textView === textView,
+              self.buffer === buffer,
+              currentTabId == tabId else { return }
+        let ranges = viewState.selectedRanges.map { value in
+            let range = value.rangeValue
+            let location = min(range.location, buffer.storage.length)
+            let length = min(range.length, buffer.storage.length - location)
+            return NSValue(range: NSRange(location: location, length: length))
+        }
+        textView.setSelectedRanges(ranges, affinity: .downstream, stillSelecting: false)
+        scroll(textView, to: viewState.scrollOrigin)
+    }
+
+    private func scroll(_ textView: CodeTextView, to origin: NSPoint) {
+        guard let scrollView = textView.enclosingScrollView else { return }
+        scrollView.contentView.scroll(to: origin)
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
+
     func detach() {
         let detachedTextView = textView
+        saveViewState()
         // LSP open/close for external buffers is managed by TabsManager
         // (tied to the buffer's cached lifetime), not by the coordinator
         // (which is torn down on every tab switch by SwiftUI's dismantleNSView).

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -130,6 +130,9 @@ final class EditorBuffer {
     /// the view detaches it without releasing it.
     let storage: NSTextStorage
 
+    @ObservationIgnored
+    var viewStates: [TabID: (selectedRanges: [NSValue], scrollOrigin: NSPoint)] = [:]
+
     private(set) var originalText: String = ""
     private(set) var originalMtime: Date = .distantPast
     private(set) var permissions: mode_t = 0o644

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -1178,6 +1178,142 @@ struct EditorBufferTests {
         #expect(!buffer.storage.layoutManagers.contains { $0 === layoutManager })
     }
 
+    @Test func coordinatorRestoresSelectionAndScrollPositionAfterRemount() async throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", String(repeating: "0123456789\n", count: 200))
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        await buffer.awaitLoadForTesting()
+        let theme = try ThemeStore().current
+
+        func mount() -> (CodeEditorCoordinator, CodeTextView, NSScrollView) {
+            let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 240, height: 120))
+            scrollView.hasVerticalScroller = true
+            scrollView.hasHorizontalScroller = true
+            scrollView.contentView = CodeEditorLeadingClipView(frame: .zero)
+            let layoutManager = NSLayoutManager()
+            let textContainer = NSTextContainer(size: NSSize(width: 1_200, height: 2_400))
+            layoutManager.addTextContainer(textContainer)
+            let textView = CodeTextView(
+                frame: NSRect(x: 0, y: 0, width: 1_200, height: 2_400),
+                textContainer: textContainer
+            )
+            scrollView.documentView = textView
+            let coordinator = CodeEditorCoordinator(appState: AppState())
+            coordinator.attach(
+                textView: textView,
+                buffer: buffer,
+                layoutManager: layoutManager,
+                worktreeId: "wt",
+                worktreeRoot: root,
+                tabId: "t",
+                revealLine: nil,
+                revealCharacter: nil,
+                theme: theme
+            )
+            return (coordinator, textView, scrollView)
+        }
+
+        let first = mount()
+        let expectedSelections = [
+            NSValue(range: NSRange(location: 150, length: 7)),
+            NSValue(range: NSRange(location: 250, length: 0)),
+        ]
+        let expectedOrigin = NSPoint(x: 45, y: 160)
+        first.1.setSelectedRanges(expectedSelections, affinity: .downstream, stillSelecting: false)
+        first.2.contentView.scroll(to: expectedOrigin)
+        #expect(first.2.contentView.bounds.origin == expectedOrigin)
+        first.0.detach()
+
+        let restored = mount()
+        let deadline = Date(timeIntervalSinceNow: 1)
+        while (restored.1.selectedRanges != expectedSelections
+            || restored.2.contentView.bounds.origin != expectedOrigin), Date() < deadline {
+            await Task.yield()
+        }
+
+        #expect(restored.1.selectedRanges == expectedSelections)
+        #expect(restored.2.contentView.bounds.origin == expectedOrigin)
+    }
+
+    @Test func coordinatorRestoresSelectionAndScrollPositionAfterRebind() async throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", String(repeating: "0123456789\n", count: 200))
+        _ = try writeFile(root, "b.txt", String(repeating: "abcdefghij\n", count: 200))
+        let appState = AppState()
+        let buffer = appState.tabs.buffer(worktreeId: "wt", tabId: "a", worktreeRoot: root, relativePath: "a.txt")
+        await buffer.awaitLoadForTesting()
+        _ = appState.tabs.buffer(worktreeId: "wt", tabId: "b", worktreeRoot: root, relativePath: "b.txt")
+        let theme = try ThemeStore().current
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 240, height: 120))
+        scrollView.contentView = CodeEditorLeadingClipView(frame: .zero)
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 1_200, height: 2_400))
+        layoutManager.addTextContainer(textContainer)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 1_200, height: 2_400), textContainer: textContainer)
+        scrollView.documentView = textView
+        let coordinator = CodeEditorCoordinator(appState: appState)
+        coordinator.attach(textView: textView, buffer: buffer, layoutManager: layoutManager, worktreeId: "wt", worktreeRoot: root, tabId: "a", revealLine: nil, revealCharacter: nil, theme: theme)
+
+        let expectedSelections = [
+            NSValue(range: NSRange(location: 150, length: 7)),
+            NSValue(range: NSRange(location: 250, length: 0)),
+        ]
+        let expectedOrigin = NSPoint(x: 45, y: 160)
+        textView.setSelectedRanges(expectedSelections, affinity: .downstream, stillSelecting: false)
+        scrollView.contentView.scroll(to: expectedOrigin)
+        coordinator.updateIfNeeded(worktreeId: "wt", worktreeRoot: root, relativePath: "b.txt", tabId: "b", revealLine: nil, revealCharacter: nil, theme: theme)
+        coordinator.updateIfNeeded(worktreeId: "wt", worktreeRoot: root, relativePath: "a.txt", tabId: "a", revealLine: nil, revealCharacter: nil, theme: theme)
+
+        let deadline = Date(timeIntervalSinceNow: 1)
+        while (textView.selectedRanges != expectedSelections
+            || scrollView.contentView.bounds.origin != expectedOrigin), Date() < deadline {
+            await Task.yield()
+        }
+
+        #expect(textView.selectedRanges == expectedSelections)
+        #expect(scrollView.contentView.bounds.origin == expectedOrigin)
+    }
+
+    @Test func coordinatorKeepsSamePathTabViewStatesIndependent() async throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", String(repeating: "0123456789\n", count: 200))
+        let appState = AppState()
+        let buffer = appState.tabs.buffer(worktreeId: "wt", tabId: "a", worktreeRoot: root, relativePath: "a.txt")
+        await buffer.awaitLoadForTesting()
+        #expect(appState.tabs.buffer(worktreeId: "wt", tabId: "b", worktreeRoot: root, relativePath: "a.txt") === buffer)
+        let theme = try ThemeStore().current
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 240, height: 120))
+        scrollView.contentView = CodeEditorLeadingClipView(frame: .zero)
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 1_200, height: 2_400))
+        layoutManager.addTextContainer(textContainer)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 1_200, height: 2_400), textContainer: textContainer)
+        scrollView.documentView = textView
+        let coordinator = CodeEditorCoordinator(appState: appState)
+        coordinator.attach(textView: textView, buffer: buffer, layoutManager: layoutManager, worktreeId: "wt", worktreeRoot: root, tabId: "a", revealLine: nil, revealCharacter: nil, theme: theme)
+
+        let tabASelections = [NSValue(range: NSRange(location: 150, length: 7))]
+        let tabBSelections = [NSValue(range: NSRange(location: 260, length: 3))]
+        textView.setSelectedRanges(tabASelections, affinity: .downstream, stillSelecting: false)
+        scrollView.contentView.scroll(to: NSPoint(x: 45, y: 160))
+        coordinator.updateIfNeeded(worktreeId: "wt", worktreeRoot: root, relativePath: "a.txt", tabId: "b", revealLine: nil, revealCharacter: nil, theme: theme)
+        #expect(scrollView.contentView.bounds.origin == .zero)
+        textView.setSelectedRanges(tabBSelections, affinity: .downstream, stillSelecting: false)
+        scrollView.contentView.scroll(to: NSPoint(x: 10, y: 20))
+        coordinator.updateIfNeeded(worktreeId: "wt", worktreeRoot: root, relativePath: "a.txt", tabId: "a", revealLine: nil, revealCharacter: nil, theme: theme)
+        coordinator.updateIfNeeded(worktreeId: "wt", worktreeRoot: root, relativePath: "a.txt", tabId: "b", revealLine: nil, revealCharacter: nil, theme: theme)
+        coordinator.updateIfNeeded(worktreeId: "wt", worktreeRoot: root, relativePath: "a.txt", tabId: "a", revealLine: nil, revealCharacter: nil, theme: theme)
+
+        let deadline = Date(timeIntervalSinceNow: 1)
+        while (textView.selectedRanges != tabASelections
+            || scrollView.contentView.bounds.origin != NSPoint(x: 45, y: 160)), Date() < deadline {
+            await Task.yield()
+        }
+
+        #expect(textView.selectedRanges == tabASelections)
+        #expect(scrollView.contentView.bounds.origin == NSPoint(x: 45, y: 160))
+    }
+
     @Test func coordinatorCallsDirectAttachAndDetachCallbacks() async throws {
         let root = tempWorktree()
         _ = try writeFile(root, "a.txt", "v1\n")


### PR DESCRIPTION
## Summary
- Preserve editor selection and scroll origin when switching away from an editor tab and back.
- Restore saved view state on remount unless the tab has an explicit reveal target.
- Add a regression test covering selection and scroll restoration.

## Verification
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet test-without-building -only-testing:AlasTests/EditorBufferTests

Full suite note: local full `xcodebuild ... test` encountered existing unrelated failures, then hung during integration tests after spawning LSP servers.