### PR TITLE
fix(theme): never trap at startup when bundled themes fail to load

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -629,7 +629,10 @@ final class AppState {
             _ = try? store.write(spacesManager.file, to: Paths.spacesFile)
         }
         self.spacesManager = spacesManager
-        let themeStore = (try? ThemeStore(initialId: config.themeId)) ?? (try! ThemeStore())
+        // Non-throwing on purpose: theme resources can be missing (partial
+        // build, test host, corrupted install) and startup must never trap
+        // in a `try!`. Falls back persisted id → bundled ids → fallback.
+        let themeStore = ThemeStore.creating(initialId: config.themeId)
         // Apply the persisted accent override so the picker's selection
         // survives relaunches; otherwise launches always show the theme's
         // built-in accent until the user re-clicks the picker.

--- a/Alas/Sources/Theme/Theme.swift
+++ b/Alas/Sources/Theme/Theme.swift
@@ -47,6 +47,11 @@ struct Theme: Codable, Equatable, Hashable {
 
     static let bundledIds = ["cool-slate", "light"]
 
+    /// Last-resort theme used when no bundled theme resource can be loaded
+    /// (e.g. missing bundle resources). Renders plain but keeps the app
+    /// running; `color(_:)` returns its pink sentinel for missing tokens.
+    static let fallback = Theme(id: "fallback", name: "Fallback", tokens: [:])
+
     /// Hex strings for the 5 named accents in AppearancePane.
     /// Keep in sync with the picker's `accents` array.
     static let accentHexById: [String: String] = [

--- a/Alas/Sources/Theme/ThemeStore.swift
+++ b/Alas/Sources/Theme/ThemeStore.swift
@@ -61,6 +61,7 @@ final class ThemeStore {
     private init(fallbackWithCurrent theme: Theme) {
         self.userPickedId = theme.id
         self.current = theme
+        registerAppearanceObserver()
     }
 
     /// `AppleInterfaceThemeChangedNotification` is delivered on the

--- a/Alas/Sources/Theme/ThemeStore.swift
+++ b/Alas/Sources/Theme/ThemeStore.swift
@@ -26,20 +26,54 @@ final class ThemeStore {
     init(initialId: String = "cool-slate") throws {
         self.userPickedId = initialId
         self.current = try Theme.loadBundled(id: initialId)
-        // `AppleInterfaceThemeChangedNotification` is delivered on the
-        // *distributed* notification center (macOS broadcasts it across
-        // process boundaries). Observing the in-process default center
-        // would silently never fire.
+        registerAppearanceObserver()
+    }
+
+    /// Non-throwing factory for startup paths. Resolves the requested id,
+    /// then any bundled id, then a guaranteed in-code fallback theme — a
+    /// missing or unloadable bundle resource must never trap the app at
+    /// launch (see AppState.init).
+    static func creating(
+        initialId: String,
+        loader: (String) throws -> Theme = Theme.loadBundled(id:)
+    ) -> ThemeStore {
+        if let theme = try? loader(initialId) {
+            return ThemeStore(resolvedTheme: theme, initialId: initialId)
+        }
+        for id in Theme.bundledIds {
+            if let theme = try? loader(id) {
+                return ThemeStore(resolvedTheme: theme, initialId: id)
+            }
+        }
+        return ThemeStore(fallbackWithCurrent: .fallback)
+    }
+
+    deinit {
+        DistributedNotificationCenter.default().removeObserver(self)
+    }
+
+    private init(resolvedTheme: Theme, initialId: String) {
+        self.userPickedId = initialId
+        self.current = resolvedTheme
+        registerAppearanceObserver()
+    }
+
+    private init(fallbackWithCurrent theme: Theme) {
+        self.userPickedId = theme.id
+        self.current = theme
+    }
+
+    /// `AppleInterfaceThemeChangedNotification` is delivered on the
+    /// *distributed* notification center (macOS broadcasts it across
+    /// process boundaries). Observing the in-process default center
+    /// would silently never fire.
+    private func registerAppearanceObserver() {
         DistributedNotificationCenter.default().addObserver(
             self,
             selector: #selector(systemAppearanceDidChange),
             name: NSNotification.Name("AppleInterfaceThemeChangedNotification"),
             object: nil
         )
-    }
-
-    deinit {
-        DistributedNotificationCenter.default().removeObserver(self)
     }
 
     func activate(id: String) throws {

--- a/AlasTests/ThemeStoreTests.swift
+++ b/AlasTests/ThemeStoreTests.swift
@@ -39,6 +39,17 @@ struct ThemeStoreTests {
         #expect(store.current.id == "cool-slate")
     }
 
+    @Test func creatingTriesPersistedThenBundledOrderWithInjectedLoader() {
+        var requestedIds: [String] = []
+        let store = ThemeStore.creating(initialId: "nope") { id in
+            requestedIds.append(id)
+            if id == "light" { return Theme(id: id, name: "Light", tokens: [:]) }
+            throw NSError(domain: "Theme", code: 1)
+        }
+        #expect(requestedIds == ["nope", "cool-slate", "light"])
+        #expect(store.current.id == "light")
+    }
+
     @Test func creatingNeverThrowsWhenNothingLoads() {
         let store = ThemeStore.creating(initialId: "nope") { _ in
             throw NSError(domain: "Theme", code: 1)

--- a/AlasTests/ThemeStoreTests.swift
+++ b/AlasTests/ThemeStoreTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Alas
 
@@ -26,6 +27,23 @@ struct ThemeStoreTests {
         store.setMatchSystem(true)
         store.setMatchSystem(false)
         #expect(store.current.id == "light")
+    }
+
+    @Test func creatingUsesInitialIdWhenLoadable() {
+        let store = ThemeStore.creating(initialId: "light")
+        #expect(store.current.id == "light")
+    }
+
+    @Test func creatingFallsBackToBundledThemeWhenInitialIdMissing() {
+        let store = ThemeStore.creating(initialId: "nope")
+        #expect(store.current.id == "cool-slate")
+    }
+
+    @Test func creatingNeverThrowsWhenNothingLoads() {
+        let store = ThemeStore.creating(initialId: "nope") { _ in
+            throw NSError(domain: "Theme", code: 1)
+        }
+        #expect(store.current.id == "fallback")
     }
 
     @Test func failedActivationPreservesUserPick() throws {


### PR DESCRIPTION
## Problem

`/tmp/alascrash1.log` showed a startup SIGTRAP on the main thread:

```
0 libswiftCore  _assertionFailure
1 libswiftCore  swift_unexpectedError
2 Alas          AppState.init(...) + 9512
```

Symbolication of the exact crashed binary (UUID `6e28a752…`) plus
disassembly pinned the faulting call to **AppState.swift:632:71** — the
`(try! ThemeStore())` fallback. When the bundled `cool-slate.json`
could not be loaded from `Bundle.main` (partial build, test host,
corrupted install), both theme attempts threw and the `try!` trapped
before the app could show a window.

## Fix

- Replace the `try!` with a new non-throwing factory
  `ThemeStore.creating(initialId:loader:)` that resolves
  persisted id → bundled ids → an in-code `Theme.fallback`, so theme
  loading can never trap app launch.
- Add `Theme.fallback`, matching the fallback convention already used
  by `CodeEditorCoordinator` and `ThemeEnvironment`.
- Extract the shared distributed-notification observer registration.

## Tests

Three new `ThemeStoreTests` cover each fallback tier (persisted id,
bundled fallback, nothing-loads). Written first and watched fail before
implementing.