### PR TITLE
fix(ui): keep spinner animating

### DIFF
--- a/Alas/Sources/UI/Spinner.swift
+++ b/Alas/Sources/UI/Spinner.swift
@@ -5,15 +5,17 @@ struct Spinner: View {
     var duration: Double = 0.8
     var color: Color?
 
-    @State private var angle: Double = 0
     @Environment(\.theme) private var theme
 
     var body: some View {
-        Circle()
-            .trim(from: 0, to: 0.75)
-            .stroke(color ?? theme.color("accent"), style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
-            .rotationEffect(.degrees(angle))
-            .animation(.linear(duration: duration).repeatForever(autoreverses: false), value: angle)
-            .onAppear { angle = 360 }
+        TimelineView(.animation) { context in
+            Circle()
+                .trim(from: 0, to: 0.75)
+                .stroke(color ?? theme.color("accent"), style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                .rotationEffect(.degrees(
+                    context.date.timeIntervalSinceReferenceDate
+                        .truncatingRemainder(dividingBy: duration) / duration * 360
+                ))
+        }
     }
 }


### PR DESCRIPTION
## Summary

- keep SwiftUI spinners moving when their hosting view refreshes

## Testing

- xcodebuild focused gg and Changes tests
- xcodebuild macOS build