### PR TITLE
fix(gg): show amend progress

### DIFF
--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -356,7 +356,7 @@ struct ChangesPreparationCard: View {
 
     private func ggSubtitle(for action: ChangesPreparationModel.GGAction) -> String {
         if action.isInFlight {
-            switch action.kind {
+            return switch action.kind {
             case .amendCurrent: "Amending…"
             case .absorbIntoStack: "Absorbing…"
             case .newStackCommit: action.title

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -271,7 +271,7 @@ struct ChangesPreparationCard: View {
         }
         .buttonStyle(.plain)
         .disabled(!action.isEnabled)
-        .opacity(action.isEnabled ? 1 : 0.5)
+        .opacity(action.isEnabled || action.isInFlight ? 1 : 0.5)
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(theme.color("bg-2").opacity(0.72))
@@ -355,6 +355,13 @@ struct ChangesPreparationCard: View {
     }
 
     private func ggSubtitle(for action: ChangesPreparationModel.GGAction) -> String {
+        if action.isInFlight {
+            switch action.kind {
+            case .amendCurrent: "Amending…"
+            case .absorbIntoStack: "Absorbing…"
+            case .newStackCommit: action.title
+            }
+        }
         if let disabledReason = action.disabledReason {
             return disabledReason
         }

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -245,7 +245,13 @@ struct ChangesPreparationCard: View {
         } label: {
             VStack(alignment: .leading, spacing: 4) {
                 HStack(alignment: .firstTextBaseline, spacing: 5) {
-                    Icon(name: ggIconName(for: action.kind), size: 10, color: theme.color("fg-dim"))
+                    if action.isInFlight {
+                        Spinner(lineWidth: 1.5, duration: 0.7)
+                            .frame(width: 10, height: 10)
+                            .accessibilityHidden(true)
+                    } else {
+                        Icon(name: ggIconName(for: action.kind), size: 10, color: theme.color("fg-dim"))
+                    }
                     Text(action.title)
                         .font(.system(size: 10.5, weight: .semibold))
                         .foregroundColor(theme.color("fg"))
@@ -275,6 +281,7 @@ struct ChangesPreparationCard: View {
                 .strokeBorder(theme.color("line").opacity(0.65), lineWidth: 0.75)
         )
         .help(action.disabledReason ?? action.title)
+        .accessibilityValue(action.isInFlight ? "In progress" : "")
         .accessibilityIdentifier("changes-preparation-gg-\(ggIdentifier(for: action.kind))")
     }
 

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -47,6 +47,7 @@ struct ChangesPreparationModel: Equatable {
         let stats: StagedStats
         let hasNonEmptyDraft: Bool
         let disabledReason: String?
+        let isInFlight: Bool
 
         var isEnabled: Bool { disabledReason == nil }
     }
@@ -67,6 +68,7 @@ struct ChangesPreparationModel: Equatable {
                 || reconciliationAction != nil
                 || syncProgress != nil
                 || reviewAction != nil
+                || ggActions.contains(where: \.isInFlight)
                 || ggAction(.newStackCommit)?.isEnabled == true
         }
         return reviewAction != nil || draftAction != nil || !reviewRequestActions.isEmpty
@@ -129,6 +131,7 @@ struct ChangesPreparationModel: Equatable {
         capabilities: GGCapabilities,
         hasLoadedCommit: Bool = true,
         mutationDisabledReason: String? = nil,
+        inFlightAction: GGStackActionKind? = nil,
         newCommitDisabledReason: String? = nil,
         mutationError: String? = nil,
         reconciliationAction: GGStackReadinessModel.Action? = nil,
@@ -147,6 +150,7 @@ struct ChangesPreparationModel: Equatable {
             capabilities: capabilities,
             hasLoadedCommit: hasLoadedCommit,
             mutationDisabledReason: mutationDisabledReason,
+            inFlightAction: inFlightAction,
             newCommitDisabledReason: newCommitDisabledReason,
             mutationError: mutationError,
             reconciliationAction: reconciliationAction,
@@ -161,6 +165,7 @@ struct ChangesPreparationModel: Equatable {
         capabilities: GGCapabilities,
         hasLoadedCommit: Bool = true,
         mutationDisabledReason: String? = nil,
+        inFlightAction: GGStackActionKind? = nil,
         newCommitDisabledReason: String? = nil,
         mutationError: String? = nil,
         reconciliationAction: GGStackReadinessModel.Action? = nil,
@@ -179,6 +184,7 @@ struct ChangesPreparationModel: Equatable {
             capabilities: capabilities,
             hasLoadedCommit: hasLoadedCommit,
             mutationDisabledReason: mutationDisabledReason,
+            inFlightAction: inFlightAction,
             newCommitDisabledReason: newCommitDisabledReason,
             mutationError: mutationError,
             reconciliationAction: reconciliationAction,
@@ -197,6 +203,7 @@ struct ChangesPreparationModel: Equatable {
         capabilities: GGCapabilities,
         hasLoadedCommit: Bool,
         mutationDisabledReason: String?,
+        inFlightAction: GGStackActionKind?,
         newCommitDisabledReason: String?,
         mutationError: String?,
         reconciliationAction: GGStackReadinessModel.Action?,
@@ -233,21 +240,24 @@ struct ChangesPreparationModel: Equatable {
                     title: "New stack commit",
                     stats: staged,
                     hasNonEmptyDraft: hasDraft,
-                    disabledReason: effectiveNewCommitDisabledReason
+                    disabledReason: effectiveNewCommitDisabledReason,
+                    isInFlight: false
                 ),
                 GGAction(
                     kind: .amendCurrent,
                     title: "Amend current",
                     stats: staged,
                     hasNonEmptyDraft: false,
-                    disabledReason: amendDisabledReason
+                    disabledReason: amendDisabledReason,
+                    isInFlight: inFlightAction == .amendCurrent
                 ),
                 GGAction(
                     kind: .absorbIntoStack,
                     title: "Absorb into stack",
                     stats: staged,
                     hasNonEmptyDraft: false,
-                    disabledReason: rewriteDisabledReason
+                    disabledReason: rewriteDisabledReason,
+                    isInFlight: inFlightAction == .absorbStaged
                 ),
             ]
         )

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -29,6 +29,7 @@ struct ChangesTabView: View {
                 capabilities: GGAvailability.shared.capabilities,
                 hasLoadedCommit: rps.ggStackLoadState.hasLoadedCommit,
                 mutationDisabledReason: ggPreparationMutationDisabledReason,
+                inFlightAction: rps.ggActionState.inFlightAction,
                 newCommitDisabledReason: Self.ggNewStackCommitDisabledReason(
                     contextIsActive: rps.ggContext.isActive,
                     stackLoadState: rps.ggStackLoadState,

--- a/AlasTests/Right/ChangesPreparationModelTests.swift
+++ b/AlasTests/Right/ChangesPreparationModelTests.swift
@@ -150,6 +150,19 @@ struct ChangesPreparationModelTests {
         #expect(!model.isVisible)
     }
 
+    @Test func amendingKeepsPreparationVisible() {
+        let model = ChangesPreparationModel.makeGG(
+            staged: .zero,
+            hasDraft: false,
+            capabilities: stagedOnlyCapabilities,
+            mutationDisabledReason: "Another GG operation is running.",
+            inFlightAction: .amendCurrent
+        )
+
+        #expect(model.isVisible)
+        #expect(model.ggAction(.amendCurrent)?.isInFlight == true)
+    }
+
     @Test func ggReconciliationMakesEmptyPreparationVisible() {
         let reconciliationAction = GGStackReadinessModel.Action(
             kind: .sync,


### PR DESCRIPTION
- Keep the gg preparation card visible while amending
- Show a spinner on the active amend action
- Cover the in-flight amend presentation