### PR TITLE
fix(diff): cull gutter drawing to dirty rows

### DIFF
--- a/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
+++ b/Alas/Sources/Center/Diff/DiffPaneTextDocumentView.swift
@@ -2129,6 +2129,10 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
     private var cachedGeometry: RulerGeometry?
     private var rowGeometryComputationCount = 0
 
+    #if DEBUG
+    private(set) var drawnRowCountForTesting = 0
+    #endif
+
     var rowGeometryComputationCountForTesting: Int {
         rowGeometryComputationCount
     }
@@ -2270,16 +2274,28 @@ final class DiffPaneLineNumberRulerView: NSRulerView {
     }
 
     override func drawHashMarksAndLabels(in rect: NSRect) {
+        #if DEBUG
+        drawnRowCountForTesting = 0
+        #endif
+        let dirtyRect = rect.intersection(visibleRect).intersection(bounds)
+        guard !dirtyRect.isEmpty else { return }
         guard let theme else { return }
         NSColor(theme.color("bg-0")).setFill()
-        bounds.fill()
+        dirtyRect.fill()
 
         guard let scrollView, !labels.isEmpty else { return }
         let visible = scrollView.contentView.bounds
         let geometry = rowGeometry()
         let rowRects = geometry.rowRects
         guard !rowRects.isEmpty else { return }
-        let visibleRows = visibleRowIndices(in: visible, rowRects: rowRects)
+        // The inner horizontal scroll view spans the whole hunk. Only the
+        // ruler's exposed dirty region reflects clipping by the review viewport.
+        let dirtyDocumentRect = dirtyRect.offsetBy(dx: 0, dy: visible.minY)
+        let visibleRows = visibleRowIndices(in: dirtyDocumentRect, rowRects: rowRects)
+
+        #if DEBUG
+        drawnRowCountForTesting = visibleRows.count
+        #endif
 
         for index in visibleRows {
             let sourceRowRect = rowRects[index]

--- a/AlasTests/DiffPaneViewTests.swift
+++ b/AlasTests/DiffPaneViewTests.swift
@@ -4551,6 +4551,95 @@ let second = true
         #expect(codeView.rowGeometryComputationCountForTesting == geometryComputations)
     }
 
+    @Test func lineNumberRulerDoesNotPaintOverAdjacentCode() throws {
+        let parent = NSView(frame: NSRect(x: 0, y: 0, width: 600, height: 200))
+        parent.clipsToBounds = true
+        let scrollView = NSScrollView(frame: parent.bounds)
+        let ruler = DiffPaneLineNumberRulerView(scrollView: scrollView)
+        ruler.update(
+            labels: [], lineTones: [], rowHeight: 20, contentTopInset: 0,
+            theme: try Theme.loadBundled(id: "cool-slate"),
+            expansionRequests: [], activeCommentHighlight: nil,
+            onContextExpansion: { _, _, _ in }
+        )
+        parent.addSubview(ruler)
+        ruler.frame = NSRect(x: 0, y: 0, width: 42, height: 200)
+        ruler.clipsToBounds = false
+        #expect(ruler.visibleRect.width > ruler.bounds.width)
+
+        let bitmap = try #require(NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: 600, pixelsHigh: 200,
+            bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true,
+            isPlanar: false, colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0
+        ))
+        NSGraphicsContext.saveGraphicsState()
+        defer { NSGraphicsContext.restoreGraphicsState() }
+        NSGraphicsContext.current = try #require(NSGraphicsContext(bitmapImageRep: bitmap))
+        NSColor.magenta.setFill()
+        parent.bounds.fill()
+
+        ruler.drawHashMarksAndLabels(in: parent.bounds)
+
+        let codePixel = try #require(bitmap.colorAt(x: 200, y: 100)?.usingColorSpace(.deviceRGB))
+        #expect(codePixel.redComponent > 0.9)
+        #expect(codePixel.greenComponent < 0.1)
+        #expect(codePixel.blueComponent > 0.9)
+        let gutterPixel = try #require(bitmap.colorAt(x: 20, y: 100)?.usingColorSpace(.deviceRGB))
+        #expect(gutterPixel.redComponent < 0.9)
+    }
+
+    @Test func lineNumberRulerDrawsOnlyDirtyRowsInTallHunks() throws {
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 420, height: 20_000))
+        scrollView.documentView = NSView(frame: scrollView.bounds)
+        let ruler = DiffPaneLineNumberRulerView(scrollView: scrollView)
+        scrollView.verticalRulerView = ruler
+        scrollView.hasVerticalRuler = true
+        scrollView.rulersVisible = true
+        ruler.update(
+            labels: (1...1_000).map(String.init),
+            lineTones: Array(repeating: .context, count: 1_000),
+            rowHeight: 20,
+            contentTopInset: 0,
+            theme: try Theme.loadBundled(id: "cool-slate"),
+            expansionRequests: [],
+            activeCommentHighlight: nil,
+            onContextExpansion: { _, _, _ in }
+        )
+        scrollView.layoutSubtreeIfNeeded()
+        let bitmap = try #require(NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: 80, pixelsHigh: 100,
+            bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true,
+            isPlanar: false, colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0
+        ))
+        NSGraphicsContext.saveGraphicsState()
+        defer { NSGraphicsContext.restoreGraphicsState() }
+        NSGraphicsContext.current = try #require(NSGraphicsContext(bitmapImageRep: bitmap))
+
+        ruler.drawHashMarksAndLabels(in: NSRect(x: 0, y: 4_005, width: 60, height: 90))
+
+        #expect(ruler.drawnRowCountForTesting == 5)
+
+        let outerScrollView = AppKitDiffScrollView(frame: NSRect(x: 0, y: 0, width: 420, height: 90))
+        outerScrollView.flippedDocumentView.addSubview(scrollView)
+        outerScrollView.setDocumentHeight(20_000)
+        outerScrollView.layoutSubtreeIfNeeded()
+        outerScrollView.setScrollY(4_005, animated: false)
+        #expect(abs(ruler.visibleRect.minY - 4_005) < 0.5)
+        #expect(ruler.visibleRect.height == 90)
+
+        ruler.drawHashMarksAndLabels(in: ruler.bounds)
+        #expect(ruler.drawnRowCountForTesting == 5)
+
+        ruler.drawHashMarksAndLabels(in: NSRect(x: 0, y: 0, width: 60, height: 90))
+        #expect(ruler.drawnRowCountForTesting == 0)
+
+        scrollView.removeFromSuperview()
+        scrollView.documentView?.setFrameSize(NSSize(width: 1_000, height: 40_000))
+        scrollView.contentView.setBoundsOrigin(NSPoint(x: 100, y: 19_995))
+        ruler.drawHashMarksAndLabels(in: NSRect(x: 0, y: 0, width: 60, height: 90))
+        #expect(ruler.drawnRowCountForTesting == 1)
+    }
+
     @Test func diffPaneLineNumberRulerCachesMappedRowGeometryForVisibleLookups() throws {
         let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
         let lines = (1...80).map { "let value\($0) = \($0)" }


### PR DESCRIPTION
## Summary
- limit diff line-number gutter drawing to dirty visible rows
- avoid gutter background overpainting adjacent code when AppKit exposes a wider visible rect
- add regression coverage for clipping and tall-hunk row culling

## Verification
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffPaneViewTests -only-testing:AlasTests/AppKitDiffScrollerReconcilerTests -only-testing:AlasTests/AppKitDiffScrollerStressTests -only-testing:AlasTests/AppKitDiffReviewFlingPerfTests test

Note: the full local test command was interrupted after the xcodebuild driver sat idle for several minutes with no active xctest host. CI should provide the full-suite signal.