### PR TITLE
feat(acp): add push-to-talk dictation to chat composer

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -479,6 +479,7 @@
 		4937795BA36F920B9930C916 /* ACPPermissionDecisionLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F1C71C2574B1077964E5E1 /* ACPPermissionDecisionLogTests.swift */; };
 		4977422707F8C79E2BD5E337 /* AppKitDiffReviewScrollerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6C1F946AC7EC621C5A8A59 /* AppKitDiffReviewScrollerTests.swift */; };
 		497D21A67A062CE6282008CD /* PathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295319DB8544C170DDD6328D /* PathsTests.swift */; };
+		497FF183AAA6C00F88E8AEB2 /* ACPSpeechDictationEngineFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A01B605D486C5FE112088E /* ACPSpeechDictationEngineFormatTests.swift */; };
 		49C8C4C8B34444953FBA1809 /* DebounceTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */; };
 		4A99239BAD338EDCE7BE5F0E /* GGMutationModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1276253D1FB205BC9B5AEDF1 /* GGMutationModelsTests.swift */; };
 		4AFE4A55AF808EEFE3AA4DE2 /* ACPDelegatedSessionsPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0235A58C8825D42F1C406C /* ACPDelegatedSessionsPolicyTests.swift */; };
@@ -2868,6 +2869,7 @@
 		D020BC9CC6586ECAB8A38042 /* ACPReconnectPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPReconnectPolicy.swift; sourceTree = "<group>"; };
 		D02E429B37288215EBC89571 /* CommitHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderView.swift; sourceTree = "<group>"; };
 		D081C8802733D2532DBCD74D /* BlockedLanguageServerNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolverTests.swift; sourceTree = "<group>"; };
+		D0A01B605D486C5FE112088E /* ACPSpeechDictationEngineFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSpeechDictationEngineFormatTests.swift; sourceTree = "<group>"; };
 		D0A8DE0526D46C36C672213B /* TrackedRevisionTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackedRevisionTargetTests.swift; sourceTree = "<group>"; };
 		D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStateTests.swift; sourceTree = "<group>"; };
 		D0EE31A4EB90FFE45DC46420 /* BuildIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildIdentityTests.swift; sourceTree = "<group>"; };
@@ -5776,6 +5778,7 @@
 			children = (
 				F226886130D09669EEEBD381 /* ACPDictationLocaleFormatterTests.swift */,
 				EF5F310D158323C328E56929 /* ACPDictationServiceTests.swift */,
+				D0A01B605D486C5FE112088E /* ACPSpeechDictationEngineFormatTests.swift */,
 				050948BA098978A818ABC0F2 /* ACPSpeechDictationEngineLocaleTests.swift */,
 			);
 			path = Dictation;
@@ -7046,6 +7049,7 @@
 				AC2574A26E931F0881F560C6 /* ACPSetupCheckerTests.swift in Sources */,
 				07BB2B329992BA535053BB80 /* ACPSetupNudgeBannerModeTests.swift in Sources */,
 				A975EADB16D1050CA973B5B3 /* ACPSlashPickerTests.swift in Sources */,
+				497FF183AAA6C00F88E8AEB2 /* ACPSpeechDictationEngineFormatTests.swift in Sources */,
 				44A5CAA6C9B420636540569A /* ACPSpeechDictationEngineLocaleTests.swift in Sources */,
 				E239749EA0CB37C2C12B3591 /* ACPStdioClientTests.swift in Sources */,
 				588A1EB3D20EB2419A5A03B4 /* ACPStdioQuestionDispatchTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		01568CB821D2E938C51BBCAB /* ACPHarnessBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A5A3E6B2F9AC2CBB1CDA78E /* ACPHarnessBridgeTests.swift */; };
 		018E8980EAA0FA97A08A6EF6 /* RevisionSnapshotCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12DA5ED8195BBE603DFC5B61 /* RevisionSnapshotCache.swift */; };
 		018F0BE1174B9020C52007BE /* ACPRemoteFileServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BDAB5BEDF7FE5EBFBFE9A2 /* ACPRemoteFileServerTests.swift */; };
+		0191E2173516054F2E502C8E /* ACPComposerControlPresentationDictationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE91017BB71AB08265C7B56E /* ACPComposerControlPresentationDictationTests.swift */; };
 		019CF838931D47EB13E8C107 /* PiMCPConfigWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B36F1F6A541E5ADB96FCA6 /* PiMCPConfigWriterTests.swift */; };
 		019D3627B3CEB44C34CC34F9 /* RemoteHelperProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B0D8590E0335CD31B758E0 /* RemoteHelperProtocol.swift */; };
 		019EE52A9C64CF5D15AD9AF2 /* RightPaneStateContentFingerprintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8233D58F8A76CFFA25EE8D22 /* RightPaneStateContentFingerprintTests.swift */; };
@@ -193,6 +194,7 @@
 		1ED78A36E993D85D0DD1E3CC /* ACPSessionUsageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF05DF16587C5A48A9E04B2A /* ACPSessionUsageTests.swift */; };
 		1F3AA3B31A896A0608970906 /* AppConfigHarnessMCPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9261D66BAD364C3EEAB4DA /* AppConfigHarnessMCPTests.swift */; };
 		1F3EF4D7DFC6A640FA731EAA /* GGActionEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F0EED235328724082B570B /* GGActionEvents.swift */; };
+		1F55E63544597FED6F86C395 /* ACPDictationEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B6C07991FB2F02E081C669 /* ACPDictationEngine.swift */; };
 		1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */; };
 		1F84796DE0ABC832C0303B27 /* ACPSessionStoreDedupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFC82400385AD76A200A2B /* ACPSessionStoreDedupTests.swift */; };
 		1F860C66D658B0DA5A0599F6 /* RemoteZmxInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4239E76E57C63CD983437F /* RemoteZmxInstaller.swift */; };
@@ -298,6 +300,7 @@
 		2FAA421AF3C23D27A864FDCA /* AgentBuiltins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */; };
 		2FAAA60EF431D109D842428F /* SelfUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBDEF50915BACBD0C3EE36AE /* SelfUpdaterTests.swift */; };
 		2FE10FC44BD9CDBD0C969374 /* MergeBulkResolvePromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */; };
+		305078D3F8573E2B659E704D /* ACPDictationLocaleFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F226886130D09669EEEBD381 /* ACPDictationLocaleFormatterTests.swift */; };
 		30582A6DE1CFD0B9D5CB2E14 /* RemoteFileStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB8BF6C61840B9F972ABACC /* RemoteFileStats.swift */; };
 		30604716147E0B9C558244F3 /* ACPSessionOrchestrationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD63F297F7735AD9E1841ACF /* ACPSessionOrchestrationPolicy.swift */; };
 		3068E2E9A175FD2430C684D1 /* DiffPaneAppKitScrollerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AB88006D9C1857616D5035 /* DiffPaneAppKitScrollerTests.swift */; };
@@ -443,6 +446,7 @@
 		443F48C0A1AF36BFAB8B61E8 /* UnionCanvasGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650B300A5337E2A9149CF083 /* UnionCanvasGeometry.swift */; };
 		445DAFBF3E820823AA2779B4 /* ACPElicitationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E1A9B42D47CC0244C24F7B /* ACPElicitationTests.swift */; };
 		449C7E4A63455D01633B791A /* PendingDiscard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */; };
+		44A5CAA6C9B420636540569A /* ACPSpeechDictationEngineLocaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050948BA098978A818ABC0F2 /* ACPSpeechDictationEngineLocaleTests.swift */; };
 		44E3D7C4CAC4E2481778C35F /* MermaidDiagramLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F002B796231A05FD113BDA3 /* MermaidDiagramLayout.swift */; };
 		45290287102551CF8726F0EF /* ACPSessionInfoUpdateDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68AC15742E7423AE2F3A203A /* ACPSessionInfoUpdateDecodeTests.swift */; };
 		4565825A901B119DCD1037ED /* SymbolsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */; };
@@ -853,6 +857,7 @@
 		8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */; };
 		8B2A37F58F2C7D842204A596 /* ImageDiffOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87F114EBEEACCC95B9EF8D5 /* ImageDiffOverlayView.swift */; };
 		8B3D1B7B55629E989FCE53D1 /* ACPPermissionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F31D837F83B4F8B9FB348BD /* ACPPermissionPolicyTests.swift */; };
+		8B46DD8DE4E960A8A70B665D /* ACPDictationLocaleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69B7A776BD633CA046DA4C /* ACPDictationLocaleFormatter.swift */; };
 		8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBEFD27FD7013D458435779 /* ACPSession.swift */; };
 		8C1E756AFF4125E7ED04E0B8 /* RemoteConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2EFB5253073D6A4A328FE0 /* RemoteConnection.swift */; };
 		8C492CBACC6D6DACE56DADA9 /* RemoteWorktreeSummaryBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD81682586D187AB70D1CDB /* RemoteWorktreeSummaryBuilder.swift */; };
@@ -1270,6 +1275,7 @@
 		CF6CC4CD0C7841CA79DB0E4E /* ACPPlanPillState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDDDC4C6146165CA4C7474E /* ACPPlanPillState.swift */; };
 		CF81F0AE28C56D1DF5AD871B /* SurfaceViewShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */; };
 		CFA6B63752FF405E2BABDB48 /* NewWorktreeIssueState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E76A376D202F7144C03F221 /* NewWorktreeIssueState.swift */; };
+		CFD4BC59E32060DCBB101D56 /* ACPSpeechDictationEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 145669B8ECC803C942A6FB42 /* ACPSpeechDictationEngine.swift */; };
 		D002012348D4DA7E124632BF /* SpacePagerIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9294E94F46763CC8DCD93A3 /* SpacePagerIndicator.swift */; };
 		D02BB257817B709817CAB2B6 /* ACPRemoteMCPFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB5D1C8046EF9B6A95C41CD /* ACPRemoteMCPFilter.swift */; };
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
@@ -1293,6 +1299,7 @@
 		D28EE6309DBB51EFEDCEAC18 /* ACPSessionManagerLeaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C13707B79B7A4F4BB2608E /* ACPSessionManagerLeaseTests.swift */; };
 		D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */; };
 		D2D5D79EE8DE82FC44C2D36A /* CompletionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D510DACCD80A328B2DFABDC0 /* CompletionFeature.swift */; };
+		D2DBD17549E31DAAF87EE4A9 /* ACPDictationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF5F310D158323C328E56929 /* ACPDictationServiceTests.swift */; };
 		D36A33178D064DBD5DFD9B6D /* PairedAuthoredContentSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBB557833D3939208D75FB7 /* PairedAuthoredContentSurfaceTests.swift */; };
 		D397C3E94E3F00F012CBE5AE /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27595490B7D883CF5D9FFD5 /* Tab.swift */; };
 		D3A67696B13E8F9E31B10DC0 /* DiffReviewRailThreadCountsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E933EFC52B5E3D12133B1306 /* DiffReviewRailThreadCountsTests.swift */; };
@@ -1369,6 +1376,7 @@
 		DE33366A35436471AE0DAE96 /* DiffReviewRenderBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE54F0320B9F40BEF46FB85 /* DiffReviewRenderBudgetTests.swift */; };
 		DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB52B59655B85764D85CFB7F /* LineEndingTests.swift */; };
 		DE431266B60826A2EA3736DF /* LineBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C954F77AD0867F7FD39A5ED7 /* LineBuffer.swift */; };
+		DE91F7958CC50097DF9CAF8F /* ACPDictationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2117FFCCDC663D9083D0791E /* ACPDictationService.swift */; };
 		DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */; };
 		DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */; };
 		DEC1744FA9C8A26294FF0671 /* CompletionEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0CD4F3AC6DD83BC45459475 /* CompletionEngineTests.swift */; };
@@ -1427,6 +1435,7 @@
 		E551A81EBC839478D6999A97 /* ACPComposerDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */; };
 		E5648509F3F1EA4297E856A1 /* GGStackCreateMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B7A6EC8A1372E76F0B934D /* GGStackCreateMode.swift */; };
 		E5D32C15B08F30DF3B46CA74 /* DiffReviewScrollSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D73C433B373577FD515FECD3 /* DiffReviewScrollSpy.swift */; };
+		E5E6CB61C4776CD48C3AF563 /* ACPDictationRegionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD3B4EB4344DFAF081D72D5 /* ACPDictationRegionTests.swift */; };
 		E6119C80C9AFF38EB308301A /* GGMCPInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1E93FE66457A82A3348EDA /* GGMCPInjection.swift */; };
 		E6426E94A57602E76D401D21 /* AlasActionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005F92E45C7D391D8BD5A3FD /* AlasActionService.swift */; };
 		E681EB5B83BAC199B1ED5E24 /* WorktreeWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */; };
@@ -1521,6 +1530,7 @@
 		F71446E57FF4879C9A9B0686 /* RightPaneStatePullTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B1ED890A8A45244572D8A3 /* RightPaneStatePullTests.swift */; };
 		F72AFDC819B805B3F1FFFB9A /* CommitReviewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A240CD3EF074300828A1214 /* CommitReviewLoader.swift */; };
 		F73063B2384B650C227BD09E /* ACPHistorySidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C5BD0110EB8EDE7BB4ED93 /* ACPHistorySidebar.swift */; };
+		F7C010994E85C805815654A7 /* ACPDictationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE5299FFB65B9D72EF1682B /* ACPDictationState.swift */; };
 		F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */; };
 		F8501BB64D3150892C46D4B3 /* FollowRevisionPrefillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736203E6989B9E0200B93E0A /* FollowRevisionPrefillTests.swift */; };
 		F855DEEEE005795EC6B13544 /* AlasFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169FC38D03727F34855EB521 /* AlasFieldTests.swift */; };
