### PR TITLE
feat(files): create file and folder actions

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4134,6 +4134,117 @@ final class AppState {
         }
     }
 
+    func newFile(
+        in worktreeId: String,
+        directoryPath: String,
+        onCreated: @escaping @MainActor () -> Void
+    ) {
+        guard let (project, worktree) = projectAndWorktree(withWorktreeId: worktreeId),
+              let name = promptForChildName(title: "New File", defaultValue: "untitled.txt")
+        else { return }
+        let relativePath = "\(directoryPath)/\(name)"
+
+        if let host = project.host {
+            Task { @MainActor [weak self] in
+                do {
+                    try await Self.createRemoteEmptyFile(
+                        host: host,
+                        worktreeRoot: worktree.path,
+                        relativePath: relativePath
+                    )
+                    self?.openFile(relativePath: relativePath, worktreeId: worktreeId)
+                    onCreated()
+                } catch {
+                    self?.showFileActionError(title: "New File Failed", message: error.localizedDescription)
+                }
+            }
+            return
+        }
+
+        let url = worktree.path.appendingPathComponent(relativePath)
+        do {
+            try Data().write(to: url, options: .withoutOverwriting)
+            openFile(relativePath: relativePath, worktreeId: worktreeId)
+            onCreated()
+        } catch {
+            showFileActionError(title: "New File Failed", message: error.localizedDescription)
+        }
+    }
+
+    func newFolder(
+        in worktreeId: String,
+        directoryPath: String,
+        onCreated: @escaping @MainActor () -> Void
+    ) {
+        guard let (project, worktree) = projectAndWorktree(withWorktreeId: worktreeId),
+              let name = promptForChildName(title: "New Folder", defaultValue: "New Folder")
+        else { return }
+        let relativePath = "\(directoryPath)/\(name)"
+
+        if let host = project.host {
+            Task { @MainActor [weak self] in
+                do {
+                    try await Self.createRemoteDirectory(
+                        host: host,
+                        worktreeRoot: worktree.path,
+                        relativePath: relativePath
+                    )
+                    onCreated()
+                } catch {
+                    self?.showFileActionError(title: "New Folder Failed", message: error.localizedDescription)
+                }
+            }
+            return
+        }
+
+        do {
+            try FileManager.default.createDirectory(
+                at: worktree.path.appendingPathComponent(relativePath, isDirectory: true),
+                withIntermediateDirectories: false
+            )
+            onCreated()
+        } catch {
+            showFileActionError(title: "New Folder Failed", message: error.localizedDescription)
+        }
+    }
+
+    nonisolated static func normalizedChildName(_ raw: String) throws -> String {
+        let name = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty,
+              name != ".",
+              name != "..",
+              !name.contains("/"),
+              !name.contains("\\"),
+              name.rangeOfCharacter(from: .controlCharacters) == nil
+        else {
+            throw NSError(
+                domain: "AppState",
+                code: 7,
+                userInfo: [NSLocalizedDescriptionKey: "Enter a name without path separators."]
+            )
+        }
+        return name
+    }
+
+    private func promptForChildName(title: String, defaultValue: String) -> String? {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = "Enter a name."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Create")
+        alert.addButton(withTitle: "Cancel")
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 280, height: 24))
+        field.stringValue = defaultValue
+        alert.accessoryView = field
+        guard alert.runModal() == .alertFirstButtonReturn else { return nil }
+        do {
+            return try Self.normalizedChildName(field.stringValue)
+        } catch {
+            showFileActionError(title: "Invalid Name", message: error.localizedDescription)
+            return nil
+        }
+    }
+
     nonisolated private static func createRemoteEmptyFile(host: String, worktreeRoot: URL, relativePath: String) async throws {
         let path = worktreeRoot.appendingPathComponent(relativePath).path
         try await RemotePathContainment.verifyRemoteContainment(host: host, path: path, worktreeRoot: worktreeRoot.path)
@@ -4145,6 +4256,18 @@ final class AppState {
             if result.exitCode == 1 {
                 throw CocoaError(.fileWriteFileExists)
             }
+            throw RemoteFileAccessError.writeFailed(result.stderr)
+        }
+    }
+
+    nonisolated private static func createRemoteDirectory(host: String, worktreeRoot: URL, relativePath: String) async throws {
+        let path = worktreeRoot.appendingPathComponent(relativePath).path
+        try await RemotePathContainment.verifyRemoteContainment(host: host, path: path, worktreeRoot: worktreeRoot.path)
+        let result = try await RemoteExec.run(host: host, cwd: nil, command: RemoteFileOps.createDirectoryCommand(path: path))
+        if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
+            throw RemoteFileAccessError.connectionFailed(result.stderr)
+        }
+        guard result.exitCode == 0 else {
             throw RemoteFileAccessError.writeFailed(result.stderr)
         }
     }

