### PR TITLE
fix(acp): hide provider pill when there's nothing to switch to

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -197,12 +197,15 @@ final class ACPSession: ObservableObject, Identifiable {
         return availableModels.first { $0.id == id }?.name ?? id
     }
 
+    /// The provider pill is informational, so it only earns composer space when
+    /// the adapter actually offers a choice. A lone active provider — required
+    /// or not, and ignoring any disabled ones sitting alongside it — tells the
+    /// user nothing they can act on, so it stays hidden.
     var currentProviderDisplayName: String? {
         guard agentState == .ready, providerCapabilities != nil else { return nil }
         let currentProviders = availableProviders.filter { $0.current != nil }
-        guard currentProviders.count != 1 || !currentProviders[0].required else { return nil }
-        let names = currentProviders
-            .map { $0.name ?? $0.providerId }
+        guard currentProviders.count > 1 else { return nil }
+        let names = currentProviders.map { $0.name ?? $0.providerId }
         return names.isEmpty ? nil : names.joined(separator: ", ")
     }
 

--- a/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
@@ -72,6 +72,44 @@ struct ACPSessionAgentStateTests {
 
         #expect(session.currentProviderDisplayName == nil)
     }
+
+    @Test("lone optional provider is hidden — nothing to switch to")
+    func loneOptionalProviderIsHidden() {
+        let session = ACPSession(id: "s1", agentId: "codex", worktreeId: "wt", title: "one")
+        session.providerCapabilities = .init()
+        session.availableProviders = [.init(
+            providerId: "main",
+            name: "main",
+            supported: ["openai"],
+            required: false,
+            current: .init(apiType: "openai", baseUrl: "https://api.openai.com")
+        )]
+        session.agentState = .ready
+
+        #expect(session.currentProviderDisplayName == nil)
+    }
+
+    @Test("a disabled provider alongside the active one doesn't count as a choice")
+    func disabledProviderDoesNotKeepPillVisible() {
+        let session = ACPSession(id: "s1", agentId: "codex", worktreeId: "wt", title: "one")
+        session.providerCapabilities = .init()
+        session.availableProviders = [.init(
+            providerId: "main",
+            name: "main",
+            supported: ["openai"],
+            required: false,
+            current: .init(apiType: "openai", baseUrl: "https://api.openai.com")
+        ), .init(
+            providerId: "gateway",
+            name: "Enterprise Gateway",
+            supported: ["anthropic"],
+            required: false,
+            current: nil
+        )]
+        session.agentState = .ready
+
+        #expect(session.currentProviderDisplayName == nil)
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

- The composer's provider pill (`Provider: main`) is purely informational, so it should only take up space when the adapter actually offers a choice between providers.
- Extends the existing "hide the lone required provider" rule (#1068) to hide the pill whenever there's at most one *active* provider — required or not.
- Ignores disabled providers (no `current` config) sitting alongside the active one when deciding whether a real choice exists, so a single usable provider with a disabled sibling still hides the pill.

### Reviewer notes

- `ACPSession.currentProviderDisplayName` now filters to providers with `current != nil` first, then requires more than one before showing anything — same shape as before, just gated on count rather than the required-flag special case.
- Added coverage in `ACPSessionAgentStateTests` for the lone-optional-provider and disabled-sibling cases.