@@ -1628,6 +1638,7 @@
 		04601C00F293AAB0EE4209E1 /* RunScriptStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptStore.swift; sourceTree = "<group>"; };
 		04B44F1DD775D2543439D508 /* ACPTranscriptMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMarkdown.swift; sourceTree = "<group>"; };
 		04F003E5F05AD5F1039736D1 /* GGStreamingProcessTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStreamingProcessTree.swift; sourceTree = "<group>"; };
+		050948BA098978A818ABC0F2 /* ACPSpeechDictationEngineLocaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSpeechDictationEngineLocaleTests.swift; sourceTree = "<group>"; };
 		0535D92433898E76670B9FF0 /* ACPUserScrollEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPUserScrollEventTests.swift; sourceTree = "<group>"; };
 		0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessPill.swift; sourceTree = "<group>"; };
 		0582531788CE9D1D49769F6B /* ACPVisibleRowsCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPVisibleRowsCache.swift; sourceTree = "<group>"; };
@@ -1710,6 +1721,7 @@
 		137F79BD0DEB96B6F756ABD4 /* JSONHookSettingsFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONHookSettingsFile.swift; sourceTree = "<group>"; };
 		14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabView.swift; sourceTree = "<group>"; };
 		141C4CAF1B49032EDF0FF404 /* ProjectIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectIconTests.swift; sourceTree = "<group>"; };
+		145669B8ECC803C942A6FB42 /* ACPSpeechDictationEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSpeechDictationEngine.swift; sourceTree = "<group>"; };
 		14907D679267359B3FB8A848 /* TabMergeConflictCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabMergeConflictCodingTests.swift; sourceTree = "<group>"; };
 		14CAEDA53AADBCE77C694E7B /* CodeHostModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostModelsTests.swift; sourceTree = "<group>"; };
 		14CEB6C5C076B4147D587909 /* ReviewThreadMutations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewThreadMutations.swift; sourceTree = "<group>"; };
@@ -1779,6 +1791,7 @@
 		208C9ABAF59F523D2DDC2F2A /* EditorOverlayPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorOverlayPanelTests.swift; sourceTree = "<group>"; };
 		209B2EDBA4EB4BF7A854FF96 /* EditorLSPStatusResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatusResolverTests.swift; sourceTree = "<group>"; };
 		20A5D6E7C4527B459EFC2CBB /* RemoteWorktreeSummaryBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreeSummaryBuilderTests.swift; sourceTree = "<group>"; };
+		2117FFCCDC663D9083D0791E /* ACPDictationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDictationService.swift; sourceTree = "<group>"; };
 		2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.App.swift; sourceTree = "<group>"; };
 		215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyHost.swift; sourceTree = "<group>"; };
 		21C7D51D781D8191004C6C90 /* ReviewChangesModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesModels.swift; sourceTree = "<group>"; };
@@ -2738,6 +2751,7 @@
 		BEBCF3820A017BBF33B0AB07 /* ACPProtocolVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPProtocolVersion.swift; sourceTree = "<group>"; };
 		BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationHelperTests.swift; sourceTree = "<group>"; };
 		BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
+		BEE5299FFB65B9D72EF1682B /* ACPDictationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDictationState.swift; sourceTree = "<group>"; };
 		BEFDCAF3F099FE539D9737E9 /* InstallSplitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallSplitButton.swift; sourceTree = "<group>"; };
 		BF3AC3A1F7C5649E75015293 /* CreatingWorktreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatingWorktreeView.swift; sourceTree = "<group>"; };
 		BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInstallerTests.swift; sourceTree = "<group>"; };
@@ -2874,6 +2888,7 @@
 		D3552BE48184E15F0BE6084C /* TrackedRevisionCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackedRevisionCodingTests.swift; sourceTree = "<group>"; };
 		D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeServiceTests.swift; sourceTree = "<group>"; };
 		D36EA68CE127E24991ABD5A6 /* ReviewDraftCommentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentStoreTests.swift; sourceTree = "<group>"; };
+		D3B6C07991FB2F02E081C669 /* ACPDictationEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDictationEngine.swift; sourceTree = "<group>"; };
 		D3D8F686002C542458620289 /* PiMCPAdapterInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiMCPAdapterInspector.swift; sourceTree = "<group>"; };
 		D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitEventFilterTests.swift; sourceTree = "<group>"; };
 		D3EDEEB00185F9C717205540 /* ACPAutoRunToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAutoRunToggle.swift; sourceTree = "<group>"; };
@@ -3054,9 +3069,11 @@
 		EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParserTests.swift; sourceTree = "<group>"; };
 		EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRow.swift; sourceTree = "<group>"; };
 		EE6F36C31DB1C13D86416B4B /* PiACPInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiACPInstaller.swift; sourceTree = "<group>"; };
+		EE91017BB71AB08265C7B56E /* ACPComposerControlPresentationDictationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerControlPresentationDictationTests.swift; sourceTree = "<group>"; };
 		EECB91379591DA21D216A894 /* RelativeTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelativeTime.swift; sourceTree = "<group>"; };
 		EECD5B53A23694EF60F63041 /* MergeConflictAgentProposalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictAgentProposalView.swift; sourceTree = "<group>"; };
 		EF5F20AB3B3F7BCEAA56B143 /* SQLiteDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDatabase.swift; sourceTree = "<group>"; };
+		EF5F310D158323C328E56929 /* ACPDictationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDictationServiceTests.swift; sourceTree = "<group>"; };
 		EF69D638124D1B4D1C04BD31 /* ProviderReviewPublishConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewPublishConfirmationView.swift; sourceTree = "<group>"; };
 		EF9480C66C4CDDB090A5F4FB /* GGAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGAvailabilityTests.swift; sourceTree = "<group>"; };
 		EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateSpacesTests.swift; sourceTree = "<group>"; };
@@ -3076,6 +3093,7 @@
 		F1BA8B1CD4334FF7F7082E9A /* ACPTranscriptScrollerLiveScrollTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollerLiveScrollTests.swift; sourceTree = "<group>"; };
 		F1F0EED235328724082B570B /* GGActionEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGActionEvents.swift; sourceTree = "<group>"; };
 		F205138E6ECCFA7DD392E3CE /* GGSplitPreviewRowPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGSplitPreviewRowPlanTests.swift; sourceTree = "<group>"; };
+		F226886130D09669EEEBD381 /* ACPDictationLocaleFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDictationLocaleFormatterTests.swift; sourceTree = "<group>"; };
 		F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarMaterialChoiceTests.swift; sourceTree = "<group>"; };
 		F2AC43D07BE4012DB52A2D1B /* ChatFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFontCatalog.swift; sourceTree = "<group>"; };
 		F2C9F8BAEDB1D157E321A328 /* ReviewChangesScrollSpyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesScrollSpyTests.swift; sourceTree = "<group>"; };
@@ -3136,8 +3154,10 @@
 		FC8E722C16FFBEEEC43337D5 /* ACPSetupCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSetupCheck.swift; sourceTree = "<group>"; };
 		FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorView.swift; sourceTree = "<group>"; };
 		FC961032C642C166F17EFD99 /* QueuedPromptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuedPromptTests.swift; sourceTree = "<group>"; };
+		FCD3B4EB4344DFAF081D72D5 /* ACPDictationRegionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDictationRegionTests.swift; sourceTree = "<group>"; };
 		FD0EBA9DC694E3F11300FC6C /* GeminiInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiInstaller.swift; sourceTree = "<group>"; };
 		FD2672B5B84D96BDDE9D80A0 /* AppQuitActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppQuitActionTests.swift; sourceTree = "<group>"; };
+		FD69B7A776BD633CA046DA4C /* ACPDictationLocaleFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDictationLocaleFormatter.swift; sourceTree = "<group>"; };
 		FDB4C80D9DD6DA28DE182955 /* InstallRecipeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallRecipeTests.swift; sourceTree = "<group>"; };
 		FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageEncodingTests.swift; sourceTree = "<group>"; };
 		FDED017DE2DF29C817EF178C /* NewWorktreeIssueStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorktreeIssueStateTests.swift; sourceTree = "<group>"; };
@@ -3189,6 +3209,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		05FF29C6C59AB1522F9C7D57 /* Dictation */ = {
+			isa = PBXGroup;
+			children = (
+				D3B6C07991FB2F02E081C669 /* ACPDictationEngine.swift */,
+				FD69B7A776BD633CA046DA4C /* ACPDictationLocaleFormatter.swift */,
+				2117FFCCDC663D9083D0791E /* ACPDictationService.swift */,
+				BEE5299FFB65B9D72EF1682B /* ACPDictationState.swift */,
+				145669B8ECC803C942A6FB42 /* ACPSpeechDictationEngine.swift */,
+			);
+			path = Dictation;
+			sourceTree = "<group>";
+		};
 		073D86784AF420D20A2149BB /* Remote */ = {
 			isa = PBXGroup;
 			children = (
@@ -4090,6 +4122,7 @@
 				45EABFDF5380D8D48B15312C /* ACPHarnessBridge.swift */,
 				0A9B6A8C7372DB9E6C627A0E /* Adapter */,
 				0F049E087B583485A8588D8A /* Broker */,
+				05FF29C6C59AB1522F9C7D57 /* Dictation */,
 				22693797F2929554193802B2 /* FileWriter */,
 				0C652107D8258A12E8774EF5 /* Orchestration */,
 				3265338C21E4088B279578DE /* Permissions */,
@@ -4251,6 +4284,7 @@
 				3659703F6EB9AD2454C2898B /* ACPChatTypographyTests.swift */,
 				81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */,
 				2B7ADCB7C4178FE036A31214 /* ACPComposerActionButtonMetricsTests.swift */,
+				EE91017BB71AB08265C7B56E /* ACPComposerControlPresentationDictationTests.swift */,
 				B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */,
 				98CA6A0F4862D9A29E4151B5 /* ACPComposerFocusPolicyTests.swift */,
 				A637073E5D65DAA4E0CF6EA4 /* ACPComposerImageExtractTests.swift */,
@@ -4260,6 +4294,7 @@
 				ECD9419E685AD7EED286006B /* ACPContextRingTests.swift */,
 				DC76F9150CC29A324D785C29 /* ACPDelayedHoverVisibilityTests.swift */,
 				AE0235A58C8825D42F1C406C /* ACPDelegatedSessionsPolicyTests.swift */,
+				FCD3B4EB4344DFAF081D72D5 /* ACPDictationRegionTests.swift */,
 				F6EDDD4D22267C26B496A6FF /* ACPFirstRunConnectingPolicyTests.swift */,
 				8BA7FA6A8011D88FDFEE30A0 /* ACPGoalPillTests.swift */,
 				FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */,
@@ -4568,6 +4603,7 @@
 				5027B783605BE1C0189308CC /* ACPTranscriptChangeLogTests.swift */,
 				C1CE17139DAF0E60FE9D92C2 /* Adapter */,
 				E983FBC642810DD8F47702D8 /* Broker */,
+				FCAF9E5F220AB1D0B05279AB /* Dictation */,
 				E6055B84E3F6E5717B873689 /* E2E */,
 				075A0E441C47ACE7EEA52334 /* FileWriter */,
 				895189284B82DBD794D9F2F0 /* Fixtures */,
@@ -5735,6 +5771,16 @@
 			path = App;
 			sourceTree = "<group>";
 		};
+		FCAF9E5F220AB1D0B05279AB /* Dictation */ = {
+			isa = PBXGroup;
+			children = (
+				F226886130D09669EEEBD381 /* ACPDictationLocaleFormatterTests.swift */,
+				EF5F310D158323C328E56929 /* ACPDictationServiceTests.swift */,
+				050948BA098978A818ABC0F2 /* ACPSpeechDictationEngineLocaleTests.swift */,
+			);
+			path = Dictation;
+			sourceTree = "<group>";
+		};
 		FCE6979EDAEAE45BC2A49A20 /* CommitAI */ = {
 			isa = PBXGroup;
 			children = (
@@ -6071,6 +6117,10 @@
 				85B8A8B929BD4ED4DC21FEDD /* ACPDelayedHoverVisibility.swift in Sources */,
 				2E77FDE42FBD83BBCBC8DE80 /* ACPDelegatedPromptSource.swift in Sources */,
 				FB8B530E472D1C22B78F12EE /* ACPDelegatedSessionsPolicy.swift in Sources */,
+				1F55E63544597FED6F86C395 /* ACPDictationEngine.swift in Sources */,
+				8B46DD8DE4E960A8A70B665D /* ACPDictationLocaleFormatter.swift in Sources */,
+				DE91F7958CC50097DF9CAF8F /* ACPDictationService.swift in Sources */,
+				F7C010994E85C805815654A7 /* ACPDictationState.swift in Sources */,
 				2A19A7B4B392979989E25EC0 /* ACPDiffGenerator.swift in Sources */,
 				16EFA072E6C91CF41269482C /* ACPElicitation.swift in Sources */,
 				9ECB0CE387C7078D238B3A15 /* ACPElicitationCoordinator.swift in Sources */,
@@ -6157,6 +6207,7 @@
 				9DF0D37CE59DF8AAD7172443 /* ACPSetupChecker.swift in Sources */,
 				3F54F0437585F96F5774A3BD /* ACPSetupNudgeBanner.swift in Sources */,
 				C5644E1144140B99E8676064 /* ACPSlashPicker.swift in Sources */,
+				CFD4BC59E32060DCBB101D56 /* ACPSpeechDictationEngine.swift in Sources */,
 				2D3E3F75B6CBDF63A3FF2CD7 /* ACPStarterPrompt.swift in Sources */,
 				A3EE2DE5C01EB87DE7BCC801 /* ACPStdioClient.swift in Sources */,
 				1B7A283F7F585BA8D67C1959 /* ACPSteerUndoToast.swift in Sources */,
@@ -6883,6 +6934,7 @@
 				5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */,
 				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,
 				33A0FC862C45CDFF47053A04 /* ACPComposerActionButtonMetricsTests.swift in Sources */,
+				0191E2173516054F2E502C8E /* ACPComposerControlPresentationDictationTests.swift in Sources */,
 				1721FFC6A99B6E2683378552 /* ACPComposerDraftBridgeTests.swift in Sources */,
 				3518735F0614C32919E3FC27 /* ACPComposerDraftTests.swift in Sources */,
 				B430895772AC7AA84932905E /* ACPComposerFocusPolicyTests.swift in Sources */,
@@ -6896,6 +6948,9 @@
 				316ABEA3944051EA41569FDC /* ACPContextRingTests.swift in Sources */,
 				DADDDA3FA289B52415EF4379 /* ACPDelayedHoverVisibilityTests.swift in Sources */,
 				4AFE4A55AF808EEFE3AA4DE2 /* ACPDelegatedSessionsPolicyTests.swift in Sources */,
+				305078D3F8573E2B659E704D /* ACPDictationLocaleFormatterTests.swift in Sources */,
+				E5E6CB61C4776CD48C3AF563 /* ACPDictationRegionTests.swift in Sources */,
+				D2DBD17549E31DAAF87EE4A9 /* ACPDictationServiceTests.swift in Sources */,
 				47789166FA5C563AE2F550ED /* ACPDiffGeneratorTests.swift in Sources */,
 				AA19B3B2B1CE418BFD6FD134 /* ACPElicitationCoordinatorTests.swift in Sources */,
 				445DAFBF3E820823AA2779B4 /* ACPElicitationTests.swift in Sources */,
@@ -6991,6 +7046,7 @@
 				AC2574A26E931F0881F560C6 /* ACPSetupCheckerTests.swift in Sources */,
 				07BB2B329992BA535053BB80 /* ACPSetupNudgeBannerModeTests.swift in Sources */,
 				A975EADB16D1050CA973B5B3 /* ACPSlashPickerTests.swift in Sources */,
+				44A5CAA6C9B420636540569A /* ACPSpeechDictationEngineLocaleTests.swift in Sources */,
 				E239749EA0CB37C2C12B3591 /* ACPStdioClientTests.swift in Sources */,
 				588A1EB3D20EB2419A5A03B4 /* ACPStdioQuestionDispatchTests.swift in Sources */,
 				929C2E12D6178FF3728365A2 /* ACPStdioTerminalDispatchTests.swift in Sources */,

--- a/Alas/Resources/Alas.entitlements
+++ b/Alas/Resources/Alas.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<false/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 </dict>

--- a/Alas/Resources/Info.plist
+++ b/Alas/Resources/Info.plist
@@ -34,7 +34,11 @@
 	<string>15.0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2026 Nacho Lopez</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Alas uses the microphone to dictate text into the chat composer.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Alas uses on-device speech recognition to transcribe dictated text into the chat composer.</string>
 </dict>
 </plist>

--- a/Alas/Sources/ACP/Dictation/ACPDictationEngine.swift
+++ b/Alas/Sources/ACP/Dictation/ACPDictationEngine.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Callbacks a dictation engine reports through. Grouped into one value so
+/// `start` keeps a readable signature as the engine grew a preferred
+/// locale and a silence report.
+struct ACPDictationCallbacks {
+    /// Setup finished and audio is being captured.
+    let onReady: () -> Void
+    /// A transcript update. Volatile updates repeat as the utterance is
+    /// corrected; each utterance ends with exactly one final update.
+    let onResult: (_ text: String, _ isFinal: Bool) -> Void
+    /// Setup or transcription failed; dictation is over.
+    let onFailure: (_ message: String) -> Void
+    /// Audio is flowing but every sample so far has been silence, which
+    /// almost always means the wrong input device is selected. Reported at
+    /// most once per session, and does NOT stop dictation, since sound may
+    /// still start. Carries the input device name when it's known.
+    let onSilence: (_ deviceName: String?) -> Void
+}
+
+/// Seam between `ACPDictationService` (the state machine) and whatever
+/// actually captures audio and transcribes it. Isolating this behind a
+/// protocol lets the state machine be tested without a microphone or the
+/// Speech framework.
+@MainActor
+protocol ACPDictationEngine: AnyObject {
+    /// False when this OS has no speech-to-text engine available — the
+    /// service starts `.unavailable` and `start()` is a no-op.
+    var isAvailable: Bool { get }
+
+    /// Locale identifiers whose assets are already downloaded, so picking
+    /// one starts transcribing without waiting on a model download.
+    func installedLocaleIdentifiers() async -> [String]
+
+    /// Requests permissions, prepares the transcriber, and begins
+    /// streaming microphone audio into it. Exactly one of `onReady` or
+    /// `onFailure` fires once setup resolves; `onResult` may then fire any
+    /// number of times until `stop()` is called.
+    ///
+    /// `preferredLocaleIdentifier` is the user's explicit language choice,
+    /// or nil to detect one automatically.
+    func start(preferredLocaleIdentifier: String?, callbacks: ACPDictationCallbacks)
+
+    /// Tears down the audio tap and transcriber. Safe to call even if
+    /// `start` never reached `onReady`.
+    func stop()
+}

--- a/Alas/Sources/ACP/Dictation/ACPDictationLocaleFormatter.swift
+++ b/Alas/Sources/ACP/Dictation/ACPDictationLocaleFormatter.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Turns dictation locale identifiers into names for the UI.
+///
+/// Names are rendered in English rather than the user's language because
+/// the app itself ships English-only; a Spanish-region user reading an
+/// otherwise-English Settings pane should see "Spanish (Spain)", not
+/// "español (España)".
+enum ACPDictationLocaleFormatter {
+    /// Identifier meaning "detect the language automatically".
+    static let automaticIdentifier = ""
+
+    private static let displayLocale = Locale(identifier: "en_US")
+
+    static func displayName(for identifier: String) -> String {
+        guard !identifier.isEmpty else { return "Automatic" }
+        let normalized = identifier.replacingOccurrences(of: "-", with: "_")
+        guard let name = displayLocale.localizedString(forIdentifier: normalized), !name.isEmpty else {
+            return identifier
+        }
+        return name
+    }
+
+    static func sortedByDisplayName(_ identifiers: [String]) -> [String] {
+        identifiers.sorted {
+            displayName(for: $0).localizedCaseInsensitiveCompare(displayName(for: $1)) == .orderedAscending
+        }
+    }
+}
+
+/// One entry in the mic button's language menu.
+struct ACPDictationMenuItem: Equatable, Identifiable {
+    /// Empty string means the automatic choice.
+    let localeIdentifier: String
+    let title: String
+    let isSelected: Bool
+
+    var id: String { localeIdentifier }
+}

--- a/Alas/Sources/ACP/Dictation/ACPDictationService.swift
+++ b/Alas/Sources/ACP/Dictation/ACPDictationService.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Drives the composer's push-to-talk dictation button. Owns no audio or
+/// speech APIs itself — `engine` does the actual work — so this class is
+/// just the state machine: idle → preparing → listening, with `failed`
+/// surfacing engine errors and `unavailable` hiding the control entirely.
+@MainActor
+final class ACPDictationService: ObservableObject {
+    @Published private(set) var state: ACPDictationState
+
+    /// Fires for every transcript update while listening — volatile
+    /// updates (not yet final) may repeat as the utterance is corrected,
+    /// followed by exactly one final update per utterance.
+    var onTranscriptUpdate: ((_ text: String, _ isFinal: Bool) -> Void)?
+    /// Fires whenever listening ends, for any reason (manual stop or
+    /// engine failure) — used to stop tracking the in-progress dictation
+    /// span without touching already-committed text.
+    var onStop: (() -> Void)?
+    /// Fires with a human-readable warning that doesn't end dictation, so
+    /// the composer can surface it in its notice line.
+    var onNotice: ((String) -> Void)?
+
+    /// The user's explicit language choice. Empty means automatic.
+    var preferredLocaleIdentifier: String = ACPDictationLocaleFormatter.automaticIdentifier
+
+    private let engine: ACPDictationEngine
+
+    init(engine: ACPDictationEngine) {
+        self.engine = engine
+        self.state = engine.isAvailable ? .idle : .unavailable
+    }
+
+    /// Languages ready to transcribe without a model download.
+    func installedLocaleIdentifiers() async -> [String] {
+        await engine.installedLocaleIdentifiers()
+    }
+
+    func toggle() {
+        switch state {
+        case .idle, .failed:
+            start()
+        case .preparing, .listening:
+            stop()
+        case .unavailable:
+            break
+        }
+    }
+
+    func start() {
+        guard state == .idle || isFailed else { return }
+        state = .preparing
+        let preferred = preferredLocaleIdentifier.isEmpty ? nil : preferredLocaleIdentifier
+        engine.start(
+            preferredLocaleIdentifier: preferred,
+            callbacks: ACPDictationCallbacks(
+                onReady: { [weak self] in
+                    guard let self, self.state == .preparing else { return }
+                    self.state = .listening
+                },
+                onResult: { [weak self] text, isFinal in
+                    guard let self, self.state == .listening else { return }
+                    self.onTranscriptUpdate?(text, isFinal)
+                },
+                onFailure: { [weak self] message in
+                    guard let self else { return }
+                    self.state = .failed(message)
+                    self.onStop?()
+                },
+                onSilence: { [weak self] deviceName in
+                    guard let self, self.state == .listening else { return }
+                    self.onNotice?(Self.silenceMessage(deviceName: deviceName))
+                }
+            )
+        )
+    }
+
+    /// Wording for the "we're hearing nothing" warning. Naming the device
+    /// matters: the usual cause is a virtual input (conferencing or VR
+    /// software) sitting in front of the real microphone, and the fix is in
+    /// the Sound settings rather than in this app.
+    nonisolated static func silenceMessage(deviceName: String?) -> String {
+        guard let deviceName, !deviceName.isEmpty else {
+            return "No audio from the microphone. Check Sound settings."
+        }
+        return "No audio from “\(deviceName)”. Check Sound settings."
+    }
+
+    func stop() {
+        guard state == .preparing || state == .listening else { return }
+        engine.stop()
+        state = .idle
+        onStop?()
+    }
+
+    private var isFailed: Bool {
+        if case .failed = state { return true }
+        return false
+    }
+}

--- a/Alas/Sources/ACP/Dictation/ACPDictationState.swift
+++ b/Alas/Sources/ACP/Dictation/ACPDictationState.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Lifecycle of the composer's push-to-talk dictation control.
+///
+/// `.unavailable` means no speech-to-text engine exists for this OS/locale —
+/// the mic button isn't shown at all in that case. Every other case assumes
+/// the button is visible.
+enum ACPDictationState: Equatable {
+    case unavailable
+    case idle
+    case preparing
+    case listening
+    case failed(String)
+}

--- a/Alas/Sources/ACP/Dictation/ACPSpeechDictationEngine.swift
+++ b/Alas/Sources/ACP/Dictation/ACPSpeechDictationEngine.swift
@@ -222,9 +222,26 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
             let onReady = callbacks.onReady
             let onResult = callbacks.onResult
             let onFailure = callbacks.onFailure
+            // Cancelling `runTask` (see `stop()`) can't interrupt this
+            // function directly — it only takes effect at the next `await`
+            // that actually checks cancellation, and none of the calls
+            // below do. A stop requested before this task's first
+            // scheduling quantum — plausible on a fast double-toggle —
+            // would otherwise still prompt for microphone access for a
+            // session that's already over.
+            guard !stopped else { return }
             guard await Self.requestMicrophoneAccess() else {
                 throw DictationError.microphoneDenied
             }
+            // `withCheckedContinuation` (used by both permission requests
+            // below) has no cancellation support — cancelling `runTask`
+            // while this is in flight does nothing until the system's TCC
+            // callback actually fires. If the session was stopped while
+            // waiting on the mic prompt and mic access is then granted,
+            // this must not fall straight into requesting speech access
+            // too and presenting a second unwanted system prompt for a
+            // session that's already over.
+            guard !stopped else { return }
             guard await Self.requestSpeechAuthorization() else {
                 throw DictationError.speechDenied
             }

--- a/Alas/Sources/ACP/Dictation/ACPSpeechDictationEngine.swift
+++ b/Alas/Sources/ACP/Dictation/ACPSpeechDictationEngine.swift
@@ -3,26 +3,35 @@ import Foundation
 import Speech
 import os
 
-/// Counters updated on CoreAudio's realtime tap thread. `buffers` and
-/// `lastConvertedFrames` are logging-only and only ever touched from that
-/// one thread, so they're plain properties. `peak` is different: the
-/// main-actor silence watchdog reads it too, so writes and reads both go
-/// through `os_unfair_lock` — an uncontended, non-blocking-in-practice lock
+/// Counters updated on CoreAudio's realtime tap thread. `lastConvertedFrames`
+/// is only ever read from that same thread (a per-buffer log line), so it's
+/// a plain property. `buffers` and `peak` are different: the main-actor
+/// silence watchdog reads both — in its own log line and in the actual
+/// silence check — so every access to either goes through `os_unfair_lock`,
+/// taken once per buffer via `recordBuffer(peak:)` rather than once per
+/// field. `os_unfair_lock` is an uncontended, non-blocking-in-practice lock
 /// safe to take from a realtime thread, unlike a queue or `NSLock`. Without
-/// it this would be a real data race (the compiler's `@unchecked Sendable`
+/// it these would be real data races (the compiler's `@unchecked Sendable`
 /// only suppresses the warning; it doesn't provide synchronization), and
-/// the watchdog could read a stale value and report silence over live audio.
+/// the watchdog could read stale values and report silence over live audio.
 private final class ACPDictationTapStats: @unchecked Sendable {
-    var buffers = 0
     var lastConvertedFrames: AVAudioFrameCount = 0
 
     private var lock = os_unfair_lock_s()
+    private var _buffers = 0
     private var _peak: Float = 0
 
-    func recordPeak(_ value: Float) {
+    func recordBuffer(peak: Float) {
         os_unfair_lock_lock(&lock)
-        _peak = max(_peak, value)
+        _buffers += 1
+        _peak = max(_peak, peak)
         os_unfair_lock_unlock(&lock)
+    }
+
+    var buffers: Int {
+        os_unfair_lock_lock(&lock)
+        defer { os_unfair_lock_unlock(&lock) }
+        return _buffers
     }
 
     var peak: Float {
@@ -119,7 +128,7 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
                 callbacks.onSilence(deviceName)
             }
         )
-        Task {
+        session.runTask = Task {
             await session.run(preferredLocaleIdentifier: preferredLocaleIdentifier, callbacks: wrapped)
         }
     }
@@ -170,6 +179,11 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
         private var inputContinuation: AsyncStream<AnalyzerInput>.Continuation?
         private var resultsTask: Task<Void, Never>?
         private var silenceTask: Task<Void, Never>?
+        /// The task running `run(preferredLocaleIdentifier:callbacks:)`,
+        /// cancelled by `stop()` so a stop requested mid-setup doesn't
+        /// leave, say, a speech-model download running unattended in the
+        /// background after the user asked to cancel.
+        var runTask: Task<Void, Never>?
         /// Set by `stop()`. Checked after every `await` in `start()` so a
         /// stop requested mid-setup (permission prompts, model download)
         /// aborts cleanly instead of spinning up an engine nobody wants
@@ -181,7 +195,15 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
             do {
                 try await start(preferredLocaleIdentifier: preferredLocaleIdentifier, callbacks: callbacks)
             } catch {
+                // A stop-triggered cancellation surfaces here as a thrown
+                // `CancellationError` (or any error a cancelled `await`
+                // happened to raise) — `stopped` is already true by the
+                // time it's caught, since `stop()` sets it before
+                // cancelling this task. Reporting that as onFailure would
+                // show a spurious error notice after a deliberate stop.
+                let wasAlreadyStopped = stopped
                 stop()
+                guard !wasAlreadyStopped else { return }
                 callbacks.onFailure(Self.userMessage(for: error))
             }
         }
@@ -250,23 +272,22 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
             // `continuation.yield` is safe to call from any thread.
             let stats = ACPDictationTapStats()
             audioEngine.inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { buffer, _ in
-                stats.buffers += 1
                 // A multichannel USB/aggregate input may carry the active
                 // microphone on any channel, not just 0 — checking only
                 // channel 0 would report silence (and eventually the false
                 // "no audio" warning) while a working mic was plugged into
                 // a different channel.
+                var bufferPeak: Float = 0
                 if let channelData = buffer.floatChannelData {
                     let frameCount = Int(buffer.frameLength)
-                    var bufferPeak: Float = 0
                     for c in 0..<Int(buffer.format.channelCount) {
                         let channel = channelData[c]
                         for i in 0..<frameCount { bufferPeak = max(bufferPeak, abs(channel[i])) }
                     }
-                    // One lock acquisition per buffer, not per sample —
-                    // this runs on a realtime thread every ~85ms.
-                    stats.recordPeak(bufferPeak)
                 }
+                // One lock acquisition per buffer, not per sample or per
+                // field — this runs on a realtime thread every ~85ms.
+                stats.recordBuffer(peak: bufferPeak)
                 guard let converted = Self.convert(buffer, using: converter, to: analyzerFormat) else {
                     Self.logger.error("convert returned nil for buffer \(stats.buffers)")
                     return
@@ -342,6 +363,15 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
         func stop() {
             Self.logger.info("stop requested (engine running=\(self.audioEngine?.isRunning ?? false))")
             stopped = true
+            // Cancels whatever `start()` is currently awaiting — permission
+            // prompts, and notably `AssetInstallationRequest.downloadAndInstall()`,
+            // which would otherwise keep fetching an unwanted speech model
+            // in the background after the user asked to stop. The `guard
+            // !stopped` checkpoints in `start()` only run on normal return
+            // from an await; a cancelled await instead throws, which
+            // `run()`'s catch handles.
+            runTask?.cancel()
+            runTask = nil
             audioEngine?.inputNode.removeTap(onBus: 0)
             audioEngine?.stop()
             audioEngine = nil

--- a/Alas/Sources/ACP/Dictation/ACPSpeechDictationEngine.swift
+++ b/Alas/Sources/ACP/Dictation/ACPSpeechDictationEngine.swift
@@ -40,6 +40,17 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
         return await DictationTranscriber.installedLocales.map(\.identifier)
     }
 
+    /// True when `format` is a real, capturable hardware format. A Mac with
+    /// no active input device — no built-in mic, external input
+    /// disconnected mid-session — reports a degenerate (zero-rate or
+    /// zero-channel) format on the input node. Installing a tap with that
+    /// format hits an `AVAudioEngine` precondition and crashes the process
+    /// rather than throwing a catchable error, so callers must check this
+    /// first and fail through `onFailure` instead.
+    nonisolated static func isUsableInputFormat(_ format: AVAudioFormat) -> Bool {
+        format.sampleRate > 0 && format.channelCount > 0
+    }
+
     /// Every language the engine can transcribe, including ones whose
     /// assets still need downloading. Used by Settings, which offers the
     /// full list; the mic menu sticks to installed ones.
@@ -58,8 +69,15 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
         let wrapped = ACPDictationCallbacks(
             onReady: callbacks.onReady,
             onResult: callbacks.onResult,
-            onFailure: { [weak self] message in
-                self?.session = nil
+            onFailure: { [weak self, weak session] message in
+                // A failure that resolves after a newer session has already
+                // replaced this one (e.g. this session was mid-permission-
+                // prompt or mid-download when stopped, and a fresh one was
+                // started before the throw actually landed) must not clear
+                // that newer session or report its own failure as the
+                // current state.
+                guard let self, let session, self.session as? Session === session else { return }
+                self.session = nil
                 callbacks.onFailure(message)
             },
             onSilence: callbacks.onSilence
@@ -179,8 +197,13 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
             let audioEngine = AVAudioEngine()
             self.audioEngine = audioEngine
             let inputFormat = audioEngine.inputNode.outputFormat(forBus: 0)
-            let converter = AVAudioConverter(from: inputFormat, to: analyzerFormat)
-            Self.logger.info("formats: input=\(inputFormat) analyzer=\(analyzerFormat) converter=\(converter != nil)")
+            guard ACPSpeechDictationEngine.isUsableInputFormat(inputFormat) else {
+                throw DictationError.noInputDevice
+            }
+            guard let converter = AVAudioConverter(from: inputFormat, to: analyzerFormat) else {
+                throw DictationError.noCompatibleAudioFormat
+            }
+            Self.logger.info("formats: input=\(inputFormat) analyzer=\(analyzerFormat)")
 
             let (stream, continuation) = AsyncStream.makeStream(of: AnalyzerInput.self)
             inputContinuation = continuation
@@ -367,6 +390,7 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
             case speechDenied
             case localeUnsupported
             case noCompatibleAudioFormat
+            case noInputDevice
 
             var message: String {
                 switch self {
@@ -374,6 +398,7 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
                 case .speechDenied: return "Speech recognition access denied"
                 case .localeUnsupported: return "Dictation isn't supported for this language"
                 case .noCompatibleAudioFormat: return "No compatible audio format found"
+                case .noInputDevice: return "No microphone is available"
                 }
             }
         }

--- a/Alas/Sources/ACP/Dictation/ACPSpeechDictationEngine.swift
+++ b/Alas/Sources/ACP/Dictation/ACPSpeechDictationEngine.swift
@@ -1,0 +1,381 @@
+@preconcurrency import AVFoundation
+import Foundation
+import Speech
+import os
+
+/// Counters updated on CoreAudio's realtime thread and reported through
+/// the log; never read for control flow.
+private final class ACPDictationTapStats: @unchecked Sendable {
+    var buffers = 0
+    var peak: Float = 0
+    var lastConvertedFrames: AVAudioFrameCount = 0
+}
+
+/// Concrete `ACPDictationEngine` backed by macOS 26's on-device
+/// `SpeechAnalyzer` / `DictationTranscriber` pipeline: captures microphone
+/// audio via `AVAudioEngine`, converts it to the transcriber's preferred
+/// format, and streams results back through the `ACPDictationEngine`
+/// callbacks.
+///
+/// Below macOS 26, `isAvailable` is false and `ACPDictationService` never
+/// calls `start` (the composer hides the mic button entirely in that
+/// case), but `start` still reports failure defensively if it ever is.
+///
+/// All macOS-26-only state lives in the nested `Session` type so this
+/// class itself stays instantiable on every OS version the app supports.
+@MainActor
+final class ACPSpeechDictationEngine: ACPDictationEngine {
+    var isAvailable: Bool {
+        if #available(macOS 26.0, *) {
+            return true
+        }
+        return false
+    }
+
+    /// Type-erased because `Session` only exists on macOS 26+.
+    private var session: Any?
+
+    func installedLocaleIdentifiers() async -> [String] {
+        guard #available(macOS 26.0, *) else { return [] }
+        return await DictationTranscriber.installedLocales.map(\.identifier)
+    }
+
+    /// Every language the engine can transcribe, including ones whose
+    /// assets still need downloading. Used by Settings, which offers the
+    /// full list; the mic menu sticks to installed ones.
+    static func supportedLocaleIdentifiers() async -> [String] {
+        guard #available(macOS 26.0, *) else { return [] }
+        return await DictationTranscriber.supportedLocales.map(\.identifier)
+    }
+
+    func start(preferredLocaleIdentifier: String?, callbacks: ACPDictationCallbacks) {
+        guard #available(macOS 26.0, *) else {
+            callbacks.onFailure("Dictation requires macOS 26 or later.")
+            return
+        }
+        let session = Session()
+        self.session = session
+        let wrapped = ACPDictationCallbacks(
+            onReady: callbacks.onReady,
+            onResult: callbacks.onResult,
+            onFailure: { [weak self] message in
+                self?.session = nil
+                callbacks.onFailure(message)
+            },
+            onSilence: callbacks.onSilence
+        )
+        Task {
+            await session.run(preferredLocaleIdentifier: preferredLocaleIdentifier, callbacks: wrapped)
+        }
+    }
+
+    func stop() {
+        if #available(macOS 26.0, *), let session = session as? Session {
+            session.stop()
+        }
+        session = nil
+    }
+
+    /// Locales to try, in order, when picking the transcriber's language:
+    /// the app's effective locale first, then the user's preferred
+    /// languages, then `en_US` as a last resort. Identifiers are
+    /// normalized to underscore form and de-duplicated.
+    ///
+    /// `Locale.current` inside this (English-only) bundle is not the
+    /// system locale — macOS combines the bundle's best-matching
+    /// localization with the user's region, so a Spanish-system user gets
+    /// `en_ES`, which the transcriber rejects outright. Each candidate is
+    /// therefore resolved through `supportedLocale(equivalentTo:)`
+    /// (`en_ES` → `en_US`) rather than matched exactly.
+    /// `explicit` is the user's chosen language, which leads the chain when
+    /// set. It's a candidate rather than an override so an unsupported
+    /// choice degrades to automatic detection instead of failing outright.
+    nonisolated static func localeCandidates(
+        explicit: String? = nil,
+        current: Locale,
+        preferredLanguages: [String]
+    ) -> [Locale] {
+        var seen = Set<String>()
+        var result: [Locale] = []
+        let leading = (explicit?.isEmpty == false) ? [explicit!] : []
+        let raw = leading + [current.identifier] + preferredLanguages + ["en_US"]
+        for identifier in raw {
+            let normalized = identifier.replacingOccurrences(of: "-", with: "_")
+            guard seen.insert(normalized).inserted else { continue }
+            result.append(Locale(identifier: normalized))
+        }
+        return result
+    }
+
+    @available(macOS 26.0, *)
+    @MainActor
+    private final class Session {
+        private var audioEngine: AVAudioEngine?
+        private var analyzer: SpeechAnalyzer?
+        private var inputContinuation: AsyncStream<AnalyzerInput>.Continuation?
+        private var resultsTask: Task<Void, Never>?
+        private var silenceTask: Task<Void, Never>?
+        /// Set by `stop()`. Checked after every `await` in `start()` so a
+        /// stop requested mid-setup (permission prompts, model download)
+        /// aborts cleanly instead of spinning up an engine nobody wants
+        /// anymore.
+        private var stopped = false
+        nonisolated private static let logger = Logger(subsystem: "io.nlopez.alas", category: "dictation")
+
+        func run(preferredLocaleIdentifier: String?, callbacks: ACPDictationCallbacks) async {
+            do {
+                try await start(preferredLocaleIdentifier: preferredLocaleIdentifier, callbacks: callbacks)
+            } catch {
+                stop()
+                callbacks.onFailure(Self.userMessage(for: error))
+            }
+        }
+
+        private func start(
+            preferredLocaleIdentifier: String?,
+            callbacks: ACPDictationCallbacks
+        ) async throws {
+            let onReady = callbacks.onReady
+            let onResult = callbacks.onResult
+            let onFailure = callbacks.onFailure
+            guard await Self.requestMicrophoneAccess() else {
+                throw DictationError.microphoneDenied
+            }
+            guard await Self.requestSpeechAuthorization() else {
+                throw DictationError.speechDenied
+            }
+            Self.logger.info("auth ok: mic=\(AVCaptureDevice.authorizationStatus(for: .audio).rawValue) speech=\(SFSpeechRecognizer.authorizationStatus().rawValue)")
+            guard !stopped else { return }
+
+            guard let locale = await Self.resolveLocale(explicit: preferredLocaleIdentifier) else {
+                throw DictationError.localeUnsupported
+            }
+            Self.logger.info("locale resolved: \(locale.identifier)")
+            let transcriber = DictationTranscriber(
+                locale: locale,
+                contentHints: [.shortForm],
+                transcriptionOptions: [.punctuation],
+                reportingOptions: [.volatileResults],
+                attributeOptions: []
+            )
+
+            guard await AssetInventory.status(forModules: [transcriber]) != .unsupported else {
+                throw DictationError.localeUnsupported
+            }
+            if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
+                try await request.downloadAndInstall()
+            }
+            guard !stopped else { return }
+
+            guard let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber])
+            else {
+                throw DictationError.noCompatibleAudioFormat
+            }
+            guard !stopped else { return }
+
+            let analyzer = SpeechAnalyzer(modules: [transcriber])
+            self.analyzer = analyzer
+
+            let audioEngine = AVAudioEngine()
+            self.audioEngine = audioEngine
+            let inputFormat = audioEngine.inputNode.outputFormat(forBus: 0)
+            let converter = AVAudioConverter(from: inputFormat, to: analyzerFormat)
+            Self.logger.info("formats: input=\(inputFormat) analyzer=\(analyzerFormat) converter=\(converter != nil)")
+
+            let (stream, continuation) = AsyncStream.makeStream(of: AnalyzerInput.self)
+            inputContinuation = continuation
+
+            // Runs on CoreAudio's realtime render thread, not the main
+            // actor — `convert` is a `nonisolated` pure function and
+            // `continuation.yield` is safe to call from any thread.
+            let stats = ACPDictationTapStats()
+            audioEngine.inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { buffer, _ in
+                stats.buffers += 1
+                if let channel = buffer.floatChannelData?[0] {
+                    for i in 0..<Int(buffer.frameLength) { stats.peak = max(stats.peak, abs(channel[i])) }
+                }
+                guard let converted = Self.convert(buffer, using: converter, to: analyzerFormat) else {
+                    Self.logger.error("convert returned nil for buffer \(stats.buffers)")
+                    return
+                }
+                stats.lastConvertedFrames = converted.frameLength
+                if stats.buffers % 50 == 0 {
+                    Self.logger.info("tap: buffers=\(stats.buffers) peak=\(stats.peak) convertedFrames=\(stats.lastConvertedFrames)")
+                }
+                continuation.yield(AnalyzerInput(buffer: converted))
+            }
+
+            audioEngine.prepare()
+            try audioEngine.start()
+            guard !stopped else {
+                stop()
+                return
+            }
+
+            resultsTask = Task { [weak self] in
+                do {
+                    var count = 0
+                    for try await result in transcriber.results {
+                        count += 1
+                        let text = String(result.text.characters)
+                        Self.logger.info("result #\(count) final=\(result.isFinal) chars=\(text.count)")
+                        onResult(text, result.isFinal)
+                    }
+                    Self.logger.info("results stream ended after \(count) results")
+                } catch {
+                    Self.logger.error("results stream threw: \(String(describing: error))")
+                    self?.stop()
+                    onFailure(Self.userMessage(for: error))
+                }
+            }
+
+            try await analyzer.start(inputSequence: stream)
+            Self.logger.info("analyzer started; engine running=\(audioEngine.isRunning)")
+            startSilenceWatchdog(stats: stats, onSilence: callbacks.onSilence)
+            onReady()
+        }
+
+        /// Amplitude at or below this counts as digital silence. Real
+        /// microphones always carry some noise floor, so anything this
+        /// quiet means no signal is reaching us at all.
+        private static let silenceThreshold: Float = 1e-5
+        /// How long to listen before concluding the input is dead. Long
+        /// enough that a slow starter isn't nagged, short enough to save
+        /// the user from talking into the void.
+        private static let silenceGraceSeconds: UInt64 = 4
+
+        /// Warns once if every sample in the opening seconds was silence.
+        /// Deliberately does not stop dictation: the user may simply not
+        /// have started talking yet, and a wrong guess shouldn't cost them
+        /// their session.
+        private func startSilenceWatchdog(
+            stats: ACPDictationTapStats,
+            onSilence: @escaping (String?) -> Void
+        ) {
+            silenceTask = Task { [weak self] in
+                try? await Task.sleep(nanoseconds: Self.silenceGraceSeconds * 1_000_000_000)
+                guard let self, !Task.isCancelled, !self.stopped else { return }
+                guard stats.peak <= Self.silenceThreshold else { return }
+                let deviceName = AVCaptureDevice.default(for: .audio)?.localizedName
+                Self.logger.error("silent input after \(Self.silenceGraceSeconds)s: device=\(deviceName ?? "unknown") buffers=\(stats.buffers)")
+                onSilence(deviceName)
+            }
+        }
+
+        /// Tears down the tap, engine, and analyzer immediately. Whatever
+        /// transcript was already applied to the composer (the last
+        /// volatile update) stays in place as plain, editable text — this
+        /// does not wait for a trailing final result.
+        func stop() {
+            Self.logger.info("stop requested (engine running=\(self.audioEngine?.isRunning ?? false))")
+            stopped = true
+            audioEngine?.inputNode.removeTap(onBus: 0)
+            audioEngine?.stop()
+            audioEngine = nil
+            inputContinuation?.finish()
+            inputContinuation = nil
+            resultsTask?.cancel()
+            resultsTask = nil
+            silenceTask?.cancel()
+            silenceTask = nil
+            let analyzer = analyzer
+            self.analyzer = nil
+            Task { await analyzer?.cancelAndFinishNow() }
+        }
+
+        /// Converts one buffer through `converter` to `format`. Not
+        /// actor-isolated: called directly from the audio tap's realtime
+        /// thread, which cannot `await` a hop to the main actor.
+        nonisolated private static func convert(
+            _ buffer: AVAudioPCMBuffer,
+            using converter: AVAudioConverter?,
+            to format: AVAudioFormat
+        ) -> AVAudioPCMBuffer? {
+            guard let converter else { return nil }
+            let ratio = converter.outputFormat.sampleRate / converter.inputFormat.sampleRate
+            let capacity = AVAudioFrameCount((Double(buffer.frameLength) * ratio).rounded(.up)) + 16
+            guard let output = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: capacity) else { return nil }
+            // The input block below runs synchronously, once, inline within
+            // this call to `convert` (never concurrently) — `AVAudioConverter`
+            // just types the block `@Sendable` because it COULD in principle
+            // call back on another thread for other conversion shapes.
+            nonisolated(unsafe) var suppliedInput = false
+            var conversionError: NSError?
+            let status = converter.convert(to: output, error: &conversionError) { _, inputStatus in
+                if suppliedInput {
+                    inputStatus.pointee = .noDataNow
+                    return nil
+                }
+                suppliedInput = true
+                inputStatus.pointee = .haveData
+                return buffer
+            }
+            guard status != .error, conversionError == nil else { return nil }
+            return output
+        }
+
+        /// First candidate from `localeCandidates` that the transcriber
+        /// can serve, mapped to its exact supported form.
+        private static func resolveLocale(explicit: String?) async -> Locale? {
+            let candidates = ACPSpeechDictationEngine.localeCandidates(
+                explicit: explicit,
+                current: Locale.current,
+                preferredLanguages: Locale.preferredLanguages
+            )
+            for candidate in candidates {
+                if let match = await DictationTranscriber.supportedLocale(equivalentTo: candidate) {
+                    return match
+                }
+            }
+            return nil
+        }
+
+        private static func requestMicrophoneAccess() async -> Bool {
+            switch AVCaptureDevice.authorizationStatus(for: .audio) {
+            case .authorized:
+                return true
+            case .notDetermined:
+                return await withCheckedContinuation { continuation in
+                    AVCaptureDevice.requestAccess(for: .audio) { granted in
+                        continuation.resume(returning: granted)
+                    }
+                }
+            case .denied, .restricted:
+                return false
+            @unknown default:
+                return false
+            }
+        }
+
+        private static func requestSpeechAuthorization() async -> Bool {
+            if SFSpeechRecognizer.authorizationStatus() == .authorized {
+                return true
+            }
+            return await withCheckedContinuation { continuation in
+                SFSpeechRecognizer.requestAuthorization { status in
+                    continuation.resume(returning: status == .authorized)
+                }
+            }
+        }
+
+        private static func userMessage(for error: Error) -> String {
+            (error as? DictationError)?.message ?? "Dictation failed to start."
+        }
+
+        private enum DictationError: Error {
+            case microphoneDenied
+            case speechDenied
+            case localeUnsupported
+            case noCompatibleAudioFormat
+
+            var message: String {
+                switch self {
+                case .microphoneDenied: return "Microphone access denied"
+                case .speechDenied: return "Speech recognition access denied"
+                case .localeUnsupported: return "Dictation isn't supported for this language"
+                case .noCompatibleAudioFormat: return "No compatible audio format found"
+                }
+            }
+        }
+    }
+}