--- a/Alas/Sources/Right/FileContextMenuActions.swift
+++ b/Alas/Sources/Right/FileContextMenuActions.swift
@@ -18,7 +18,7 @@ struct FileContextMenuTarget: Equatable {
 }
 
 enum FileContextMenuAction: Hashable {
-    case openInAlas, open, openWith, viewAtHEAD, compareWithHEAD
+    case newFile, newFolder, openInAlas, open, openWith, viewAtHEAD, compareWithHEAD
     case fileHistory, copyRelativePath, copyFullPath, revealInFinder
 }
 
@@ -36,6 +36,7 @@ struct FileContextMenuConfiguration: Equatable {
 
     static func filesTab(target: FileContextMenuTarget) -> Self {
         var actions: [FileContextMenuAction] = []
+        if target.kind == .dir { actions += [.newFile, .newFolder] }
         if target.kind == .file { actions.append(.openInAlas) }
         if target.localURL != nil {
             actions.append(.open)
@@ -50,6 +51,8 @@ struct FileContextMenuConfiguration: Equatable {
 
 struct FileContextMenuActions: View {
     let configuration: FileContextMenuConfiguration
+    var onNewFile: (() -> Void)? = nil
+    var onNewFolder: (() -> Void)? = nil
     var onOpenInAlas: (() -> Void)? = nil
     var openInAlasEnabled = true
     var onViewAtHEAD: (() -> Void)? = nil
@@ -62,6 +65,12 @@ struct FileContextMenuActions: View {
     @ViewBuilder var body: some View {
         ForEach(configuration.actions, id: \.self) { action in
             switch action {
+            case .newFile:
+                Button("New File…") { onNewFile?() }
+                    .disabled(onNewFile == nil)
+            case .newFolder:
+                Button("New Folder…") { onNewFolder?() }
+                    .disabled(onNewFolder == nil)
             case .openInAlas:
                 Button("Open in Alas") { onOpenInAlas?() }
                     .disabled(!openInAlasEnabled || onOpenInAlas == nil)

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -7,6 +7,8 @@ struct FilesTabView: View {
     @Binding var openPaths: Set<String>
     let onSelectFile: (FileTreeNode) -> Void
     let onFileHistory: (FileTreeNode) -> Void
+    let onCreateFile: (String) -> Void
+    let onCreateFolder: (String) -> Void
     let shouldAutoLoadChildren: (String, DirectoryChildrenState) -> Bool
     let onLoadChildren: (String) -> Void
     let showIgnored: Bool
@@ -236,6 +238,14 @@ struct FilesTabView: View {
         )
         FileContextMenuActions(
             configuration: .filesTab(target: target),
+            onNewFile: node.kind == .dir ? {
+                openPaths.insert(node.path)
+                onCreateFile(node.path)
+            } : nil,
+            onNewFolder: node.kind == .dir ? {
+                openPaths.insert(node.path)
+                onCreateFolder(node.path)
+            } : nil,
             onOpenInAlas: node.kind == .file ? { onSelectFile(node) } : nil,
             onFileHistory: node.kind == .file ? { onFileHistory(node) } : nil,
             onCopyRelativePath: { Clipboard.copy(node.path) },

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -85,6 +85,16 @@ struct RightPaneView: View {
                                 onFileHistory: { node in
                                     state.openFileHistory(relativePath: node.path, worktreeId: worktree.id)
                                 },
+                                onCreateFile: { path in
+                                    state.newFile(in: worktree.id, directoryPath: path) {
+                                        Task { await rps.refresh() }
+                                    }
+                                },
+                                onCreateFolder: { path in
+                                    state.newFolder(in: worktree.id, directoryPath: path) {
+                                        Task { await rps.refresh() }
+                                    }
+                                },
                                 shouldAutoLoadChildren: { path, childrenState in
                                     rps.shouldAutoLoadFileTreeChildren(path: path, childrenState: childrenState)
                                 },

--- a/Alas/Sources/SSH/RemoteFileOps.swift
+++ b/Alas/Sources/SSH/RemoteFileOps.swift
@@ -21,4 +21,9 @@ enum RemoteFileOps {
         let quotedPath = SSHCommand.shellQuote(path)
         return "\(mkdirCommand(parentOf: path)) && f=\(quotedPath) && [ ! -e \"$f\" ] && [ ! -L \"$f\" ] && (set -C; : > \"$f\")"
     }
+
+    static func createDirectoryCommand(path: String) -> String {
+        let quotedPath = SSHCommand.shellQuote(path)
+        return "d=\(quotedPath); [ ! -e \"$d\" ] && [ ! -L \"$d\" ] && mkdir \"$d\""
+    }
 }

--- a/AlasTests/FileContextMenuActionsTests.swift
+++ b/AlasTests/FileContextMenuActionsTests.swift
@@ -58,7 +58,7 @@ struct FileContextMenuActionsTests {
     @Test func filesTabDirectoryOmitsEditorHistoryAndOpenWith() {
         let target = FileContextMenuTarget(kind: .dir, localURL: URL(fileURLWithPath: "/repo/Sources"))
         #expect(FileContextMenuConfiguration.filesTab(target: target).actions == [
-            .open, .copyRelativePath, .copyFullPath, .revealInFinder
+            .newFile, .newFolder, .open, .copyRelativePath, .copyFullPath, .revealInFinder
         ])
     }
 
@@ -69,7 +69,19 @@ struct FileContextMenuActionsTests {
             .openInAlas, .fileHistory, .copyRelativePath, .copyFullPath
         ])
         #expect(FileContextMenuConfiguration.filesTab(target: directory).actions == [
-            .copyRelativePath, .copyFullPath
+            .newFile, .newFolder, .copyRelativePath, .copyFullPath
         ])
+    }
+
+    @Test(arguments: ["README.md", "New Folder", ".env"])
+    func acceptsChildNames(_ name: String) throws {
+        #expect(try AppState.normalizedChildName("  \(name)  ") == name)
+    }
+
+    @Test(arguments: ["", "   ", ".", "..", "Sources/App.swift", "Sources\\App.swift", "line\nbreak"])
+    func rejectsInvalidChildNames(_ name: String) {
+        #expect(throws: Error.self) {
+            try AppState.normalizedChildName(name)
+        }
     }
 }

--- a/AlasTests/SSH/RemoteFileOpsTests.swift
+++ b/AlasTests/SSH/RemoteFileOpsTests.swift
@@ -21,4 +21,10 @@ struct RemoteFileOpsTests {
             path: "/srv/repo/sub dir/new.txt"
         ) == "mkdir -p '/srv/repo/sub dir' && f='/srv/repo/sub dir/new.txt' && [ ! -e \"$f\" ] && [ ! -L \"$f\" ] && (set -C; : > \"$f\")")
     }
+
+    @Test func createDirectoryCommandDoesNotClobber() {
+        #expect(RemoteFileOps.createDirectoryCommand(
+            path: "/srv/repo/sub dir/new folder"
+        ) == "d='/srv/repo/sub dir/new folder'; [ ! -e \"$d\" ] && [ ! -L \"$d\" ] && mkdir \"$d\"")
+    }
 }


### PR DESCRIPTION
## Summary

Adds file and folder creation to folder menus for local and SSH worktrees.

## Changes

- Prompt for and validate a child name.
- Do not overwrite existing paths.
- Refresh the tree and open new files in the editor.

## Verification

- xcodegen
- macOS build
- Focused Files menu and remote file-operation tests