### PR TITLE
fix(ui): keep refresh spinners animating

### DIFF
--- a/Alas/Sources/UI/Spinner.swift
+++ b/Alas/Sources/UI/Spinner.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct Spinner: View {
@@ -8,14 +9,77 @@ struct Spinner: View {
     @Environment(\.theme) private var theme
 
     var body: some View {
-        TimelineView(.animation) { context in
-            Circle()
-                .trim(from: 0, to: 0.75)
-                .stroke(color ?? theme.color("accent"), style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
-                .rotationEffect(.degrees(
-                    context.date.timeIntervalSinceReferenceDate
-                        .truncatingRemainder(dividingBy: duration) / duration * 360
-                ))
-        }
+        SpinnerRepresentable(
+            lineWidth: lineWidth,
+            duration: duration,
+            color: NSColor(color ?? theme.color("accent"))
+        )
+    }
+}
+
+private struct SpinnerRepresentable: NSViewRepresentable {
+    let lineWidth: CGFloat
+    let duration: Double
+    let color: NSColor
+
+    func makeNSView(context: Context) -> SpinnerAnimationView {
+        SpinnerAnimationView(lineWidth: lineWidth, duration: duration, color: color)
+    }
+
+    func updateNSView(_ view: SpinnerAnimationView, context: Context) {
+        view.update(lineWidth: lineWidth, duration: duration, color: color)
+    }
+}
+
+@MainActor
+final class SpinnerAnimationView: NSView {
+    static let rotationAnimationKey = "rotation"
+
+    let spinnerLayer = CAShapeLayer()
+    private var animationDuration: Double
+
+    init(lineWidth: CGFloat, duration: Double, color: NSColor) {
+        animationDuration = duration
+        super.init(frame: .zero)
+        wantsLayer = true
+        spinnerLayer.fillColor = nil
+        spinnerLayer.lineCap = .round
+        spinnerLayer.strokeEnd = 0.75
+        layer?.addSublayer(spinnerLayer)
+        update(lineWidth: lineWidth, duration: duration, color: color)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("not supported") }
+
+    override func layout() {
+        super.layout()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        spinnerLayer.frame = bounds
+        spinnerLayer.path = CGPath(
+            ellipseIn: bounds.insetBy(dx: spinnerLayer.lineWidth / 2, dy: spinnerLayer.lineWidth / 2),
+            transform: nil
+        )
+        CATransaction.commit()
+    }
+
+    func update(lineWidth: CGFloat, duration: Double, color: NSColor) {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        spinnerLayer.lineWidth = lineWidth
+        spinnerLayer.strokeColor = color.cgColor
+        CATransaction.commit()
+
+        guard spinnerLayer.animation(forKey: Self.rotationAnimationKey) == nil
+                || animationDuration != duration
+        else { return }
+        animationDuration = duration
+        let animation = CABasicAnimation(keyPath: "transform.rotation")
+        animation.fromValue = 0
+        animation.toValue = Double.pi * 2
+        animation.duration = duration
+        animation.repeatCount = .infinity
+        spinnerLayer.add(animation, forKey: Self.rotationAnimationKey)
     }
 }

--- a/AlasTests/Right/ChangesPreparationModelTests.swift
+++ b/AlasTests/Right/ChangesPreparationModelTests.swift
@@ -1,8 +1,25 @@
+import AppKit
 import Foundation
 import Testing
 @testable import Alas
 
 struct ChangesPreparationModelTests {
+    @MainActor
+    @Test func spinnerUsesCoreAnimation() throws {
+        let view = SpinnerAnimationView(
+            lineWidth: 1.4,
+            duration: 0.8,
+            color: .systemBlue
+        )
+
+        let animation = try #require(
+            view.spinnerLayer.animation(forKey: SpinnerAnimationView.rotationAnimationKey)
+                as? CABasicAnimation
+        )
+        #expect(animation.duration == 0.8)
+        #expect(animation.repeatCount == .infinity)
+    }
+
     @Test func syncStepAccessibilityStatesAreExplicit() {
         #expect(ChangesPreparationCardText.syncStepState(.pending) == "Pending")
         #expect(ChangesPreparationCardText.syncStepState(.current) == "In progress")


### PR DESCRIPTION
<!-- gg:managed:start -->
- Move the shared spinner to Core Animation
- Cover the animation configuration with a regression test
<!-- gg:managed:end -->