### PR TITLE
perf(acp): skip unchanged transcript scroll layout passes

### DIFF
--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -718,7 +718,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             // explicit call is needed at either site.
             guard !isProgrammatic else {
                 if !reconciler.isApplyingSpecs {
-                    reconciler.layoutMountedRows()
+                    reconciler.layoutMountedRowsForScroll()
                 }
                 syncLogicalScrollerMetrics()
                 return
@@ -810,7 +810,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             // first means that belief is already correct by the time any
             // row is mounted.
             if !reconciler.isApplyingSpecs {
-                reconciler.layoutMountedRows()
+                reconciler.layoutMountedRowsForScroll()
             }
 
             let threshold = ACPTranscriptScroller.headStepThreshold(viewportHeight: viewportHeight)

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -77,6 +77,7 @@ final class ACPTranscriptScrollerReconciler {
     /// pass just mounted.
     private var isLayingOutRows = false
     private var pendingRelayout = false
+    private var lastLaidOutBand: Range<Int>?
 
     /// A scroll anchor whose row was removed by an update, kept so the
     /// position can be recovered if the row comes back.
@@ -794,12 +795,18 @@ final class ACPTranscriptScrollerReconciler {
         }
     }
 
-    /// Mount hosting views for rows in the band, position them, unmount the
-    /// rest. Called after every apply and on every scroll tick. Re-entrant
-    /// calls (triggered by AppKit/SwiftUI invalidating a row's intrinsic
-    /// size as a side effect of a mount/measure happening inside a pass)
-    /// coalesce into an extra pass afterward instead of recursing.
+    /// Scrolling only changes which rows need hosting views. Between band
+    /// crossings, their content and document-relative frames stay unchanged.
+    func layoutMountedRowsForScroll() {
+        guard currentMountBand != lastLaidOutBand else { return }
+        layoutMountedRows()
+    }
+
+    /// Mount and position rows after content or geometry changes. Reentrant
+    /// invalidations coalesce into another pass before the scroll fast path
+    /// can reuse the resulting band.
     func layoutMountedRows() {
+        lastLaidOutBand = nil
         guard !isLayingOutRows else {
             pendingRelayout = true
             return
@@ -818,6 +825,17 @@ final class ACPTranscriptScrollerReconciler {
                 break
             }
         }
+        if !pendingRelayout {
+            lastLaidOutBand = currentMountBand
+        }
+    }
+
+    private var currentMountBand: Range<Int> {
+        tiling.mountBand(
+            viewportMinY: scroller.scrollY,
+            viewportHeight: scroller.viewportHeight,
+            overscan: Self.overscan
+        )
     }
 
     private func performLayoutPass() {
@@ -825,11 +843,7 @@ final class ACPTranscriptScrollerReconciler {
             pool.releaseAll()
             return
         }
-        let band = tiling.mountBand(
-            viewportMinY: scroller.scrollY,
-            viewportHeight: scroller.viewportHeight,
-            overscan: Self.overscan
-        )
+        let band = currentMountBand
         // Rows in the band, PLUS any row exempted from unmounting regardless
         // of distance from the viewport (an in-progress form prompt, say).
         // The exemption only widens which rows get mounted/kept — `band`

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
@@ -117,6 +117,114 @@ private final class RowBuildCounter {
 @MainActor
 @Suite("ACPTranscriptScrollerReconciler apply")
 struct ACPTranscriptScrollerReconcilerApplyTests {
+    private struct CountingToken: Equatable {
+        var revision = 0
+        let recordComparison: () -> Void
+
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.recordComparison()
+            return lhs.revision == rhs.revision
+        }
+    }
+
+    @Test("scrolling within the mounted band does not revisit row content", arguments: [800, 2160])
+    func unchangedScrollBandSkipsRowWork(viewportHeight: Int) {
+        let (reconciler, scroller, _) = makeStack()
+        scroller.frame.size.height = CGFloat(viewportHeight)
+        scroller.layoutSubtreeIfNeeded()
+        var comparisons = 0
+        let specs = (0..<100).map { index in
+            ACPTranscriptRowSpec(
+                id: "r\(index)",
+                equalityToken: ACPRowEqualityToken(CountingToken { comparisons += 1 }),
+                build: { AnyView(Color.clear.frame(height: 100)) }
+            )
+        }
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: false)
+        scroller.setScrollY(2000)
+        reconciler.layoutMountedRowsForScroll()
+        comparisons = 0
+
+        for offset in 1...20 {
+            scroller.setScrollY(2000 + CGFloat(offset))
+            reconciler.layoutMountedRowsForScroll()
+        }
+
+        #expect(comparisons == 0)
+    }
+
+    @Test("scroll band changes mount new rows and preserve an offscreen form")
+    func scrollBandChangeUpdatesMountedRows() throws {
+        let (reconciler, scroller, _, pool) = makeStackWithPool()
+        let specs = (0..<100).map { spec("r\($0)", keepsMountedOffscreen: $0 == 0) }
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: false)
+        let form = try #require(pool.mountedView(id: "r0"))
+        #expect(pool.mountedView(id: "r50") == nil)
+
+        scroller.setScrollY(5900)
+        reconciler.layoutMountedRowsForScroll()
+
+        #expect(pool.mountedView(id: "r50")?.superview === scroller.flippedDocumentView)
+        #expect(pool.mountedView(id: "r1") == nil)
+        #expect(pool.mountedView(id: "r0") === form)
+
+        scroller.setScrollY(0)
+        reconciler.layoutMountedRowsForScroll()
+        #expect(pool.mountedView(id: "r1")?.superview === scroller.flippedDocumentView)
+        #expect(pool.mountedView(id: "r50") == nil)
+    }
+
+    @Test("content and intrinsic height changes still reposition rows within the same scroll band")
+    func contentChangesBypassScrollFastPath() throws {
+        let (reconciler, scroller, _, pool) = makeStackWithPool()
+        reconciler.apply(specs: [spec("a"), spec("b")], contentWidth: 600, followsTail: false)
+        reconciler.layoutMountedRowsForScroll()
+
+        reconciler.apply(
+            specs: [spec("a", token: 1, height: 200), spec("b")],
+            contentWidth: 600, followsTail: false
+        )
+        #expect(pool.mountedView(id: "b")?.frame.minY == 242)
+
+        let first = try #require(pool.mountedView(id: "a"))
+        first.updateRootView(AnyView(Color.clear.frame(height: 300)))
+        reconciler.remeasureRow(id: "a")
+        reconciler.layoutMountedRowsForScroll()
+        #expect(pool.mountedView(id: "b")?.frame.minY == 342)
+        #expect(scroller.contentHeight == 442)
+    }
+
+    @Test("scroll-time remeasurement fills the expanded band before caching it")
+    func scrollRemeasureConvergesBeforeCaching() {
+        let (reconciler, scroller, tiling) = makeStack()
+        var comparisons = 0
+        func rows(shrunk: Bool) -> [ACPTranscriptRowSpec] {
+            (0..<60).map { index in
+                ACPTranscriptRowSpec(
+                    id: "r\(index)",
+                    equalityToken: ACPRowEqualityToken(CountingToken(
+                        revision: shrunk && index == 20 ? 1 : 0,
+                        recordComparison: { comparisons += 1 }
+                    )),
+                    build: { AnyView(Color.clear.frame(height: !shrunk && index == 20 ? 1000 : 100)) }
+                )
+            }
+        }
+        reconciler.apply(specs: rows(shrunk: false), contentWidth: 600, followsTail: false)
+        reconciler.apply(specs: rows(shrunk: true), contentWidth: 600, followsTail: false)
+        #expect(tiling.row(withId: "r20")?.height == 1000)
+
+        scroller.setScrollY(1000)
+        reconciler.layoutMountedRowsForScroll()
+
+        #expect(tiling.row(withId: "r20")?.height == 100)
+        #expect(reconciler.mountedRowIdsForTesting == Set((0...21).map { "r\($0)" }))
+        comparisons = 0
+        scroller.setScrollY(1001)
+        reconciler.layoutMountedRowsForScroll()
+        #expect(comparisons == 0)
+    }
+
     private func makeStack() -> (ACPTranscriptScrollerReconciler, ACPTranscriptScrollerView, ACPTranscriptTilingController) {
         let scroller = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
         let tiling = ACPTranscriptTilingController()


### PR DESCRIPTION
Scrolling the ACP transcript revisited every mounted row on each tick, even when the mounted range was unchanged. Taller viewports increased these redundant content comparisons and frame assignments.

Skip those layout passes until the mounted range changes. Content updates, resizing, and intrinsic height changes still run full layout, and the cached range is published only after reentrant layout converges.

Validation:
- In 20 small scroll steps, row comparisons fell from 560 to zero at an 800-point viewport and from 800 to zero at 2160 points.
- macOS build and SwiftFormat lint passed.
- 96 tests across 10 scroller suites passed, including band crossings, retained offscreen forms, content growth, and mount-time remeasurement.
- The full local suite stalled with terminal-cleanup workers blocked after three worktree-creation timeouts. Those three tests and the stalled Mermaid test all passed in a fresh, isolated run.

Actual 4K frame-rate improvement has not been profiled yet.