--- a/Alas/Sources/ACP/Dictation/ACPSpeechDictationEngine.swift
+++ b/Alas/Sources/ACP/Dictation/ACPSpeechDictationEngine.swift
@@ -66,21 +66,37 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
         }
         let session = Session()
         self.session = session
+        // Every callback must check it's still hearing from the session
+        // `self.session` currently points to. A session can keep running
+        // asynchronously (mid-permission-prompt, mid-download, or a
+        // straggling result) after being superseded by a fresh one — e.g.
+        // stop() followed immediately by start() — and an unscoped callback
+        // would let the stale session mark the new one ready, splice its
+        // transcript into the new one's, or report its own failure as the
+        // current state.
+        //
+        // All four closures capture `self` and `session` weakly: they're
+        // held by `session` for as long as it runs, so a strong capture of
+        // either would keep this engine (and every session it ever
+        // started) alive until the app quits.
         let wrapped = ACPDictationCallbacks(
-            onReady: callbacks.onReady,
-            onResult: callbacks.onResult,
+            onReady: { [weak self, weak session] in
+                guard let self, let session, self.session as? Session === session else { return }
+                callbacks.onReady()
+            },
+            onResult: { [weak self, weak session] text, isFinal in
+                guard let self, let session, self.session as? Session === session else { return }
+                callbacks.onResult(text, isFinal)
+            },
             onFailure: { [weak self, weak session] message in
-                // A failure that resolves after a newer session has already
-                // replaced this one (e.g. this session was mid-permission-
-                // prompt or mid-download when stopped, and a fresh one was
-                // started before the throw actually landed) must not clear
-                // that newer session or report its own failure as the
-                // current state.
                 guard let self, let session, self.session as? Session === session else { return }
                 self.session = nil
                 callbacks.onFailure(message)
             },
-            onSilence: callbacks.onSilence
+            onSilence: { [weak self, weak session] deviceName in
+                guard let self, let session, self.session as? Session === session else { return }
+                callbacks.onSilence(deviceName)
+            }
         )
         Task {
             await session.run(preferredLocaleIdentifier: preferredLocaleIdentifier, callbacks: wrapped)
@@ -214,8 +230,17 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
             let stats = ACPDictationTapStats()
             audioEngine.inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { buffer, _ in
                 stats.buffers += 1
-                if let channel = buffer.floatChannelData?[0] {
-                    for i in 0..<Int(buffer.frameLength) { stats.peak = max(stats.peak, abs(channel[i])) }
+                // A multichannel USB/aggregate input may carry the active
+                // microphone on any channel, not just 0 — checking only
+                // channel 0 would report silence (and eventually the false
+                // "no audio" warning) while a working mic was plugged into
+                // a different channel.
+                if let channelData = buffer.floatChannelData {
+                    let frameCount = Int(buffer.frameLength)
+                    for c in 0..<Int(buffer.format.channelCount) {
+                        let channel = channelData[c]
+                        for i in 0..<frameCount { stats.peak = max(stats.peak, abs(channel[i])) }
+                    }
                 }
                 guard let converted = Self.convert(buffer, using: converter, to: analyzerFormat) else {
                     Self.logger.error("convert returned nil for buffer \(stats.buffers)")

--- a/Alas/Sources/ACP/Dictation/ACPSpeechDictationEngine.swift
+++ b/Alas/Sources/ACP/Dictation/ACPSpeechDictationEngine.swift
@@ -3,12 +3,33 @@ import Foundation
 import Speech
 import os
 
-/// Counters updated on CoreAudio's realtime thread and reported through
-/// the log; never read for control flow.
+/// Counters updated on CoreAudio's realtime tap thread. `buffers` and
+/// `lastConvertedFrames` are logging-only and only ever touched from that
+/// one thread, so they're plain properties. `peak` is different: the
+/// main-actor silence watchdog reads it too, so writes and reads both go
+/// through `os_unfair_lock` — an uncontended, non-blocking-in-practice lock
+/// safe to take from a realtime thread, unlike a queue or `NSLock`. Without
+/// it this would be a real data race (the compiler's `@unchecked Sendable`
+/// only suppresses the warning; it doesn't provide synchronization), and
+/// the watchdog could read a stale value and report silence over live audio.
 private final class ACPDictationTapStats: @unchecked Sendable {
     var buffers = 0
-    var peak: Float = 0
     var lastConvertedFrames: AVAudioFrameCount = 0
+
+    private var lock = os_unfair_lock_s()
+    private var _peak: Float = 0
+
+    func recordPeak(_ value: Float) {
+        os_unfair_lock_lock(&lock)
+        _peak = max(_peak, value)
+        os_unfair_lock_unlock(&lock)
+    }
+
+    var peak: Float {
+        os_unfair_lock_lock(&lock)
+        defer { os_unfair_lock_unlock(&lock) }
+        return _peak
+    }
 }
 
 /// Concrete `ACPDictationEngine` backed by macOS 26's on-device
@@ -237,10 +258,14 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
                 // a different channel.
                 if let channelData = buffer.floatChannelData {
                     let frameCount = Int(buffer.frameLength)
+                    var bufferPeak: Float = 0
                     for c in 0..<Int(buffer.format.channelCount) {
                         let channel = channelData[c]
-                        for i in 0..<frameCount { stats.peak = max(stats.peak, abs(channel[i])) }
+                        for i in 0..<frameCount { bufferPeak = max(bufferPeak, abs(channel[i])) }
                     }
+                    // One lock acquisition per buffer, not per sample —
+                    // this runs on a realtime thread every ~85ms.
+                    stats.recordPeak(bufferPeak)
                 }
                 guard let converted = Self.convert(buffer, using: converter, to: analyzerFormat) else {
                     Self.logger.error("convert returned nil for buffer \(stats.buffers)")

--- a/Alas/Sources/ACP/Dictation/ACPSpeechDictationEngine.swift
+++ b/Alas/Sources/ACP/Dictation/ACPSpeechDictationEngine.swift
@@ -189,6 +189,13 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
         /// aborts cleanly instead of spinning up an engine nobody wants
         /// anymore.
         private var stopped = false
+        /// `removeTap(onBus:)` hits an `AVAudioNode` precondition (a crash,
+        /// not a catchable error) if no tap was ever installed on that bus.
+        /// `audioEngine` is assigned before the format/converter checks
+        /// that can throw ahead of `installTap`, so `stop()` — reached via
+        /// `run()`'s catch on exactly that throw — needs to know whether
+        /// installation actually happened before it tries to remove one.
+        private var tapInstalled = false
         nonisolated private static let logger = Logger(subsystem: "io.nlopez.alas", category: "dictation")
 
         func run(preferredLocaleIdentifier: String?, callbacks: ACPDictationCallbacks) async {
@@ -298,6 +305,7 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
                 }
                 continuation.yield(AnalyzerInput(buffer: converted))
             }
+            tapInstalled = true
 
             audioEngine.prepare()
             try audioEngine.start()
@@ -372,7 +380,10 @@ final class ACPSpeechDictationEngine: ACPDictationEngine {
             // `run()`'s catch handles.
             runTask?.cancel()
             runTask = nil
-            audioEngine?.inputNode.removeTap(onBus: 0)
+            if tapInstalled {
+                audioEngine?.inputNode.removeTap(onBus: 0)
+                tapInstalled = false
+            }
             audioEngine?.stop()
             audioEngine = nil
             inputContinuation?.finish()

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -675,6 +675,17 @@ final class ACPNSTextView: PairedDelimiterTextView {
         super.didChangeText()
         // Trigger placeholder redraw when text becomes (non-)empty.
         needsDisplay = true
+        // A dictation span's tracked range is only valid until the next
+        // edit — typing elsewhere, pasting, or any other change shifts
+        // offsets without updating it. `replaceDictationRegion` itself
+        // sets `isApplyingDictationUpdate` around its own edit so this
+        // doesn't invalidate the span it just wrote; anything else means
+        // a manual edit landed while a span was open, so the next
+        // transcript update must start fresh rather than replace
+        // characters that moved.
+        if dictationRange != nil, !isApplyingDictationUpdate {
+            dictationRange = nil
+        }
     }
 
     /// A restored draft can already contain an active "/" token before
@@ -727,6 +738,11 @@ final class ACPNSTextView: PairedDelimiterTextView {
                     return
                 }
             case 53:                                    // escape
+                // Harmless no-op when dictation isn't active. Without this,
+                // Esc while the slash panel is open returns here before
+                // `doCommandBy:`'s cancelOperation handling ever runs,
+                // silently skipping the same stop that bare Esc performs.
+                coordinator?.onStopDictation()
                 closeSlashPanel()
                 return
             default: break
@@ -1114,6 +1130,9 @@ final class ACPNSTextView: PairedDelimiterTextView {
     /// (the next volatile update then starts a fresh span after the
     /// committed text) or once dictation stops.
     private var dictationRange: NSRange?
+    /// Set around `replaceDictationRegion`'s own edit so `didChangeText()`
+    /// doesn't mistake it for the manual edit that invalidates the span.
+    private var isApplyingDictationUpdate = false
 
     /// Inserts or replaces the live dictation transcript. Volatile
     /// updates (`isFinal == false`) replace the previous volatile span in
@@ -1135,9 +1154,11 @@ final class ACPNSTextView: PairedDelimiterTextView {
         }
         let attrs = baseTypingAttributes
         typingAttributes = attrs
+        isApplyingDictationUpdate = true
         performNativeTextInsertion {
             insertText(text, replacementRange: target)
         }
+        isApplyingDictationUpdate = false
         typingAttributes = attrs
         let inserted = NSRange(location: target.location, length: (text as NSString).length)
         if isFinal {

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -675,16 +675,24 @@ final class ACPNSTextView: PairedDelimiterTextView {
         super.didChangeText()
         // Trigger placeholder redraw when text becomes (non-)empty.
         needsDisplay = true
-        // A dictation span's tracked range is only valid until the next
-        // edit — typing elsewhere, pasting, or any other change shifts
-        // offsets without updating it. `replaceDictationRegion` itself
-        // sets `isApplyingDictationUpdate` around its own edit so this
-        // doesn't invalidate the span it just wrote; anything else means
-        // a manual edit landed while a span was open, so the next
-        // transcript update must start fresh rather than replace
-        // characters that moved.
+        // A manual edit while a dictation span is open (typing elsewhere,
+        // pasting) leaves the underlying speech session mid-utterance —
+        // it keeps analyzing and will emit more corrections for that same
+        // utterance, unaware the user just took over. Untracking the span
+        // alone stops those corrections from overwriting the wrong
+        // characters, but not from landing at all: the analyzer's next
+        // "corrected" hypothesis would still be inserted as a fresh span,
+        // duplicating whatever partial text it already committed. Stopping
+        // dictation outright is what actually prevents that — the partial
+        // transcript already applied stays as ordinary editable text, and
+        // nothing more arrives to duplicate it.
+        //
+        // `replaceDictationRegion` sets `isApplyingDictationUpdate` around
+        // its own edit so this doesn't fire in response to dictation's own
+        // writes.
         if dictationRange != nil, !isApplyingDictationUpdate {
             dictationRange = nil
+            coordinator?.onStopDictation()
         }
     }
 

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -28,6 +28,10 @@ struct ACPInputField: NSViewRepresentable {
     let onDraftChange: (ACPComposerDraft) -> Void
     /// Clears the persisted draft after an accepted submission.
     let onDraftClear: () -> Void
+    /// Stops the composer's dictation session (if one is active) without
+    /// touching committed text — called when Esc is pressed or the
+    /// composer is torn down (tab switch, window close).
+    let onStopDictation: () -> Void
     /// Returns `true` when the host accepted the submission (and the
     /// textview should be cleared) or `false` to keep the draft in
     /// place (e.g. session not ready, prompt already in flight).
@@ -67,6 +71,14 @@ struct ACPInputField: NSViewRepresentable {
         actions.presentImagePicker = { [weak coord] in
             guard let coord, let tv = coord.textView as? ACPNSTextView else { return }
             tv.presentImagePicker()
+        }
+        actions.applyDictationTranscript = { [weak coord] text, isFinal in
+            guard let coord, let tv = coord.textView as? ACPNSTextView else { return }
+            tv.replaceDictationRegion(text, isFinal: isFinal)
+        }
+        actions.cancelDictationRegion = { [weak coord] in
+            guard let coord, let tv = coord.textView as? ACPNSTextView else { return }
+            tv.cancelDictationRegion()
         }
         actions.insertQuote = { [weak coord] message in
             guard let coord, let textView = coord.textView else { return }
@@ -121,6 +133,7 @@ struct ACPInputField: NSViewRepresentable {
     static func dismantleNSView(_ nsView: NSScrollView, coordinator: Coordinator) {
         coordinator.isFocused.wrappedValue = false
         coordinator.flushPendingRestyleNow()
+        coordinator.onStopDictation()
         if let tv = nsView.documentView as? ACPNSTextView {
             coordinator.dropRouter.detach(tv)
             tv.dismissFloatingPanels()
@@ -153,6 +166,7 @@ struct ACPInputField: NSViewRepresentable {
             typography: typography,
             onDraftChange: onDraftChange,
             onDraftClear: onDraftClear,
+            onStopDictation: onStopDictation,
             onSubmit: onSubmit,
             filesProvider: filesProvider,
             dropRouter: dropRouter
@@ -176,6 +190,7 @@ struct ACPInputField: NSViewRepresentable {
         var typography: ACPChatTypography
         let onDraftChange: (ACPComposerDraft) -> Void
         let onDraftClear: () -> Void
+        let onStopDictation: () -> Void
         let onSubmit: ACPComposerSubmitHandler
         let filesProvider: (@Sendable () async -> [URL])?
         let dropRouter: ACPComposerDropRouter
@@ -220,6 +235,7 @@ struct ACPInputField: NSViewRepresentable {
             typography: ACPChatTypography = .default,
             onDraftChange: @escaping (ACPComposerDraft) -> Void,
             onDraftClear: @escaping () -> Void,
+            onStopDictation: @escaping () -> Void = {},
             onSubmit: @escaping ACPComposerSubmitHandler,
             filesProvider: (@Sendable () async -> [URL])? = nil,
             dropRouter: ACPComposerDropRouter = ACPComposerDropRouter()
@@ -233,6 +249,7 @@ struct ACPInputField: NSViewRepresentable {
             self.lastSyncedDraft = initialDraft
             self.onDraftChange = onDraftChange
             self.onDraftClear = onDraftClear
+            self.onStopDictation = onStopDictation
             self.onSubmit = onSubmit
             self.filesProvider = filesProvider
             self.dropRouter = dropRouter
@@ -255,11 +272,13 @@ struct ACPInputField: NSViewRepresentable {
             // routes Esc through `cancelOperation:` after the input
             // method system gets a crack at it. If the panel is still
             // open here, close it and swallow the event.
-            if selector == #selector(NSResponder.cancelOperation(_:)),
-               let tv = textView as? ACPNSTextView,
-               tv.isSlashPanelOpen {
-                tv.dismissSlashPanel()
-                return true
+            if selector == #selector(NSResponder.cancelOperation(_:)) {
+                // Harmless no-op when dictation isn't active.
+                onStopDictation()
+                if let tv = textView as? ACPNSTextView, tv.isSlashPanelOpen {
+                    tv.dismissSlashPanel()
+                    return true
+                }
             }
             // ⌥⏎ steers. AppKit's standard key binding routes Option-Return
             // to `insertNewlineIgnoringFieldEditor:`, NOT `insertNewline:`,
@@ -1087,6 +1106,53 @@ final class ACPNSTextView: PairedDelimiterTextView {
         }
         typingAttributes = attrs
         return true
+    }
+
+    /// Tracks the not-yet-finalized dictation span so each subsequent
+    /// volatile transcript update can replace it in place instead of
+    /// appending alongside it. `nil` once a final result commits the span
+    /// (the next volatile update then starts a fresh span after the
+    /// committed text) or once dictation stops.
+    private var dictationRange: NSRange?
+
+    /// Inserts or replaces the live dictation transcript. Volatile
+    /// updates (`isFinal == false`) replace the previous volatile span in
+    /// place so mid-utterance corrections don't pile up as duplicate
+    /// text. A final update commits the span: the text stays, but the
+    /// next volatile update starts a new span appended after it rather
+    /// than overwriting it.
+    @discardableResult
+    func replaceDictationRegion(_ text: String, isFinal: Bool) -> Bool {
+        guard let textStorage else { return false }
+        let target: NSRange
+        if let existing = dictationRange {
+            target = NSRange(
+                location: min(existing.location, textStorage.length),
+                length: min(existing.length, max(0, textStorage.length - existing.location))
+            )
+        } else {
+            target = selectedRange()
+        }
+        let attrs = baseTypingAttributes
+        typingAttributes = attrs
+        performNativeTextInsertion {
+            insertText(text, replacementRange: target)
+        }
+        typingAttributes = attrs
+        let inserted = NSRange(location: target.location, length: (text as NSString).length)
+        if isFinal {
+            dictationRange = nil
+            setSelectedRange(NSRange(location: NSMaxRange(inserted), length: 0))
+        } else {
+            dictationRange = inserted
+        }
+        return true
+    }
+
+    /// Stops tracking the live dictation span without altering the
+    /// committed text — used when dictation is toggled off mid-utterance.
+    func cancelDictationRegion() {
+        dictationRange = nil
     }
 
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {

--- a/Alas/Sources/ACP/UI/ACPComposerActions.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerActions.swift
@@ -23,6 +23,13 @@ final class ACPComposerActions: ObservableObject {
     /// Published by the coordinator; opens an image picker and inserts the
     /// chosen files as chips.
     var presentImagePicker: (() -> Void)?
+    /// Published by the coordinator; applies a live dictation transcript
+    /// update to the composer's tracked dictation span.
+    var applyDictationTranscript: ((_ text: String, _ isFinal: Bool) -> Void)?
+    /// Published by the coordinator; stops tracking the dictation span
+    /// (used when dictation is toggled off) without altering already
+    /// committed text.
+    var cancelDictationRegion: (() -> Void)?
     /// Convenience used by call sites that just want default submit.
     func submit() { submitWithIntent?(.auto) }
     func quote(_ message: String) { insertQuote?(message) }

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -311,6 +311,14 @@ struct ACPComposer: View {
                 installedDictationLocales = await dictation.installedLocaleIdentifiers()
             }
             .onChange(of: dictationLocale) { _, newValue in
+                // Settings lives in its own window and can be open next to
+                // an actively dictating composer. Without stopping first,
+                // a language change made there would leave the running
+                // session transcribing under its original locale while the
+                // mic menu already shows the new one — mirrors the same
+                // guard `selectDictationLocale` applies for changes made
+                // through the mic's own menu.
+                dictation.stop()
                 dictation.preferredLocaleIdentifier = newValue
             }
             .onChange(of: composer.revision) { _, _ in

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -9,6 +9,46 @@ enum ACPComposerControlPresentation {
         isEnabled ? "play.fill" : "play"
     }
 
+    static func micIconName(for state: ACPDictationState) -> String {
+        state == .listening ? "mic.fill" : "mic"
+    }
+
+    /// Entries for the mic button's language menu: the automatic choice
+    /// first, then the installed languages by name. A language the user
+    /// picked in Settings but hasn't downloaded yet is included too, so the
+    /// menu never contradicts the actual setting.
+    static func dictationMenuItems(installed: [String], selected: String) -> [ACPDictationMenuItem] {
+        var identifiers = installed
+        let normalizedSelection = selected.replacingOccurrences(of: "-", with: "_")
+        if !normalizedSelection.isEmpty,
+           !identifiers.contains(where: { $0.replacingOccurrences(of: "-", with: "_") == normalizedSelection }) {
+            identifiers.append(normalizedSelection)
+        }
+        let items = ACPDictationLocaleFormatter.sortedByDisplayName(identifiers).map { identifier in
+            ACPDictationMenuItem(
+                localeIdentifier: identifier,
+                title: ACPDictationLocaleFormatter.displayName(for: identifier),
+                isSelected: identifier.replacingOccurrences(of: "-", with: "_") == normalizedSelection
+            )
+        }
+        let automatic = ACPDictationMenuItem(
+            localeIdentifier: ACPDictationLocaleFormatter.automaticIdentifier,
+            title: ACPDictationLocaleFormatter.displayName(for: ACPDictationLocaleFormatter.automaticIdentifier),
+            isSelected: normalizedSelection.isEmpty
+        )
+        return [automatic] + items
+    }
+
+    static func micHelp(for state: ACPDictationState) -> String {
+        switch state {
+        case .unavailable: return "Dictation unavailable"
+        case .idle: return "Dictate into the composer"
+        case .preparing: return "Preparing dictation…"
+        case .listening: return "Listening — click to stop"
+        case .failed(let message): return message
+        }
+    }
+
     static func fastModeHelp(isEnabled: Bool, canToggle: Bool) -> String {
         guard canToggle else { return "Fast mode cannot be changed" }
         return isEnabled
@@ -100,6 +140,11 @@ struct ACPComposer: View {
     /// `ACPInputField` so its placeholder reflects whichever action ⏎
     /// triggers under the current mapping.
     let sendOnEnter: Bool
+    /// Current value of the `acpDictationLocale` setting. Empty means the
+    /// dictation engine picks a language automatically.
+    let dictationLocale: String
+    /// Persists a language chosen from the mic's context menu.
+    let onSelectDictationLocale: (String) -> Void
     let focusRequest: Int
     let dropRouter: ACPComposerDropRouter
     let placement: ACPComposerPlacement
@@ -112,7 +157,10 @@ struct ACPComposer: View {
     @Environment(\.theme) private var theme
     @State private var inputFocused = false
     @State private var hasText: Bool = false
-    @State private var imageNotice: String?
+    @State private var composerNotice: String?
+    @StateObject private var dictation = ACPDictationService(engine: ACPSpeechDictationEngine())
+    /// Languages ready to use without a download, for the mic's menu.
+    @State private var installedDictationLocales: [String] = []
 
     init(
         session: ACPSession,
@@ -120,6 +168,8 @@ struct ACPComposer: View {
         worktreeRoot: URL,
         agentLookup: @escaping (String) -> AgentDefinition?,
         sendOnEnter: Bool,
+        dictationLocale: String = "",
+        onSelectDictationLocale: @escaping (String) -> Void = { _ in },
         focusRequest: Int = 0,
         dropRouter: ACPComposerDropRouter,
         placement: ACPComposerPlacement = .bottom,
@@ -135,6 +185,8 @@ struct ACPComposer: View {
         self.worktreeRoot = worktreeRoot
         self.agentLookup = agentLookup
         self.sendOnEnter = sendOnEnter
+        self.dictationLocale = dictationLocale
+        self.onSelectDictationLocale = onSelectDictationLocale
         self.focusRequest = focusRequest
         self.dropRouter = dropRouter
         self.placement = placement
@@ -205,8 +257,8 @@ struct ACPComposer: View {
 
     private var pill: some View {
         VStack(spacing: 6) {
-            if let imageNotice {
-                Text(imageNotice)
+            if let composerNotice {
+                Text(composerNotice)
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(theme.color("del"))
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -227,11 +279,15 @@ struct ACPComposer: View {
                     hasText = draft.hasContent
                 },
                 onDraftClear: { manager.clearComposerDraft(for: session) },
-                onSubmit: onSubmit,
+                onStopDictation: { dictation.stop() },
+                onSubmit: { text, attachments, intent, draft, completion in
+                    dictation.stop()
+                    return onSubmit(text, attachments, intent, draft, completion)
+                },
                 onImageError: { error in
-                    imageNotice = error.userMessage
+                    composerNotice = error.userMessage
                     DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                        if imageNotice == error.userMessage { imageNotice = nil }
+                        if composerNotice == error.userMessage { composerNotice = nil }
                     }
                 },
                 filesProvider: filesProvider
@@ -239,9 +295,33 @@ struct ACPComposer: View {
             .frame(minHeight: 44, maxHeight: 140)
             .onAppear {
                 hasText = composer.draft.hasContent
+                dictation.onTranscriptUpdate = { text, isFinal in
+                    actions.applyDictationTranscript?(text, isFinal)
+                }
+                dictation.onStop = { actions.cancelDictationRegion?() }
+                dictation.onNotice = { message in
+                    composerNotice = message
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                        if composerNotice == message { composerNotice = nil }
+                    }
+                }
+                dictation.preferredLocaleIdentifier = dictationLocale
+            }
+            .task {
+                installedDictationLocales = await dictation.installedLocaleIdentifiers()
+            }
+            .onChange(of: dictationLocale) { _, newValue in
+                dictation.preferredLocaleIdentifier = newValue
             }
             .onChange(of: composer.revision) { _, _ in
                 hasText = composer.draft.hasContent
+            }
+            .onChange(of: dictation.state) { _, state in
+                guard case .failed(let message) = state else { return }
+                composerNotice = message
+                DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                    if composerNotice == message { composerNotice = nil }
+                }
             }
 
             HStack(spacing: 8) {
@@ -249,6 +329,9 @@ struct ACPComposer: View {
                 Spacer()
                 ACPContextUsageButton(usage: session.contextUsage,
                                       modelName: session.currentModelDisplayName)
+                if dictation.state != .unavailable {
+                    micButton
+                }
                 attachButton
                 if let fastMode = fastModeParameter {
                     selectFastModeToggle(fastMode)
@@ -430,6 +513,57 @@ struct ACPComposer: View {
         session.autoRunEnabled
             ? Color.blend(theme.color("caution"), .white, t: 0.55)
             : theme.color("fg-muted")
+    }
+
+    private var micButton: some View {
+        Button {
+            dictation.toggle()
+        } label: {
+            Image(systemName: ACPComposerControlPresentation.micIconName(for: dictation.state))
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(
+                    dictation.state == .listening
+                        ? Color.blend(theme.color("caution"), .white, t: 0.55)
+                        : theme.color("fg-muted")
+                )
+                .frame(width: 28, height: 24)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(
+                            dictation.state == .listening
+                                ? theme.color("caution").opacity(0.55)
+                                : theme.color("bg-3").opacity(0.7)
+                        )
+                )
+                .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line"), lineWidth: 0.75))
+        }
+        .buttonStyle(.plain)
+        .disabled(dictation.state == .preparing)
+        .accessibilityLabel("Dictate")
+        .help(ACPComposerControlPresentation.micHelp(for: dictation.state))
+        .contextMenu {
+            ForEach(ACPComposerControlPresentation.dictationMenuItems(
+                installed: installedDictationLocales,
+                selected: dictationLocale
+            )) { item in
+                Button {
+                    selectDictationLocale(item.localeIdentifier)
+                } label: {
+                    // A checkmark prefix rather than a Toggle: these are
+                    // mutually exclusive and Toggle rows in a context menu
+                    // read as independently switchable.
+                    Text(item.isSelected ? "✓ \(item.title)" : item.title)
+                }
+            }
+        }
+    }
+
+    /// Applies a language picked from the mic's menu. Any active dictation
+    /// stops first, so a session never keeps running under a language the
+    /// menu no longer shows as current.
+    private func selectDictationLocale(_ identifier: String) {
+        dictation.stop()
+        onSelectDictationLocale(identifier)
     }
 
     private var attachButton: some View {

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -538,7 +538,6 @@ struct ACPComposer: View {
                 .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line"), lineWidth: 0.75))
         }
         .buttonStyle(.plain)
-        .disabled(dictation.state == .preparing)
         .accessibilityLabel("Dictate")
         .help(ACPComposerControlPresentation.micHelp(for: dictation.state))
         .contextMenu {

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -500,6 +500,11 @@ private struct ACPSessionView: View {
             worktreeRoot: worktree.path,
             agentLookup: { state.agent(id: $0) },
             sendOnEnter: state.config.harness.acpSendOnEnter,
+            dictationLocale: state.config.harness.acpDictationLocale,
+            onSelectDictationLocale: { [state] identifier in
+                state.config.harness.acpDictationLocale = identifier
+                state.saveConfig()
+            },
             focusRequest: composerFocusRequest,
             dropRouter: composerDropRouter,
             placement: placement,

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -248,12 +248,16 @@ struct AppConfig: Codable, Equatable {
         var exposeAlasMCP: Bool
         /// How the built-in "alas" MCP server is delivered. Default: stdio.
         var alasMCPTransport: AlasMCPTransport
+        /// Language used for composer dictation, as a locale identifier
+        /// (e.g. "en_US"). Empty (the default) means detect automatically
+        /// from the app locale and the user's preferred languages.
+        var acpDictationLocale: String
 
         enum CodingKeys: String, CodingKey {
             case notifyOnFinish, notifyOnAwaiting,
                  dismissedHookInstallNudges, dismissedACPSetupNudges,
                  confirmCloseChatTabs, acpSendOnEnter, acpAutoRunByDefault,
-                 exposeAlasMCP, alasMCPTransport
+                 exposeAlasMCP, alasMCPTransport, acpDictationLocale
         }
 
         init(notifyOnFinish: Bool = true, notifyOnAwaiting: Bool = true,
@@ -263,7 +267,8 @@ struct AppConfig: Codable, Equatable {
              acpSendOnEnter: Bool = true,
              acpAutoRunByDefault: Bool = false,
              exposeAlasMCP: Bool = true,
-             alasMCPTransport: AlasMCPTransport = .stdio)
+             alasMCPTransport: AlasMCPTransport = .stdio,
+             acpDictationLocale: String = "")
         {
             self.notifyOnFinish = notifyOnFinish
             self.notifyOnAwaiting = notifyOnAwaiting
@@ -274,6 +279,7 @@ struct AppConfig: Codable, Equatable {
             self.acpAutoRunByDefault = acpAutoRunByDefault
             self.exposeAlasMCP = exposeAlasMCP
             self.alasMCPTransport = alasMCPTransport
+            self.acpDictationLocale = acpDictationLocale
         }
 
         init(from decoder: Decoder) throws {
@@ -287,6 +293,7 @@ struct AppConfig: Codable, Equatable {
             acpAutoRunByDefault = (try? c.decode(Bool.self, forKey: .acpAutoRunByDefault)) ?? false
             exposeAlasMCP = (try? c.decode(Bool.self, forKey: .exposeAlasMCP)) ?? true
             alasMCPTransport = (try? c.decode(AlasMCPTransport.self, forKey: .alasMCPTransport)) ?? .stdio
+            acpDictationLocale = (try? c.decode(String.self, forKey: .acpDictationLocale)) ?? ""
         }
     }
 

--- a/Alas/Sources/Settings/ChatPane.swift
+++ b/Alas/Sources/Settings/ChatPane.swift
@@ -16,6 +16,7 @@ struct ChatPane: View {
         static let fontSize = "Font size"
         static let defaultLaunchSurface = "Default launch surface"
         static let sendOnEnter = "While busy, ⏎ queues; ⌥⏎ steers"
+        static let dictationLanguage = "Dictation language"
         static let confirmCloseChatTabs = "Confirm before closing chat tabs"
         static let autoRun = "⚡ Auto-run"
     }
@@ -39,7 +40,13 @@ struct ChatPane: View {
         RowLabels.sendOnEnter,
         RowLabels.confirmCloseChatTabs,
         RowLabels.autoRun,
+        RowLabels.dictationLanguage,
     ]
+
+    /// Languages the dictation engine can transcribe. Loaded asynchronously
+    /// because the Speech framework resolves them off-disk; stays empty
+    /// below macOS 26, which also hides the row.
+    @State private var dictationLocales: [String] = []
 
     var body: some View {
         ScrollView {
@@ -90,6 +97,14 @@ struct ChatPane: View {
                             }
                         ))
                     }
+                    if !dictationLocales.isEmpty {
+                        SettingsRow(
+                            name: RowLabels.dictationLanguage,
+                            desc: "Language the 🎤 button transcribes. Automatic follows your app and system languages. Picking one that isn't downloaded yet fetches it the first time you dictate."
+                        ) {
+                            dictationLanguagePicker
+                        }
+                    }
                 }
 
                 SettingsGroup(title: GroupTitles.sessions) {
@@ -117,6 +132,30 @@ struct ChatPane: View {
             }
             .padding(.horizontal, 32).padding(.vertical, 24)
         }
+        .task {
+            dictationLocales = ACPDictationLocaleFormatter.sortedByDisplayName(
+                await ACPSpeechDictationEngine.supportedLocaleIdentifiers()
+            )
+        }
+    }
+
+    private var dictationLanguagePicker: some View {
+        Picker("", selection: Binding(
+            get: { state.config.harness.acpDictationLocale },
+            set: { newValue in
+                state.config.harness.acpDictationLocale = newValue
+                state.saveConfig()
+            }
+        )) {
+            Text(ACPDictationLocaleFormatter.displayName(for: ACPDictationLocaleFormatter.automaticIdentifier))
+                .tag(ACPDictationLocaleFormatter.automaticIdentifier)
+            Divider()
+            ForEach(dictationLocales, id: \.self) { identifier in
+                Text(ACPDictationLocaleFormatter.displayName(for: identifier)).tag(identifier)
+            }
+        }
+        .labelsHidden()
+        .frame(width: 220)
     }
 
     private var defaultLauncherModePicker: some View {

--- a/AlasTests/ACP/Dictation/ACPDictationLocaleFormatterTests.swift
+++ b/AlasTests/ACP/Dictation/ACPDictationLocaleFormatterTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACP dictation locale names and menu")
+struct ACPDictationLocaleFormatterTests {
+    @Test("locale identifiers render as English display names")
+    func identifiersRenderAsEnglishNames() {
+        #expect(ACPDictationLocaleFormatter.displayName(for: "en_US") == "English (United States)")
+        #expect(ACPDictationLocaleFormatter.displayName(for: "es_ES") == "Spanish (Spain)")
+        #expect(ACPDictationLocaleFormatter.displayName(for: "pt_BR") == "Portuguese (Brazil)")
+    }
+
+    @Test("an empty identifier is the automatic choice")
+    func emptyIdentifierIsAutomatic() {
+        #expect(ACPDictationLocaleFormatter.displayName(for: "") == "Automatic")
+    }
+
+    @Test("identifiers sort by display name, not raw code")
+    func sortsByDisplayName() {
+        // A discriminating case: sorting the raw identifiers would give
+        // de_DE, en_US, es_ES, but the names are German, English, Spanish,
+        // so English must come first.
+        let sorted = ACPDictationLocaleFormatter.sortedByDisplayName(["es_ES", "en_US", "de_DE"])
+        #expect(sorted == ["en_US", "de_DE", "es_ES"])
+    }
+
+    @Test("menu lists automatic first, then installed languages by name")
+    func menuListsAutomaticFirst() {
+        let items = ACPComposerControlPresentation.dictationMenuItems(
+            installed: ["es_ES", "en_US"],
+            selected: ""
+        )
+
+        #expect(items.map(\.localeIdentifier) == ["", "en_US", "es_ES"])
+        #expect(items.map(\.title) == ["Automatic", "English (United States)", "Spanish (Spain)"])
+        #expect(items.map(\.isSelected) == [true, false, false])
+    }
+
+    @Test("the chosen language is the one marked selected")
+    func chosenLanguageIsMarked() {
+        let items = ACPComposerControlPresentation.dictationMenuItems(
+            installed: ["es_ES", "en_US"],
+            selected: "es_ES"
+        )
+
+        #expect(items.map(\.isSelected) == [false, false, true])
+    }
+
+    @Test("a chosen language that is not installed still appears, so the menu shows the truth")
+    func chosenLanguageAppearsEvenWhenNotInstalled() {
+        let items = ACPComposerControlPresentation.dictationMenuItems(
+            installed: ["en_US"],
+            selected: "fr_FR"
+        )
+
+        #expect(items.map(\.localeIdentifier) == ["", "en_US", "fr_FR"])
+        #expect(items.first(where: { $0.localeIdentifier == "fr_FR" })?.isSelected == true)
+    }
+}

--- a/AlasTests/ACP/Dictation/ACPDictationServiceTests.swift
+++ b/AlasTests/ACP/Dictation/ACPDictationServiceTests.swift
@@ -1,0 +1,241 @@
+import Testing
+@testable import Alas
+
+@MainActor
+private final class FakeDictationEngine: ACPDictationEngine {
+    var isAvailable: Bool
+    var installed: [String]
+    private(set) var startCallCount = 0
+    private(set) var stopCallCount = 0
+    private(set) var lastPreferredLocale: String?
+    private var callbacks: ACPDictationCallbacks?
+
+    init(isAvailable: Bool = true, installed: [String] = ["en_US"]) {
+        self.isAvailable = isAvailable
+        self.installed = installed
+    }
+
+    func installedLocaleIdentifiers() async -> [String] { installed }
+
+    func start(preferredLocaleIdentifier: String?, callbacks: ACPDictationCallbacks) {
+        startCallCount += 1
+        lastPreferredLocale = preferredLocaleIdentifier
+        self.callbacks = callbacks
+    }
+
+    // Deliberately keeps `callbacks` after stopping: the real engine's
+    // async setup can fire a callback late, so holding onto them lets the
+    // tests exercise the service's own state guards rather than a
+    // convenience of this fake.
+    func stop() {
+        stopCallCount += 1
+    }
+
+    func simulateReady() { callbacks?.onReady() }
+    func simulateResult(_ text: String, isFinal: Bool) { callbacks?.onResult(text, isFinal) }
+    func simulateFailure(_ message: String) { callbacks?.onFailure(message) }
+    func simulateSilence(deviceName: String?) { callbacks?.onSilence(deviceName) }
+}
+
+@MainActor
+@Suite("ACP dictation service state machine")
+struct ACPDictationServiceTests {
+    @Test("starts idle when the engine is available")
+    func startsIdleWhenAvailable() {
+        let service = ACPDictationService(engine: FakeDictationEngine(isAvailable: true))
+        #expect(service.state == .idle)
+    }
+
+    @Test("starts unavailable when the engine reports no support")
+    func startsUnavailableWhenUnsupported() {
+        let service = ACPDictationService(engine: FakeDictationEngine(isAvailable: false))
+        #expect(service.state == .unavailable)
+    }
+
+    @Test("toggling from idle asks the engine to start and enters preparing")
+    func toggleFromIdleStartsEngine() {
+        let engine = FakeDictationEngine()
+        let service = ACPDictationService(engine: engine)
+
+        service.toggle()
+
+        #expect(engine.startCallCount == 1)
+        #expect(service.state == .preparing)
+    }
+
+    @Test("engine readiness moves preparing to listening")
+    func engineReadinessEntersListening() {
+        let engine = FakeDictationEngine()
+        let service = ACPDictationService(engine: engine)
+
+        service.toggle()
+        engine.simulateReady()
+
+        #expect(service.state == .listening)
+    }
+
+    @Test("toggling while listening stops the engine, returns to idle, and notifies onStop")
+    func toggleWhileListeningStops() {
+        let engine = FakeDictationEngine()
+        let service = ACPDictationService(engine: engine)
+        var stopNotified = false
+        service.onStop = { stopNotified = true }
+
+        service.toggle()
+        engine.simulateReady()
+        service.toggle()
+
+        #expect(engine.stopCallCount == 1)
+        #expect(service.state == .idle)
+        #expect(stopNotified)
+    }
+
+    @Test("engine failure while preparing surfaces the message and notifies onStop")
+    func engineFailureSurfacesMessage() {
+        let engine = FakeDictationEngine()
+        let service = ACPDictationService(engine: engine)
+        var stopNotified = false
+        service.onStop = { stopNotified = true }
+
+        service.toggle()
+        engine.simulateFailure("No microphone access")
+
+        #expect(service.state == .failed("No microphone access"))
+        #expect(stopNotified)
+    }
+
+    @Test("toggling from a failed state retries")
+    func toggleFromFailedRetries() {
+        let engine = FakeDictationEngine()
+        let service = ACPDictationService(engine: engine)
+
+        service.toggle()
+        engine.simulateFailure("boom")
+        service.toggle()
+
+        #expect(engine.startCallCount == 2)
+        #expect(service.state == .preparing)
+    }
+
+    @Test("results while listening forward to onTranscriptUpdate")
+    func resultsForwardToTranscriptUpdate() {
+        let engine = FakeDictationEngine()
+        let service = ACPDictationService(engine: engine)
+        var received: [(String, Bool)] = []
+        service.onTranscriptUpdate = { received.append(($0, $1)) }
+
+        service.toggle()
+        engine.simulateReady()
+        engine.simulateResult("hello", isFinal: false)
+        engine.simulateResult("hello world", isFinal: true)
+
+        #expect(received.count == 2)
+        #expect(received[0] == ("hello", false))
+        #expect(received[1] == ("hello world", true))
+    }
+
+    @Test("toggling while unavailable does nothing")
+    func toggleWhileUnavailableDoesNothing() {
+        let engine = FakeDictationEngine(isAvailable: false)
+        let service = ACPDictationService(engine: engine)
+
+        service.toggle()
+
+        #expect(engine.startCallCount == 0)
+        #expect(service.state == .unavailable)
+    }
+
+    @Test("starting again while already preparing is a no-op")
+    func startWhileAlreadyPreparingIsNoOp() {
+        let engine = FakeDictationEngine()
+        let service = ACPDictationService(engine: engine)
+
+        service.start()
+        service.start()
+
+        #expect(engine.startCallCount == 1)
+    }
+
+    @Test("stopping while idle is a no-op")
+    func stopWhileIdleIsNoOp() {
+        let engine = FakeDictationEngine()
+        let service = ACPDictationService(engine: engine)
+        var stopNotified = false
+        service.onStop = { stopNotified = true }
+
+        service.stop()
+
+        #expect(engine.stopCallCount == 0)
+        #expect(!stopNotified)
+    }
+
+    // MARK: - Preferred locale
+
+    @Test("the chosen locale is handed to the engine on start")
+    func preferredLocaleReachesEngine() {
+        let engine = FakeDictationEngine()
+        let service = ACPDictationService(engine: engine)
+        service.preferredLocaleIdentifier = "es_ES"
+
+        service.start()
+
+        #expect(engine.lastPreferredLocale == "es_ES")
+    }
+
+    @Test("an empty locale preference reaches the engine as nil, meaning automatic")
+    func emptyLocalePreferenceBecomesNil() {
+        let engine = FakeDictationEngine()
+        let service = ACPDictationService(engine: engine)
+        service.preferredLocaleIdentifier = ""
+
+        service.start()
+
+        #expect(engine.startCallCount == 1)
+        #expect(engine.lastPreferredLocale == nil)
+    }
+
+    // MARK: - Silence notices
+
+    @Test("a silence report while listening names the offending input device")
+    func silenceNoticeNamesDevice() {
+        let engine = FakeDictationEngine()
+        let service = ACPDictationService(engine: engine)
+        var notices: [String] = []
+        service.onNotice = { notices.append($0) }
+
+        service.toggle()
+        engine.simulateReady()
+        engine.simulateSilence(deviceName: "Virtual Desktop Mic")
+
+        #expect(notices == ["No audio from “Virtual Desktop Mic”. Check Sound settings."])
+    }
+
+    @Test("a silence report without a device name still explains the problem")
+    func silenceNoticeWithoutDeviceName() {
+        let engine = FakeDictationEngine()
+        let service = ACPDictationService(engine: engine)
+        var notices: [String] = []
+        service.onNotice = { notices.append($0) }
+
+        service.toggle()
+        engine.simulateReady()
+        engine.simulateSilence(deviceName: nil)
+
+        #expect(notices == ["No audio from the microphone. Check Sound settings."])
+    }
+
+    @Test("a silence report that lands after stopping is ignored")
+    func silenceNoticeAfterStopIsIgnored() {
+        let engine = FakeDictationEngine()
+        let service = ACPDictationService(engine: engine)
+        var notices: [String] = []
+        service.onNotice = { notices.append($0) }
+
+        service.toggle()
+        engine.simulateReady()
+        service.stop()
+        engine.simulateSilence(deviceName: "Virtual Desktop Mic")
+
+        #expect(notices.isEmpty)
+    }
+}

--- a/AlasTests/ACP/Dictation/ACPSpeechDictationEngineFormatTests.swift
+++ b/AlasTests/ACP/Dictation/ACPSpeechDictationEngineFormatTests.swift
@@ -1,0 +1,18 @@
+import AVFoundation
+import Testing
+@testable import Alas
+
+@Suite("ACP speech dictation hardware format validation")
+struct ACPSpeechDictationEngineFormatTests {
+    @Test("a normal two-channel 48kHz format is usable")
+    func normalFormatIsUsable() {
+        let format = AVAudioFormat(standardFormatWithSampleRate: 48000, channels: 2)!
+        #expect(ACPSpeechDictationEngine.isUsableInputFormat(format))
+    }
+
+    @Test("a zero sample rate format is unusable, as reported with no input device")
+    func zeroSampleRateIsUnusable() {
+        let format = AVAudioFormat()
+        #expect(!ACPSpeechDictationEngine.isUsableInputFormat(format))
+    }
+}

--- a/AlasTests/ACP/Dictation/ACPSpeechDictationEngineLocaleTests.swift
+++ b/AlasTests/ACP/Dictation/ACPSpeechDictationEngineLocaleTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACP speech dictation locale candidates")
+struct ACPSpeechDictationEngineLocaleTests {
+    @Test("app locale comes first, then preferred languages, then en_US")
+    func orderIsAppLocaleThenPreferredThenFallback() {
+        let candidates = ACPSpeechDictationEngine.localeCandidates(
+            current: Locale(identifier: "en_ES"),
+            preferredLanguages: ["es-ES", "de-DE"]
+        )
+
+        #expect(candidates.map(\.identifier) == ["en_ES", "es_ES", "de_DE", "en_US"])
+    }
+
+    @Test("duplicates collapse regardless of dash or underscore separators")
+    func duplicatesCollapse() {
+        let candidates = ACPSpeechDictationEngine.localeCandidates(
+            current: Locale(identifier: "en_US"),
+            preferredLanguages: ["en-US", "es-ES", "es_ES"]
+        )
+
+        #expect(candidates.map(\.identifier) == ["en_US", "es_ES"])
+    }
+
+    @Test("an explicit choice leads the chain")
+    func explicitChoiceLeadsChain() {
+        let candidates = ACPSpeechDictationEngine.localeCandidates(
+            explicit: "fr_FR",
+            current: Locale(identifier: "en_ES"),
+            preferredLanguages: ["es-ES"]
+        )
+
+        #expect(candidates.map(\.identifier) == ["fr_FR", "en_ES", "es_ES", "en_US"])
+    }
+
+    @Test("the automatic chain is unchanged when no explicit choice is set")
+    func noExplicitChoiceKeepsAutomaticChain() {
+        for explicit in [nil, ""] as [String?] {
+            let candidates = ACPSpeechDictationEngine.localeCandidates(
+                explicit: explicit,
+                current: Locale(identifier: "en_ES"),
+                preferredLanguages: ["es-ES"]
+            )
+
+            #expect(candidates.map(\.identifier) == ["en_ES", "es_ES", "en_US"])
+        }
+    }
+
+    @Test("an explicit choice already in the chain is not duplicated")
+    func explicitChoiceIsNotDuplicated() {
+        let candidates = ACPSpeechDictationEngine.localeCandidates(
+            explicit: "es-ES",
+            current: Locale(identifier: "en_ES"),
+            preferredLanguages: ["es-ES"]
+        )
+
+        #expect(candidates.map(\.identifier) == ["es_ES", "en_ES", "en_US"])
+    }
+}

--- a/AlasTests/ACP/UI/ACPComposerControlPresentationDictationTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerControlPresentationDictationTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import Alas
+
+@Suite("ACP composer mic button presentation")
+struct ACPComposerControlPresentationDictationTests {
+    @Test("icon reflects listening vs every other state")
+    func micIconReflectsState() {
+        #expect(ACPComposerControlPresentation.micIconName(for: .idle) == "mic")
+        #expect(ACPComposerControlPresentation.micIconName(for: .preparing) == "mic")
+        #expect(ACPComposerControlPresentation.micIconName(for: .listening) == "mic.fill")
+        #expect(ACPComposerControlPresentation.micIconName(for: .failed("boom")) == "mic")
+    }
+
+    @Test("help text is state-specific")
+    func micHelpTextIsStateSpecific() {
+        #expect(ACPComposerControlPresentation.micHelp(for: .idle) == "Dictate into the composer")
+        #expect(ACPComposerControlPresentation.micHelp(for: .preparing) == "Preparing dictation…")
+        #expect(ACPComposerControlPresentation.micHelp(for: .listening) == "Listening — click to stop")
+        #expect(ACPComposerControlPresentation.micHelp(for: .failed("No microphone access")) == "No microphone access")
+        #expect(ACPComposerControlPresentation.micHelp(for: .unavailable) == "Dictation unavailable")
+    }
+}

--- a/AlasTests/ACP/UI/ACPDictationRegionTests.swift
+++ b/AlasTests/ACP/UI/ACPDictationRegionTests.swift
@@ -72,30 +72,70 @@ struct ACPDictationRegionTests {
         #expect(textView.string == "partial thought new")
     }
 
-    @Test("a manual edit while a span is tracked stops tracking it, instead of the next update replacing the wrong text")
+    @Test("a manual edit while a span is tracked stops dictation outright")
+    func manualEditDuringTrackingStopsDictation() {
+        let textView = ACPNSTextView()
+        textView.string = ""
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+        var stopCount = 0
+        // `coordinator` is a weak property on the text view — this local
+        // keeps it alive for the test, exactly as the real composer's
+        // owning view does.
+        let coordinator = makeCoordinator(onStopDictation: { stopCount += 1 })
+        textView.coordinator = coordinator
+
+        textView.replaceDictationRegion("Hell", isFinal: false)
+        #expect(stopCount == 0)
+
+        // A keystroke elsewhere in the buffer — not through
+        // replaceDictationRegion — while "Hell" is still an open span.
+        // Untracking the span alone isn't enough: the speech session is
+        // still analyzing that utterance and would otherwise emit more
+        // corrections nobody asked for once the user has taken over.
+        textView.insertText(" note", replacementRange: NSRange(location: 0, length: 0))
+
+        #expect(stopCount == 1)
+        // Repeated edits don't fire it again — dictation only needed to be
+        // told once, and there's no longer a tracked span to invalidate.
+        textView.insertText("!", replacementRange: NSRange(location: 0, length: 0))
+        #expect(stopCount == 1)
+    }
+
+    @Test("a manual edit while a span is tracked stops tracking it, instead of a late result replacing the wrong text")
     func manualEditDuringTrackingStopsTracking() {
         let textView = ACPNSTextView()
         textView.string = ""
         textView.setSelectedRange(NSRange(location: 0, length: 0))
 
         textView.replaceDictationRegion("Hell", isFinal: false)
-        // A keystroke elsewhere in the buffer — not through
-        // replaceDictationRegion — while "Hell" is still an open span at
-        // offset (0, 4). It shifts "Hell" to offset 5 without updating the
-        // tracked range.
+        // A keystroke elsewhere in the buffer while "Hell" is still an
+        // open span at offset (0, 4). It shifts "Hell" to offset 5 without
+        // updating the tracked range.
         textView.insertText(" note", replacementRange: NSRange(location: 0, length: 0))
-        // Without invalidation this replaces the now-stale (0, 4) span —
-        // " not", the buffer's first four characters after the manual
-        // edit — corrupting text the manual edit shifted into place and
-        // losing track of "Hell" entirely.
+        // The manual edit above stops dictation (see the sibling test), so
+        // in practice no more results arrive. This exercises the residual
+        // safety net for whatever the engine may have already queued
+        // before the stop took effect: without range invalidation, this
+        // would replace the now-stale (0, 4) span — " not", the buffer's
+        // first four characters after the manual edit — corrupting text
+        // the edit shifted into place and losing track of "Hell" entirely.
         textView.replaceDictationRegion("Hello world", isFinal: false)
 
-        // The exact landing spot for the fresh span isn't the point here;
-        // what matters is that "Hell" survives untouched rather than
-        // being partially overwritten by the stale-range bug.
         #expect(textView.string.contains("Hell"))
-        #expect(textView.string.contains("Hello world"))
         #expect(!textView.string.contains("Hello worldeHell"))
+    }
+
+    private func makeCoordinator(onStopDictation: @escaping () -> Void) -> ACPInputField.Coordinator {
+        ACPInputField.Coordinator(
+            worktreeRoot: URL(fileURLWithPath: "/tmp"),
+            initialDraft: .empty,
+            focusRequest: 0,
+            sendOnEnter: true,
+            onDraftChange: { _ in },
+            onDraftClear: {},
+            onStopDictation: onStopDictation,
+            onSubmit: { _, _, _, _, _ in true }
+        )
     }
 
     @Test("dictation region preserves surrounding text")

--- a/AlasTests/ACP/UI/ACPDictationRegionTests.swift
+++ b/AlasTests/ACP/UI/ACPDictationRegionTests.swift
@@ -72,6 +72,32 @@ struct ACPDictationRegionTests {
         #expect(textView.string == "partial thought new")
     }
 
+    @Test("a manual edit while a span is tracked stops tracking it, instead of the next update replacing the wrong text")
+    func manualEditDuringTrackingStopsTracking() {
+        let textView = ACPNSTextView()
+        textView.string = ""
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        textView.replaceDictationRegion("Hell", isFinal: false)
+        // A keystroke elsewhere in the buffer — not through
+        // replaceDictationRegion — while "Hell" is still an open span at
+        // offset (0, 4). It shifts "Hell" to offset 5 without updating the
+        // tracked range.
+        textView.insertText(" note", replacementRange: NSRange(location: 0, length: 0))
+        // Without invalidation this replaces the now-stale (0, 4) span —
+        // " not", the buffer's first four characters after the manual
+        // edit — corrupting text the manual edit shifted into place and
+        // losing track of "Hell" entirely.
+        textView.replaceDictationRegion("Hello world", isFinal: false)
+
+        // The exact landing spot for the fresh span isn't the point here;
+        // what matters is that "Hell" survives untouched rather than
+        // being partially overwritten by the stale-range bug.
+        #expect(textView.string.contains("Hell"))
+        #expect(textView.string.contains("Hello world"))
+        #expect(!textView.string.contains("Hello worldeHell"))
+    }
+
     @Test("dictation region preserves surrounding text")
     func dictationRegionPreservesSurroundingText() {
         let textView = ACPNSTextView()

--- a/AlasTests/ACP/UI/ACPDictationRegionTests.swift
+++ b/AlasTests/ACP/UI/ACPDictationRegionTests.swift
@@ -1,0 +1,86 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACP composer dictation region editing")
+struct ACPDictationRegionTests {
+    @Test("first volatile update inserts at the caret")
+    func firstVolatileUpdateInsertsAtCaret() {
+        let textView = ACPNSTextView()
+        textView.string = "before  after"
+        textView.setSelectedRange(NSRange(location: 7, length: 0))
+
+        textView.replaceDictationRegion("hello", isFinal: false)
+
+        #expect(textView.string == "before hello after")
+    }
+
+    @Test("second volatile update replaces the first instead of appending")
+    func secondVolatileUpdateReplacesFirst() {
+        let textView = ACPNSTextView()
+        textView.string = ""
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        textView.replaceDictationRegion("Hell", isFinal: false)
+        textView.replaceDictationRegion("Hello world", isFinal: false)
+
+        #expect(textView.string == "Hello world")
+    }
+
+    @Test("final update commits the span so the next volatile update starts fresh")
+    func finalUpdateCommitsSpan() {
+        let textView = ACPNSTextView()
+        textView.string = ""
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        textView.replaceDictationRegion("Hello world", isFinal: true)
+        textView.replaceDictationRegion("Next", isFinal: false)
+
+        #expect(textView.string == "Hello worldNext")
+    }
+
+    @Test("volatile update after a final commit corrects only the new span")
+    func volatileAfterFinalCorrectsOnlyNewSpan() {
+        let textView = ACPNSTextView()
+        textView.string = ""
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        textView.replaceDictationRegion("Hello world. ", isFinal: true)
+        textView.replaceDictationRegion("Nex", isFinal: false)
+        textView.replaceDictationRegion("Next sentence", isFinal: false)
+
+        #expect(textView.string == "Hello world. Next sentence")
+    }
+
+    @Test("canceling the region leaves committed text but stops tracking it")
+    func cancelingRegionLeavesTextInPlace() {
+        let textView = ACPNSTextView()
+        textView.string = ""
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        textView.replaceDictationRegion("partial thought", isFinal: false)
+        textView.cancelDictationRegion()
+
+        #expect(textView.string == "partial thought")
+
+        // A later dictation session inserts fresh text after the leftover
+        // instead of overwriting it, because canceling stopped tracking.
+        textView.setSelectedRange(NSRange(location: textView.string.utf16.count, length: 0))
+        textView.replaceDictationRegion(" new", isFinal: false)
+
+        #expect(textView.string == "partial thought new")
+    }
+
+    @Test("dictation region preserves surrounding text")
+    func dictationRegionPreservesSurroundingText() {
+        let textView = ACPNSTextView()
+        textView.string = "keep-before  keep-after"
+        textView.setSelectedRange(NSRange(location: 12, length: 0))
+
+        textView.replaceDictationRegion("middle", isFinal: false)
+        textView.replaceDictationRegion("middle text", isFinal: true)
+
+        #expect(textView.string == "keep-before middle text keep-after")
+    }
+}

--- a/AlasTests/GitServiceStagedTests.swift
+++ b/AlasTests/GitServiceStagedTests.swift
@@ -137,8 +137,16 @@ struct GitServiceStagedTests {
             originalPath: "old.txt"
         )
 
-        #expect(diff.hunks.flatMap(\.lines).filter { $0.kind == .add }.count == 1)
-        #expect(diff.hunks.flatMap(\.lines).filter { $0.kind == .delete }.count == 1)
+        // Split into a typed intermediate and explicitly-typed closures —
+        // the single-expression chain occasionally sends the type checker
+        // into a multi-minute timeout under load (observed both locally
+        // and in CI), failing the whole file with "unable to type-check
+        // this expression in reasonable time".
+        let lines: [ParsedDiff.Hunk.Line] = diff.hunks.flatMap(\.lines)
+        let addCount: Int = lines.filter { (line: ParsedDiff.Hunk.Line) -> Bool in line.kind == .add }.count
+        let deleteCount: Int = lines.filter { (line: ParsedDiff.Hunk.Line) -> Bool in line.kind == .delete }.count
+        #expect(addCount == 1)
+        #expect(deleteCount == 1)
     }
 
     /// Renames stage as `D <old>` + `A <new>` in the index. Unstaging both

--- a/project.yml
+++ b/project.yml
@@ -60,6 +60,8 @@ targets:
         LSMinimumSystemVersion: "15.0"
         NSHumanReadableCopyright: "Copyright © 2026 Nacho Lopez"
         NSPrincipalClass: NSApplication
+        NSMicrophoneUsageDescription: "Alas uses the microphone to dictate text into the chat composer."
+        NSSpeechRecognitionUsageDescription: "Alas uses on-device speech recognition to transcribe dictated text into the chat composer."
         LSApplicationCategoryType: public.app-category.developer-tools
         CFBundleIconFile: AppIcon
         CFBundleIconName: AppIcon

--- a/project.yml
+++ b/project.yml
@@ -118,6 +118,7 @@ targets:
       path: Alas/Resources/Alas.entitlements
       properties:
         com.apple.security.app-sandbox: false
+        com.apple.security.device.audio-input: true
         com.apple.security.files.user-selected.read-write: true
 
   AlasTests:


### PR DESCRIPTION
## Summary

Adds a mic button to the ACP chat composer for push-to-talk dictation, backed by macOS 26's on-device SpeechAnalyzer/DictationTranscriber pipeline. The button is hidden entirely below macOS 26.

- Click to start/stop; volatile transcript updates replace their span in place as the utterance is corrected, and a final result commits the span so text stays editable before sending.
- Dictation stops on submit, Esc, or the composer being torn down.
- Language is auto-detected (app locale -> preferred languages -> en_US) with an explicit override available from Settings > Chat or the mic's right-click menu, which lists installed languages so switching never blocks on a download.
- If the input carries no signal after a few seconds (e.g. a virtual audio device like a conferencing or VR app has taken over the system default), a composer notice names the device rather than silently transcribing nothing.

## Testing

- Full `xcodebuild build`: clean, no errors.
- 95 tests across 7 suites pass (`ACPDictationServiceTests`, `ACPDictationLocaleFormatterTests`, `ACPSpeechDictationEngineLocaleTests`, `ACPDictationRegionTests`, `ACPComposerControlPresentationDictationTests`, plus the pre-existing `ACPComposerDraftBridgeTests`/`ACPComposerPairedDelimiterTests` that share touched files).
- Manually verified end-to-end on real hardware (mic permission prompt, live transcription, language switching, silence detection after a virtual-mic misconfiguration).