### PR TITLE
fix(gg): dismiss failed sync preparation

### DIFF
--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -290,9 +290,17 @@ final class GGMutationCoordinator {
                 supportsSyncJSONL: syncJSONLCapability(),
                 onSyncEvent: { [actionState] event in
                     actionState.appendSyncEvent(event)
-                    if case .error(_, _, let message) = event { actionState.setError(message) }
+                    if case .error(_, _, let message) = event {
+                        actionState.setError(message, for: request.actionKind)
+                    }
                 }
             )
+            if request == .sync, actionState.syncProgress.contains(where: {
+                if case .error = $0 { return true }
+                return false
+            }) {
+                actionState.markSyncTerminalFailure()
+            }
             await recordUndoMarker(
                 after: request,
                 result: result,
@@ -322,9 +330,13 @@ final class GGMutationCoordinator {
             if !toleratesMalformedRemoteOutput {
                 if request == .sync {
                     actionState.markSyncTerminalFailure()
-                    if case .malformedOutput = error { actionState.setError(error.userMessage) }
+                    if case .malformedOutput = error {
+                        actionState.setError(error.userMessage, for: request.actionKind)
+                    }
                 }
-                if actionState.lastError == nil { actionState.setError(error.userMessage) }
+                if actionState.lastErrorAction != request.actionKind {
+                    actionState.setError(error.userMessage, for: request.actionKind)
+                }
             }
             if request == .sync {
                 await refresh(after: request, result: .none)
@@ -338,7 +350,7 @@ final class GGMutationCoordinator {
         } catch {
             reconcilePausedState(after: request, error: error)
             if request == .sync { actionState.markSyncTerminalFailure() }
-            actionState.setError(error.localizedDescription)
+            actionState.setError(error.localizedDescription, for: request.actionKind)
             if request == .sync {
                 await refresh(after: request, result: .none)
                 releaseAction()

--- a/Alas/Sources/Integrations/GG/GGStackActionState.swift
+++ b/Alas/Sources/Integrations/GG/GGStackActionState.swift
@@ -29,6 +29,7 @@ final class GGStackActionState {
     private(set) var syncProgress: [GGSyncEvent] = []
     private(set) var syncHasTerminalFailure = false
     private(set) var lastError: String?
+    private(set) var lastErrorAction: GGStackActionKind?
     private(set) var pausedOperation: GGPausedOperation?
     private(set) var lastActionSummary: String?
     @ObservationIgnored private(set) var actionGeneration: UInt = 0
@@ -38,7 +39,7 @@ final class GGStackActionState {
         guard inFlightAction == nil else { return false }
         if !syncProgress.isEmpty { syncProgress = [] }
         if syncHasTerminalFailure { syncHasTerminalFailure = false }
-        if lastError != nil { lastError = nil }
+        clearError()
         if lastActionSummary != nil { lastActionSummary = nil }
         actionGeneration &+= 1
         inFlightAction = action
@@ -52,14 +53,32 @@ final class GGStackActionState {
 
     func appendSyncEvent(_ event: GGSyncEvent) { syncProgress.append(event) }
     func clearSyncProgress() { if !syncProgress.isEmpty { syncProgress = [] } }
+    var canDismissCompletedSyncFailure: Bool {
+        inFlightAction == nil && pausedOperation == nil && syncHasTerminalFailure
+    }
+    func dismissCompletedSyncFailure() {
+        guard canDismissCompletedSyncFailure else { return }
+        syncProgress = []
+        syncHasTerminalFailure = false
+        if lastErrorAction == .sync { clearError() }
+    }
     func markSyncTerminalFailure() {
-        if inFlightAction == .sync, !syncHasTerminalFailure { syncHasTerminalFailure = true }
+        if !syncHasTerminalFailure { syncHasTerminalFailure = true }
     }
-    func shouldPublishError(forActionGeneration generation: UInt) -> Bool {
-        actionGeneration == generation && lastError == nil
+    func shouldPublishError(
+        forActionGeneration generation: UInt,
+        action: GGStackActionKind
+    ) -> Bool {
+        actionGeneration == generation && lastErrorAction != action
     }
-    func setError(_ message: String) { lastError = message }
-    func clearError() { if lastError != nil { lastError = nil } }
+    func setError(_ message: String, for action: GGStackActionKind? = nil) {
+        lastError = message
+        lastErrorAction = action
+    }
+    func clearError() {
+        if lastError != nil { lastError = nil }
+        if lastErrorAction != nil { lastErrorAction = nil }
+    }
     func setPaused(_ paused: GGPausedOperation) { if pausedOperation != paused { pausedOperation = paused } }
     func clearPaused() { if pausedOperation != nil { pausedOperation = nil } }
     func setActionSummary(_ message: String) { lastActionSummary = message }

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -44,6 +44,7 @@ struct ChangesPreparationCard: View {
     let onGGAction: (GGChangesPreparationAction) -> Void
     let onGGStackAction: (GGStackActionKind) -> Void
     let onReviewRequestAction: (ReviewReadinessActionKind) -> Void
+    let onDismissSyncFailure: () -> Void
 
     @Environment(\.theme) private var theme
 
@@ -146,6 +147,16 @@ struct ChangesPreparationCard: View {
                 .foregroundColor(theme.color("fg-muted"))
                 .textCase(.uppercase)
             Spacer(minLength: 0)
+            if model.canDismissSyncFailure {
+                Button(action: onDismissSyncFailure) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(theme.color("fg-faint"))
+                        .frame(width: 16, height: 16)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss sync failure")
+            }
         }
     }
 

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -57,6 +57,7 @@ struct ChangesPreparationModel: Equatable {
     let reviewRequestActions: [ReviewRequestAction]
     let reconciliationAction: GGStackReadinessModel.Action?
     let syncProgress: GGSyncProgressPresentation?
+    let canDismissSyncFailure: Bool
     let ggActions: [GGAction]
     let mutationError: String?
 
@@ -112,6 +113,7 @@ struct ChangesPreparationModel: Equatable {
         draftAction = builtDraftAction
         reconciliationAction = nil
         syncProgress = nil
+        canDismissSyncFailure = false
         ggActions = []
         mutationError = nil
         let builtActions = Self.compactReviewRequestActions(from: readinessActions)
@@ -135,7 +137,8 @@ struct ChangesPreparationModel: Equatable {
         newCommitDisabledReason: String? = nil,
         mutationError: String? = nil,
         reconciliationAction: GGStackReadinessModel.Action? = nil,
-        syncProgress: GGSyncProgressPresentation? = nil
+        syncProgress: GGSyncProgressPresentation? = nil,
+        canDismissSyncFailure: Bool = false
     ) -> ChangesPreparationModel {
         let summary = ReviewChangesTriggerSummary.summary(for: changes)
         let stagedChanges = changes.filter { $0.stage == .staged }
@@ -155,6 +158,7 @@ struct ChangesPreparationModel: Equatable {
             mutationError: mutationError,
             reconciliationAction: reconciliationAction,
             syncProgress: syncProgress,
+            canDismissSyncFailure: canDismissSyncFailure,
             reviewSummary: summary
         )
     }
@@ -169,7 +173,8 @@ struct ChangesPreparationModel: Equatable {
         newCommitDisabledReason: String? = nil,
         mutationError: String? = nil,
         reconciliationAction: GGStackReadinessModel.Action? = nil,
-        syncProgress: GGSyncProgressPresentation? = nil
+        syncProgress: GGSyncProgressPresentation? = nil,
+        canDismissSyncFailure: Bool = false
     ) -> ChangesPreparationModel {
         let summary = staged.hasChanges
             ? ReviewChangesTriggerSummary(
@@ -189,6 +194,7 @@ struct ChangesPreparationModel: Equatable {
             mutationError: mutationError,
             reconciliationAction: reconciliationAction,
             syncProgress: syncProgress,
+            canDismissSyncFailure: canDismissSyncFailure,
             reviewSummary: summary
         )
     }
@@ -208,6 +214,7 @@ struct ChangesPreparationModel: Equatable {
         mutationError: String?,
         reconciliationAction: GGStackReadinessModel.Action?,
         syncProgress: GGSyncProgressPresentation?,
+        canDismissSyncFailure: Bool,
         reviewSummary: ReviewChangesTriggerSummary?
     ) -> ChangesPreparationModel {
         let reviewAction = reviewSummary.map {
@@ -233,6 +240,7 @@ struct ChangesPreparationModel: Equatable {
             reviewAction: reviewAction,
             reconciliationAction: reconciliationAction,
             syncProgress: syncProgress,
+            canDismissSyncFailure: canDismissSyncFailure,
             mutationError: mutationError,
             ggActions: [
                 GGAction(
@@ -267,6 +275,7 @@ struct ChangesPreparationModel: Equatable {
         reviewAction: ReviewAction?,
         reconciliationAction: GGStackReadinessModel.Action?,
         syncProgress: GGSyncProgressPresentation?,
+        canDismissSyncFailure: Bool,
         mutationError: String?,
         ggActions: [GGAction]
     ) {
@@ -275,6 +284,7 @@ struct ChangesPreparationModel: Equatable {
         reviewRequestActions = []
         self.reconciliationAction = reconciliationAction
         self.syncProgress = syncProgress
+        self.canDismissSyncFailure = canDismissSyncFailure
         self.mutationError = mutationError
         self.ggActions = ggActions
     }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -49,7 +49,8 @@ struct ChangesTabView: View {
                         )
                     } ?? rps.behindBase?.count ?? 0,
                     effectiveConfig: rps.ggEffectiveConfig
-                )
+                ),
+                canDismissSyncFailure: rps.ggActionState.canDismissCompletedSyncFailure
             )
         }
         let readiness = ReviewReadinessModel(
@@ -263,7 +264,8 @@ struct ChangesTabView: View {
                     },
                     onReviewRequestAction: { action in
                         rps.handleReviewReadinessAction(action, appState: appState)
-                    }
+                    },
+                    onDismissSyncFailure: { rps.ggActionState.dismissCompletedSyncFailure() }
                 )
             }
             workingTreeSection
@@ -372,7 +374,8 @@ struct ChangesTabView: View {
                     onDraftCommit: openDraftTab,
                     onGGAction: handleGGPreparationAction,
                     onGGStackAction: { rps.onGGStackAction($0, appState: appState) },
-                    onReviewRequestAction: { rps.handleReviewReadinessAction($0, appState: appState) }
+                    onReviewRequestAction: { rps.handleReviewReadinessAction($0, appState: appState) },
+                    onDismissSyncFailure: { rps.ggActionState.dismissCompletedSyncFailure() }
                 )
             })
         }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1626,9 +1626,17 @@ final class RightPaneState: GGSplitCommitServicing {
                 default:
                     break
                 }
-                publishGGMutationPresentationError(error, forActionGeneration: actionGeneration)
+                publishGGMutationPresentationError(
+                    error,
+                    for: prepared.request.actionKind,
+                    actionGeneration: actionGeneration
+                )
             } catch {
-                publishGGMutationPresentationError(error, forActionGeneration: actionGeneration)
+                publishGGMutationPresentationError(
+                    error,
+                    for: prepared.request.actionKind,
+                    actionGeneration: actionGeneration
+                )
             }
         }
     }
@@ -1848,7 +1856,11 @@ final class RightPaneState: GGSplitCommitServicing {
             do {
                 try await operation.value
             } catch {
-                publishGGMutationPresentationError(error, forActionGeneration: actionGeneration)
+                publishGGMutationPresentationError(
+                    error,
+                    for: request.actionKind,
+                    actionGeneration: actionGeneration
+                )
             }
         }
     }
@@ -1863,17 +1875,24 @@ final class RightPaneState: GGSplitCommitServicing {
             do {
                 try await operation.value
             } catch {
-                publishGGMutationPresentationError(error, forActionGeneration: actionGeneration)
+                publishGGMutationPresentationError(
+                    error,
+                    for: prepared.request.actionKind,
+                    actionGeneration: actionGeneration
+                )
             }
         }
     }
 
     private func publishGGMutationPresentationError(
         _ error: Error,
-        forActionGeneration generation: UInt
+        for action: GGStackActionKind,
+        actionGeneration generation: UInt
     ) {
-        guard ggActionState.shouldPublishError(forActionGeneration: generation) else { return }
-        ggActionState.setError(GGErrorPresentation.message(for: error))
+        guard ggActionState.actionGeneration == generation else { return }
+        if action == .sync { ggActionState.markSyncTerminalFailure() }
+        guard ggActionState.shouldPublishError(forActionGeneration: generation, action: action) else { return }
+        ggActionState.setError(GGErrorPresentation.message(for: error), for: action)
     }
 
     func markSnapshotUnknown() {

--- a/AlasTests/Integrations/GGMutationCoordinatorTests.swift
+++ b/AlasTests/Integrations/GGMutationCoordinatorTests.swift
@@ -1490,6 +1490,7 @@ struct GGMutationCoordinatorTests {
         }
 
         #expect(harness.actionState.lastError == "push rejected by protected branch")
+        #expect(harness.actionState.syncHasTerminalFailure)
         let progress = GGStackReadinessModel.make(
             stack: stack(head: "a").stack!,
             action: harness.actionState
@@ -1500,6 +1501,20 @@ struct GGMutationCoordinatorTests {
         ])
         #expect(progress?.liveStatus == nil)
         #expect(progress?.showsSpinner == false)
+    }
+
+    @Test func streamedSyncErrorBecomesTerminalOnlyAfterSyncCompletes() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "a")])
+        harness.service.syncEvents = [.error(position: 1, operation: "push", message: "push failed")]
+        harness.service.blockExecution = true
+
+        let task = try #require(harness.coordinator.startApplying(.sync, confirmedAgainst: nil))
+        try await waitUntil { harness.actionState.lastError == "push failed" }
+        #expect(!harness.actionState.syncHasTerminalFailure)
+
+        harness.service.resumeExecution()
+        try await task.value
+        #expect(harness.actionState.syncHasTerminalFailure)
     }
 
     @Test func undoRechecksNewestOperationImmediatelyBeforeLaunch() async {

--- a/AlasTests/Integrations/GGStackReadinessModelTests.swift
+++ b/AlasTests/Integrations/GGStackReadinessModelTests.swift
@@ -596,6 +596,48 @@ struct GGStackReadinessModelTests {
         #expect(!model.facts.isEmpty)
     }
 
+    @Test func dismissingCompletedSyncFailureClearsRetainedFeedback() {
+        let action = GGStackActionState()
+        _ = action.beginAction(.sync)
+        action.markSyncTerminalFailure()
+        action.endAction(.sync)
+        action.setError("push failed", for: .sync)
+
+        action.dismissCompletedSyncFailure()
+
+        #expect(action.syncProgress.isEmpty)
+        #expect(!action.syncHasTerminalFailure)
+        #expect(action.lastError == nil)
+    }
+
+    @Test func unrelatedErrorDuringSyncCannotBeDismissedAsASyncFailure() {
+        let action = GGStackActionState()
+        _ = action.beginAction(.sync)
+        action.setError("provider failed")
+        action.endAction(.sync)
+
+        #expect(!action.canDismissCompletedSyncFailure)
+        action.dismissCompletedSyncFailure()
+        #expect(action.lastError == "provider failed")
+    }
+
+    @Test func dismissingSyncFailureKeepsALaterUnrelatedError() {
+        let action = GGStackActionState()
+        _ = action.beginAction(.sync)
+        action.markSyncTerminalFailure()
+        action.appendSyncEvent(.start(totalEntries: 1))
+        action.setError("sync failed", for: .sync)
+        action.endAction(.sync)
+        action.setError("provider failed")
+
+        #expect(action.canDismissCompletedSyncFailure)
+        action.dismissCompletedSyncFailure()
+
+        #expect(action.syncProgress.isEmpty)
+        #expect(!action.syncHasTerminalFailure)
+        #expect(action.lastError == "provider failed")
+    }
+
     @Test func actionSummarySurfacesWhenIdleOnly() {
         let action = GGStackActionState()
         action.setActionSummary("Synced · 1 pushed")


### PR DESCRIPTION
## Summary

A failed `gg sync` left the Prepare pane permanently occupied, even after the command had finished. This adds a dismiss control for that retained failure state without hiding active or paused operations.

## Changes

- Clear retained sync progress, terminal failure state, and error together.
- Show an accessible close button only after a completed sync failure.
- Cover the state transition with a regression test.

## Verification

- `xcrun swiftc -parse` passed for all changed Swift files.
- `git diff --check` passed.
- Local `xcodebuild test` is blocked before compilation because Xcode rejects the worktree Ghostty XCFramework despite it matching the main checkout artifact. CI will provide the full build and test result.