### PR TITLE
feat(files): add root creation context menu

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4142,7 +4142,7 @@ final class AppState {
         guard let (project, worktree) = projectAndWorktree(withWorktreeId: worktreeId),
               let name = promptForChildName(title: "New File", defaultValue: "untitled.txt")
         else { return }
-        let relativePath = "\(directoryPath)/\(name)"
+        let relativePath = Self.childPath(name: name, directoryPath: directoryPath)
 
         if let host = project.host {
             Task { @MainActor [weak self] in
@@ -4179,7 +4179,7 @@ final class AppState {
         guard let (project, worktree) = projectAndWorktree(withWorktreeId: worktreeId),
               let name = promptForChildName(title: "New Folder", defaultValue: "New Folder")
         else { return }
-        let relativePath = "\(directoryPath)/\(name)"
+        let relativePath = Self.childPath(name: name, directoryPath: directoryPath)
 
         if let host = project.host {
             Task { @MainActor [weak self] in
@@ -4206,6 +4206,10 @@ final class AppState {
         } catch {
             showFileActionError(title: "New Folder Failed", message: error.localizedDescription)
         }
+    }
+
+    nonisolated static func childPath(name: String, directoryPath: String) -> String {
+        directoryPath.isEmpty ? name : "\(directoryPath)/\(name)"
     }
 
     nonisolated static func normalizedChildName(_ raw: String) throws -> String {

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -42,6 +42,7 @@ struct FilesTabView: View {
                     }
                     .padding(.vertical, 4)
                 }
+                .contextMenu { rootContextMenu }
                 .onChange(of: revealTick) { _, _ in
                     guard let path = revealPath else { return }
                     proxy.scrollTo("file:\(path)", anchor: .top)
@@ -250,6 +251,21 @@ struct FilesTabView: View {
             onFileHistory: node.kind == .file ? { onFileHistory(node) } : nil,
             onCopyRelativePath: { Clipboard.copy(node.path) },
             onCopyFullPath: { Clipboard.copy(worktreePath.appendingPathComponent(node.path).path) }
+        )
+    }
+
+    @ViewBuilder private var rootContextMenu: some View {
+        let target = FileContextMenuTarget.resolve(
+            kind: .dir,
+            worktreePath: worktreePath,
+            relativePath: ""
+        )
+        FileContextMenuActions(
+            configuration: .filesTab(target: target),
+            onNewFile: { onCreateFile("") },
+            onNewFolder: { onCreateFolder("") },
+            onCopyRelativePath: { Clipboard.copy(".") },
+            onCopyFullPath: { Clipboard.copy(worktreePath.path) }
         )
     }
 

--- a/AlasTests/FileContextMenuActionsTests.swift
+++ b/AlasTests/FileContextMenuActionsTests.swift
@@ -84,4 +84,9 @@ struct FileContextMenuActionsTests {
             try AppState.normalizedChildName(name)
         }
     }
+
+    @Test func buildsChildPathsForRootAndNestedDirectories() {
+        #expect(AppState.childPath(name: "README.md", directoryPath: "") == "README.md")
+        #expect(AppState.childPath(name: "App.swift", directoryPath: "Sources") == "Sources/App.swift")
+    }
 }


### PR DESCRIPTION
## Summary
- Add a Files tab whitespace context menu for worktree-root actions.
- Create root-level files and folders with relative paths.
- Cover root and nested child-path construction.

## Verification
- xcodegen
- xcodebuild macOS build
- Files tab and context-menu test suites

The full local suite exposed unrelated GG suite-order failures and a late-run test-host hang. The two reported GG tests pass in isolation; CI will provide the clean-environment full-suite result.