### PR TITLE
fix(editor): completion acceptance

### DIFF
--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -278,6 +278,19 @@ final class CodeTextView: NSTextView, FontSizeResponder {
 
     // MARK: - Text insertion overrides
 
+    override func keyDown(with event: NSEvent) {
+        let modifiers = event.modifierFlags.intersection([.command, .control, .option, .shift])
+        if !hasMarkedText(), modifiers.isEmpty {
+            switch event.keyCode {
+            case 36, 76, 48: // Return, keypad Enter, Tab
+                if routeCompletionKey(.acceptSelected) { return }
+            default:
+                break
+            }
+        }
+        super.keyDown(with: event)
+    }
+
     override func didChangeText() {
         super.didChangeText()
         notifyCompletionChanged()
@@ -455,7 +468,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     }
 
     override func insertTab(_ sender: Any?) {
-        if routeCompletionKey(.acceptTop) { return }
+        if routeCompletionKey(.acceptSelected) { return }
         super.insertTab(sender)
     }
 

--- a/AlasTests/CodeTextViewCompletionTests.swift
+++ b/AlasTests/CodeTextViewCompletionTests.swift
@@ -28,7 +28,7 @@ struct CodeTextViewCompletionTests {
         #expect(calls == 1)
     }
 
-    @Test func insertTabRoutesAcceptTopAndDoesNotMutateTextWhenHandled() {
+    @Test func insertTabRoutesAcceptSelectedAndDoesNotMutateTextWhenHandled() {
         let textView = makeTextView("let value = open")
         var actions: [CodeTextView.CompletionKeyAction] = []
         textView.completionKeyHandler = { action in
@@ -38,7 +38,7 @@ struct CodeTextViewCompletionTests {
 
         textView.insertTab(nil)
 
-        #expect(actions == [.acceptTop])
+        #expect(actions == [.acceptSelected])
         #expect(textView.string == "let value = open")
     }
 
@@ -54,6 +54,23 @@ struct CodeTextViewCompletionTests {
 
         #expect(actions == [.acceptSelected])
         #expect(textView.string == "let value = open")
+    }
+
+    @Test("Return, Enter, and Tab accept the selected completion")
+    func completionAcceptanceKeysRouteBeforeAppKitEditsText() throws {
+        for (characters, keyCode) in [("\r", UInt16(36)), ("\r", UInt16(76)), ("\t", UInt16(48))] {
+            let textView = makeTextView("let value = open")
+            var actions: [CodeTextView.CompletionKeyAction] = []
+            textView.completionKeyHandler = { action in
+                actions.append(action)
+                return true
+            }
+
+            textView.keyDown(with: try keyEvent(characters: characters, keyCode: keyCode))
+
+            #expect(actions == [.acceptSelected])
+            #expect(textView.string == "let value = open")
+        }
     }
 
     @Test func cancelOperationRoutesDismiss() {
@@ -178,5 +195,20 @@ struct CodeTextViewCompletionTests {
 
         #expect(finalLine.minY > firstLine.minY)
         #expect(finalLine.minX <= firstLine.minX + 1)
+    }
+
+    private func keyEvent(characters: String, keyCode: UInt16) throws -> NSEvent {
+        try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: keyCode
+        ))
     }
 }


### PR DESCRIPTION
## Summary

Fixes file-editor completions being dismissed without insertion when accepted with Return, keypad Enter, or Tab.

## Changes

- Route completion acceptance keys before AppKit consumes the text command.
- Accept the currently selected completion for Tab.
- Add physical-key regression coverage for Return, Enter, and Tab.

## Verification

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-autocomplete-derived -quiet test -only-testing:AlasTests/CodeTextViewCompletionTests`\n- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`