### PR TITLE
feat(editor): code boxes for triple-backtick fences in markdown editors

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -957,6 +957,7 @@
 		9B00878F781FADB428684B2D /* DiffDisplaySignatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 283613E170E25F69521F64ED /* DiffDisplaySignatureTests.swift */; };
 		9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */; };
 		9BA16B0D5FC26501D54B5192 /* WorkingTreeStageAllActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F931B1EEA7F04855BAE5A43 /* WorkingTreeStageAllActionTests.swift */; };
+		9BAF14A88AEB1F888D7541DC /* MarkdownCodeBoxSurfaceOptInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED105A2C41B953A4DC9B8F6 /* MarkdownCodeBoxSurfaceOptInTests.swift */; };
 		9C03E77926427C9236E2922C /* ReviewCommentWireDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D7BE909731E9D15A032A6E0 /* ReviewCommentWireDTO.swift */; };
 		9C20E8B060C753308748CE05 /* ProjectsManagerProjectOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0315FB9B537C0A240CFA32 /* ProjectsManagerProjectOrderingTests.swift */; };
 		9C394F07FDB8E398A034B778 /* SessionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */; };
@@ -2283,6 +2284,7 @@
 		6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutResolverTests.swift; sourceTree = "<group>"; };
 		6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitIgnoreServiceTests.swift; sourceTree = "<group>"; };
 		6EC184A7BDBFF2156FD2AD44 /* ACPOrchestrationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPOrchestrationModels.swift; sourceTree = "<group>"; };
+		6ED105A2C41B953A4DC9B8F6 /* MarkdownCodeBoxSurfaceOptInTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCodeBoxSurfaceOptInTests.swift; sourceTree = "<group>"; };
 		6F0AE27D70E34430C71AAF84 /* ProviderReviewMutationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewMutationController.swift; sourceTree = "<group>"; };
 		6F4D0EAA4C7CB45617BDD3FE /* ReadonlyTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadonlyTextView.swift; sourceTree = "<group>"; };
 		6F88DEFC78E8D8AF65CB740A /* PairedReviewComposerSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedReviewComposerSurfaceTests.swift; sourceTree = "<group>"; };
@@ -4870,6 +4872,7 @@
 			isa = PBXGroup;
 			children = (
 				039CD39D75F64498A6C8320A /* MarkdownCodeBlockStylerTests.swift */,
+				6ED105A2C41B953A4DC9B8F6 /* MarkdownCodeBoxSurfaceOptInTests.swift */,
 				6D7B2B217CFB556E9AFDDE5A /* MarkdownFenceEditingTests.swift */,
 				5B40A20BB651C706C9C6FAAA /* PairedDelimiterFenceBoxTests.swift */,
 				06241E3F5DD1D1E06E57813A /* PairedDelimiterFenceTests.swift */,
@@ -7412,6 +7415,7 @@
 				686BB3FB9735836CFCAAE0D1 /* MCPRegistrationDecisionTests.swift in Sources */,
 				B3DEC3EEA46D77D7BE864A74 /* MCPRegistrationRegistryTests.swift in Sources */,
 				21F53035247CA88EA8DBB1AC /* MarkdownCodeBlockStylerTests.swift in Sources */,
+				9BAF14A88AEB1F888D7541DC /* MarkdownCodeBoxSurfaceOptInTests.swift in Sources */,
 				35E3ADFBC4F9CE3202773505 /* MarkdownFenceEditingTests.swift in Sources */,
 				165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */,
 				6A5D19016FE0100CD54D24B2 /* MarkdownImageLoaderTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1282,6 +1282,7 @@
 		CFD4BC59E32060DCBB101D56 /* ACPSpeechDictationEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 145669B8ECC803C942A6FB42 /* ACPSpeechDictationEngine.swift */; };
 		D002012348D4DA7E124632BF /* SpacePagerIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9294E94F46763CC8DCD93A3 /* SpacePagerIndicator.swift */; };
 		D02BB257817B709817CAB2B6 /* ACPRemoteMCPFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB5D1C8046EF9B6A95C41CD /* ACPRemoteMCPFilter.swift */; };
+		D034E719261C62047659AD68 /* PairedDelimiterFenceBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B40A20BB651C706C9C6FAAA /* PairedDelimiterFenceBoxTests.swift */; };
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
 		D063240A6A5B8C4766B36F7B /* ACPToolCallCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 869F008CBAF90B11A48EFD46 /* ACPToolCallCardTests.swift */; };
 		D0E9985350ECD64F1D042345 /* MermaidModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33AEF4AA4C36DBC1B912F25 /* MermaidModelsTests.swift */; };
@@ -2161,6 +2162,7 @@
 		5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateFileTreeTests.swift; sourceTree = "<group>"; };
 		5AA5809066E33EB30E09E0D8 /* RemoteWebAssetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWebAssetTests.swift; sourceTree = "<group>"; };
 		5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigTests.swift; sourceTree = "<group>"; };
+		5B40A20BB651C706C9C6FAAA /* PairedDelimiterFenceBoxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedDelimiterFenceBoxTests.swift; sourceTree = "<group>"; };
 		5B4239E76E57C63CD983437F /* RemoteZmxInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteZmxInstaller.swift; sourceTree = "<group>"; };
 		5B5EA9E4B728B9C4FDA2E104 /* MCPRegistrationRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPRegistrationRegistry.swift; sourceTree = "<group>"; };
 		5B6C1F946AC7EC621C5A8A59 /* AppKitDiffReviewScrollerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffReviewScrollerTests.swift; sourceTree = "<group>"; };
@@ -4858,6 +4860,7 @@
 			children = (
 				039CD39D75F64498A6C8320A /* MarkdownCodeBlockStylerTests.swift */,
 				6D7B2B217CFB556E9AFDDE5A /* MarkdownFenceEditingTests.swift */,
+				5B40A20BB651C706C9C6FAAA /* PairedDelimiterFenceBoxTests.swift */,
 				06241E3F5DD1D1E06E57813A /* PairedDelimiterFenceTests.swift */,
 			);
 			path = UI;
@@ -7431,6 +7434,7 @@
 				7EB1A9415AE49BBB694946AC /* PairedComposerTextControlsTests.swift in Sources */,
 				407C480A97251F3D342D84F7 /* PairedDelimiterDeadKeyTests.swift in Sources */,
 				DCF52CA0F7607995402CED3D /* PairedDelimiterEditingTests.swift in Sources */,
+				D034E719261C62047659AD68 /* PairedDelimiterFenceBoxTests.swift in Sources */,
 				05188310E27A5460F614BC83 /* PairedDelimiterFenceTests.swift in Sources */,
 				DDE5BE847DFFF54429D61D4E /* PairedPrimaryComposerSurfaceTests.swift in Sources */,
 				E4BE423D04F69D25C520A80B /* PairedReviewComposerSurfaceTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -211,6 +211,7 @@
 		21A94ADFA16F85C7ACAB4DA1 /* ACPMarkdownBlockCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */; };
 		21D97FBF7356BC50400E0265 /* CommitContextBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F544A8DC56D0D4166E0A4F /* CommitContextBuilderTests.swift */; };
 		21DDC95793C87C46FB46E3D6 /* ImageDiffSwipeViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7018E992654E19345D8BD723 /* ImageDiffSwipeViewTests.swift */; };
+		21F53035247CA88EA8DBB1AC /* MarkdownCodeBlockStylerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039CD39D75F64498A6C8320A /* MarkdownCodeBlockStylerTests.swift */; };
 		21FBAF70DBD55FF57DAB796D /* ReviewRequestDiffLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCAB297DB983CBDD70CDDB24 /* ReviewRequestDiffLoaderTests.swift */; };
 		2281077800674169E69C6C3B /* HoverWindowControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9032BA9542C617A09EF848 /* HoverWindowControllerTests.swift */; };
 		22FDE2FB05952993DA2D0EB7 /* WorkingTreeSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */; };
@@ -929,6 +930,7 @@
 		9737C1A3CD708D28C62FD6A5 /* ACPMessageStableIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6048519B4C444FCB46A11E49 /* ACPMessageStableIdTests.swift */; };
 		9782C5866410EFE13E670AFF /* FilesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4A3B9B1103346242438940 /* FilesTabView.swift */; };
 		97D86F05B3993A61A0302B97 /* DefinitionSnippetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */; };
+		97DC7798FBDEBD8F0B433D25 /* MarkdownCodeBlockStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DD2FEF5D33576B468300C9 /* MarkdownCodeBlockStyler.swift */; };
 		97E90C02DD115438B5E12DF2 /* ACPPlanPillStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */; };
 		981730A24BE369F4AE9012F3 /* ChatPaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3986789560012DF861565F12 /* ChatPaneTests.swift */; };
 		9831EFFF98FCEC663309D8A9 /* ACPMarkdownInlineTextViewHeightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CCF73DAD392176A774ABA67 /* ACPMarkdownInlineTextViewHeightTests.swift */; };
@@ -1630,6 +1632,7 @@
 		0359D6646D12B66B70B5BB43 /* AiSplitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiSplitButton.swift; sourceTree = "<group>"; };
 		039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceTests.swift; sourceTree = "<group>"; };
 		039C5E652B7A9457EB13BD70 /* ReviewRequestContextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestContextBuilder.swift; sourceTree = "<group>"; };
+		039CD39D75F64498A6C8320A /* MarkdownCodeBlockStylerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCodeBlockStylerTests.swift; sourceTree = "<group>"; };
 		03A4B0CD519C39CCB197CBD4 /* GitInvocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitInvocationTests.swift; sourceTree = "<group>"; };
 		03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreQueueTests.swift; sourceTree = "<group>"; };
 		03E54D3FBA0EB8B5DCF52179 /* RemoteHelperACPTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperACPTransport.swift; sourceTree = "<group>"; };
@@ -3126,6 +3129,7 @@
 		F89DAC6A8A16FADF8D614D0A /* PairedPrimaryComposerSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedPrimaryComposerSurfaceTests.swift; sourceTree = "<group>"; };
 		F8A5D091F06D7B2D02072492 /* ACPTranscriptScrollerReconcilerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptScrollerReconcilerTests.swift; sourceTree = "<group>"; };
 		F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerAttachRestoreTests.swift; sourceTree = "<group>"; };
+		F8DD2FEF5D33576B468300C9 /* MarkdownCodeBlockStyler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCodeBlockStyler.swift; sourceTree = "<group>"; };
 		F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceDiscardTests.swift; sourceTree = "<group>"; };
 		F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchDialog.swift; sourceTree = "<group>"; };
 		F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessServiceTests.swift; sourceTree = "<group>"; };
@@ -4042,6 +4046,7 @@
 				5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */,
 				7BEC4E033DB3BA44C825D453 /* EmojiPickerButton.swift */,
 				16CA8FEE64D73BDEBAF74878 /* Kbd.swift */,
+				F8DD2FEF5D33576B468300C9 /* MarkdownCodeBlockStyler.swift */,
 				CB90EF05C6A486F35ACD0E1B /* MarkdownFenceEditing.swift */,
 				36B8003F90C5FD770A293717 /* PairedComposerTextControls.swift */,
 				9C4B3503EDFD4AAEAA6894FE /* PairedDelimiterEditing.swift */,
@@ -4849,6 +4854,7 @@
 		8C9686DB6E16B49CAF3AE6FF /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				039CD39D75F64498A6C8320A /* MarkdownCodeBlockStylerTests.swift */,
 				6D7B2B217CFB556E9AFDDE5A /* MarkdownFenceEditingTests.swift */,
 			);
 			path = UI;
@@ -6608,6 +6614,7 @@
 				01BB37E08A2DCC66374F643B /* MCPHelloEvent.swift in Sources */,
 				F11A596534EEDD3C678DF196 /* MCPRegistrationDecision.swift in Sources */,
 				81F6E32B97FCE84E5F986A31 /* MCPRegistrationRegistry.swift in Sources */,
+				97DC7798FBDEBD8F0B433D25 /* MarkdownCodeBlockStyler.swift in Sources */,
 				0FD892082365E7FCFD0526F3 /* MarkdownFenceEditing.swift in Sources */,
 				2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */,
 				B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */,
@@ -7383,6 +7390,7 @@
 				7FF3268907E59906B3862648 /* MCPHelloEventTests.swift in Sources */,
 				686BB3FB9735836CFCAAE0D1 /* MCPRegistrationDecisionTests.swift in Sources */,
 				B3DEC3EEA46D77D7BE864A74 /* MCPRegistrationRegistryTests.swift in Sources */,
+				21F53035247CA88EA8DBB1AC /* MarkdownCodeBlockStylerTests.swift in Sources */,
 				35E3ADFBC4F9CE3202773505 /* MarkdownFenceEditingTests.swift in Sources */,
 				165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */,
 				6A5D19016FE0100CD54D24B2 /* MarkdownImageLoaderTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		128B611E5324A5621897A267 /* ACPVisibleRowsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0582531788CE9D1D49769F6B /* ACPVisibleRowsCache.swift */; };
 		1298147855092677E3184AC2 /* ACPConfigOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C6356C759B509DD81EDEBB /* ACPConfigOption.swift */; };
 		12EB0B042A0225258B8A6C99 /* ACPOrchestrationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC184A7BDBFF2156FD2AD44 /* ACPOrchestrationModels.swift */; };
+		12FD90326DDF6E8BDF2A67B4 /* ACPComposerCodeFenceKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F1A28F4C52A2FC6B0B4186 /* ACPComposerCodeFenceKeyTests.swift */; };
 		133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */; };
 		1339BE8F736D53991DDD19CD /* FileSearchBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D68E2007F0370A6C4E7DBC7 /* FileSearchBackend.swift */; };
 		137BF3AED8FFF6D42228EFC0 /* PiMCPAdapterInspectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40A1779F98074142F57210B /* PiMCPAdapterInspectorTests.swift */; };
@@ -2017,6 +2018,7 @@
 		41B7844FCFC1DD54B2B471F8 /* InstallNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallNudgeBanner.swift; sourceTree = "<group>"; };
 		4246F7A17DCEC4D2A669BC43 /* ImageDiffDifferenceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDifferenceView.swift; sourceTree = "<group>"; };
 		4261E417947C1A21E77C1587 /* GitStatusCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusCache.swift; sourceTree = "<group>"; };
+		42F1A28F4C52A2FC6B0B4186 /* ACPComposerCodeFenceKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerCodeFenceKeyTests.swift; sourceTree = "<group>"; };
 		4306DE43C5ADCC65310C1169 /* ACPQuestionPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionPrompt.swift; sourceTree = "<group>"; };
 		430FCE70CDAB35CB0594CF44 /* AlasCLIReviewTargetResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIReviewTargetResolver.swift; sourceTree = "<group>"; };
 		431BECA1461B76DF86BBFBDF /* FileTreeRowIndentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeRowIndentationTests.swift; sourceTree = "<group>"; };
@@ -4297,6 +4299,7 @@
 				81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */,
 				2B7ADCB7C4178FE036A31214 /* ACPComposerActionButtonMetricsTests.swift */,
 				DE2ABBFA4FB2E5FC2D38C5D3 /* ACPComposerCodeBlockStylingTests.swift */,
+				42F1A28F4C52A2FC6B0B4186 /* ACPComposerCodeFenceKeyTests.swift */,
 				EE91017BB71AB08265C7B56E /* ACPComposerControlPresentationDictationTests.swift */,
 				B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */,
 				98CA6A0F4862D9A29E4151B5 /* ACPComposerFocusPolicyTests.swift */,
@@ -6962,6 +6965,7 @@
 				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,
 				33A0FC862C45CDFF47053A04 /* ACPComposerActionButtonMetricsTests.swift in Sources */,
 				C31DBE249E28F1C82421537C /* ACPComposerCodeBlockStylingTests.swift in Sources */,
+				12FD90326DDF6E8BDF2A67B4 /* ACPComposerCodeFenceKeyTests.swift in Sources */,
 				0191E2173516054F2E502C8E /* ACPComposerControlPresentationDictationTests.swift in Sources */,
 				1721FFC6A99B6E2683378552 /* ACPComposerDraftBridgeTests.swift in Sources */,
 				3518735F0614C32919E3FC27 /* ACPComposerDraftTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -821,6 +821,7 @@
 		85B8A8B929BD4ED4DC21FEDD /* ACPDelayedHoverVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3D3BB0A631D42AD22DBE0F /* ACPDelayedHoverVisibility.swift */; };
 		85C7E65296AB9500FF52060A /* session-update-plan.json in Resources */ = {isa = PBXBuildFile; fileRef = 7094534860369BA79FC5A877 /* session-update-plan.json */; };
 		85EAA2D64D794E045BDF7532 /* MergeAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14BF0C745544F99CB3C6006 /* MergeAgentTests.swift */; };
+		860779AD10CE0B382D196FD4 /* MarkdownCodeBlockStyle+Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F6C56877C39525B529A251B /* MarkdownCodeBlockStyle+Theme.swift */; };
 		861DC3733D8F7A5339C3489E /* AlasDropPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23CC75D28C2EE22D16E24964 /* AlasDropPayload.swift */; };
 		864B31874E286ED036347975 /* ACPLaunchSpecNpmPackageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDB3231FFACC0398F973876 /* ACPLaunchSpecNpmPackageTests.swift */; };
 		86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */; };
@@ -1197,6 +1198,7 @@
 		C245DDADA1D81810E9302134 /* VerdictSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2942AD875C0E7AB71E8E3CAD /* VerdictSheet.swift */; };
 		C2CE2E3DE88344FDDE67D66A /* LSPTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */; };
 		C2EDB6A5E6149758C4A0051E /* ConflictMarkerParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2392A88D394E21DAB8C6EF33 /* ConflictMarkerParser.swift */; };
+		C31DBE249E28F1C82421537C /* ACPComposerCodeBlockStylingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2ABBFA4FB2E5FC2D38C5D3 /* ACPComposerCodeBlockStylingTests.swift */; };
 		C3292966568305E004CF6604 /* ACPMCPPromptPreambleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1508D249784E402C9167186 /* ACPMCPPromptPreambleTests.swift */; };
 		C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */; };
 		C3840EDD0105467D0678B69C /* AppConfigSidebarChromeOverridesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */; };
@@ -1700,6 +1702,7 @@
 		0EE97D2D6875CD6A1DBF4DE9 /* GitService+ReviewRequestDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+ReviewRequestDraft.swift"; sourceTree = "<group>"; };
 		0F2A5B37528AD21CAD5ED051 /* ACPSessionAgentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionAgentStateTests.swift; sourceTree = "<group>"; };
 		0F68A9692F85197ED9E16262 /* WorktreesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreesPane.swift; sourceTree = "<group>"; };
+		0F6C56877C39525B529A251B /* MarkdownCodeBlockStyle+Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MarkdownCodeBlockStyle+Theme.swift"; sourceTree = "<group>"; };
 		0FA3C5D49DC1B6AB83479412 /* SSHHostPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHHostPicker.swift; sourceTree = "<group>"; };
 		0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPThoughtView.swift; sourceTree = "<group>"; };
 		100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeatureTests.swift; sourceTree = "<group>"; };
@@ -2957,6 +2960,7 @@
 		DD1F34E025D235A5CECCE36E /* ACPSessionUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUpdate.swift; sourceTree = "<group>"; };
 		DDBB557833D3939208D75FB7 /* PairedAuthoredContentSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedAuthoredContentSurfaceTests.swift; sourceTree = "<group>"; };
 		DDE8B45ECF898B83A616586D /* SubHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubHeader.swift; sourceTree = "<group>"; };
+		DE2ABBFA4FB2E5FC2D38C5D3 /* ACPComposerCodeBlockStylingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerCodeBlockStylingTests.swift; sourceTree = "<group>"; };
 		DE2AC16E9220C05F670BE3EB /* ACPMarkdownText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownText.swift; sourceTree = "<group>"; };
 		DE2F61CCAFB23F6C394ACD8D /* ACPAdapterInstallCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterInstallCoordinatorTests.swift; sourceTree = "<group>"; };
 		DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostRemoteDetectorTests.swift; sourceTree = "<group>"; };
@@ -4052,6 +4056,7 @@
 				5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */,
 				7BEC4E033DB3BA44C825D453 /* EmojiPickerButton.swift */,
 				16CA8FEE64D73BDEBAF74878 /* Kbd.swift */,
+				0F6C56877C39525B529A251B /* MarkdownCodeBlockStyle+Theme.swift */,
 				F8DD2FEF5D33576B468300C9 /* MarkdownCodeBlockStyler.swift */,
 				CB90EF05C6A486F35ACD0E1B /* MarkdownFenceEditing.swift */,
 				36B8003F90C5FD770A293717 /* PairedComposerTextControls.swift */,
@@ -4291,6 +4296,7 @@
 				3659703F6EB9AD2454C2898B /* ACPChatTypographyTests.swift */,
 				81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */,
 				2B7ADCB7C4178FE036A31214 /* ACPComposerActionButtonMetricsTests.swift */,
+				DE2ABBFA4FB2E5FC2D38C5D3 /* ACPComposerCodeBlockStylingTests.swift */,
 				EE91017BB71AB08265C7B56E /* ACPComposerControlPresentationDictationTests.swift */,
 				B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */,
 				98CA6A0F4862D9A29E4151B5 /* ACPComposerFocusPolicyTests.swift */,
@@ -6623,6 +6629,7 @@
 				01BB37E08A2DCC66374F643B /* MCPHelloEvent.swift in Sources */,
 				F11A596534EEDD3C678DF196 /* MCPRegistrationDecision.swift in Sources */,
 				81F6E32B97FCE84E5F986A31 /* MCPRegistrationRegistry.swift in Sources */,
+				860779AD10CE0B382D196FD4 /* MarkdownCodeBlockStyle+Theme.swift in Sources */,
 				97DC7798FBDEBD8F0B433D25 /* MarkdownCodeBlockStyler.swift in Sources */,
 				0FD892082365E7FCFD0526F3 /* MarkdownFenceEditing.swift in Sources */,
 				2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */,
@@ -6954,6 +6961,7 @@
 				5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */,
 				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,
 				33A0FC862C45CDFF47053A04 /* ACPComposerActionButtonMetricsTests.swift in Sources */,
+				C31DBE249E28F1C82421537C /* ACPComposerCodeBlockStylingTests.swift in Sources */,
 				0191E2173516054F2E502C8E /* ACPComposerControlPresentationDictationTests.swift in Sources */,
 				1721FFC6A99B6E2683378552 /* ACPComposerDraftBridgeTests.swift in Sources */,
 				3518735F0614C32919E3FC27 /* ACPComposerDraftTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1242,6 +1242,7 @@
 		C9BC01285F80FB20F665A765 /* CodeTextViewMultiCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */; };
 		C9C01E8A89C6767524FAC63B /* RemoteHTTPResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85AC3FB0255285382EF24D8D /* RemoteHTTPResponder.swift */; };
 		C9DAC0F907752F6D3B955DD8 /* HoverFeatureRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1D8FEB5416139D8B2BA780 /* HoverFeatureRenderingTests.swift */; };
+		C9DCF97ADE5B0664AD2D0035 /* PairedTextEditorMarkdownStylingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2C55C7FEAEBBB60A829C248 /* PairedTextEditorMarkdownStylingTests.swift */; };
 		CA4A81EE17E955229258DBB6 /* ACPComposerPairedDelimiterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8A1143A53C09FD0B4D5CF6 /* ACPComposerPairedDelimiterTests.swift */; };
 		CA4CE5E97DB02330A1151245 /* ACPSetupCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8E722C16FFBEEEC43337D5 /* ACPSetupCheck.swift */; };
 		CA7269D9237C925D7C1358D7 /* RemoteWorktreePollTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EEB37C08A315D65558B273 /* RemoteWorktreePollTests.swift */; };
@@ -3101,6 +3102,7 @@
 		F226886130D09669EEEBD381 /* ACPDictationLocaleFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDictationLocaleFormatterTests.swift; sourceTree = "<group>"; };
 		F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarMaterialChoiceTests.swift; sourceTree = "<group>"; };
 		F2AC43D07BE4012DB52A2D1B /* ChatFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFontCatalog.swift; sourceTree = "<group>"; };
+		F2C55C7FEAEBBB60A829C248 /* PairedTextEditorMarkdownStylingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedTextEditorMarkdownStylingTests.swift; sourceTree = "<group>"; };
 		F2C9F8BAEDB1D157E321A328 /* ReviewChangesScrollSpyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesScrollSpyTests.swift; sourceTree = "<group>"; };
 		F2F50B2E7675F40749566F54 /* FileSearchRankerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchRankerTests.swift; sourceTree = "<group>"; };
 		F31E42DEC85081FEA8CA1BC3 /* ACPSessionLeaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionLeaseTests.swift; sourceTree = "<group>"; };
@@ -4862,6 +4864,7 @@
 				6D7B2B217CFB556E9AFDDE5A /* MarkdownFenceEditingTests.swift */,
 				5B40A20BB651C706C9C6FAAA /* PairedDelimiterFenceBoxTests.swift */,
 				06241E3F5DD1D1E06E57813A /* PairedDelimiterFenceTests.swift */,
+				F2C55C7FEAEBBB60A829C248 /* PairedTextEditorMarkdownStylingTests.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -7438,6 +7441,7 @@
 				05188310E27A5460F614BC83 /* PairedDelimiterFenceTests.swift in Sources */,
 				DDE5BE847DFFF54429D61D4E /* PairedPrimaryComposerSurfaceTests.swift in Sources */,
 				E4BE423D04F69D25C520A80B /* PairedReviewComposerSurfaceTests.swift in Sources */,
+				C9DCF97ADE5B0664AD2D0035 /* PairedTextEditorMarkdownStylingTests.swift in Sources */,
 				439761195191FAC857E78705 /* PaneDragMathTests.swift in Sources */,
 				4BDE8C92734D3A60645C0500 /* PaneLeafEncodeTests.swift in Sources */,
 				CAE7524F4289A256FF1069FC /* PaneTreeTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		04C778DB96502CD36E4C031B /* MergeConflictTabModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5825E49F6DC54DC35132D2F /* MergeConflictTabModelTests.swift */; };
 		04D55B4985BDF4CEF0BA3C0E /* GGMutationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993FD1C9788DEA6AD643A444 /* GGMutationModels.swift */; };
 		04EC051D5AEE99A4841B29C7 /* PiInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4749A35B3BEF89C8E7B92CD7 /* PiInstallerTests.swift */; };
+		05188310E27A5460F614BC83 /* PairedDelimiterFenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06241E3F5DD1D1E06E57813A /* PairedDelimiterFenceTests.swift */; };
 		0561D8980B46B5000799E7EE /* RunScriptPaletteEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4B9AC0713D961FC7E1DE22 /* RunScriptPaletteEnvironment.swift */; };
 		0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */; };
 		0575E49BE44BEB8AB9D4977F /* MergeConflictAgentProposalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECD5B53A23694EF60F63041 /* MergeConflictAgentProposalView.swift */; };
@@ -1648,6 +1649,7 @@
 		05B122F66B2DEA7853804624 /* ShortcutRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorder.swift; sourceTree = "<group>"; };
 		05C9583C0CA5EDE7D2A1B7DF /* ACPDiffGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDiffGeneratorTests.swift; sourceTree = "<group>"; };
 		05EE713DD3CACF29F206553C /* ThemeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStore.swift; sourceTree = "<group>"; };
+		06241E3F5DD1D1E06E57813A /* PairedDelimiterFenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedDelimiterFenceTests.swift; sourceTree = "<group>"; };
 		06375E561569DA36EC289C6F /* JSONRPCNewlineFramer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCNewlineFramer.swift; sourceTree = "<group>"; };
 		069895A7C4E29B3275D8320E /* ACPSessionManagerRemoteRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerRemoteRestoreTests.swift; sourceTree = "<group>"; };
 		0704EBDA62931ADE79B04F30 /* ReviewSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionStore.swift; sourceTree = "<group>"; };
@@ -4856,6 +4858,7 @@
 			children = (
 				039CD39D75F64498A6C8320A /* MarkdownCodeBlockStylerTests.swift */,
 				6D7B2B217CFB556E9AFDDE5A /* MarkdownFenceEditingTests.swift */,
+				06241E3F5DD1D1E06E57813A /* PairedDelimiterFenceTests.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -7428,6 +7431,7 @@
 				7EB1A9415AE49BBB694946AC /* PairedComposerTextControlsTests.swift in Sources */,
 				407C480A97251F3D342D84F7 /* PairedDelimiterDeadKeyTests.swift in Sources */,
 				DCF52CA0F7607995402CED3D /* PairedDelimiterEditingTests.swift in Sources */,
+				05188310E27A5460F614BC83 /* PairedDelimiterFenceTests.swift in Sources */,
 				DDE5BE847DFFF54429D61D4E /* PairedPrimaryComposerSurfaceTests.swift in Sources */,
 				E4BE423D04F69D25C520A80B /* PairedReviewComposerSurfaceTests.swift in Sources */,
 				439761195191FAC857E78705 /* PaneDragMathTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		0F556F82FA5BF1E8D50096E2 /* RemoteConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3066B2C18213B0105D32213F /* RemoteConfigTests.swift */; };
 		0F560F9B2458B94C807E96A1 /* CodeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */; };
 		0FA612529F7E2BC05E577420 /* RemoteAccessPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DAD29A75E3651CA720017D /* RemoteAccessPolicy.swift */; };
+		0FD892082365E7FCFD0526F3 /* MarkdownFenceEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB90EF05C6A486F35ACD0E1B /* MarkdownFenceEditing.swift */; };
 		0FE1A3CCEB283E8780F52076 /* QueuedPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE0C069E5446132D39C4DE5 /* QueuedPrompt.swift */; };
 		10190501C79554DA17FBC5F7 /* permission-request.json in Resources */ = {isa = PBXBuildFile; fileRef = C48DB0098D71F26ABF594615 /* permission-request.json */; };
 		102686FD795DE94337B3A030 /* SQLiteError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D0843198D3386919147FF /* SQLiteError.swift */; };
@@ -336,6 +337,7 @@
 		35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */; };
 		35A0942B075D267EBB9A4484 /* RightPaneStateFileTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */; };
 		35B9709D0B74BA6B5E3FC0EF /* RunScriptStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04601C00F293AAB0EE4209E1 /* RunScriptStore.swift */; };
+		35E3ADFBC4F9CE3202773505 /* MarkdownFenceEditingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D7B2B217CFB556E9AFDDE5A /* MarkdownFenceEditingTests.swift */; };
 		362A966BA9FED1E92B8410CC /* GGInboxHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C407678AABCFACDBB04B339 /* GGInboxHelpersTests.swift */; };
 		363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */; };
 		370EA3E196540ACC6174D5CC /* GitLabCLIProviderVerdictTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D95FBEE2C9BF1AD1A602C28 /* GitLabCLIProviderVerdictTests.swift */; };
@@ -2257,6 +2259,7 @@
 		6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerRetentionTests.swift; sourceTree = "<group>"; };
 		6D46BDE72E52818061452ECB /* CommitRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitRowTests.swift; sourceTree = "<group>"; };
 		6D788808DF3BE405143F91F7 /* ReleaseInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseInfoTests.swift; sourceTree = "<group>"; };
+		6D7B2B217CFB556E9AFDDE5A /* MarkdownFenceEditingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFenceEditingTests.swift; sourceTree = "<group>"; };
 		6D7BE909731E9D15A032A6E0 /* ReviewCommentWireDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewCommentWireDTO.swift; sourceTree = "<group>"; };
 		6D8E02BB3FEB3C71AEEBBE6F /* ACPChatLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatLayout.swift; sourceTree = "<group>"; };
 		6D95FBEE2C9BF1AD1A602C28 /* GitLabCLIProviderVerdictTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLabCLIProviderVerdictTests.swift; sourceTree = "<group>"; };
@@ -2827,6 +2830,7 @@
 		CB2EB554CB6AF797545DB95D /* HeadReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadReader.swift; sourceTree = "<group>"; };
 		CB5E3661944CDA65ABCCB826 /* AgentsPaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsPaneTests.swift; sourceTree = "<group>"; };
 		CB68E9C3C8853AF7E8AB5DB4 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		CB90EF05C6A486F35ACD0E1B /* MarkdownFenceEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFenceEditing.swift; sourceTree = "<group>"; };
 		CBFD1CE53DE229626220B457 /* ACPTerminalTailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalTailView.swift; sourceTree = "<group>"; };
 		CC13E4C0AF55A2524341EB36 /* ImageDiffSideBySideViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSideBySideViewTests.swift; sourceTree = "<group>"; };
 		CC2A20311755AEE2EDD25815 /* RunScriptPaletteModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptPaletteModel.swift; sourceTree = "<group>"; };
@@ -3792,6 +3796,7 @@
 				34382081666B7E8A95C0DA37 /* Settings */,
 				5FA3F5C4A99F2C74080DA0EF /* SQLiteKit */,
 				BB299962DBB46EEC6165F3D3 /* SSH */,
+				8C9686DB6E16B49CAF3AE6FF /* UI */,
 				B637910FC726CC3C2C8983C1 /* Updates */,
 			);
 			path = AlasTests;
@@ -4037,6 +4042,7 @@
 				5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */,
 				7BEC4E033DB3BA44C825D453 /* EmojiPickerButton.swift */,
 				16CA8FEE64D73BDEBAF74878 /* Kbd.swift */,
+				CB90EF05C6A486F35ACD0E1B /* MarkdownFenceEditing.swift */,
 				36B8003F90C5FD770A293717 /* PairedComposerTextControls.swift */,
 				9C4B3503EDFD4AAEAA6894FE /* PairedDelimiterEditing.swift */,
 				7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */,
@@ -4838,6 +4844,14 @@
 				D081C8802733D2532DBCD74D /* BlockedLanguageServerNudgeResolverTests.swift */,
 			);
 			path = Editor;
+			sourceTree = "<group>";
+		};
+		8C9686DB6E16B49CAF3AE6FF /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				6D7B2B217CFB556E9AFDDE5A /* MarkdownFenceEditingTests.swift */,
+			);
+			path = UI;
 			sourceTree = "<group>";
 		};
 		8E450763881EC336B91FA7E8 /* Integrations */ = {
@@ -6594,6 +6608,7 @@
 				01BB37E08A2DCC66374F643B /* MCPHelloEvent.swift in Sources */,
 				F11A596534EEDD3C678DF196 /* MCPRegistrationDecision.swift in Sources */,
 				81F6E32B97FCE84E5F986A31 /* MCPRegistrationRegistry.swift in Sources */,
+				0FD892082365E7FCFD0526F3 /* MarkdownFenceEditing.swift in Sources */,
 				2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */,
 				B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */,
 				29418562DE5554B282C83D75 /* MarkdownParser.swift in Sources */,
@@ -7368,6 +7383,7 @@
 				7FF3268907E59906B3862648 /* MCPHelloEventTests.swift in Sources */,
 				686BB3FB9735836CFCAAE0D1 /* MCPRegistrationDecisionTests.swift in Sources */,
 				B3DEC3EEA46D77D7BE864A74 /* MCPRegistrationRegistryTests.swift in Sources */,
+				35E3ADFBC4F9CE3202773505 /* MarkdownFenceEditingTests.swift in Sources */,
 				165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */,
 				6A5D19016FE0100CD54D24B2 /* MarkdownImageLoaderTests.swift in Sources */,
 				E2279478EBE8BF9CDC412EDE /* MarkdownParserTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -823,7 +823,12 @@ final class ACPNSTextView: PairedDelimiterTextView {
             case 125: panel.model.moveDown()
             return    // down
             case 36, 76, 48:                            // return / enter / tab
-                if let pick = panel.model.selected() {
+                // Only without Command. ⌘⏎ is a send, not an accept, and this
+                // branch runs first — so swallowing it here would make the
+                // picker the one state where ⌘⏎ does not reach the send
+                // handler below.
+                if !event.modifierFlags.contains(.command),
+                   let pick = panel.model.selected() {
                     insertSlash(pick)
                     return
                 }

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -703,15 +703,33 @@ final class ACPNSTextView: PairedDelimiterTextView {
         ]
     }
 
+    /// Whether a restyle has already run with a non-nil `markdownCodeBlockStyle`.
+    ///
+    /// `makeNSView` applies the typography and restores the persisted draft
+    /// before `updateNSView` — the only place the code box style is handed
+    /// over — has ever run, so on first mount both of those happen while the
+    /// style is still nil. Without this the typography guard below would then
+    /// swallow `updateNSView`'s own call (same typography, non-nil font) and a
+    /// remounted draft's fenced block would stay unstyled until the user's next
+    /// edit. One shot: once the style has been applied every later render
+    /// re-enters the guard and returns, so SwiftUI updates do not each re-parse
+    /// and re-attribute the whole storage.
+    private var hasAppliedCodeBlockStyle = false
+
     func applyChatTypography(_ typography: ACPChatTypography) {
-        guard chatTypography != typography || font == nil else { return }
+        let codeBlockStyleBecameAvailable = markdownCodeBlockStyle != nil && !hasAppliedCodeBlockStyle
+        guard chatTypography != typography || font == nil || codeBlockStyleBecameAvailable else { return }
         chatTypography = typography
         font = typography.appKitFont()
         typingAttributes = baseTypingAttributes
         if let textStorage {
-            let blockRanges = markdownCodeBlockStyle.map {
-                MarkdownCodeBlockStyler.restyle(textStorage, in: nil, style: $0).map(\.outerRange)
-            } ?? []
+            var blockRanges: [NSRange] = []
+            if let style = markdownCodeBlockStyle {
+                blockRanges = MarkdownCodeBlockStyler
+                    .restyle(textStorage, in: nil, style: style)
+                    .map(\.outerRange)
+                hasAppliedCodeBlockStyle = true
+            }
             ACPMarkdownLiveStyler.restyle(
                 textStorage,
                 typography: typography,

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -501,6 +501,10 @@ struct ACPInputField: NSViewRepresentable {
             invalidatePendingImageFileInsertions()
             restoringDraft = true
             storage.setAttributedString(Self.attributedString(from: draft, typography: typography))
+            // `restoringDraft` short-circuits `textDidChange`, where the fence
+            // cache is normally refreshed, so refresh it here or it keeps
+            // describing the document this one replaced.
+            lastBlocks = MarkdownFenceEditing.blocks(in: storage.string)
             let blockRanges: [NSRange]
             if let style = codeBlockStyle {
                 blockRanges = MarkdownCodeBlockStyler.restyle(storage, in: nil, style: style).map(\.outerRange)
@@ -520,6 +524,10 @@ struct ACPInputField: NSViewRepresentable {
             invalidatePendingImageFileInsertions()
             restoringDraft = true
             textView.string = ""
+            // Same as `restore`: the cache has to follow the storage even when
+            // `textDidChange` is short-circuited. An empty document has no
+            // fenced blocks.
+            lastBlocks = []
             textView.needsDisplay = true
             restoringDraft = false
         }

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -306,9 +306,18 @@ struct ACPInputField: NSViewRepresentable {
                 return true
             }
             if selector == #selector(NSResponder.insertNewline(_:)) {
+                let modifiers = NSApp.currentEvent?.modifierFlags ?? []
                 // ⇧⏎ inserts a literal newline. (⌥⏎ never reaches here — it
-                // routes to `insertNewlineIgnoringFieldEditor:` above.)
-                if NSApp.currentEvent?.modifierFlags.contains(.shift) == true {
+                // routes to `insertNewlineIgnoringFieldEditor:` above. ⌘⏎ is
+                // caught in ACPNSTextView.keyDown.)
+                if modifiers.contains(.shift) {
+                    textView.insertText("\n", replacementRange: textView.selectedRange())
+                    return true
+                }
+                // Inside a code box ⏎ is a plain newline, so a multi-line
+                // snippet doesn't need ⇧⏎ on every line. ⌘⏎ still sends.
+                if let tv = textView as? ACPNSTextView,
+                   tv.fencedBlockRange(containing: tv.selectedRange().location) != nil {
                     textView.insertText("\n", replacementRange: textView.selectedRange())
                     return true
                 }
@@ -802,6 +811,15 @@ final class ACPNSTextView: PairedDelimiterTextView {
                 return
             default: break
             }
+        }
+
+        // ⌘⏎ always sends, including from inside a code box where bare ⏎ is a
+        // newline. Handled here rather than in `doCommandBy` because AppKit
+        // does not reliably route Command-Return to `insertNewline:`.
+        if event.keyCode == 36 || event.keyCode == 76,
+           event.modifierFlags.contains(.command) {
+            coordinator?.submit(self, intent: .auto)
+            return
         }
 
         if event.charactersIgnoringModifiers == "@" {

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -121,11 +121,10 @@ struct ACPInputField: NSViewRepresentable {
         }
         if let tv = nsView.documentView as? ACPNSTextView {
             let baseFont = typography.appKitFont()
-            let style = MarkdownCodeBlockStyle.standard(
+            let style = Self.codeBlockStyle(
                 theme: context.environment.theme,
                 baseFont: baseFont,
-                baseColor: .labelColor,
-                monoSize: typography.codeSize
+                typography: typography
             )
             tv.markdownFencesEnabled = true
             tv.markdownCodeBlockStyle = style
@@ -149,6 +148,24 @@ struct ACPInputField: NSViewRepresentable {
             tv.dismissFloatingPanels()
             coordinator.editorUndoManager.removeAllActions()
         }
+    }
+
+    /// Builds the composer's code box style, threading the configured chat
+    /// font family through so the in-progress box matches the font the
+    /// transcript's rendered code block uses once the message is submitted
+    /// — see `MarkdownCodeBlockStyle.standard`'s doc comment.
+    static func codeBlockStyle(
+        theme: Theme,
+        baseFont: NSFont,
+        typography: ACPChatTypography
+    ) -> MarkdownCodeBlockStyle {
+        MarkdownCodeBlockStyle.standard(
+            theme: theme,
+            baseFont: baseFont,
+            baseColor: .labelColor,
+            monoSize: typography.codeSize,
+            monoFontFamily: typography.fontFamily
+        )
     }
 
     /// When busy, the placeholder advertises whichever action ⏎ will

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -120,6 +120,16 @@ struct ACPInputField: NSViewRepresentable {
             }
         }
         if let tv = nsView.documentView as? ACPNSTextView {
+            let baseFont = typography.appKitFont()
+            let style = MarkdownCodeBlockStyle.standard(
+                theme: context.environment.theme,
+                baseFont: baseFont,
+                baseColor: .labelColor,
+                monoSize: typography.codeSize
+            )
+            tv.markdownFencesEnabled = true
+            tv.markdownCodeBlockStyle = style
+            context.coordinator.codeBlockStyle = style
             tv.applyChatTypography(typography)
             tv.placeholderText = Self.placeholder(for: session.transcript.streamingState, sendOnEnter: sendOnEnter)
             tv.needsDisplay = true
@@ -212,6 +222,8 @@ struct ACPInputField: NSViewRepresentable {
         private var pendingRestyleWork: DispatchWorkItem?
         private var pendingRestyleGeneration = 0
         private var pendingRestyleRange: NSRange?
+        var codeBlockStyle: MarkdownCodeBlockStyle?
+        private var lastBlocks: [FencedBlock] = []
         private static let restyleDebounceInterval: Double = 0.5
 
         func reportImageError(_ error: ACPImageStaging.StagingError) {
@@ -331,19 +343,41 @@ struct ACPInputField: NSViewRepresentable {
             let draft = Self.draft(from: storage)
             lastSyncedDraft = draft
             onDraftChange(draft)
+            // Block detection is a line-prefix scan, not a regex over the whole
+            // document, so it is cheap enough to run synchronously here. Only
+            // the attribute application stays on the debounce below.
+            let blocks = MarkdownFenceEditing.blocks(in: storage.string)
+            var dirty = ACPMarkdownLiveStyler.editedLineRange(in: storage)
+            if let fenceDirty = ACPMarkdownLiveStyler.dirtyRange(
+                previous: lastBlocks,
+                current: blocks,
+                storageLength: storage.length
+            ) {
+                dirty = dirty.map { NSUnionRange($0, fenceDirty) } ?? fenceDirty
+            }
+            lastBlocks = blocks
             pendingRestyleRange = pendingRestyleRange.map { existing in
-                NSUnionRange(existing, ACPMarkdownLiveStyler.editedLineRange(in: storage) ?? existing)
-            } ?? ACPMarkdownLiveStyler.editedLineRange(in: storage)
+                dirty.map { NSUnionRange(existing, $0) } ?? existing
+            } ?? dirty
             pendingRestyleWork?.cancel()
             pendingRestyleGeneration += 1
             let generation = pendingRestyleGeneration
             let work = DispatchWorkItem { [weak self] in
                 guard let self else { return }
                 guard self.pendingRestyleGeneration == generation else { return }
+                let blockRanges: [NSRange]
+                if let style = self.codeBlockStyle {
+                    blockRanges = MarkdownCodeBlockStyler
+                        .restyle(storage, in: self.pendingRestyleRange, style: style)
+                        .map(\.outerRange)
+                } else {
+                    blockRanges = []
+                }
                 ACPMarkdownLiveStyler.restyle(
                     storage,
                     in: self.pendingRestyleRange,
-                    typography: self.typography
+                    typography: self.typography,
+                    excluding: blockRanges
                 )
                 self.pendingRestyleRange = nil
                 self.pendingRestyleWork = nil
@@ -458,7 +492,13 @@ struct ACPInputField: NSViewRepresentable {
             invalidatePendingImageFileInsertions()
             restoringDraft = true
             storage.setAttributedString(Self.attributedString(from: draft, typography: typography))
-            ACPMarkdownLiveStyler.restyle(storage, typography: typography)
+            let blockRanges: [NSRange]
+            if let style = codeBlockStyle {
+                blockRanges = MarkdownCodeBlockStyler.restyle(storage, in: nil, style: style).map(\.outerRange)
+            } else {
+                blockRanges = []
+            }
+            ACPMarkdownLiveStyler.restyle(storage, typography: typography, excluding: blockRanges)
             textView.needsDisplay = true
             restoringDraft = false
             lastSyncedDraft = draft
@@ -652,7 +692,14 @@ final class ACPNSTextView: PairedDelimiterTextView {
         font = typography.appKitFont()
         typingAttributes = baseTypingAttributes
         if let textStorage {
-            ACPMarkdownLiveStyler.restyle(textStorage, typography: typography)
+            let blockRanges = markdownCodeBlockStyle.map {
+                MarkdownCodeBlockStyler.restyle(textStorage, in: nil, style: $0).map(\.outerRange)
+            } ?? []
+            ACPMarkdownLiveStyler.restyle(
+                textStorage,
+                typography: typography,
+                excluding: blockRanges
+            )
         }
         needsDisplay = true
     }

--- a/Alas/Sources/ACP/UI/ACPMarkdownLiveStyler.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownLiveStyler.swift
@@ -126,19 +126,27 @@ enum ACPMarkdownLiveStyler {
         others.contains { NSIntersectionRange(range, $0).length > 0 }
     }
 
-    /// The span that must be restyled when the set of fenced blocks changed.
+    /// The span that must be restyled when the document's fences moved.
     ///
     /// A single new ``` flips the open/closed parity of every block below it,
     /// so the range runs from the first differing fence to end of storage.
-    /// Returns nil when the fence set is unchanged, in which case the caller
-    /// keeps its existing edited-line-range behaviour.
+    ///
+    /// Closers count as much as openers. Closing a block that ran to the end of
+    /// the document, or deleting the closer of one that didn't, changes where
+    /// the block's body stops without moving a single opener — and the text it
+    /// gives up (or absorbs) is exactly what needs restyling. Comparing openers
+    /// alone reports "nothing changed" there and leaves that tail wearing the
+    /// attributes of a block it is no longer part of.
+    ///
+    /// Returns nil when no fence appeared, vanished, or moved, in which case
+    /// the caller keeps its cheaper edited-line-range behaviour.
     static func dirtyRange(
         previous: [FencedBlock],
         current: [FencedBlock],
         storageLength: Int
     ) -> NSRange? {
-        let previousFences = previous.map(\.openFenceRange.location)
-        let currentFences = current.map(\.openFenceRange.location)
+        let previousFences = previous.flatMap(fenceLocations(of:))
+        let currentFences = current.flatMap(fenceLocations(of:))
         guard previousFences != currentFences else { return nil }
 
         let firstDifference = zip(previousFences, currentFences)
@@ -148,5 +156,17 @@ enum ACPMarkdownLiveStyler {
             ?? 0
         let start = max(0, min(firstDifference, storageLength))
         return NSRange(location: start, length: storageLength - start)
+    }
+
+    /// Every fence position a block owns, in document order: its opener, then
+    /// its closer when it has one. Flattening the blocks this way keeps the
+    /// combined sequence ascending — a block's closer always precedes the next
+    /// block's opener — so the caller's "first differing position" scan works
+    /// on it unchanged.
+    private static func fenceLocations(of block: FencedBlock) -> [Int] {
+        guard let closeFenceRange = block.closeFenceRange else {
+            return [block.openFenceRange.location]
+        }
+        return [block.openFenceRange.location, closeFenceRange.location]
     }
 }

--- a/Alas/Sources/ACP/UI/ACPMarkdownLiveStyler.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownLiveStyler.swift
@@ -15,15 +15,17 @@ enum ACPMarkdownLiveStyler {
 
     static func restyle(
         _ storage: NSTextStorage,
-        typography: ACPChatTypography = .default
+        typography: ACPChatTypography = .default,
+        excluding excludedRanges: [NSRange] = []
     ) {
-        restyle(storage, in: nil, typography: typography)
+        restyle(storage, in: nil, typography: typography, excluding: excludedRanges)
     }
 
     static func restyle(
         _ storage: NSTextStorage,
         in requestedRange: NSRange?,
-        typography: ACPChatTypography = .default
+        typography: ACPChatTypography = .default,
+        excluding excludedRanges: [NSRange] = []
     ) {
         guard storage.length > 0 else { return }
 
@@ -57,29 +59,29 @@ enum ACPMarkdownLiveStyler {
         // mention AND image chips don't get bulldozed (their `.attachment`
         // cell stripped) by every keystroke's restyle.
         storage.enumerateAttributes(in: target) { attrs, range, _ in
-            if attrs[.attachmentURI] == nil, attrs[.imageAttachmentURI] == nil {
-                storage.setAttributes([
-                    .font: baseFont,
-                    .foregroundColor: NSColor.labelColor,
-                ], range: range)
-            }
+            guard attrs[.attachmentURI] == nil, attrs[.imageAttachmentURI] == nil else { return }
+            guard !Self.intersects(range, excludedRanges) else { return }
+            storage.setAttributes([
+                .font: baseFont,
+                .foregroundColor: NSColor.labelColor,
+            ], range: range)
         }
 
         apply(regex: bold, in: storage, range: target, attrs: [
             .font: boldFont,
             .foregroundColor: NSColor.labelColor,
-        ])
+        ], excluding: excludedRanges)
         let italicAttrs: [NSAttributedString.Key: Any] = [
             .font: italicFont,
             .foregroundColor: NSColor.labelColor,
         ]
-        apply(regex: italicStar, in: storage, range: target, attrs: italicAttrs)
-        apply(regex: italicUnder, in: storage, range: target, attrs: italicAttrs)
+        apply(regex: italicStar, in: storage, range: target, attrs: italicAttrs, excluding: excludedRanges)
+        apply(regex: italicUnder, in: storage, range: target, attrs: italicAttrs, excluding: excludedRanges)
         apply(regex: code, in: storage, range: target, attrs: [
             .font: codeFont,
             .foregroundColor: NSColor(calibratedRed: 0.78, green: 0.86, blue: 0.92, alpha: 1),
             .backgroundColor: NSColor.white.withAlphaComponent(0.06),
-        ])
+        ], excluding: excludedRanges)
     }
 
     static func editedLineRange(in storage: NSTextStorage) -> NSRange? {
@@ -102,9 +104,11 @@ enum ACPMarkdownLiveStyler {
     private static func apply(regex: NSRegularExpression,
                               in storage: NSTextStorage,
                               range: NSRange,
-                              attrs: [NSAttributedString.Key: Any]) {
+                              attrs: [NSAttributedString.Key: Any],
+                              excluding excludedRanges: [NSRange] = []) {
         regex.enumerateMatches(in: storage.string, range: range) { match, _, _ in
             guard let m = match else { return }
+            guard !intersects(m.range, excludedRanges) else { return }
             // Don't double-style chip mentions or image chips.
             var skip = false
             storage.enumerateAttributes(in: m.range) { attrs, _, stop in
@@ -116,5 +120,33 @@ enum ACPMarkdownLiveStyler {
             if skip { return }
             storage.addAttributes(attrs, range: m.range)
         }
+    }
+
+    private static func intersects(_ range: NSRange, _ others: [NSRange]) -> Bool {
+        others.contains { NSIntersectionRange(range, $0).length > 0 }
+    }
+
+    /// The span that must be restyled when the set of fenced blocks changed.
+    ///
+    /// A single new ``` flips the open/closed parity of every block below it,
+    /// so the range runs from the first differing fence to end of storage.
+    /// Returns nil when the fence set is unchanged, in which case the caller
+    /// keeps its existing edited-line-range behaviour.
+    static func dirtyRange(
+        previous: [FencedBlock],
+        current: [FencedBlock],
+        storageLength: Int
+    ) -> NSRange? {
+        let previousFences = previous.map(\.openFenceRange.location)
+        let currentFences = current.map(\.openFenceRange.location)
+        guard previousFences != currentFences else { return nil }
+
+        let firstDifference = zip(previousFences, currentFences)
+            .first { $0 != $1 }
+            .map { min($0, $1) }
+            ?? (previousFences + currentFences).min()
+            ?? 0
+        let start = max(0, min(firstDifference, storageLength))
+        return NSRange(location: start, length: storageLength - start)
     }
 }

--- a/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
+++ b/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
@@ -158,6 +158,12 @@ struct CommitMessageEditorView: View {
                     if value { focused = .body }
                     else if focused == .body { focused = nil }
                 }
+            ),
+            codeBlockStyle: .standard(
+                theme: theme,
+                baseFont: .monospacedSystemFont(ofSize: 12, weight: .regular),
+                baseColor: NSColor(theme.color("fg")),
+                monoSize: 12
             )
         )
             .frame(minHeight: 70, maxHeight: 150)

--- a/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
+++ b/Alas/Sources/Center/DiffReview/AppKitDiffReviewRowPlan.swift
@@ -1610,6 +1610,12 @@ struct AppKitDiffReviewComposerRowBody: View {
                         ReviewDraftQuote.markdown(path: $0.path, selectedText: $0.selectedText)
                     },
                     quoteInsertionGeneration: input.state.quoteInsertionGeneration,
+                    codeBlockStyle: .standard(
+                        theme: input.theme,
+                        baseFont: .systemFont(ofSize: 12),
+                        baseColor: NSColor(input.theme.color("fg")),
+                        monoSize: 12
+                    ),
                     onSave: input.savePendingDraft,
                     onCancel: input.clearPendingDraft
                 )

--- a/Alas/Sources/Center/DiffReview/DiffReviewComments.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewComments.swift
@@ -111,6 +111,7 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
     let focusRequestGeneration: Int
     let quoteMarkdown: String?
     let quoteInsertionGeneration: Int
+    let codeBlockStyle: MarkdownCodeBlockStyle?
     let onSave: () -> Void
     let onCancel: () -> Void
 
@@ -121,6 +122,7 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         focusRequestGeneration: Int = 0,
         quoteMarkdown: String? = nil,
         quoteInsertionGeneration: Int = 0,
+        codeBlockStyle: MarkdownCodeBlockStyle? = nil,
         onSave: @escaping () -> Void,
         onCancel: @escaping () -> Void
     ) {
@@ -130,6 +132,7 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         self.focusRequestGeneration = focusRequestGeneration
         self.quoteMarkdown = quoteMarkdown
         self.quoteInsertionGeneration = quoteInsertionGeneration
+        self.codeBlockStyle = codeBlockStyle
         self.onSave = onSave
         self.onCancel = onCancel
     }
@@ -175,6 +178,7 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         scrollView.documentView = textView
         context.coordinator.textView = textView
         applyTheme(to: scrollView, textView: textView)
+        applyCodeBlockStyle(to: textView)
         context.coordinator.requestFocusIfNeeded()
         return scrollView
     }
@@ -190,6 +194,7 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
             coordinator?.requestFocusIfNeeded()
         }
         applyTheme(to: scrollView, textView: textView)
+        applyCodeBlockStyle(to: textView)
         context.coordinator.requestQuoteInsertionIfNeeded()
         context.coordinator.requestFocusIfNeeded()
     }
@@ -210,6 +215,19 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         textView.font = .systemFont(ofSize: 12)
         textView.textColor = NSColor(theme.color("fg"))
         textView.insertionPointColor = NSColor(theme.color("accent"))
+    }
+
+    private func applyCodeBlockStyle(to textView: PairedDelimiterTextView) {
+        textView.markdownFencesEnabled = codeBlockStyle != nil
+        textView.markdownCodeBlockStyle = codeBlockStyle
+        // `textView.string = text` above (on both the initial `makeNSView`
+        // build and every `updateNSView` sync) discards every attribute, so
+        // the restyle has to run on each sync here, not only on
+        // `textDidChange` — otherwise a fenced draft restored from a store
+        // reload after the composer already mounted would render unstyled.
+        guard let codeBlockStyle, let storage = textView.textStorage else { return }
+        MarkdownCodeBlockStyler.restyle(storage, in: nil, style: codeBlockStyle)
+        textView.needsDisplay = true
     }
 
     @MainActor
@@ -237,6 +255,10 @@ struct ReviewDraftComposerTextEditor: NSViewRepresentable {
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
             parent.text = textView.string
+            if let style = parent.codeBlockStyle, let storage = textView.textStorage {
+                MarkdownCodeBlockStyler.restyle(storage, in: nil, style: style)
+                textView.needsDisplay = true
+            }
         }
 
         func textDidBeginEditing(_ notification: Notification) {
@@ -1030,6 +1052,12 @@ struct ReviewDraftCommentCard: View {
                         text: editorStateBinding.editingBody,
                         theme: theme,
                         isFocused: $editorFocused,
+                        codeBlockStyle: .standard(
+                            theme: theme,
+                            baseFont: .systemFont(ofSize: 12),
+                            baseColor: NSColor(theme.color("fg")),
+                            monoSize: 12
+                        ),
                         onSave: saveEditingComment,
                         onCancel: cancelEditingComment
                     )

--- a/Alas/Sources/Center/DiffReview/DiffReviewComments.swift
+++ b/Alas/Sources/Center/DiffReview/DiffReviewComments.swift
@@ -1548,7 +1548,13 @@ struct DiffReviewInlineFeedbackCard: View {
                     text: replyEditorBinding.body,
                     font: .systemFont(ofSize: 11.5),
                     textColor: NSColor(theme.color("fg")),
-                    placeholder: "Reply"
+                    placeholder: "Reply",
+                    codeBlockStyle: .standard(
+                        theme: theme,
+                        baseFont: .systemFont(ofSize: 11.5),
+                        baseColor: NSColor(theme.color("fg")),
+                        monoSize: 11.5
+                    )
                 )
                     .frame(minHeight: 32, maxHeight: 96)
                     .padding(7)

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -888,6 +888,12 @@ struct DiffTabView: View {
                     ReviewDraftQuote.markdown(path: $0.path, selectedText: $0.selectedText)
                 },
                 quoteInsertionGeneration: quoteInsertionGeneration,
+                codeBlockStyle: .standard(
+                    theme: theme,
+                    baseFont: .systemFont(ofSize: 12),
+                    baseColor: NSColor(theme.color("fg")),
+                    monoSize: 12
+                ),
                 onSave: savePendingDraft,
                 onCancel: clearPendingDraft
             )

--- a/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
+++ b/Alas/Sources/Center/Review/DiffInlineCommentCard.swift
@@ -26,6 +26,7 @@ struct DiffInlineCommentCard: View {
     var onActiveChange: (Bool) -> Void = { _ in }
     var editorState: Binding<DiffInlineCommentCardEditorState>?
 
+    @Environment(\.theme) private var theme
     @State private var isExpanded: Bool
     @State private var localEditorState = DiffInlineCommentCardEditorState()
     @State private var isHovered = false
@@ -183,6 +184,12 @@ struct DiffInlineCommentCard: View {
                                     focusedEditor = nil
                                 }
                             }
+                        ),
+                        codeBlockStyle: .standard(
+                            theme: theme,
+                            baseFont: .systemFont(ofSize: 11),
+                            baseColor: .labelColor,
+                            monoSize: 11
                         )
                     )
                         .frame(minHeight: 60)
@@ -290,6 +297,12 @@ struct DiffInlineCommentCard: View {
                                     focusedEditor = nil
                                 }
                             }
+                        ),
+                        codeBlockStyle: .standard(
+                            theme: theme,
+                            baseFont: .systemFont(ofSize: 11),
+                            baseColor: .labelColor,
+                            monoSize: 11
                         )
                     )
                     .frame(minHeight: 60)

--- a/Alas/Sources/Center/Review/VerdictSheet.swift
+++ b/Alas/Sources/Center/Review/VerdictSheet.swift
@@ -50,7 +50,13 @@ struct VerdictSheet: View {
                 PairedTextEditor(
                     text: $summaryBody,
                     font: .systemFont(ofSize: 12),
-                    textColor: NSColor(theme.color("fg"))
+                    textColor: NSColor(theme.color("fg")),
+                    codeBlockStyle: .standard(
+                        theme: theme,
+                        baseFont: .systemFont(ofSize: 12),
+                        baseColor: NSColor(theme.color("fg")),
+                        monoSize: 12
+                    )
                 )
                     .frame(minHeight: 80)
                     .background(theme.color("bg-1"))

--- a/Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ProviderReviewPublishConfirmationView.swift
@@ -53,7 +53,13 @@ struct ProviderReviewPublishConfirmationView: View {
                         text: $summaryBody,
                         font: .systemFont(ofSize: 12),
                         textColor: NSColor(theme.color("fg")),
-                        isEnabled: !isPublishing
+                        isEnabled: !isPublishing,
+                        codeBlockStyle: .standard(
+                            theme: theme,
+                            baseFont: .systemFont(ofSize: 12),
+                            baseColor: NSColor(theme.color("fg")),
+                            monoSize: 12
+                        )
                     )
                         .frame(minHeight: 72)
                         .padding(6)

--- a/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
+++ b/Alas/Sources/Center/ReviewWorkspace/ReviewDraftSummaryRail.swift
@@ -806,7 +806,13 @@ struct ReviewDraftSummaryCommentEditor: View {
         PairedTextEditor(
             text: $text,
             font: .systemFont(ofSize: 11.5),
-            textColor: NSColor(theme.color("fg"))
+            textColor: NSColor(theme.color("fg")),
+            codeBlockStyle: .standard(
+                theme: theme,
+                baseFont: .systemFont(ofSize: 11.5),
+                baseColor: NSColor(theme.color("fg")),
+                monoSize: 11.5
+            )
         )
         .frame(minHeight: 62)
         .background(theme.color("bg-2"))

--- a/Alas/Sources/Settings/PromptEditorBody.swift
+++ b/Alas/Sources/Settings/PromptEditorBody.swift
@@ -28,7 +28,13 @@ struct PromptEditorBody: View {
                 }
                 PairedTextEditor(
                     text: $draftPrompt,
-                    font: .monospacedSystemFont(ofSize: 12, weight: .regular)
+                    font: .monospacedSystemFont(ofSize: 12, weight: .regular),
+                    codeBlockStyle: .standard(
+                        theme: theme,
+                        baseFont: .monospacedSystemFont(ofSize: 12, weight: .regular),
+                        baseColor: .labelColor,
+                        monoSize: 12
+                    )
                 )
                     .background(theme.color("bg-2"))
                     .overlay(

--- a/Alas/Sources/UI/MarkdownCodeBlockStyle+Theme.swift
+++ b/Alas/Sources/UI/MarkdownCodeBlockStyle+Theme.swift
@@ -5,16 +5,21 @@ extension MarkdownCodeBlockStyle {
     /// The standard code box for editable surfaces. Colours mirror the
     /// transcript's rendered code block (`ACPMarkdownText.swift:574-576`) so an
     /// in-progress box matches the block it becomes once submitted.
+    /// `monoFontFamily` defaults to `""`, which preserves system monospace —
+    /// the behaviour every call site got before this parameter existed.
+    /// Pass a configured fixed-pitch family (e.g. the ACP chat font) to make
+    /// the box track that font instead.
     static func standard(
         theme: Theme,
         baseFont: NSFont,
         baseColor: NSColor,
-        monoSize: CGFloat
+        monoSize: CGFloat,
+        monoFontFamily: String = ""
     ) -> MarkdownCodeBlockStyle {
         MarkdownCodeBlockStyle(
             baseFont: baseFont,
             baseColor: baseColor,
-            monoFont: .monospacedSystemFont(ofSize: monoSize, weight: .regular),
+            monoFont: CenterTypography.resolveCodeFont(family: monoFontFamily, size: monoSize),
             bodyColor: baseColor,
             fenceColor: NSColor(theme.color("fg-dim")),
             backgroundColor: NSColor(theme.color("bg-0")).withAlphaComponent(0.6),

--- a/Alas/Sources/UI/MarkdownCodeBlockStyle+Theme.swift
+++ b/Alas/Sources/UI/MarkdownCodeBlockStyle+Theme.swift
@@ -1,0 +1,24 @@
+import AppKit
+import SwiftUI
+
+extension MarkdownCodeBlockStyle {
+    /// The standard code box for editable surfaces. Colours mirror the
+    /// transcript's rendered code block (`ACPMarkdownText.swift:574-576`) so an
+    /// in-progress box matches the block it becomes once submitted.
+    static func standard(
+        theme: Theme,
+        baseFont: NSFont,
+        baseColor: NSColor,
+        monoSize: CGFloat
+    ) -> MarkdownCodeBlockStyle {
+        MarkdownCodeBlockStyle(
+            baseFont: baseFont,
+            baseColor: baseColor,
+            monoFont: .monospacedSystemFont(ofSize: monoSize, weight: .regular),
+            bodyColor: baseColor,
+            fenceColor: NSColor(theme.color("fg-dim")),
+            backgroundColor: NSColor(theme.color("bg-0")).withAlphaComponent(0.6),
+            borderColor: NSColor(theme.color("line"))
+        )
+    }
+}

--- a/Alas/Sources/UI/MarkdownCodeBlockStyler.swift
+++ b/Alas/Sources/UI/MarkdownCodeBlockStyler.swift
@@ -1,0 +1,86 @@
+import AppKit
+
+/// Visual treatment for a fenced code block in an editable surface. Values
+/// mirror the transcript's rendered code block (`ACPMarkdownText.swift:574-576`)
+/// so an in-progress box and the block it becomes once sent look the same.
+struct MarkdownCodeBlockStyle: Equatable {
+    var baseFont: NSFont
+    var baseColor: NSColor
+    var monoFont: NSFont
+    var bodyColor: NSColor
+    var fenceColor: NSColor
+    var backgroundColor: NSColor
+    var borderColor: NSColor
+    var cornerRadius: CGFloat = 6
+    var borderWidth: CGFloat = 0.5
+}
+
+/// Applies fenced-code-block attributes to an `NSTextStorage`. The markers stay
+/// literal in the storage — only attributes change — so the surface's plain-text
+/// binding keeps carrying valid markdown.
+///
+/// This resets its target range to the style's base attributes before applying
+/// block attributes, so in the composer it must run BEFORE `ACPMarkdownLiveStyler`,
+/// which is given the returned block ranges as an exclusion list.
+enum MarkdownCodeBlockStyler {
+    @discardableResult
+    static func restyle(
+        _ storage: NSTextStorage,
+        in requestedRange: NSRange?,
+        style: MarkdownCodeBlockStyle
+    ) -> [FencedBlock] {
+        let blocks = MarkdownFenceEditing.blocks(in: storage.string)
+        guard storage.length > 0 else { return blocks }
+
+        let full = NSRange(location: 0, length: storage.length)
+        let target = requestedRange.map { NSIntersectionRange($0, full) } ?? full
+        guard target.length > 0 else { return blocks }
+
+        storage.beginEditing()
+        defer { storage.endEditing() }
+
+        // Preserve mention and image chips — their `.attachment` cell would be
+        // stripped by a blanket `setAttributes`.
+        storage.enumerateAttributes(in: target) { attrs, range, _ in
+            if attrs[.attachmentURI] == nil, attrs[.imageAttachmentURI] == nil {
+                storage.setAttributes([
+                    .font: style.baseFont,
+                    .foregroundColor: style.baseColor,
+                ], range: range)
+            }
+        }
+
+        let fenceAttributes: [NSAttributedString.Key: Any] = [
+            .font: style.monoFont,
+            .foregroundColor: style.fenceColor,
+        ]
+        let bodyAttributes: [NSAttributedString.Key: Any] = [
+            .font: style.monoFont,
+            .foregroundColor: style.bodyColor,
+        ]
+
+        for block in blocks {
+            apply(fenceAttributes, to: block.openFenceRange, clippedTo: target, in: storage)
+            if let closeFenceRange = block.closeFenceRange {
+                apply(fenceAttributes, to: closeFenceRange, clippedTo: target, in: storage)
+            }
+            apply(bodyAttributes, to: block.bodyRange, clippedTo: target, in: storage)
+        }
+
+        return blocks
+    }
+
+    private static func apply(
+        _ attributes: [NSAttributedString.Key: Any],
+        to range: NSRange,
+        clippedTo target: NSRange,
+        in storage: NSTextStorage
+    ) {
+        let clipped = NSIntersectionRange(range, target)
+        guard clipped.length > 0 else { return }
+        storage.enumerateAttributes(in: clipped) { attrs, subrange, _ in
+            guard attrs[.attachmentURI] == nil, attrs[.imageAttachmentURI] == nil else { return }
+            storage.addAttributes(attributes, range: subrange)
+        }
+    }
+}

--- a/Alas/Sources/UI/MarkdownFenceEditing.swift
+++ b/Alas/Sources/UI/MarkdownFenceEditing.swift
@@ -1,5 +1,14 @@
 import Foundation
 
+/// What a keystroke should do about code fences. `.none` means the caller
+/// falls through to `PairedDelimiterEditing`, whose one- and two-backtick
+/// wrapping behaviour is unchanged by this feature.
+enum FenceEditAction: Equatable {
+    case openBlock
+    case wrapSelection
+    case none
+}
+
 /// A fenced code block found in markdown source.
 ///
 /// `openFenceRange` and `closeFenceRange` are content ranges — they exclude the
@@ -143,5 +152,87 @@ enum MarkdownFenceEditing {
             length -= 1
         }
         return NSRange(location: range.location, length: length)
+    }
+
+    static func resolve(
+        insertedText: String,
+        in text: String,
+        selectedRange: NSRange
+    ) -> FenceEditAction {
+        guard insertedText == "`" else { return .none }
+        let ns = text as NSString
+        guard isValid(selectedRange, in: ns) else { return .none }
+        // Exactly two backticks before the caret: keystroke one paired, two
+        // stepped over, and this is the third.
+        guard backtickRunLength(before: selectedRange.location, in: ns) == 2 else {
+            return .none
+        }
+        guard block(containing: selectedRange.location, in: text) == nil else {
+            return .none
+        }
+
+        if selectedRange.length == 0 {
+            return .openBlock
+        }
+        // Wrapping already ran twice, so the selection is flanked by exactly
+        // two backticks on each side by the time the third keystroke lands.
+        guard backtickRunLength(after: NSMaxRange(selectedRange), in: ns) == 2 else {
+            return .none
+        }
+        return .wrapSelection
+    }
+
+    /// The block whose interior contains `location`, if any. The interior
+    /// starts at the end of the opening fence's backticks — so the info-string
+    /// slot counts as inside — and ends at the start of the closing fence.
+    static func block(containing location: Int, in text: String) -> FencedBlock? {
+        blocks(in: text).first { block in
+            let lower = NSMaxRange(block.openFenceRange)
+            let upper = block.closeFenceRange?.location ?? NSMaxRange(block.outerRange)
+            return location >= lower && location <= upper
+        }
+    }
+
+    /// How many auto-paired backticks sit immediately after `location`, capped
+    /// at two.
+    ///
+    /// Whether a pending closer exists depends on what preceded the run.
+    /// From an empty line the keystrokes go pair → step-over, leaving `` `` ``
+    /// with nothing after the caret. After a word the first backtick resolves
+    /// `.native` (the preceding character is identifier-like) and the second
+    /// pairs, leaving a closer parked after the caret. Opening a block has to
+    /// swallow that closer or it survives as a stray backtick below the box.
+    static func trailingBacktickRun(at location: Int, in text: String) -> Int {
+        let ns = text as NSString
+        guard location >= 0, location <= ns.length else { return 0 }
+        return min(2, backtickRunLength(after: location, in: ns))
+    }
+
+    private static func backtickRunLength(before location: Int, in ns: NSString) -> Int {
+        var cursor = location
+        var count = 0
+        while cursor > 0, cursor <= ns.length, ns.character(at: cursor - 1) == backtick {
+            cursor -= 1
+            count += 1
+        }
+        return count
+    }
+
+    private static func backtickRunLength(after location: Int, in ns: NSString) -> Int {
+        var cursor = location
+        var count = 0
+        while cursor >= 0, cursor < ns.length, ns.character(at: cursor) == backtick {
+            cursor += 1
+            count += 1
+        }
+        return count
+    }
+
+    private static func isValid(_ range: NSRange, in ns: NSString) -> Bool {
+        range.location != NSNotFound
+            && range.location >= 0
+            && range.length >= 0
+            && range.location <= ns.length
+            && range.length <= ns.length - range.location
     }
 }

--- a/Alas/Sources/UI/MarkdownFenceEditing.swift
+++ b/Alas/Sources/UI/MarkdownFenceEditing.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+/// A fenced code block found in markdown source.
+///
+/// `openFenceRange` and `closeFenceRange` are content ranges — they exclude the
+/// line terminator. `bodyRange` spans everything between the two fence lines,
+/// including each body line's own terminator. `outerRange` covers the block from
+/// the first backtick of the opening fence to the last backtick of the closing
+/// fence, or to end of text when the block is still unclosed.
+struct FencedBlock: Equatable {
+    var openFenceRange: NSRange
+    var bodyRange: NSRange
+    var closeFenceRange: NSRange?
+    var infoString: String
+    var outerRange: NSRange
+}
+
+enum MarkdownFenceEditing {
+    /// CommonMark's minimum fence width.
+    static let minimumFenceLength = 3
+    /// CommonMark allows a fence to be indented by at most three spaces.
+    private static let maximumFenceIndent = 3
+
+    private static let space: unichar = 0x20
+    private static let backtick: unichar = 0x60
+    private static let lineFeed: unichar = 0x0A
+    private static let carriageReturn: unichar = 0x0D
+
+    private struct FenceLine {
+        var lineRange: NSRange      // includes the trailing terminator
+        var contentRange: NSRange   // excludes the trailing terminator
+        var backtickCount: Int
+        var info: String
+    }
+
+    static func blocks(in text: String) -> [FencedBlock] {
+        let ns = text as NSString
+        let fences = fenceLines(in: ns)
+        var blocks: [FencedBlock] = []
+        var index = 0
+
+        while index < fences.count {
+            let opener = fences[index]
+            // Inside a block every line is content until a fence that is at
+            // least as wide as the opener and carries no info string.
+            var closerIndex: Int?
+            var scan = index + 1
+            while scan < fences.count {
+                let candidate = fences[scan]
+                if candidate.backtickCount >= opener.backtickCount, candidate.info.isEmpty {
+                    closerIndex = scan
+                    break
+                }
+                scan += 1
+            }
+
+            if let closerIndex {
+                let closer = fences[closerIndex]
+                let bodyStart = NSMaxRange(opener.lineRange)
+                blocks.append(FencedBlock(
+                    openFenceRange: opener.contentRange,
+                    bodyRange: NSRange(
+                        location: bodyStart,
+                        length: max(0, closer.lineRange.location - bodyStart)
+                    ),
+                    closeFenceRange: closer.contentRange,
+                    infoString: opener.info,
+                    outerRange: NSRange(
+                        location: opener.contentRange.location,
+                        length: NSMaxRange(closer.contentRange) - opener.contentRange.location
+                    )
+                ))
+                index = closerIndex + 1
+            } else {
+                let bodyStart = min(NSMaxRange(opener.lineRange), ns.length)
+                blocks.append(FencedBlock(
+                    openFenceRange: opener.contentRange,
+                    bodyRange: NSRange(location: bodyStart, length: ns.length - bodyStart),
+                    closeFenceRange: nil,
+                    infoString: opener.info,
+                    outerRange: NSRange(
+                        location: opener.contentRange.location,
+                        length: ns.length - opener.contentRange.location
+                    )
+                ))
+                index = fences.count
+            }
+        }
+
+        return blocks
+    }
+
+    private static func fenceLines(in ns: NSString) -> [FenceLine] {
+        var lines: [FenceLine] = []
+        var location = 0
+        while location < ns.length {
+            let lineRange = ns.lineRange(for: NSRange(location: location, length: 0))
+            guard lineRange.length > 0 else { break }
+            let contentRange = trimmingLineTerminator(lineRange, in: ns)
+            if let fence = parseFence(contentRange, in: ns) {
+                lines.append(FenceLine(
+                    lineRange: lineRange,
+                    contentRange: contentRange,
+                    backtickCount: fence.count,
+                    info: fence.info
+                ))
+            }
+            location = NSMaxRange(lineRange)
+        }
+        return lines
+    }
+
+    private static func parseFence(_ range: NSRange, in ns: NSString) -> (count: Int, info: String)? {
+        var index = range.location
+        let end = NSMaxRange(range)
+
+        var indent = 0
+        while index < end, indent < maximumFenceIndent, ns.character(at: index) == space {
+            index += 1
+            indent += 1
+        }
+
+        var count = 0
+        while index < end, ns.character(at: index) == backtick {
+            index += 1
+            count += 1
+        }
+        guard count >= minimumFenceLength else { return nil }
+
+        let info = ns.substring(with: NSRange(location: index, length: end - index))
+            .trimmingCharacters(in: .whitespaces)
+        // A backtick-fence info string may not itself contain a backtick.
+        guard !info.contains("`") else { return nil }
+        return (count, info)
+    }
+
+    private static func trimmingLineTerminator(_ range: NSRange, in ns: NSString) -> NSRange {
+        var length = range.length
+        if length > 0, ns.character(at: range.location + length - 1) == lineFeed {
+            length -= 1
+        }
+        if length > 0, ns.character(at: range.location + length - 1) == carriageReturn {
+            length -= 1
+        }
+        return NSRange(location: range.location, length: length)
+    }
+}

--- a/Alas/Sources/UI/MarkdownFenceEditing.swift
+++ b/Alas/Sources/UI/MarkdownFenceEditing.swift
@@ -34,7 +34,12 @@ enum MarkdownFenceEditing {
     /// CommonMark's minimum fence width.
     static let minimumFenceLength = 3
     /// CommonMark allows a fence to be indented by at most three spaces.
-    private static let maximumFenceIndent = 3
+    ///
+    /// Internal rather than private: `PairedComposerTextControls` reuses it to
+    /// decide when a caret's preceding whitespace is a fence's own indentation
+    /// rather than stray padding, so that decision can never drift from what
+    /// `parseFence` itself accepts.
+    static let maximumFenceIndent = 3
 
     private static let space: unichar = 0x20
     private static let backtick: unichar = 0x60

--- a/Alas/Sources/UI/MarkdownFenceEditing.swift
+++ b/Alas/Sources/UI/MarkdownFenceEditing.swift
@@ -16,11 +16,17 @@ enum FenceEditAction: Equatable {
 /// including each body line's own terminator. `outerRange` covers the block from
 /// the first backtick of the opening fence to the last backtick of the closing
 /// fence, or to end of text when the block is still unclosed.
+///
+/// `infoRange` is the opening fence line's info-string slot: everything from the
+/// end of its backtick run to the end of the line, untrimmed. `infoString` is
+/// the trimmed contents of exactly that range. An opener with no info string
+/// still has an `infoRange` — an empty one parked where the tag would go.
 struct FencedBlock: Equatable {
     var openFenceRange: NSRange
     var bodyRange: NSRange
     var closeFenceRange: NSRange?
     var infoString: String
+    var infoRange: NSRange
     var outerRange: NSRange
 }
 
@@ -40,6 +46,7 @@ enum MarkdownFenceEditing {
         var contentRange: NSRange   // excludes the trailing terminator
         var backtickCount: Int
         var info: String
+        var infoRange: NSRange      // the slot `info` was trimmed out of
     }
 
     static func blocks(in text: String) -> [FencedBlock] {
@@ -74,6 +81,7 @@ enum MarkdownFenceEditing {
                     ),
                     closeFenceRange: closer.contentRange,
                     infoString: opener.info,
+                    infoRange: opener.infoRange,
                     outerRange: NSRange(
                         location: opener.contentRange.location,
                         length: NSMaxRange(closer.contentRange) - opener.contentRange.location
@@ -87,6 +95,7 @@ enum MarkdownFenceEditing {
                     bodyRange: NSRange(location: bodyStart, length: ns.length - bodyStart),
                     closeFenceRange: nil,
                     infoString: opener.info,
+                    infoRange: opener.infoRange,
                     outerRange: NSRange(
                         location: opener.contentRange.location,
                         length: ns.length - opener.contentRange.location
@@ -111,7 +120,8 @@ enum MarkdownFenceEditing {
                     lineRange: lineRange,
                     contentRange: contentRange,
                     backtickCount: fence.count,
-                    info: fence.info
+                    info: fence.info,
+                    infoRange: fence.infoRange
                 ))
             }
             location = NSMaxRange(lineRange)
@@ -119,7 +129,10 @@ enum MarkdownFenceEditing {
         return lines
     }
 
-    private static func parseFence(_ range: NSRange, in ns: NSString) -> (count: Int, info: String)? {
+    private static func parseFence(
+        _ range: NSRange,
+        in ns: NSString
+    ) -> (count: Int, info: String, infoRange: NSRange)? {
         var index = range.location
         let end = NSMaxRange(range)
 
@@ -136,11 +149,14 @@ enum MarkdownFenceEditing {
         }
         guard count >= minimumFenceLength else { return nil }
 
-        let info = ns.substring(with: NSRange(location: index, length: end - index))
+        // Everything past the backticks is the info-string slot, whether or
+        // not anything has been typed into it yet.
+        let infoRange = NSRange(location: index, length: end - index)
+        let info = ns.substring(with: infoRange)
             .trimmingCharacters(in: .whitespaces)
         // A backtick-fence info string may not itself contain a backtick.
         guard !info.contains("`") else { return nil }
-        return (count, info)
+        return (count, info, infoRange)
     }
 
     private static func trimmingLineTerminator(_ range: NSRange, in ns: NSString) -> NSRange {
@@ -154,6 +170,20 @@ enum MarkdownFenceEditing {
         return NSRange(location: range.location, length: length)
     }
 
+    /// What the keystroke `insertedText` at `selectedRange` should do about
+    /// code fences.
+    ///
+    /// Both non-`.none` answers rewrite a span of the document into a whole
+    /// new block, and the caller acts on them without a further structural
+    /// check of its own — unlike `.none`, which routes through
+    /// `PairedComposerTextControls`' simulate-and-compare guard. So this is
+    /// where the invariant has to hold: neither answer is ever returned when
+    /// the edit would land on an existing block. A caret is refused when it
+    /// sits in a block's interior; a selection is refused when it overlaps any
+    /// existing block's `outerRange` at all — reaching into one, running out of
+    /// one, or swallowing one whole. `blocks(in:)` has no notion of nesting, so
+    /// a block caught inside a new outer fence would have its own opener and
+    /// closer re-paired against that fence rather than each other.
     static func resolve(
         insertedText: String,
         in text: String,
@@ -174,6 +204,16 @@ enum MarkdownFenceEditing {
         if selectedRange.length == 0 {
             return .openBlock
         }
+        // A caret can only ever be inside one block or outside them all, but a
+        // selection is a span: it can start clear of every block and still run
+        // into one, out of one, or straight over one. Wrapping any of those
+        // hands the enclosed block's fence lines to the new outer fence, so
+        // refuse on any overlap at all rather than only on where it starts.
+        guard !blocks(in: text).contains(where: {
+            NSIntersectionRange($0.outerRange, selectedRange).length > 0
+        }) else {
+            return .none
+        }
         // Wrapping already ran twice, so the selection is flanked by exactly
         // two backticks on each side by the time the third keystroke lands.
         guard backtickRunLength(after: NSMaxRange(selectedRange), in: ns) == 2 else {
@@ -183,11 +223,13 @@ enum MarkdownFenceEditing {
     }
 
     /// The block whose interior contains `location`, if any. The interior
-    /// starts at the end of the opening fence's backticks — so the info-string
-    /// slot counts as inside — and ends at the start of the closing fence.
+    /// starts at the end of the opening fence's backticks — so the whole
+    /// info-string slot counts as inside, including a caret parked part-way
+    /// through a language tag the author is still typing — and ends at the
+    /// start of the closing fence.
     static func block(containing location: Int, in text: String) -> FencedBlock? {
         blocks(in: text).first { block in
-            let lower = NSMaxRange(block.openFenceRange)
+            let lower = block.infoRange.location
             let upper = block.closeFenceRange?.location ?? NSMaxRange(block.outerRange)
             return location >= lower && location <= upper
         }

--- a/Alas/Sources/UI/MarkdownFenceEditing.swift
+++ b/Alas/Sources/UI/MarkdownFenceEditing.swift
@@ -183,12 +183,23 @@ enum MarkdownFenceEditing {
     /// check of its own — unlike `.none`, which routes through
     /// `PairedComposerTextControls`' simulate-and-compare guard. So this is
     /// where the invariant has to hold: neither answer is ever returned when
-    /// the edit would land on an existing block. A caret is refused when it
-    /// sits in a block's interior; a selection is refused when it overlaps any
-    /// existing block's `outerRange` at all — reaching into one, running out of
-    /// one, or swallowing one whole. `blocks(in:)` has no notion of nesting, so
-    /// a block caught inside a new outer fence would have its own opener and
-    /// closer re-paired against that fence rather than each other.
+    /// the edit would land on an existing block. `blocks(in:)` has no notion of
+    /// nesting, so a block caught inside a new outer fence would have its own
+    /// opener and closer re-paired against that fence rather than each other,
+    /// and a block whose fence line the expansion overwrites simply loses it.
+    ///
+    /// That invariant is checked against `rewrittenRange(for:in:selectedRange:)`
+    /// — the exact span the caller will overwrite — rather than against
+    /// stand-ins for it. Two rounds of narrower preconditions each turned out
+    /// to guard a *proxy* for the edit: a caret's own position (which says
+    /// nothing about the auto-paired closer the expansion also swallows, and
+    /// which `block(containing:)` deliberately reports as outside a block when
+    /// it sits within a fence's own backticks — a marker is not an interior),
+    /// and a selection's own range (which stops two characters short of each
+    /// flank the wrap consumes). Guarding the rewritten span instead covers
+    /// every character the edit touches by construction, and keeps covering
+    /// them if that span ever changes shape, because the callers rewrite the
+    /// range this asked about.
     static func resolve(
         insertedText: String,
         in text: String,
@@ -202,29 +213,73 @@ enum MarkdownFenceEditing {
         guard backtickRunLength(before: selectedRange.location, in: ns) == 2 else {
             return .none
         }
-        guard block(containing: selectedRange.location, in: text) == nil else {
-            return .none
+
+        let action: FenceEditAction
+        if selectedRange.length == 0 {
+            action = .openBlock
+        } else {
+            // Wrapping already ran twice, so the selection is flanked by
+            // exactly two backticks on each side by the time the third
+            // keystroke lands.
+            guard backtickRunLength(after: NSMaxRange(selectedRange), in: ns) == 2 else {
+                return .none
+            }
+            action = .wrapSelection
         }
 
-        if selectedRange.length == 0 {
-            return .openBlock
-        }
-        // A caret can only ever be inside one block or outside them all, but a
-        // selection is a span: it can start clear of every block and still run
-        // into one, out of one, or straight over one. Wrapping any of those
-        // hands the enclosed block's fence lines to the new outer fence, so
-        // refuse on any overlap at all rather than only on where it starts.
-        guard !blocks(in: text).contains(where: {
-            NSIntersectionRange($0.outerRange, selectedRange).length > 0
+        guard let rewritten = rewrittenRange(
+            for: action,
+            in: text,
+            selectedRange: selectedRange
+        ), !blocks(in: text).contains(where: {
+            NSIntersectionRange($0.outerRange, rewritten).length > 0
         }) else {
             return .none
         }
-        // Wrapping already ran twice, so the selection is flanked by exactly
-        // two backticks on each side by the time the third keystroke lands.
-        guard backtickRunLength(after: NSMaxRange(selectedRange), in: ns) == 2 else {
-            return .none
+        return action
+    }
+
+    /// The span of `text` that acting on `action` rewrites into a new block,
+    /// or `nil` when `action` rewrites nothing or the range would not be a
+    /// valid one.
+    ///
+    /// The single source of truth for that span. `resolve` refuses `action`
+    /// unless this range clears every existing block, and the callers hand
+    /// this same range to their expansion — so the range that was checked and
+    /// the range that gets overwritten cannot drift apart.
+    ///
+    /// `.openBlock` consumes the two backticks already before the caret, the
+    /// keystroke itself, and any closer auto-pairing parked after the caret,
+    /// which would otherwise survive as a stray backtick below the box.
+    /// `.wrapSelection` consumes the two backticks flanking the selection on
+    /// each side along with the selection between them.
+    static func rewrittenRange(
+        for action: FenceEditAction,
+        in text: String,
+        selectedRange: NSRange
+    ) -> NSRange? {
+        let ns = text as NSString
+        guard isValid(selectedRange, in: ns), selectedRange.location >= 2 else { return nil }
+
+        let rewritten: NSRange
+        switch action {
+        case .openBlock:
+            guard selectedRange.length == 0 else { return nil }
+            rewritten = NSRange(
+                location: selectedRange.location - 2,
+                length: 2 + trailingBacktickRun(at: selectedRange.location, in: text)
+            )
+        case .wrapSelection:
+            rewritten = NSRange(
+                location: selectedRange.location - 2,
+                length: selectedRange.length + 4
+            )
+        case .none:
+            return nil
         }
-        return .wrapSelection
+
+        guard isValid(rewritten, in: ns) else { return nil }
+        return rewritten
     }
 
     /// The block whose interior contains `location`, if any. The interior
@@ -232,6 +287,13 @@ enum MarkdownFenceEditing {
     /// info-string slot counts as inside, including a caret parked part-way
     /// through a language tag the author is still typing — and ends at the
     /// start of the closing fence.
+    ///
+    /// This answers "is the caret in editable block content?", which is what
+    /// key handling wants. It is *not* an edit-safety check: a caret sitting
+    /// within a fence's own backticks reads as outside the block, by design,
+    /// even though an edit there would take the marker apart. Anything asking
+    /// whether an edit may proceed has to weigh the span that edit rewrites
+    /// against `blocks(in:)` — see `resolve`.
     static func block(containing location: Int, in text: String) -> FencedBlock? {
         blocks(in: text).first { block in
             let lower = block.infoRange.location

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -486,18 +486,65 @@ class PairedDelimiterTextView: NSTextView {
         // body already ends on a line of its own. Adding another newline there
         // would push a blank line the author never typed into their own content.
         let separator = endsWithLineTerminator(body) ? "" : "\n"
+        // A non-empty body (only `.wrapSelection` ever supplies one —
+        // `.openBlock`'s body is always empty) splices its own first
+        // character in directly after this fence's own newline, and every
+        // character in it keeps whatever line-start position it already had.
+        // A backtick run inside the body that is not currently a fence line —
+        // most commonly the body's very first run, mid-line until this edit's
+        // own leading newline relocates it — would read as one once it lands
+        // there. Widening the fence past every backtick run anywhere in the
+        // body keeps `blocks(in:)`'s closing rule (`>= opener.backtickCount`)
+        // from ever matching such a run, so it can only ever be absorbed as
+        // inert content.
+        let fence = String(repeating: "`", count: fenceWidth(for: body))
 
         return FencedBlockExpansion(
             // The opening fence's indentation, if any, already sits in the
             // document right before `replaced` — this edit never touches it,
             // so `prefix` only ever adds the fence itself.
-            prefix: leading + "```\n",
+            prefix: leading + fence + "\n",
             // The closing fence starts life on a fresh line with nothing
             // before it, so its matching indentation has to be typed in here.
-            suffix: separator + indent + "```" + trailing,
-            // "```\n" is four characters past the leading newline, if any.
-            bodyStart: replaced.location + (leading as NSString).length + 4
+            suffix: separator + indent + fence + trailing,
+            // The fence plus its own newline sit between the leading newline,
+            // if any, and the body.
+            bodyStart: replaced.location + (leading as NSString).length + fence.count + 1
         )
+    }
+
+    /// How wide a fence must be to wrap `body` without any line inside it
+    /// ever satisfying `MarkdownFenceEditing.blocks(in:)`'s closing rule
+    /// (`candidate.backtickCount >= opener.backtickCount`) against this
+    /// fence's own opener.
+    ///
+    /// Scans every character of `body`, not merely lines that already read as
+    /// fence lines: a run that is not currently line-starting can become one
+    /// purely because of the newlines this very edit inserts around `body`,
+    /// which is the failure mode this guards against. `minimumFenceLength` is
+    /// the floor so an empty or backtick-free body still gets the ordinary
+    /// three-wide fence.
+    private static func fenceWidth(for body: NSString) -> Int {
+        max(MarkdownFenceEditing.minimumFenceLength, longestBacktickRun(in: body) + 1)
+    }
+
+    /// The length of the longest contiguous run of `` ` `` anywhere in
+    /// `body`, irrespective of where it sits on its line.
+    private static func longestBacktickRun(in body: NSString) -> Int {
+        let backtick: unichar = 0x60
+        var longest = 0
+        var current = 0
+        var index = 0
+        while index < body.length {
+            if body.character(at: index) == backtick {
+                current += 1
+                longest = max(longest, current)
+            } else {
+                current = 0
+            }
+            index += 1
+        }
+        return longest
     }
 
     /// The whitespace-only run, if any, between the start of the line

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -7,6 +7,12 @@ class PairedDelimiterTextView: NSTextView {
     /// Text that the in-flight marked composition swallowed, kept so a dead-key
     /// delimiter can still wrap the selection the user had before pressing it.
     private var selectionReplacedByMarkedText: NSAttributedString?
+    /// Opt-in triple-backtick handling. Off by default so surfaces that are
+    /// not markdown — the shell startup script editors — keep plain pairing.
+    var markdownFencesEnabled = false
+    /// Set by the owning representable when fences are enabled; drives both
+    /// text styling and the box drawn in `drawBackground(in:)`.
+    var markdownCodeBlockStyle: MarkdownCodeBlockStyle?
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
@@ -48,6 +54,52 @@ class PairedDelimiterTextView: NSTextView {
         }
 
         let range = replacementRange.location == NSNotFound ? selectedRange() : replacementRange
+
+        if markdownFencesEnabled {
+            switch MarkdownFenceEditing.resolve(
+                insertedText: insertedText,
+                in: string,
+                selectedRange: range
+            ) {
+            case .openBlock:
+                // The two backticks already in the storage plus this keystroke
+                // become the whole block — and so does any closer that auto-
+                // pairing parked after the caret, or it survives as a stray
+                // backtick below the box.
+                let trailing = MarkdownFenceEditing.trailingBacktickRun(at: range.location, in: string)
+                insertFencedBlock(
+                    replacing: NSRange(location: range.location - 2, length: 2 + trailing),
+                    body: ""
+                )
+                return
+            case .wrapSelection:
+                let body = (string as NSString).substring(with: range)
+                insertFencedBlock(
+                    replacing: NSRange(location: range.location - 2, length: range.length + 4),
+                    body: body
+                )
+                return
+            case .none:
+                // `MarkdownFenceEditing.resolve` returns `.none` here on
+                // purpose — its contract is to fall through to plain pairing
+                // for anything it doesn't recognize, including a third
+                // backtick that lands inside an existing block. But
+                // `PairedDelimiterEditing` has no notion of fences: its
+                // auto-pair/step-over dance for that same keystroke leaves a
+                // bare backtick run that CommonMark reads as a real fence
+                // line, splitting the block in two. Swallow just that
+                // keystroke; a lone backtick typed anywhere else in the block
+                // is unaffected.
+                if range.length == 0,
+                   insertedText == "`",
+                   fencedBlockRange(containing: range.location) != nil,
+                   Self.isPrecededByExactlyTwoBackticks(range.location, in: string)
+                {
+                    return
+                }
+            }
+        }
+
         switch PairedDelimiterEditing.resolve(insertedText: insertedText, in: string, selectedRange: range) {
         case let .wrap(opening, closing):
             guard let textStorage, Self.isValid(range, in: textStorage) else {
@@ -81,6 +133,41 @@ class PairedDelimiterTextView: NSTextView {
         case .native:
             super.insertText(insertString, replacementRange: replacementRange)
         }
+    }
+
+    func fencedBlockRange(containing location: Int) -> FencedBlock? {
+        guard markdownFencesEnabled else { return nil }
+        return MarkdownFenceEditing.block(containing: location, in: string)
+    }
+
+    /// Replace `replaced` with a complete fenced block wrapping `body`, adding
+    /// the newlines needed to keep both fences on lines of their own, and leave
+    /// the selection on the body.
+    private func insertFencedBlock(replacing replaced: NSRange, body: String) {
+        guard let textStorage, Self.isValid(replaced, in: textStorage) else { return }
+        let ns = string as NSString
+        let needsLeadingNewline = replaced.location > 0
+            && ns.character(at: replaced.location - 1) != 0x0A
+        let suffixLocation = NSMaxRange(replaced)
+        let needsTrailingNewline = suffixLocation < ns.length
+            && ns.character(at: suffixLocation) != 0x0A
+        let leading = needsLeadingNewline ? "\n" : ""
+        let trailing = needsTrailingNewline ? "\n" : ""
+
+        let replacement = NSAttributedString(
+            string: leading + "```\n" + body + "\n```" + trailing,
+            attributes: typingAttributes
+        )
+
+        undoManager?.beginUndoGrouping()
+        performNativeTextInsertion {
+            super.insertText(replacement, replacementRange: replaced)
+        }
+        undoManager?.endUndoGrouping()
+
+        // "```\n" is four characters past the leading newline, if any.
+        let bodyStart = replaced.location + (leading as NSString).length + 4
+        setSelectedRange(NSRange(location: bodyStart, length: (body as NSString).length))
     }
 
     override func unmarkText() {
@@ -213,6 +300,18 @@ class PairedDelimiterTextView: NSTextView {
             return attributedString.string
         }
         return nil
+    }
+
+    /// Whether exactly two backticks (no more, no fewer) sit immediately
+    /// before `location` — the same precondition `MarkdownFenceEditing.resolve`
+    /// uses internally to recognize a would-be third backtick.
+    private static func isPrecededByExactlyTwoBackticks(_ location: Int, in text: String) -> Bool {
+        let ns = text as NSString
+        guard location >= 2,
+              ns.character(at: location - 1) == 0x60,
+              ns.character(at: location - 2) == 0x60
+        else { return false }
+        return location == 2 || ns.character(at: location - 3) != 0x60
     }
 
     private static func isValid(_ range: NSRange, in storage: NSTextStorage) -> Bool {

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -132,7 +132,11 @@ class PairedDelimiterTextView: NSTextView {
                 // `PairedDelimiterEditing` has no notion of fences, so the
                 // partner it adds on the user's behalf can re-cut the
                 // document's blocks — see `fenceCollisionOutcome`.
-                switch fenceCollisionOutcome(insertedText: insertedText, range: range) {
+                switch Self.fenceCollisionOutcome(
+                    insertedText: insertedText,
+                    in: string,
+                    range: range
+                ) {
                 case .pair:
                     break
                 case .insertLiterally:
@@ -197,9 +201,14 @@ class PairedDelimiterTextView: NSTextView {
         case swallow
     }
 
-    /// How to handle a delimiter landing at `range` — one
+    /// How to handle a delimiter landing at `range` in `text` — one
     /// `MarkdownFenceEditing` declined to handle, most commonly because it's
     /// on or inside an existing block.
+    ///
+    /// `text` is the document the keystroke lands in. On the ordinary keyboard
+    /// path that is the live storage; on the dead-key commit path it is the
+    /// pre-composition document `PairedDelimiterEditing.preCompositionContext`
+    /// reconstructs, because the storage still holds the marked text.
     ///
     /// `PairedDelimiterEditing` knows nothing about fences. It answers a
     /// delimiter by putting *more* than the typed character into the storage:
@@ -232,23 +241,27 @@ class PairedDelimiterTextView: NSTextView {
     /// the selection, newlines and all. That is both destructive and outside
     /// what `fenceStructure(of:)` can reason about, so a selection whose wrap
     /// would re-cut the document is refused rather than downgraded.
-    private func fenceCollisionOutcome(insertedText: String, range: NSRange) -> FenceCollisionOutcome {
-        let ns = string as NSString
-        guard Self.isValid(range, in: ns),
+    private static func fenceCollisionOutcome(
+        insertedText: String,
+        in text: String,
+        range: NSRange
+    ) -> FenceCollisionOutcome {
+        let ns = text as NSString
+        guard isValid(range, in: ns),
               // Fence lines are built out of backticks, and nothing on this
               // path ever deletes a character, so a document with no fence in
               // it cannot grow one from a keystroke that isn't a backtick.
               insertedText.contains("`" as Character)
-                  || ns.range(of: Self.narrowestFence).location != NSNotFound,
-              let padded = pairedDelimiterPaddedResult(of: insertedText, at: range)
+                  || ns.range(of: narrowestFence).location != NSNotFound,
+              let padded = pairedDelimiterPaddedResult(of: insertedText, in: text, at: range)
         else { return .pair }
 
-        let current = Self.fenceStructure(of: string)
-        guard Self.fenceStructure(of: padded) != current else { return .pair }
+        let current = fenceStructure(of: text)
+        guard fenceStructure(of: padded) != current else { return .pair }
 
         guard range.length == 0 else { return .swallow }
-        let literal = Self.fenceStructure(of: ns.replacingCharacters(in: range, with: insertedText))
-        return Self.preservesFences(literal, from: current) ? .insertLiterally : .swallow
+        let literal = fenceStructure(of: ns.replacingCharacters(in: range, with: insertedText))
+        return preservesFences(literal, from: current) ? .insertLiterally : .swallow
     }
 
     /// The narrowest backtick run CommonMark will read as a fence, and so the
@@ -273,8 +286,8 @@ class PairedDelimiterTextView: NSTextView {
             }
     }
 
-    /// The document as `PairedDelimiterEditing` would leave it, or `nil` when
-    /// the resolution adds nothing beyond the typed character.
+    /// `text` as `PairedDelimiterEditing` would leave it, or `nil` when the
+    /// resolution adds nothing beyond the typed character.
     ///
     /// `.stepOver` writes nothing at all, and `.native` writes exactly the
     /// character the user pressed. Neither is this method's business: a
@@ -284,13 +297,17 @@ class PairedDelimiterTextView: NSTextView {
     /// so the only options would be to honour it or to eat a keystroke the
     /// author deliberately typed. `fenceCollisionOutcome` honours it, and
     /// reaches for the same shape itself as a fallback.
-    private func pairedDelimiterPaddedResult(of insertedText: String, at range: NSRange) -> String? {
-        let ns = string as NSString
-        guard Self.isValid(range, in: ns) else { return nil }
+    private static func pairedDelimiterPaddedResult(
+        of insertedText: String,
+        in text: String,
+        at range: NSRange
+    ) -> String? {
+        let ns = text as NSString
+        guard isValid(range, in: ns) else { return nil }
 
         switch PairedDelimiterEditing.resolve(
             insertedText: insertedText,
-            in: string,
+            in: text,
             selectedRange: range
         ) {
         case let .wrap(opening, closing):
@@ -371,17 +388,13 @@ class PairedDelimiterTextView: NSTextView {
     /// the selection on the body.
     private func insertFencedBlock(replacing replaced: NSRange, body: String) {
         guard let textStorage, Self.isValid(replaced, in: textStorage) else { return }
-        let ns = string as NSString
-        let needsLeadingNewline = replaced.location > 0
-            && ns.character(at: replaced.location - 1) != 0x0A
-        let suffixLocation = NSMaxRange(replaced)
-        let needsTrailingNewline = suffixLocation < ns.length
-            && ns.character(at: suffixLocation) != 0x0A
-        let leading = needsLeadingNewline ? "\n" : ""
-        let trailing = needsTrailingNewline ? "\n" : ""
-
+        let expansion = Self.fencedBlockExpansion(
+            replacing: replaced,
+            body: body,
+            in: string as NSString
+        )
         let replacement = NSAttributedString(
-            string: leading + "```\n" + body + "\n```" + trailing,
+            string: expansion.replacement,
             attributes: typingAttributes
         )
 
@@ -391,9 +404,36 @@ class PairedDelimiterTextView: NSTextView {
         }
         undoManager?.endUndoGrouping()
 
-        // "```\n" is four characters past the leading newline, if any.
-        let bodyStart = replaced.location + (leading as NSString).length + 4
-        setSelectedRange(NSRange(location: bodyStart, length: (body as NSString).length))
+        setSelectedRange(NSRange(
+            location: expansion.bodyStart,
+            length: (body as NSString).length
+        ))
+    }
+
+    /// The literal text a fenced block expands to when it replaces `replaced`
+    /// in `text`, plus the offset its body will start at once installed.
+    ///
+    /// Split out of `insertFencedBlock` so the dead-key commit path can build
+    /// the identical expansion from the pre-composition document rather than
+    /// from live storage, which still holds the marked text.
+    private static func fencedBlockExpansion(
+        replacing replaced: NSRange,
+        body: String,
+        in text: NSString
+    ) -> (replacement: String, bodyStart: Int) {
+        let needsLeadingNewline = replaced.location > 0
+            && text.character(at: replaced.location - 1) != 0x0A
+        let suffixLocation = NSMaxRange(replaced)
+        let needsTrailingNewline = suffixLocation < text.length
+            && text.character(at: suffixLocation) != 0x0A
+        let leading = needsLeadingNewline ? "\n" : ""
+        let trailing = needsTrailingNewline ? "\n" : ""
+
+        return (
+            replacement: leading + "```\n" + body + "\n```" + trailing,
+            // "```\n" is four characters past the leading newline, if any.
+            bodyStart: replaced.location + (leading as NSString).length + 4
+        )
     }
 
     override func unmarkText() {
@@ -425,6 +465,82 @@ class PairedDelimiterTextView: NSTextView {
         else {
             super.insertText(insertString, replacementRange: replacementRange)
             return
+        }
+
+        // Dead-key layouts route the third backtick through here, so fence
+        // expansion and the collision guard have to be consulted on this path
+        // too — against the pre-composition document, since the marked text is
+        // still sitting in the storage.
+        if markdownFencesEnabled {
+            switch MarkdownFenceEditing.resolve(
+                insertedText: insertedText,
+                in: context.text,
+                selectedRange: context.selectedRange
+            ) {
+            case .openBlock:
+                let trailing = MarkdownFenceEditing.trailingBacktickRun(
+                    at: context.selectedRange.location,
+                    in: context.text
+                )
+                commitFencedBlock(
+                    replacing: NSRange(
+                        location: context.selectedRange.location - 2,
+                        length: 2 + trailing
+                    ),
+                    body: "",
+                    context: context,
+                    markedRange: marked
+                )
+                return
+            case .wrapSelection:
+                let body = (context.text as NSString).substring(with: context.selectedRange)
+                commitFencedBlock(
+                    replacing: NSRange(
+                        location: context.selectedRange.location - 2,
+                        length: context.selectedRange.length + 4
+                    ),
+                    body: body,
+                    context: context,
+                    markedRange: marked
+                )
+                return
+            case .none:
+                switch Self.fenceCollisionOutcome(
+                    insertedText: insertedText,
+                    in: context.text,
+                    range: context.selectedRange
+                ) {
+                case .pair:
+                    break
+                case .insertLiterally:
+                    replaceMarkedText(
+                        with: NSAttributedString(
+                            string: insertedText,
+                            attributes: typingAttributes
+                        ),
+                        markedRange: marked
+                    )
+                    setSelectedRange(NSRange(
+                        location: marked.location + (insertedText as NSString).length,
+                        length: 0
+                    ))
+                    return
+                case .swallow:
+                    // The normal path simply drops the keystroke. Here the
+                    // composition already ate whatever the selection held, so
+                    // "no visible change" means putting that back.
+                    replaceMarkedText(
+                        with: replacedSelection
+                            ?? NSAttributedString(string: "", attributes: typingAttributes),
+                        markedRange: marked
+                    )
+                    setSelectedRange(NSRange(
+                        location: marked.location,
+                        length: context.selectedRange.length
+                    ))
+                    return
+                }
+            }
         }
 
         switch PairedDelimiterEditing.resolve(
@@ -472,9 +588,58 @@ class PairedDelimiterTextView: NSTextView {
         }
     }
 
+    /// Expands a fenced block from a dead-key commit, the counterpart of
+    /// `insertFencedBlock` for the marked-text path.
+    ///
+    /// `replaced` is in the pre-composition document's coordinates, the ones
+    /// `MarkdownFenceEditing` answered in. Live storage differs from that
+    /// document in exactly one way — the composition swapped the selection for
+    /// the marked text — and that swap happens inside `replaced`, so the
+    /// equivalent live range keeps the same start and trades one length for
+    /// the other. Replacing it wholesale leaves the same bytes the ordinary
+    /// keyboard path would have produced.
+    private func commitFencedBlock(
+        replacing replaced: NSRange,
+        body: String,
+        context: (text: String, selectedRange: NSRange),
+        markedRange: NSRange
+    ) {
+        let ns = context.text as NSString
+        let live = NSRange(
+            location: replaced.location,
+            length: replaced.length - context.selectedRange.length + markedRange.length
+        )
+        guard Self.isValid(replaced, in: ns),
+              let textStorage,
+              Self.isValid(live, in: textStorage)
+        else { return }
+
+        let expansion = Self.fencedBlockExpansion(replacing: replaced, body: body, in: ns)
+
+        undoManager?.beginUndoGrouping()
+        replaceMarkedText(
+            with: NSAttributedString(
+                string: expansion.replacement,
+                attributes: typingAttributes
+            ),
+            markedRange: live
+        )
+        undoManager?.endUndoGrouping()
+
+        setSelectedRange(NSRange(
+            location: expansion.bodyStart,
+            length: (body as NSString).length
+        ))
+    }
+
     /// `NSTextView.unmarkText()` finalizes the composition by re-inserting the
     /// marked characters through `insertText`, so the whole replacement has to
     /// run with pairing suppressed or the placeholder pairs with itself.
+    ///
+    /// `markedRange` is the range the replacement is written over. It is the
+    /// marked range itself for a plain pairing commit, and a range containing
+    /// it when a fence expansion also rewrites the characters around the
+    /// composition.
     private func replaceMarkedText(with replacement: NSAttributedString, markedRange: NSRange) {
         performNativeTextInsertion {
             unmarkText()

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -82,15 +82,13 @@ class PairedDelimiterTextView: NSTextView {
             case .none:
                 // `MarkdownFenceEditing.resolve` returns `.none` here on
                 // purpose — its contract is to fall through to plain pairing
-                // for anything it doesn't recognize, including a third
-                // backtick (or a flanked selection) that lands inside an
-                // existing block. But `PairedDelimiterEditing` has no notion
-                // of fences, so completing that keystroke unguarded can leave
-                // a *bare* fence line sitting inside the block — see
-                // `swallowsFenceCollidingBacktick` for exactly which shape
-                // that is and why it's dangerous. Swallow just that
-                // keystroke; anything that can't parse as a fence line falls
-                // through untouched.
+                // for anything it doesn't recognize, including a backtick
+                // that lands inside an existing block. But
+                // `PairedDelimiterEditing` has no notion of fences, so the
+                // closer it adds on the user's behalf can turn a run of
+                // backticks into a fence line and re-cut the document's
+                // blocks — see `swallowsFenceCollidingBacktick`. Swallow just
+                // those keystrokes; everything else falls through untouched.
                 if swallowsFenceCollidingBacktick(insertedText: insertedText, range: range) {
                     return
                 }
@@ -142,53 +140,109 @@ class PairedDelimiterTextView: NSTextView {
     /// block — should be swallowed instead of falling through to
     /// `PairedDelimiterEditing`.
     ///
-    /// A caret has one flank to worry about (the two backticks already
-    /// before it, about to become three). A selection has two —
-    /// `PairedDelimiterEditing.wrap` completes both simultaneously, by
-    /// leaving whatever already flanks the selection untouched and inserting
-    /// one new character adjacent to each side. Either flank turning into a
-    /// bare fence line is enough to corrupt a block, so each flank's danger —
-    /// including whether *that flank's own position* sits inside a block —
-    /// is evaluated completely independently, with nothing shared between
-    /// them beyond "the keystroke is a backtick." Gating the right flank's
-    /// check on anything computed from the left (its backtick count, or
-    /// block containment checked only at `range.location`) would let a
-    /// dangerous right flank slip through whenever the left side happens not
-    /// to qualify — which is exactly the shape of bug this method exists to
-    /// avoid, so the two checks below must never share a precondition.
+    /// `PairedDelimiterEditing` knows nothing about fences. It answers a
+    /// backtick by putting *more* than the typed character into the storage:
+    /// `.insertPair` writes two, `.wrap` writes one against each end of the
+    /// selection. Those unrequested characters are what extend a backtick run
+    /// far enough to read as a fence line, and a fence line appearing where
+    /// the author didn't put one re-cuts the document — closing the enclosing
+    /// block early, orphaning its real closer, or widening an opener past the
+    /// closer that used to match it.
+    ///
+    /// So rather than restating the fence grammar here — line starts, indent
+    /// tolerance, info strings, how wide a run must be to close its opener —
+    /// per flank, in a form that has to be kept in step with the parser, this
+    /// asks the parser: apply the exact edit `PairedDelimiterEditing` would
+    /// apply, and refuse the keystroke when the block structure that comes
+    /// back isn't the one already on screen. Every flank the edit touches is
+    /// covered at once, because the comparison is over the whole document.
+    ///
+    /// Only the padded resolutions are inspected. `.stepOver` writes nothing,
+    /// and `.native` writes exactly the character the user pressed — vetoing
+    /// that would be a keystroke vanishing with no auto-pairing to blame,
+    /// which is a worse outcome than the markdown it produces.
     private func swallowsFenceCollidingBacktick(insertedText: String, range: NSRange) -> Bool {
-        guard insertedText == "`" else { return false }
+        guard insertedText == "`",
+              let edited = pairedDelimiterPaddedResult(of: insertedText, at: range)
+        else { return false }
+        return Self.fenceStructure(of: edited) != Self.fenceStructure(of: string)
+    }
 
-        if isFenceDangerousLeftFlank(of: range) {
-            return true
+    /// The document as `PairedDelimiterEditing` would leave it, or `nil` when
+    /// the resolution adds nothing beyond the typed character and so cannot
+    /// surprise the author with a fence.
+    private func pairedDelimiterPaddedResult(of insertedText: String, at range: NSRange) -> String? {
+        let ns = string as NSString
+        guard Self.isValid(range, in: ns) else { return nil }
+
+        switch PairedDelimiterEditing.resolve(
+            insertedText: insertedText,
+            in: string,
+            selectedRange: range
+        ) {
+        case let .wrap(opening, closing):
+            return ns.replacingCharacters(
+                in: range,
+                with: String(opening) + ns.substring(with: range) + String(closing)
+            )
+        case let .insertPair(opening, closing):
+            return ns.replacingCharacters(in: range, with: String(opening) + String(closing))
+        case .stepOver, .native:
+            return nil
         }
-        guard range.length > 0 else { return false }
-        return isFenceDangerousRightFlank(of: range)
     }
 
-    /// Whether the two backticks immediately before `range` are about to
-    /// complete a bare, line-starting run — see `swallowsFenceCollidingBacktick`.
-    private func isFenceDangerousLeftFlank(of range: NSRange) -> Bool {
-        fencedBlockRange(containing: range.location) != nil
-            && Self.isPrecededByExactlyTwoBackticks(range.location, in: string)
-            && Self.startsLine(range.location - 2, in: string)
-            && Self.isBareToEndOfLine(from: range.location, in: string)
+    /// Where every fenced block begins and ends, in line numbers.
+    ///
+    /// Line numbers rather than character offsets because the edits this
+    /// guard weighs only ever insert backticks, never line terminators — and
+    /// never between a CR and its LF, since AppKit hands over selections and
+    /// carets on composed-character-sequence boundaries — so each line keeps
+    /// its number across the edit and two fingerprints taken either side of
+    /// it compare directly. Openers and closers pin the whole structure:
+    /// everything else `blocks(in:)` reports (bodies, outer ranges, info
+    /// strings) follows from which lines fence which.
+    private static func fenceStructure(of text: String) -> [FencedBlockLines] {
+        let ns = text as NSString
+        var lineStarts: [Int] = []
+        var location = 0
+        while location < ns.length {
+            let lineRange = ns.lineRange(for: NSRange(location: location, length: 0))
+            guard lineRange.length > 0 else { break }
+            lineStarts.append(lineRange.location)
+            location = NSMaxRange(lineRange)
+        }
+
+        func lineNumber(of offset: Int) -> Int {
+            var low = 0
+            var high = lineStarts.count - 1
+            var line = 0
+            while low <= high {
+                let middle = (low + high) / 2
+                if lineStarts[middle] <= offset {
+                    line = middle
+                    low = middle + 1
+                } else {
+                    high = middle - 1
+                }
+            }
+            return line
+        }
+
+        return MarkdownFenceEditing.blocks(in: text).map { block in
+            FencedBlockLines(
+                open: lineNumber(of: block.openFenceRange.location),
+                close: block.closeFenceRange.map { lineNumber(of: $0.location) }
+            )
+        }
     }
 
-    /// Whether the two backticks immediately after `range` are about to
-    /// complete a bare, line-starting run — the mirror image of
-    /// `isFenceDangerousLeftFlank`, only ever relevant for a selection (a
-    /// caret has no trailing flank). Block containment is checked at
-    /// `NSMaxRange(range)` — the right flank's own position — not at
-    /// `range.location`, since the two can disagree: a selection can start
-    /// outside any block and still end with its right flank sitting inside
-    /// one.
-    private func isFenceDangerousRightFlank(of range: NSRange) -> Bool {
-        let end = NSMaxRange(range)
-        return fencedBlockRange(containing: end) != nil
-            && Self.isFollowedByExactlyTwoBackticks(end, in: string)
-            && Self.startsLine(end, in: string)
-            && Self.isBareToEndOfLine(from: end + 2, in: string)
+    /// One fenced block reduced to the lines its fences sit on, the unit
+    /// `fenceStructure(of:)` compares. `close` is `nil` for a block that runs
+    /// to the end of the document unclosed.
+    private struct FencedBlockLines: Equatable {
+        var open: Int
+        var close: Int?
     }
 
     /// Replace `replaced` with a complete fenced block wrapping `body`, adding
@@ -351,65 +405,6 @@ class PairedDelimiterTextView: NSTextView {
             return attributedString.string
         }
         return nil
-    }
-
-    /// Whether exactly two backticks (no more, no fewer) sit immediately
-    /// before `location` — the same precondition `MarkdownFenceEditing.resolve`
-    /// uses internally to recognize a would-be third backtick.
-    private static func isPrecededByExactlyTwoBackticks(_ location: Int, in text: String) -> Bool {
-        let ns = text as NSString
-        guard location >= 2,
-              ns.character(at: location - 1) == 0x60,
-              ns.character(at: location - 2) == 0x60
-        else { return false }
-        return location == 2 || ns.character(at: location - 3) != 0x60
-    }
-
-    /// Whether exactly two backticks (no more, no fewer) sit immediately
-    /// after `location` — the mirror image of `isPrecededByExactlyTwoBackticks`,
-    /// used for the trailing flank of a wrapped selection.
-    private static func isFollowedByExactlyTwoBackticks(_ location: Int, in text: String) -> Bool {
-        let ns = text as NSString
-        guard location >= 0, location + 2 <= ns.length,
-              ns.character(at: location) == 0x60,
-              ns.character(at: location + 1) == 0x60
-        else { return false }
-        return location + 2 == ns.length || ns.character(at: location + 2) != 0x60
-    }
-
-    /// Whether `location` sits at the start of its line, allowing up to
-    /// three leading spaces of indent — the same allowance
-    /// `MarkdownFenceEditing.parseFence` gives a real fence line.
-    private static func startsLine(_ location: Int, in text: String) -> Bool {
-        let ns = text as NSString
-        guard location >= 0, location <= ns.length else { return false }
-        var cursor = location
-        var indent = 0
-        while cursor > 0 {
-            let previous = ns.character(at: cursor - 1)
-            if previous == 0x0A || previous == 0x0D { return true }
-            guard previous == 0x20, indent < 3 else { return false }
-            cursor -= 1
-            indent += 1
-        }
-        return true
-    }
-
-    /// Whether everything from `location` to the next line break (or end of
-    /// text) is blank — i.e. a backtick run ending at `location` would carry
-    /// an empty info string once trimmed, the shape
-    /// `MarkdownFenceEditing.blocks(in:)` reads as a real fence line rather
-    /// than inline text.
-    private static func isBareToEndOfLine(from location: Int, in text: String) -> Bool {
-        let ns = text as NSString
-        var cursor = location
-        while cursor < ns.length {
-            let character = ns.character(at: cursor)
-            if character == 0x0A || character == 0x0D { return true }
-            guard character == 0x20 || character == 0x09 else { return false }
-            cursor += 1
-        }
-        return true
     }
 
     private static func isValid(_ range: NSRange, in storage: NSTextStorage) -> Bool {

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -456,24 +456,61 @@ class PairedDelimiterTextView: NSTextView {
         body: NSString,
         in text: NSString
     ) -> FencedBlockExpansion {
-        let needsLeadingNewline = replaced.location > 0
+        // A caret preceded only by up-to-tolerance spaces on its own line is
+        // sitting at the end of a fence's own indentation — a "  ```" the
+        // author meant to nest inside a list item, not stray padding above an
+        // unindented one. `parseFence` already reads that as a fence line, so
+        // treating it as one here keeps the two in lockstep instead of
+        // guessing at a tolerance of its own.
+        let precedingIndent = fenceIndent(before: replaced.location, in: text)
+        let needsLeadingNewline = precedingIndent == nil
+            && replaced.location > 0
             && text.character(at: replaced.location - 1) != 0x0A
         let suffixLocation = NSMaxRange(replaced)
         let needsTrailingNewline = suffixLocation < text.length
             && text.character(at: suffixLocation) != 0x0A
         let leading = needsLeadingNewline ? "\n" : ""
         let trailing = needsTrailingNewline ? "\n" : ""
+        let indent = precedingIndent ?? ""
         // Selecting whole lines takes the last one's terminator along, so the
         // body already ends on a line of its own. Adding another newline there
         // would push a blank line the author never typed into their own content.
         let separator = endsWithLineTerminator(body) ? "" : "\n"
 
         return FencedBlockExpansion(
+            // The opening fence's indentation, if any, already sits in the
+            // document right before `replaced` — this edit never touches it,
+            // so `prefix` only ever adds the fence itself.
             prefix: leading + "```\n",
-            suffix: separator + "```" + trailing,
+            // The closing fence starts life on a fresh line with nothing
+            // before it, so its matching indentation has to be typed in here.
+            suffix: separator + indent + "```" + trailing,
             // "```\n" is four characters past the leading newline, if any.
             bodyStart: replaced.location + (leading as NSString).length + 4
         )
+    }
+
+    /// The whitespace-only run, if any, between the start of the line
+    /// containing `location` and `location` itself.
+    ///
+    /// Returns `nil` when that span is empty (nothing to preserve — the
+    /// ordinary leading-newline logic already covers a caret right at the
+    /// start of a line), holds anything other than a plain space (a tab, or
+    /// non-whitespace content `parseFence` would never skip over), or is
+    /// wider than `MarkdownFenceEditing.maximumFenceIndent` — in every one of
+    /// those cases a fence built at `location` would not parse as a fence at
+    /// all, so the caret is better served by the fallback of a fresh, unindented
+    /// line.
+    private static func fenceIndent(before location: Int, in text: NSString) -> String? {
+        guard location > 0 else { return nil }
+        let lineStart = text.lineRange(for: NSRange(location: location, length: 0)).location
+        let span = NSRange(location: lineStart, length: location - lineStart)
+        guard span.length > 0, span.length <= MarkdownFenceEditing.maximumFenceIndent else {
+            return nil
+        }
+        let candidate = text.substring(with: span)
+        guard candidate.allSatisfy({ $0 == " " }) else { return nil }
+        return candidate
     }
 
     /// Whether `body` already ends on a line of its own. Recognizes the same

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -19,6 +19,51 @@ class PairedDelimiterTextView: NSTextView {
         isAutomaticQuoteSubstitutionEnabled = false
     }
 
+    /// Full-width rects covering each fenced block, in view coordinates.
+    ///
+    /// The `.backgroundColor` attribute is not used for this: it paints behind
+    /// glyphs only, so a code block would get a ragged right edge instead of a
+    /// box. These views are TextKit 1, so the layout manager gives us the
+    /// bounding rect directly.
+    func codeBlockBackgroundRects() -> [NSRect] {
+        guard markdownFencesEnabled,
+              let layoutManager,
+              let textContainer
+        else { return [] }
+
+        let full = NSRange(location: 0, length: (string as NSString).length)
+        let padding = textContainer.lineFragmentPadding
+
+        return MarkdownFenceEditing.blocks(in: string).compactMap { block in
+            let range = NSIntersectionRange(block.outerRange, full)
+            guard range.length > 0 else { return nil }
+            let glyphRange = layoutManager.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
+            guard glyphRange.length > 0 else { return nil }
+            var rect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+            rect.origin.x = textContainerInset.width + padding
+            rect.size.width = textContainer.size.width - padding * 2
+            rect.origin.y += textContainerInset.height
+            return rect.insetBy(dx: 0, dy: -2)
+        }
+    }
+
+    override func drawBackground(in rect: NSRect) {
+        super.drawBackground(in: rect)
+        guard let style = markdownCodeBlockStyle else { return }
+        for box in codeBlockBackgroundRects() where box.intersects(rect) {
+            let path = NSBezierPath(
+                roundedRect: box.insetBy(dx: style.borderWidth / 2, dy: style.borderWidth / 2),
+                xRadius: style.cornerRadius,
+                yRadius: style.cornerRadius
+            )
+            style.backgroundColor.setFill()
+            path.fill()
+            style.borderColor.setStroke()
+            path.lineWidth = style.borderWidth
+            path.stroke()
+        }
+    }
+
     override func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
         if !hasMarkedText() {
             let replaced = replacementRange.location == NSNotFound ? self.selectedRange() : replacementRange

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -82,14 +82,18 @@ class PairedDelimiterTextView: NSTextView {
             case .none:
                 // `MarkdownFenceEditing.resolve` returns `.none` here on
                 // purpose — its contract is to fall through to plain pairing
-                // for anything it doesn't recognize, including a backtick
-                // that lands inside an existing block. But
+                // for anything it doesn't recognize, including a delimiter
+                // that lands on or inside an existing block. But
                 // `PairedDelimiterEditing` has no notion of fences, so the
-                // closer it adds on the user's behalf can turn a run of
-                // backticks into a fence line and re-cut the document's
-                // blocks — see `swallowsFenceCollidingBacktick`. Swallow just
-                // those keystrokes; everything else falls through untouched.
-                if swallowsFenceCollidingBacktick(insertedText: insertedText, range: range) {
+                // partner it adds on the user's behalf can re-cut the
+                // document's blocks — see `fenceCollisionOutcome`.
+                switch fenceCollisionOutcome(insertedText: insertedText, range: range) {
+                case .pair:
+                    break
+                case .insertLiterally:
+                    super.insertText(insertString, replacementRange: replacementRange)
+                    return
+                case .swallow:
                     return
                 }
             }
@@ -135,42 +139,106 @@ class PairedDelimiterTextView: NSTextView {
         return MarkdownFenceEditing.block(containing: location, in: string)
     }
 
-    /// Whether a backtick landing at `range` — one `MarkdownFenceEditing`
-    /// declined to handle, most commonly because it's inside an existing
-    /// block — should be swallowed instead of falling through to
-    /// `PairedDelimiterEditing`.
+    /// What to do with a delimiter keystroke `MarkdownFenceEditing` declined
+    /// to handle, once the damage `PairedDelimiterEditing`'s pairing would do
+    /// to the document's fences is accounted for.
+    private enum FenceCollisionOutcome {
+        /// Nothing at risk — let `PairedDelimiterEditing` resolve normally.
+        case pair
+        /// Pairing would re-cut the document; the bare keystroke won't. Insert
+        /// the typed character on its own, without its partner.
+        case insertLiterally
+        /// Even the bare keystroke re-cuts the document.
+        case swallow
+    }
+
+    /// How to handle a delimiter landing at `range` — one
+    /// `MarkdownFenceEditing` declined to handle, most commonly because it's
+    /// on or inside an existing block.
     ///
     /// `PairedDelimiterEditing` knows nothing about fences. It answers a
-    /// backtick by putting *more* than the typed character into the storage:
+    /// delimiter by putting *more* than the typed character into the storage:
     /// `.insertPair` writes two, `.wrap` writes one against each end of the
-    /// selection. Those unrequested characters are what extend a backtick run
-    /// far enough to read as a fence line, and a fence line appearing where
-    /// the author didn't put one re-cuts the document — closing the enclosing
-    /// block early, orphaning its real closer, or widening an opener past the
-    /// closer that used to match it.
+    /// selection. That extra partner is what extends a backtick run far
+    /// enough to read as a fence line, or drops a quote into a closing
+    /// fence's info string where CommonMark then refuses to see a closer —
+    /// either way the document gets re-cut behind the author's back.
     ///
-    /// So rather than restating the fence grammar here — line starts, indent
+    /// Rather than restating the fence grammar here — line starts, indent
     /// tolerance, info strings, how wide a run must be to close its opener —
-    /// per flank, in a form that has to be kept in step with the parser, this
-    /// asks the parser: apply the exact edit `PairedDelimiterEditing` would
-    /// apply, and refuse the keystroke when the block structure that comes
-    /// back isn't the one already on screen. Every flank the edit touches is
-    /// covered at once, because the comparison is over the whole document.
+    /// in a form that has to be kept in step with the parser, this asks the
+    /// parser: apply the exact edit `PairedDelimiterEditing` would apply, and
+    /// compare the fenced blocks that come back against the ones already on
+    /// screen. Every position the edit touches is covered at once, because
+    /// the comparison is over the whole document, and the check holds for any
+    /// delimiter rather than only for backticks.
     ///
-    /// Only the padded resolutions are inspected. `.stepOver` writes nothing,
-    /// and `.native` writes exactly the character the user pressed — vetoing
-    /// that would be a keystroke vanishing with no auto-pairing to blame,
-    /// which is a worse outcome than the markdown it produces.
-    private func swallowsFenceCollidingBacktick(insertedText: String, range: NSRange) -> Bool {
-        guard insertedText == "`",
-              let edited = pairedDelimiterPaddedResult(of: insertedText, at: range)
-        else { return false }
-        return Self.fenceStructure(of: edited) != Self.fenceStructure(of: string)
+    /// The two halves of the edit are judged by different standards, because
+    /// they have different authors. The partner character is the editor's own
+    /// doing, so it has to leave the fences *exactly* as it found them. The
+    /// typed character is the author's, so it only has to leave the blocks
+    /// that are already closed alone — finishing a block that was left open
+    /// is the author completing their own fence, and refusing it would make
+    /// an unclosed block impossible to close by typing.
+    ///
+    /// Falling back to the bare character is offered only from a caret.
+    /// `PairedDelimiterEditing.wrap` is the only resolution a selection gets,
+    /// and its unpadded equivalent is AppKit's plain overtype — which deletes
+    /// the selection, newlines and all. That is both destructive and outside
+    /// what `fenceStructure(of:)` can reason about, so a selection whose wrap
+    /// would re-cut the document is refused rather than downgraded.
+    private func fenceCollisionOutcome(insertedText: String, range: NSRange) -> FenceCollisionOutcome {
+        let ns = string as NSString
+        guard Self.isValid(range, in: ns),
+              // Fence lines are built out of backticks, and nothing on this
+              // path ever deletes a character, so a document with no fence in
+              // it cannot grow one from a keystroke that isn't a backtick.
+              insertedText.contains("`" as Character)
+                  || ns.range(of: Self.narrowestFence).location != NSNotFound,
+              let padded = pairedDelimiterPaddedResult(of: insertedText, at: range)
+        else { return .pair }
+
+        let current = Self.fenceStructure(of: string)
+        guard Self.fenceStructure(of: padded) != current else { return .pair }
+
+        guard range.length == 0 else { return .swallow }
+        let literal = Self.fenceStructure(of: ns.replacingCharacters(in: range, with: insertedText))
+        return Self.preservesFences(literal, from: current) ? .insertLiterally : .swallow
+    }
+
+    /// The narrowest backtick run CommonMark will read as a fence, and so the
+    /// shortest substring a document must contain to have any fence at all.
+    private static let narrowestFence = String(
+        repeating: "`",
+        count: MarkdownFenceEditing.minimumFenceLength
+    )
+
+    /// Whether `edited` still fences the document the way `current` does:
+    /// the same blocks, each opening on the line it opened on, and no block
+    /// that was closed losing or moving its closer. A block left *unclosed*
+    /// may gain a closer — see `fenceCollisionOutcome` for why that one
+    /// direction of change is the author's prerogative.
+    private static func preservesFences(
+        _ edited: [FencedBlockLines],
+        from current: [FencedBlockLines]
+    ) -> Bool {
+        edited.count == current.count
+            && zip(current, edited).allSatisfy { was, now in
+                was.open == now.open && (was.close == nil || was.close == now.close)
+            }
     }
 
     /// The document as `PairedDelimiterEditing` would leave it, or `nil` when
-    /// the resolution adds nothing beyond the typed character and so cannot
-    /// surprise the author with a fence.
+    /// the resolution adds nothing beyond the typed character.
+    ///
+    /// `.stepOver` writes nothing at all, and `.native` writes exactly the
+    /// character the user pressed. Neither is this method's business: a
+    /// `.native` insertion *can* still disturb a fence — dropping a literal
+    /// backtick into an info string kills the line it lands on, as in
+    /// `` "``` swift" `` — but there is no partner character to blame it on,
+    /// so the only options would be to honour it or to eat a keystroke the
+    /// author deliberately typed. `fenceCollisionOutcome` honours it, and
+    /// reaches for the same shape itself as a fallback.
     private func pairedDelimiterPaddedResult(of insertedText: String, at range: NSRange) -> String? {
         let ns = string as NSString
         guard Self.isValid(range, in: ns) else { return nil }
@@ -194,14 +262,22 @@ class PairedDelimiterTextView: NSTextView {
 
     /// Where every fenced block begins and ends, in line numbers.
     ///
-    /// Line numbers rather than character offsets because the edits this
-    /// guard weighs only ever insert backticks, never line terminators — and
-    /// never between a CR and its LF, since AppKit hands over selections and
-    /// carets on composed-character-sequence boundaries — so each line keeps
-    /// its number across the edit and two fingerprints taken either side of
-    /// it compare directly. Openers and closers pin the whole structure:
-    /// everything else `blocks(in:)` reports (bodies, outer ranges, info
-    /// strings) follows from which lines fence which.
+    /// Line numbers rather than character offsets, so that two fingerprints
+    /// taken either side of an edit compare directly without any offset
+    /// arithmetic. Openers and closers pin the whole structure: everything
+    /// else `blocks(in:)` reports (bodies, outer ranges, info strings)
+    /// follows from which lines fence which.
+    ///
+    /// That comparison assumes the edit between the two fingerprints leaves
+    /// every line's number alone. It holds for the edits
+    /// `fenceCollisionOutcome` weighs: each inserts one or two delimiters and
+    /// deletes nothing, so no line terminator is created or destroyed —
+    /// unless the caller hands over a `replacementRange` that splits a CRLF,
+    /// which AppKit does not do because it reports carets and selections on
+    /// composed-character-sequence boundaries. Were that assumption ever
+    /// broken, the lines below the split would renumber and the two
+    /// fingerprints would compare unequal: a keystroke needlessly refused,
+    /// never a corruption let through.
     private static func fenceStructure(of text: String) -> [FencedBlockLines] {
         let ns = text as NSString
         var lineStarts: [Int] = []

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -141,8 +141,7 @@ class PairedDelimiterTextView: NSTextView {
     /// declined to handle because it's inside an existing block — should be
     /// swallowed instead of falling through to `PairedDelimiterEditing`.
     ///
-    /// The two backticks that already flank `range` (one on each side, for a
-    /// selection; just the leading pair, for a caret) are about to become
+    /// The two backticks that already flank `range` are about to become
     /// three — matching `MarkdownFenceEditing.minimumFenceLength` — which
     /// only matters if that run would sit alone on its line: starting at the
     /// line's first non-indent column, and followed by nothing but
@@ -153,20 +152,30 @@ class PairedDelimiterTextView: NSTextView {
     /// that starts mid-line, or is trailed by real content, can never parse
     /// as a fence line — `parseFence` requires the backticks to lead — so
     /// it's left alone.
+    ///
+    /// A caret has only the leading flank to check. A selection has two —
+    /// `PairedDelimiterEditing.wrap` completes both simultaneously, and
+    /// either one turning bare on its own is enough to corrupt the block, so
+    /// each is checked independently and either being dangerous swallows the
+    /// keystroke.
     private func swallowsFenceCollidingBacktick(insertedText: String, range: NSRange) -> Bool {
         guard insertedText == "`",
               fencedBlockRange(containing: range.location) != nil,
               Self.isPrecededByExactlyTwoBackticks(range.location, in: string)
         else { return false }
 
-        if range.length > 0,
-           !Self.isFollowedByExactlyTwoBackticks(NSMaxRange(range), in: string)
+        if Self.startsLine(range.location - 2, in: string),
+           Self.isBareToEndOfLine(from: range.location, in: string)
         {
-            return false
+            return true
         }
 
-        return Self.startsLine(range.location - 2, in: string)
-            && Self.isBareToEndOfLine(from: range.location, in: string)
+        guard range.length > 0,
+              Self.isFollowedByExactlyTwoBackticks(NSMaxRange(range), in: string)
+        else { return false }
+
+        return Self.startsLine(NSMaxRange(range), in: string)
+            && Self.isBareToEndOfLine(from: NSMaxRange(range) + 2, in: string)
     }
 
     /// Replace `replaced` with a complete fenced block wrapping `body`, adding

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -83,18 +83,15 @@ class PairedDelimiterTextView: NSTextView {
                 // `MarkdownFenceEditing.resolve` returns `.none` here on
                 // purpose — its contract is to fall through to plain pairing
                 // for anything it doesn't recognize, including a third
-                // backtick that lands inside an existing block. But
-                // `PairedDelimiterEditing` has no notion of fences: its
-                // auto-pair/step-over dance for that same keystroke leaves a
-                // bare backtick run that CommonMark reads as a real fence
-                // line, splitting the block in two. Swallow just that
-                // keystroke; a lone backtick typed anywhere else in the block
-                // is unaffected.
-                if range.length == 0,
-                   insertedText == "`",
-                   fencedBlockRange(containing: range.location) != nil,
-                   Self.isPrecededByExactlyTwoBackticks(range.location, in: string)
-                {
+                // backtick (or a flanked selection) that lands inside an
+                // existing block. But `PairedDelimiterEditing` has no notion
+                // of fences, so completing that keystroke unguarded can leave
+                // a *bare* fence line sitting inside the block — see
+                // `swallowsFenceCollidingBacktick` for exactly which shape
+                // that is and why it's dangerous. Swallow just that
+                // keystroke; anything that can't parse as a fence line falls
+                // through untouched.
+                if swallowsFenceCollidingBacktick(insertedText: insertedText, range: range) {
                     return
                 }
             }
@@ -138,6 +135,38 @@ class PairedDelimiterTextView: NSTextView {
     func fencedBlockRange(containing location: Int) -> FencedBlock? {
         guard markdownFencesEnabled else { return nil }
         return MarkdownFenceEditing.block(containing: location, in: string)
+    }
+
+    /// Whether a backtick landing at `range` — one `MarkdownFenceEditing`
+    /// declined to handle because it's inside an existing block — should be
+    /// swallowed instead of falling through to `PairedDelimiterEditing`.
+    ///
+    /// The two backticks that already flank `range` (one on each side, for a
+    /// selection; just the leading pair, for a caret) are about to become
+    /// three — matching `MarkdownFenceEditing.minimumFenceLength` — which
+    /// only matters if that run would sit alone on its line: starting at the
+    /// line's first non-indent column, and followed by nothing but
+    /// whitespace up to the next line break. That's precisely the shape
+    /// `MarkdownFenceEditing.blocks(in:)` reads as a real fence line with an
+    /// empty info string, closing the enclosing block early (or opening an
+    /// orphaned one) regardless of how wide that block's own fence is. A run
+    /// that starts mid-line, or is trailed by real content, can never parse
+    /// as a fence line — `parseFence` requires the backticks to lead — so
+    /// it's left alone.
+    private func swallowsFenceCollidingBacktick(insertedText: String, range: NSRange) -> Bool {
+        guard insertedText == "`",
+              fencedBlockRange(containing: range.location) != nil,
+              Self.isPrecededByExactlyTwoBackticks(range.location, in: string)
+        else { return false }
+
+        if range.length > 0,
+           !Self.isFollowedByExactlyTwoBackticks(NSMaxRange(range), in: string)
+        {
+            return false
+        }
+
+        return Self.startsLine(range.location - 2, in: string)
+            && Self.isBareToEndOfLine(from: range.location, in: string)
     }
 
     /// Replace `replaced` with a complete fenced block wrapping `body`, adding
@@ -312,6 +341,53 @@ class PairedDelimiterTextView: NSTextView {
               ns.character(at: location - 2) == 0x60
         else { return false }
         return location == 2 || ns.character(at: location - 3) != 0x60
+    }
+
+    /// Whether exactly two backticks (no more, no fewer) sit immediately
+    /// after `location` — the mirror image of `isPrecededByExactlyTwoBackticks`,
+    /// used for the trailing flank of a wrapped selection.
+    private static func isFollowedByExactlyTwoBackticks(_ location: Int, in text: String) -> Bool {
+        let ns = text as NSString
+        guard location >= 0, location + 2 <= ns.length,
+              ns.character(at: location) == 0x60,
+              ns.character(at: location + 1) == 0x60
+        else { return false }
+        return location + 2 == ns.length || ns.character(at: location + 2) != 0x60
+    }
+
+    /// Whether `location` sits at the start of its line, allowing up to
+    /// three leading spaces of indent — the same allowance
+    /// `MarkdownFenceEditing.parseFence` gives a real fence line.
+    private static func startsLine(_ location: Int, in text: String) -> Bool {
+        let ns = text as NSString
+        guard location >= 0, location <= ns.length else { return false }
+        var cursor = location
+        var indent = 0
+        while cursor > 0 {
+            let previous = ns.character(at: cursor - 1)
+            if previous == 0x0A || previous == 0x0D { return true }
+            guard previous == 0x20, indent < 3 else { return false }
+            cursor -= 1
+            indent += 1
+        }
+        return true
+    }
+
+    /// Whether everything from `location` to the next line break (or end of
+    /// text) is blank — i.e. a backtick run ending at `location` would carry
+    /// an empty info string once trimmed, the shape
+    /// `MarkdownFenceEditing.blocks(in:)` reads as a real fence line rather
+    /// than inline text.
+    private static func isBareToEndOfLine(from location: Int, in text: String) -> Bool {
+        let ns = text as NSString
+        var cursor = location
+        while cursor < ns.length {
+            let character = ns.character(at: cursor)
+            if character == 0x0A || character == 0x0D { return true }
+            guard character == 0x20 || character == 0x09 else { return false }
+            cursor += 1
+        }
+        return true
     }
 
     private static func isValid(_ range: NSRange, in storage: NSTextStorage) -> Bool {

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -114,14 +114,21 @@ class PairedDelimiterTextView: NSTextView {
                 let trailing = MarkdownFenceEditing.trailingBacktickRun(at: range.location, in: string)
                 insertFencedBlock(
                     replacing: NSRange(location: range.location - 2, length: 2 + trailing),
-                    body: ""
+                    body: NSAttributedString()
                 )
                 return
             case .wrapSelection:
-                let body = (string as NSString).substring(with: range)
+                // The selection is carried through as attributed text, not as a
+                // `String`: a mention or image chip is a single U+FFFC whose
+                // whole meaning lives in its attributes, so flattening it here
+                // would leave an inert glyph behind in the box.
+                guard let textStorage, Self.isValid(range, in: textStorage) else {
+                    super.insertText(insertString, replacementRange: replacementRange)
+                    return
+                }
                 insertFencedBlock(
                     replacing: NSRange(location: range.location - 2, length: range.length + 4),
-                    body: body
+                    body: textStorage.attributedSubstring(from: range)
                 )
                 return
             case .none:
@@ -386,41 +393,69 @@ class PairedDelimiterTextView: NSTextView {
     /// Replace `replaced` with a complete fenced block wrapping `body`, adding
     /// the newlines needed to keep both fences on lines of their own, and leave
     /// the selection on the body.
-    private func insertFencedBlock(replacing replaced: NSRange, body: String) {
+    ///
+    /// `body` is attributed rather than plain text because the selection being
+    /// fenced can hold a mention or image chip — an `NSTextAttachment` whose
+    /// identity is entirely in its attributes — and rebuilding the block from a
+    /// `String` would silently reduce that chip to a placeholder glyph.
+    private func insertFencedBlock(replacing replaced: NSRange, body: NSAttributedString) {
         guard let textStorage, Self.isValid(replaced, in: textStorage) else { return }
         let expansion = Self.fencedBlockExpansion(
             replacing: replaced,
-            body: body,
+            body: body.string as NSString,
             in: string as NSString
-        )
-        let replacement = NSAttributedString(
-            string: expansion.replacement,
-            attributes: typingAttributes
         )
 
         undoManager?.beginUndoGrouping()
         performNativeTextInsertion {
-            super.insertText(replacement, replacementRange: replaced)
+            super.insertText(
+                expansion.replacement(body: body, attributes: typingAttributes),
+                replacementRange: replaced
+            )
         }
         undoManager?.endUndoGrouping()
 
-        setSelectedRange(NSRange(
-            location: expansion.bodyStart,
-            length: (body as NSString).length
-        ))
+        setSelectedRange(NSRange(location: expansion.bodyStart, length: body.length))
     }
 
-    /// The literal text a fenced block expands to when it replaces `replaced`
-    /// in `text`, plus the offset its body will start at once installed.
+    /// The fence text a block expands to around its body, plus the offset the
+    /// body will start at once installed.
+    ///
+    /// The fences themselves are plain text — nothing about them can carry an
+    /// attachment — so they are built from `typingAttributes`. The body is
+    /// spliced in exactly as captured, which is what keeps a fenced chip a chip.
+    private struct FencedBlockExpansion {
+        /// Everything written before the body: a separating newline when the
+        /// opener needs a line of its own, the opening fence, and its terminator.
+        var prefix: String
+        /// Everything written after it: the body's own terminator when it lacks
+        /// one, the closing fence, and a separating newline when the text below
+        /// needs a line of its own.
+        var suffix: String
+        var bodyStart: Int
+
+        func replacement(
+            body: NSAttributedString,
+            attributes: [NSAttributedString.Key: Any]
+        ) -> NSAttributedString {
+            let result = NSMutableAttributedString(string: prefix, attributes: attributes)
+            result.append(body)
+            result.append(NSAttributedString(string: suffix, attributes: attributes))
+            return result
+        }
+    }
+
+    /// How a fenced block expands around `body` when it replaces `replaced` in
+    /// `text`.
     ///
     /// Split out of `insertFencedBlock` so the dead-key commit path can build
     /// the identical expansion from the pre-composition document rather than
     /// from live storage, which still holds the marked text.
     private static func fencedBlockExpansion(
         replacing replaced: NSRange,
-        body: String,
+        body: NSString,
         in text: NSString
-    ) -> (replacement: String, bodyStart: Int) {
+    ) -> FencedBlockExpansion {
         let needsLeadingNewline = replaced.location > 0
             && text.character(at: replaced.location - 1) != 0x0A
         let suffixLocation = NSMaxRange(replaced)
@@ -428,12 +463,26 @@ class PairedDelimiterTextView: NSTextView {
             && text.character(at: suffixLocation) != 0x0A
         let leading = needsLeadingNewline ? "\n" : ""
         let trailing = needsTrailingNewline ? "\n" : ""
+        // Selecting whole lines takes the last one's terminator along, so the
+        // body already ends on a line of its own. Adding another newline there
+        // would push a blank line the author never typed into their own content.
+        let separator = endsWithLineTerminator(body) ? "" : "\n"
 
-        return (
-            replacement: leading + "```\n" + body + "\n```" + trailing,
+        return FencedBlockExpansion(
+            prefix: leading + "```\n",
+            suffix: separator + "```" + trailing,
             // "```\n" is four characters past the leading newline, if any.
             bodyStart: replaced.location + (leading as NSString).length + 4
         )
+    }
+
+    /// Whether `body` already ends on a line of its own. Recognizes the same
+    /// terminators `MarkdownFenceEditing.trimmingLineTerminator` strips, so a
+    /// CRLF selection is judged the way the fence parser judges it.
+    private static func endsWithLineTerminator(_ body: NSString) -> Bool {
+        guard body.length > 0 else { return false }
+        let last = body.character(at: body.length - 1)
+        return last == 0x0A || last == 0x0D
     }
 
     override func unmarkText() {
@@ -487,13 +536,20 @@ class PairedDelimiterTextView: NSTextView {
                         location: context.selectedRange.location - 2,
                         length: 2 + trailing
                     ),
-                    body: "",
+                    body: NSAttributedString(),
                     context: context,
                     markedRange: marked
                 )
                 return
             case .wrapSelection:
-                let body = (context.text as NSString).substring(with: context.selectedRange)
+                // `replacedSelection` is exactly what the composition swallowed
+                // — the attributed text `preCompositionContext` put back at
+                // `context.selectedRange` — so it is the body, chips and all.
+                // Anything else would flatten a fenced mention into a glyph.
+                let body = replacedSelection ?? NSAttributedString(
+                    string: (context.text as NSString).substring(with: context.selectedRange),
+                    attributes: typingAttributes
+                )
                 commitFencedBlock(
                     replacing: NSRange(
                         location: context.selectedRange.location - 2,
@@ -600,7 +656,7 @@ class PairedDelimiterTextView: NSTextView {
     /// keyboard path would have produced.
     private func commitFencedBlock(
         replacing replaced: NSRange,
-        body: String,
+        body: NSAttributedString,
         context: (text: String, selectedRange: NSRange),
         markedRange: NSRange
     ) {
@@ -614,22 +670,20 @@ class PairedDelimiterTextView: NSTextView {
               Self.isValid(live, in: textStorage)
         else { return }
 
-        let expansion = Self.fencedBlockExpansion(replacing: replaced, body: body, in: ns)
+        let expansion = Self.fencedBlockExpansion(
+            replacing: replaced,
+            body: body.string as NSString,
+            in: ns
+        )
 
         undoManager?.beginUndoGrouping()
         replaceMarkedText(
-            with: NSAttributedString(
-                string: expansion.replacement,
-                attributes: typingAttributes
-            ),
+            with: expansion.replacement(body: body, attributes: typingAttributes),
             markedRange: live
         )
         undoManager?.endUndoGrouping()
 
-        setSelectedRange(NSRange(
-            location: expansion.bodyStart,
-            length: (body as NSString).length
-        ))
+        setSelectedRange(NSRange(location: expansion.bodyStart, length: body.length))
     }
 
     /// `NSTextView.unmarkText()` finalizes the composition by re-inserting the

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -107,27 +107,37 @@ class PairedDelimiterTextView: NSTextView {
                 selectedRange: range
             ) {
             case .openBlock:
-                // The two backticks already in the storage plus this keystroke
-                // become the whole block — and so does any closer that auto-
-                // pairing parked after the caret, or it survives as a stray
-                // backtick below the box.
-                let trailing = MarkdownFenceEditing.trailingBacktickRun(at: range.location, in: string)
-                insertFencedBlock(
-                    replacing: NSRange(location: range.location - 2, length: 2 + trailing),
-                    body: NSAttributedString()
-                )
+                // `rewrittenRange` owns the span — the two backticks already
+                // in the storage, this keystroke, and any closer auto-pairing
+                // parked after the caret — and `resolve` cleared that exact
+                // span against every existing block before answering.
+                guard let replaced = MarkdownFenceEditing.rewrittenRange(
+                    for: .openBlock,
+                    in: string,
+                    selectedRange: range
+                ) else {
+                    super.insertText(insertString, replacementRange: replacementRange)
+                    return
+                }
+                insertFencedBlock(replacing: replaced, body: NSAttributedString())
                 return
             case .wrapSelection:
                 // The selection is carried through as attributed text, not as a
                 // `String`: a mention or image chip is a single U+FFFC whose
                 // whole meaning lives in its attributes, so flattening it here
                 // would leave an inert glyph behind in the box.
-                guard let textStorage, Self.isValid(range, in: textStorage) else {
+                guard let textStorage, Self.isValid(range, in: textStorage),
+                      let replaced = MarkdownFenceEditing.rewrittenRange(
+                          for: .wrapSelection,
+                          in: string,
+                          selectedRange: range
+                      )
+                else {
                     super.insertText(insertString, replacementRange: replacementRange)
                     return
                 }
                 insertFencedBlock(
-                    replacing: NSRange(location: range.location - 2, length: range.length + 4),
+                    replacing: replaced,
                     body: textStorage.attributedSubstring(from: range)
                 )
                 return
@@ -564,15 +574,19 @@ class PairedDelimiterTextView: NSTextView {
                 selectedRange: context.selectedRange
             ) {
             case .openBlock:
-                let trailing = MarkdownFenceEditing.trailingBacktickRun(
-                    at: context.selectedRange.location,
-                    in: context.text
-                )
+                // Same span, and the same guarantee about it, as the ordinary
+                // keyboard path — only measured in the pre-composition
+                // document, which is the one `resolve` just answered in.
+                guard let replaced = MarkdownFenceEditing.rewrittenRange(
+                    for: .openBlock,
+                    in: context.text,
+                    selectedRange: context.selectedRange
+                ) else {
+                    super.insertText(insertString, replacementRange: replacementRange)
+                    return
+                }
                 commitFencedBlock(
-                    replacing: NSRange(
-                        location: context.selectedRange.location - 2,
-                        length: 2 + trailing
-                    ),
+                    replacing: replaced,
                     body: NSAttributedString(),
                     context: context,
                     markedRange: marked
@@ -583,15 +597,20 @@ class PairedDelimiterTextView: NSTextView {
                 // — the attributed text `preCompositionContext` put back at
                 // `context.selectedRange` — so it is the body, chips and all.
                 // Anything else would flatten a fenced mention into a glyph.
+                guard let replaced = MarkdownFenceEditing.rewrittenRange(
+                    for: .wrapSelection,
+                    in: context.text,
+                    selectedRange: context.selectedRange
+                ) else {
+                    super.insertText(insertString, replacementRange: replacementRange)
+                    return
+                }
                 let body = replacedSelection ?? NSAttributedString(
                     string: (context.text as NSString).substring(with: context.selectedRange),
                     attributes: typingAttributes
                 )
                 commitFencedBlock(
-                    replacing: NSRange(
-                        location: context.selectedRange.location - 2,
-                        length: context.selectedRange.length + 4
-                    ),
+                    replacing: replaced,
                     body: body,
                     context: context,
                     markedRange: marked

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -138,44 +138,57 @@ class PairedDelimiterTextView: NSTextView {
     }
 
     /// Whether a backtick landing at `range` — one `MarkdownFenceEditing`
-    /// declined to handle because it's inside an existing block — should be
-    /// swallowed instead of falling through to `PairedDelimiterEditing`.
+    /// declined to handle, most commonly because it's inside an existing
+    /// block — should be swallowed instead of falling through to
+    /// `PairedDelimiterEditing`.
     ///
-    /// The two backticks that already flank `range` are about to become
-    /// three — matching `MarkdownFenceEditing.minimumFenceLength` — which
-    /// only matters if that run would sit alone on its line: starting at the
-    /// line's first non-indent column, and followed by nothing but
-    /// whitespace up to the next line break. That's precisely the shape
-    /// `MarkdownFenceEditing.blocks(in:)` reads as a real fence line with an
-    /// empty info string, closing the enclosing block early (or opening an
-    /// orphaned one) regardless of how wide that block's own fence is. A run
-    /// that starts mid-line, or is trailed by real content, can never parse
-    /// as a fence line — `parseFence` requires the backticks to lead — so
-    /// it's left alone.
-    ///
-    /// A caret has only the leading flank to check. A selection has two —
-    /// `PairedDelimiterEditing.wrap` completes both simultaneously, and
-    /// either one turning bare on its own is enough to corrupt the block, so
-    /// each is checked independently and either being dangerous swallows the
-    /// keystroke.
+    /// A caret has one flank to worry about (the two backticks already
+    /// before it, about to become three). A selection has two —
+    /// `PairedDelimiterEditing.wrap` completes both simultaneously, by
+    /// leaving whatever already flanks the selection untouched and inserting
+    /// one new character adjacent to each side. Either flank turning into a
+    /// bare fence line is enough to corrupt a block, so each flank's danger —
+    /// including whether *that flank's own position* sits inside a block —
+    /// is evaluated completely independently, with nothing shared between
+    /// them beyond "the keystroke is a backtick." Gating the right flank's
+    /// check on anything computed from the left (its backtick count, or
+    /// block containment checked only at `range.location`) would let a
+    /// dangerous right flank slip through whenever the left side happens not
+    /// to qualify — which is exactly the shape of bug this method exists to
+    /// avoid, so the two checks below must never share a precondition.
     private func swallowsFenceCollidingBacktick(insertedText: String, range: NSRange) -> Bool {
-        guard insertedText == "`",
-              fencedBlockRange(containing: range.location) != nil,
-              Self.isPrecededByExactlyTwoBackticks(range.location, in: string)
-        else { return false }
+        guard insertedText == "`" else { return false }
 
-        if Self.startsLine(range.location - 2, in: string),
-           Self.isBareToEndOfLine(from: range.location, in: string)
-        {
+        if isFenceDangerousLeftFlank(of: range) {
             return true
         }
+        guard range.length > 0 else { return false }
+        return isFenceDangerousRightFlank(of: range)
+    }
 
-        guard range.length > 0,
-              Self.isFollowedByExactlyTwoBackticks(NSMaxRange(range), in: string)
-        else { return false }
+    /// Whether the two backticks immediately before `range` are about to
+    /// complete a bare, line-starting run — see `swallowsFenceCollidingBacktick`.
+    private func isFenceDangerousLeftFlank(of range: NSRange) -> Bool {
+        fencedBlockRange(containing: range.location) != nil
+            && Self.isPrecededByExactlyTwoBackticks(range.location, in: string)
+            && Self.startsLine(range.location - 2, in: string)
+            && Self.isBareToEndOfLine(from: range.location, in: string)
+    }
 
-        return Self.startsLine(NSMaxRange(range), in: string)
-            && Self.isBareToEndOfLine(from: NSMaxRange(range) + 2, in: string)
+    /// Whether the two backticks immediately after `range` are about to
+    /// complete a bare, line-starting run — the mirror image of
+    /// `isFenceDangerousLeftFlank`, only ever relevant for a selection (a
+    /// caret has no trailing flank). Block containment is checked at
+    /// `NSMaxRange(range)` — the right flank's own position — not at
+    /// `range.location`, since the two can disagree: a selection can start
+    /// outside any block and still end with its right flank sitting inside
+    /// one.
+    private func isFenceDangerousRightFlank(of range: NSRange) -> Bool {
+        let end = NSMaxRange(range)
+        return fencedBlockRange(containing: end) != nil
+            && Self.isFollowedByExactlyTwoBackticks(end, in: string)
+            && Self.startsLine(end, in: string)
+            && Self.isBareToEndOfLine(from: end + 2, in: string)
     }
 
     /// Replace `replaced` with a complete fenced block wrapping `body`, adding

--- a/Alas/Sources/UI/PairedComposerTextControls.swift
+++ b/Alas/Sources/UI/PairedComposerTextControls.swift
@@ -726,6 +726,7 @@ struct PairedTextEditor: NSViewRepresentable {
     var isFocused: Binding<Bool>?
     var textContainerInset: NSSize
     var placeholder: String?
+    var codeBlockStyle: MarkdownCodeBlockStyle?
 
     init(
         text: Binding<String>,
@@ -734,7 +735,8 @@ struct PairedTextEditor: NSViewRepresentable {
         isEnabled: Bool = true,
         isFocused: Binding<Bool>? = nil,
         textContainerInset: NSSize = .zero,
-        placeholder: String? = nil
+        placeholder: String? = nil,
+        codeBlockStyle: MarkdownCodeBlockStyle? = nil
     ) {
         _text = text
         self.font = font
@@ -743,6 +745,7 @@ struct PairedTextEditor: NSViewRepresentable {
         self.isFocused = isFocused
         self.textContainerInset = textContainerInset
         self.placeholder = placeholder
+        self.codeBlockStyle = codeBlockStyle
     }
 
     func makeCoordinator() -> Coordinator {
@@ -750,6 +753,23 @@ struct PairedTextEditor: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> NSScrollView {
+        let (scrollView, textView) = makeBackingView()
+        textView.delegate = context.coordinator
+        if let backingView = textView as? PairedTextEditorBackingView {
+            backingView.onWindowChanged = { [weak coordinator = context.coordinator, weak backingView] in
+                guard let backingView else { return }
+                coordinator?.synchronizeFocus(for: backingView)
+            }
+        }
+        context.coordinator.textView = textView
+        return scrollView
+    }
+
+    /// Test seam: builds the scroll view and its backing text view without a
+    /// SwiftUI `Context`, which cannot be constructed outside a live view
+    /// update. Coordinator wiring (delegate, window callback, back-reference)
+    /// is left to `makeNSView(context:)`.
+    func makeBackingView() -> (NSScrollView, PairedDelimiterTextView) {
         let scrollView = NSScrollView()
         scrollView.drawsBackground = false
         scrollView.borderType = .noBorder
@@ -758,7 +778,6 @@ struct PairedTextEditor: NSViewRepresentable {
         scrollView.autohidesScrollers = true
 
         let textView = PairedTextEditorBackingView()
-        textView.delegate = context.coordinator
         textView.isRichText = false
         textView.importsGraphics = false
         textView.allowsUndo = true
@@ -775,15 +794,10 @@ struct PairedTextEditor: NSViewRepresentable {
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = false
         textView.autoresizingMask = [.width]
-        textView.onWindowChanged = { [weak coordinator = context.coordinator, weak textView] in
-            guard let textView else { return }
-            coordinator?.synchronizeFocus(for: textView)
-        }
         scrollView.documentView = textView
-        context.coordinator.textView = textView
         synchronizeLayout(of: textView, in: scrollView)
         applyConfiguration(to: textView)
-        return scrollView
+        return (scrollView, textView)
     }
 
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
@@ -817,6 +831,20 @@ struct PairedTextEditor: NSViewRepresentable {
         textView.isSelectable = isEnabled
         textView.textContainerInset = textContainerInset
         textView.setAccessibilityPlaceholderValue(placeholder)
+        textView.markdownFencesEnabled = codeBlockStyle != nil
+        textView.markdownCodeBlockStyle = codeBlockStyle
+        // `textView.string = text` above discards every attribute, so the
+        // restyle has to run on each sync, not only on textDidChange.
+        if let codeBlockStyle, let storage = textView.textStorage {
+            MarkdownCodeBlockStyler.restyle(storage, in: nil, style: codeBlockStyle)
+            textView.needsDisplay = true
+        }
+    }
+
+    /// Test seam: forwards to the private `applyConfiguration(to:)` so tests
+    /// can drive configuration without a SwiftUI `Context`.
+    func applyConfigurationForTesting(to textView: PairedDelimiterTextView) {
+        applyConfiguration(to: textView)
     }
 
     private func synchronizeLayout(of textView: PairedDelimiterTextView, in scrollView: NSScrollView) {
@@ -869,6 +897,10 @@ struct PairedTextEditor: NSViewRepresentable {
                   parent.text != textView.string
             else { return }
             parent.text = textView.string
+            if let style = parent.codeBlockStyle, let storage = textView.textStorage {
+                MarkdownCodeBlockStyler.restyle(storage, in: nil, style: style)
+                textView.needsDisplay = true
+            }
         }
 
         func textDidBeginEditing(_ notification: Notification) {

--- a/AlasTests/ACP/UI/ACPComposerCodeBlockStylingTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerCodeBlockStylingTests.swift
@@ -162,6 +162,26 @@ struct ACPComposerCodeBlockStylingTests {
             as? NSFont == typography.appKitFont())
     }
 
+    @Test("the composer's code block style threads the configured chat font family through")
+    func codeBlockStyleThreadsConfiguredFontFamily() {
+        let theme = Theme(id: "test", name: "Test", tokens: [:])
+        let configured = ACPChatTypography(fontFamily: "Menlo", fontSize: 13)
+
+        let style = ACPInputField.codeBlockStyle(theme: theme, baseFont: configured.appKitFont(), typography: configured)
+
+        #expect(style.monoFont == CenterTypography.resolveCodeFont(family: "Menlo", size: configured.codeSize))
+        #expect(style.monoFont != .monospacedSystemFont(ofSize: configured.codeSize, weight: .regular))
+    }
+
+    @Test("the default (unconfigured) chat font still yields system mono")
+    func codeBlockStyleDefaultsToSystemMono() {
+        let theme = Theme(id: "test", name: "Test", tokens: [:])
+
+        let style = ACPInputField.codeBlockStyle(theme: theme, baseFont: typography.appKitFont(), typography: typography)
+
+        #expect(style.monoFont == .monospacedSystemFont(ofSize: typography.codeSize, weight: .regular))
+    }
+
     private static func codeBlockStyle(typography: ACPChatTypography) -> MarkdownCodeBlockStyle {
         MarkdownCodeBlockStyle(
             baseFont: typography.appKitFont(),

--- a/AlasTests/ACP/UI/ACPComposerCodeBlockStylingTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerCodeBlockStylingTests.swift
@@ -1,0 +1,57 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@Suite("ACP composer code block styling")
+@MainActor
+struct ACPComposerCodeBlockStylingTests {
+    private let typography = ACPChatTypography.default
+
+    @Test("inline styling skips text inside a code block")
+    func inlineStylingSkipsBlocks() {
+        let source = "**out**\n```\n**in**\n```"
+        let storage = NSTextStorage(string: source)
+        let blocks = MarkdownFenceEditing.blocks(in: source).map(\.outerRange)
+
+        ACPMarkdownLiveStyler.restyle(storage, in: nil, typography: typography, excluding: blocks)
+
+        let boldFont = typography.appKitFont(traits: .boldFontMask)
+        // "**out**" starts at 0; "**in**" starts at 12.
+        #expect(storage.attribute(.font, at: 2, effectiveRange: nil) as? NSFont == boldFont)
+        #expect(storage.attribute(.font, at: 14, effectiveRange: nil) as? NSFont != boldFont)
+    }
+
+    @Test("with no exclusions the styler behaves exactly as before")
+    func noExclusionsIsUnchanged() {
+        let storage = NSTextStorage(string: "**bold**")
+        ACPMarkdownLiveStyler.restyle(storage, in: nil, typography: typography)
+
+        #expect(storage.attribute(.font, at: 2, effectiveRange: nil) as? NSFont
+            == typography.appKitFont(traits: .boldFontMask))
+    }
+
+    @Test("a new fence extends the dirty range to end of storage")
+    func fenceChangeExtendsDirtyRange() {
+        let before = MarkdownFenceEditing.blocks(in: "a\nb\nc")
+        let after = MarkdownFenceEditing.blocks(in: "a\n```\nc")
+        #expect(before.isEmpty)
+        #expect(after.count == 1)
+
+        let range = ACPMarkdownLiveStyler.dirtyRange(
+            previous: before,
+            current: after,
+            storageLength: 7
+        )
+        #expect(range == NSRange(location: 2, length: 5))
+    }
+
+    @Test("an unchanged fence set produces no extra dirty range")
+    func unchangedFencesProduceNoRange() {
+        let blocks = MarkdownFenceEditing.blocks(in: "```\na\n```")
+        #expect(ACPMarkdownLiveStyler.dirtyRange(
+            previous: blocks,
+            current: blocks,
+            storageLength: 9
+        ) == nil)
+    }
+}

--- a/AlasTests/ACP/UI/ACPComposerCodeBlockStylingTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerCodeBlockStylingTests.swift
@@ -54,4 +54,123 @@ struct ACPComposerCodeBlockStylingTests {
             storageLength: 9
         ) == nil)
     }
+
+    @Test("closing an unclosed block dirties the tail it stopped covering")
+    func closingABlockExtendsDirtyRange() throws {
+        // The opener never moves — only the closer appears — so comparing
+        // opener locations alone reports "nothing changed" and leaves "tail"
+        // wearing the body styling it had while the block ran to end of text.
+        let after = "```\nbody\n```\ntail"
+        let previous = MarkdownFenceEditing.blocks(in: "```\nbody\ntail")
+        let current = MarkdownFenceEditing.blocks(in: after)
+        #expect(previous.first?.closeFenceRange == nil)
+        #expect(current.first?.closeFenceRange != nil)
+        #expect(previous.first?.openFenceRange.location == current.first?.openFenceRange.location)
+
+        let length = (after as NSString).length
+        let range = try #require(ACPMarkdownLiveStyler.dirtyRange(
+            previous: previous,
+            current: current,
+            storageLength: length
+        ))
+
+        // "tail" starts at 13; the range has to reach it and run to the end.
+        #expect(range.location <= 13)
+        #expect(NSMaxRange(range) == length)
+    }
+
+    @Test("deleting a closer dirties the tail the block just absorbed")
+    func unclosingABlockExtendsDirtyRange() throws {
+        let after = "```\nbody\ntail"
+        let previous = MarkdownFenceEditing.blocks(in: "```\nbody\n```\ntail")
+        let current = MarkdownFenceEditing.blocks(in: after)
+        #expect(previous.first?.openFenceRange.location == current.first?.openFenceRange.location)
+
+        let length = (after as NSString).length
+        let range = try #require(ACPMarkdownLiveStyler.dirtyRange(
+            previous: previous,
+            current: current,
+            storageLength: length
+        ))
+
+        #expect(range.location <= 9)
+        #expect(NSMaxRange(range) == length)
+    }
+
+    @Test("a persisted draft's fenced block is styled once the code box style arrives")
+    func initialDraftFenceIsStyledOnFirstUpdate() throws {
+        let draft = ACPComposerDraft(segments: [.text("intro\n```\nlet x = 1\n```")])
+        let coordinator = ACPInputField.Coordinator(
+            worktreeRoot: URL(fileURLWithPath: "/tmp"),
+            initialDraft: draft,
+            focusRequest: 0,
+            sendOnEnter: true,
+            typography: typography,
+            onDraftChange: { _ in },
+            onDraftClear: {},
+            onSubmit: { _, _, _, _, _ in true }
+        )
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 200))
+        coordinator.textView = textView
+
+        // `makeNSView`'s order: typography first, then the persisted draft —
+        // both before `updateNSView` has handed the view its code box style.
+        textView.applyChatTypography(typography)
+        coordinator.restoreInitialDraft(into: textView)
+
+        // `updateNSView`'s first pass, where the style finally shows up.
+        let style = Self.codeBlockStyle(typography: typography)
+        textView.markdownFencesEnabled = true
+        textView.markdownCodeBlockStyle = style
+        coordinator.codeBlockStyle = style
+        textView.applyChatTypography(typography)
+
+        let storage = try #require(textView.textStorage)
+        let block = try #require(MarkdownFenceEditing.blocks(in: storage.string).first)
+        #expect(storage.attribute(.font, at: block.openFenceRange.location, effectiveRange: nil)
+            as? NSFont == style.monoFont)
+        #expect(storage.attribute(.font, at: block.bodyRange.location, effectiveRange: nil)
+            as? NSFont == style.monoFont)
+        // Prose above the block keeps the ordinary chat font.
+        #expect(storage.attribute(.font, at: 0, effectiveRange: nil)
+            as? NSFont == typography.appKitFont())
+    }
+
+    @Test("a settled composer does not restyle again on later renders")
+    func settledComposerDoesNotRestyleOnEveryRender() throws {
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 200))
+        let style = Self.codeBlockStyle(typography: typography)
+        let plain: [NSAttributedString.Key: Any] = [
+            .font: typography.appKitFont(),
+            .foregroundColor: NSColor.labelColor,
+        ]
+        textView.markdownFencesEnabled = true
+        textView.markdownCodeBlockStyle = style
+        let storage = try #require(textView.textStorage)
+        storage.setAttributedString(NSAttributedString(string: "```\nx\n```", attributes: plain))
+
+        // The style's arrival restyles once…
+        textView.applyChatTypography(typography)
+        #expect(storage.attribute(.font, at: 0, effectiveRange: nil) as? NSFont == style.monoFont)
+
+        // …and every later `updateNSView` pass is a no-op, so SwiftUI renders
+        // don't each re-parse and re-attribute the whole storage.
+        storage.setAttributedString(NSAttributedString(string: "```\nx\n```", attributes: plain))
+        textView.applyChatTypography(typography)
+
+        #expect(storage.attribute(.font, at: 0, effectiveRange: nil)
+            as? NSFont == typography.appKitFont())
+    }
+
+    private static func codeBlockStyle(typography: ACPChatTypography) -> MarkdownCodeBlockStyle {
+        MarkdownCodeBlockStyle(
+            baseFont: typography.appKitFont(),
+            baseColor: .labelColor,
+            monoFont: .monospacedSystemFont(ofSize: typography.codeSize, weight: .regular),
+            bodyColor: .labelColor,
+            fenceColor: .secondaryLabelColor,
+            backgroundColor: .windowBackgroundColor,
+            borderColor: .separatorColor
+        )
+    }
 }

--- a/AlasTests/ACP/UI/ACPComposerCodeFenceKeyTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerCodeFenceKeyTests.swift
@@ -25,6 +25,14 @@ struct ACPComposerCodeFenceKeyTests {
         #expect(textView.fencedBlockRange(containing: 8) != nil)
     }
 
+    @Test("a caret part-way through the info string is reported as inside")
+    func partialInfoSlotIsInsideBlock() {
+        // Half-typed language tag: the caret sits between 's' and 'w' of
+        // "swift". ⏎ here has to insert a newline, not submit the message.
+        let textView = makeTextView("```swift\ncode\n```", caret: 4)
+        #expect(textView.fencedBlockRange(containing: 4) != nil)
+    }
+
     @Test("a caret before the opening backticks is outside")
     func beforeFenceIsOutside() {
         let textView = makeTextView("```\ncode\n```", caret: 0)

--- a/AlasTests/ACP/UI/ACPComposerCodeFenceKeyTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerCodeFenceKeyTests.swift
@@ -1,0 +1,46 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@Suite("ACP composer code fence key handling")
+@MainActor
+struct ACPComposerCodeFenceKeyTests {
+    private func makeTextView(_ text: String, caret: Int) -> ACPNSTextView {
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 200))
+        textView.markdownFencesEnabled = true
+        textView.string = text
+        textView.setSelectedRange(NSRange(location: caret, length: 0))
+        return textView
+    }
+
+    @Test("the caret in a block body is reported as inside")
+    func bodyIsInsideBlock() {
+        let textView = makeTextView("```\ncode\n```", caret: 5)
+        #expect(textView.fencedBlockRange(containing: 5) != nil)
+    }
+
+    @Test("the info-string slot is reported as inside")
+    func infoSlotIsInsideBlock() {
+        let textView = makeTextView("```swift\ncode\n```", caret: 8)
+        #expect(textView.fencedBlockRange(containing: 8) != nil)
+    }
+
+    @Test("a caret before the opening backticks is outside")
+    func beforeFenceIsOutside() {
+        let textView = makeTextView("```\ncode\n```", caret: 0)
+        #expect(textView.fencedBlockRange(containing: 0) == nil)
+    }
+
+    @Test("a caret past the closing fence is outside")
+    func afterFenceIsOutside() {
+        let textView = makeTextView("```\ncode\n```\ntail", caret: 16)
+        #expect(textView.fencedBlockRange(containing: 16) == nil)
+    }
+
+    @Test("fences disabled reports everything as outside")
+    func disabledIsAlwaysOutside() {
+        let textView = makeTextView("```\ncode\n```", caret: 5)
+        textView.markdownFencesEnabled = false
+        #expect(textView.fencedBlockRange(containing: 5) == nil)
+    }
+}

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -1061,14 +1061,16 @@ struct ACPComposerDraftBridgeTests {
         )
     }
 
-    private func makeSlashTextView() -> (ACPNSTextView, ACPInputField.Coordinator, NSWindow) {
+    private func makeSlashTextView(
+        onSubmit: @escaping ACPComposerSubmitHandler = { _, _, _, _, _ in true }
+    ) -> (ACPNSTextView, ACPInputField.Coordinator, NSWindow) {
         let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 40))
         // presentSlashPanel() needs a window to position the panel against.
         // `textView.window` is unowned, so the caller must keep the returned
         // window alive for as long as the text view is used.
         let window = NSWindow(contentRect: textView.frame, styleMask: [], backing: .buffered, defer: false)
         window.contentView?.addSubview(textView)
-        let coordinator = makeCoordinator(sendOnEnter: true) { _, _, _, _, _ in true }
+        let coordinator = makeCoordinator(sendOnEnter: true, onSubmit: onSubmit)
         coordinator.promptSuggestions = [
             ACPPromptSuggestion(command: "/init", description: "Initialize"),
             ACPPromptSuggestion(command: "/review", description: "Review"),
@@ -1249,6 +1251,52 @@ struct ACPComposerDraftBridgeTests {
 
         #expect(received == .auto)
         #expect(textView.string == "```\ncode\n```") // unchanged: no newline was inserted
+    }
+
+    @Test("⌘⏎ sends even while the slash picker has a suggestion selected")
+    func commandReturnSendsPastAnOpenSlashPanel() throws {
+        // The picker's own Return handling runs before the ⌘⏎ send handler,
+        // so without a modifier check it would accept the suggestion and
+        // return — making ⌘⏎ the one keystroke that does not "always send".
+        // Reject the submit so the visible draft survives and the string can
+        // be checked for an accidentally-accepted suggestion.
+        var received: ACPSubmitIntent?
+        let (textView, coordinator, window) = makeSlashTextView { _, _, intent, _, _ in
+            received = intent
+            return false
+        }
+        _ = (coordinator, window)
+        textView.string = "/i"
+        textView.setSelectedRange(NSRange(location: 2, length: 0))
+        textView.reconcileSlashPanel()
+        #expect(textView.isSlashPanelOpen)
+
+        textView.keyDown(with: try keyEvent(keyCode: 36, modifiers: .command))
+
+        #expect(received == .auto)
+        #expect(textView.string == "/i")   // the suggestion was not accepted
+    }
+
+    @Test("plain ⏎ still accepts the selected slash suggestion")
+    func plainReturnStillAcceptsTheSlashSuggestion() throws {
+        // Regression guard for the fix above: only ⌘⏎ skips past the
+        // picker's Return handling; bare ⏎ must keep accepting.
+        var received: ACPSubmitIntent?
+        let (textView, coordinator, window) = makeSlashTextView { _, _, intent, _, _ in
+            received = intent
+            return false
+        }
+        _ = (coordinator, window)
+        textView.string = "/i"
+        textView.setSelectedRange(NSRange(location: 2, length: 0))
+        textView.reconcileSlashPanel()
+        #expect(textView.isSlashPanelOpen)
+
+        textView.keyDown(with: try keyEvent(keyCode: 36, modifiers: []))
+
+        #expect(received == nil)
+        #expect(textView.string == "/init ")
+        #expect(!textView.isSlashPanelOpen)
     }
 
     private func keyEvent(

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -1172,6 +1172,104 @@ struct ACPComposerDraftBridgeTests {
         #expect(received == .steer)
     }
 
+    @Test("plain ⏎ inside a fenced code block inserts a newline instead of submitting")
+    func plainReturnInsideFenceInsertsNewline() {
+        // Task 8: a code box's body treats ⏎ as a plain newline, not a
+        // submit, so a multi-line snippet doesn't need ⇧⏎ on every line.
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 200))
+        textView.markdownFencesEnabled = true
+        textView.string = "```\ncode\n```"
+        textView.setSelectedRange(NSRange(location: 5, length: 0)) // inside "code", between 'c' and 'o'
+        var submitted = false
+        let coordinator = makeCoordinator(sendOnEnter: true) { _, _, _, _, _ in
+            submitted = true
+            return true
+        }
+        coordinator.textView = textView
+        textView.coordinator = coordinator
+
+        let handled = coordinator.textView(
+            textView,
+            doCommandBy: #selector(NSResponder.insertNewline(_:))
+        )
+
+        #expect(handled)                              // event swallowed (no submit)
+        #expect(!submitted)
+        #expect(textView.string == "```\nc\node\n```") // literal newline inserted at the caret
+    }
+
+    @Test("plain ⏎ outside any fenced block still submits with .auto")
+    func plainReturnOutsideFenceStillSubmits() {
+        // Regression guard: the fenced-block check must not swallow ⏎
+        // outside a code box, even when the text view has fences enabled.
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 200))
+        textView.markdownFencesEnabled = true
+        textView.string = "send this"
+        textView.setSelectedRange(NSRange(location: (textView.string as NSString).length, length: 0))
+        var received: ACPSubmitIntent?
+        let coordinator = makeCoordinator(sendOnEnter: true) { _, _, intent, _, _ in
+            received = intent
+            return true
+        }
+        coordinator.textView = textView
+        textView.coordinator = coordinator
+
+        let handled = coordinator.textView(
+            textView,
+            doCommandBy: #selector(NSResponder.insertNewline(_:))
+        )
+
+        #expect(handled)
+        #expect(received == .auto)
+    }
+
+    @Test("⌘⏎ sends immediately, even inside a code box, without inserting a newline")
+    func commandReturnSendsWithoutInsertingNewline() throws {
+        // Task 8: Cmd-Return is handled in ACPNSTextView.keyDown (not
+        // doCommandBy) because AppKit doesn't reliably route it to
+        // insertNewline:. It must send even from inside a fenced block,
+        // where plain ⏎ is a literal newline, and it must return before
+        // `super.keyDown` runs so no newline sneaks in alongside the submit.
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 200))
+        textView.markdownFencesEnabled = true
+        textView.string = "```\ncode\n```"
+        textView.setSelectedRange(NSRange(location: 5, length: 0)) // inside "code"
+        var received: ACPSubmitIntent?
+        // Reject the submit so `clearVisibleDraft` doesn't wipe the text
+        // view's string afterward — that would make it impossible to tell
+        // whether keyDown itself left a stray newline behind.
+        let coordinator = makeCoordinator(sendOnEnter: true) { _, _, intent, _, _ in
+            received = intent
+            return false
+        }
+        coordinator.textView = textView
+        textView.coordinator = coordinator
+
+        textView.keyDown(with: try keyEvent(keyCode: 36, modifiers: .command))
+
+        #expect(received == .auto)
+        #expect(textView.string == "```\ncode\n```") // unchanged: no newline was inserted
+    }
+
+    private func keyEvent(
+        keyCode: UInt16,
+        modifiers: NSEvent.ModifierFlags,
+        characters: String = "\r"
+    ) throws -> NSEvent {
+        try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: keyCode
+        ))
+    }
+
     // MARK: - Restoring a queued item into the composer (blocks → draft)
 
     @Test("draft from content blocks replaces the @marker with the chip in place")

--- a/AlasTests/ACP/UI/ACPComposerPairedDelimiterTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerPairedDelimiterTests.swift
@@ -44,6 +44,108 @@ struct ACPComposerPairedDelimiterTests {
         #expect(textView.selectedRange() == NSRange(location: 1, length: 1))
     }
 
+    @Test("three backticks fence a mention attachment without losing its URI")
+    func tripleBackticksFenceMentionAttachment() throws {
+        let uri = "file:///tmp/File.swift"
+        let textView = makeChipTextView(attributes: [.attachmentURI: uri])
+        let cell = try #require(
+            textView.textStorage?.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment
+        )
+
+        typeBackticks(3, into: textView)
+
+        #expect(textView.string == "```\n\u{fffc}\n```")
+        let storage = try #require(textView.textStorage)
+        // The attachment character surviving is not enough — a chip stripped of
+        // its `.attachment` cell and `.attachmentURI` is an inert glyph that
+        // draws as a placeholder and submits as nothing.
+        #expect(storage.attribute(.attachmentURI, at: 4, effectiveRange: nil) as? String == uri)
+        #expect(storage.attribute(.attachment, at: 4, effectiveRange: nil) as? NSTextAttachment === cell)
+        // …and the fence characters must not inherit the chip's identity.
+        #expect(storage.attribute(.attachmentURI, at: 0, effectiveRange: nil) == nil)
+        #expect(storage.attribute(.attachmentURI, at: 8, effectiveRange: nil) == nil)
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 1))
+    }
+
+    @Test("three backticks fence an image chip without losing its URI")
+    func tripleBackticksFenceImageAttachment() throws {
+        let uri = "file:///tmp/shot.png"
+        let textView = makeChipTextView(attributes: [
+            .imageAttachmentURI: uri,
+            .imageAttachmentMime: "image/png",
+        ])
+        let cell = try #require(
+            textView.textStorage?.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment
+        )
+
+        typeBackticks(3, into: textView)
+
+        #expect(textView.string == "```\n\u{fffc}\n```")
+        let storage = try #require(textView.textStorage)
+        #expect(storage.attribute(.imageAttachmentURI, at: 4, effectiveRange: nil) as? String == uri)
+        #expect(storage.attribute(.imageAttachmentMime, at: 4, effectiveRange: nil) as? String == "image/png")
+        #expect(storage.attribute(.attachment, at: 4, effectiveRange: nil) as? NSTextAttachment === cell)
+        #expect(storage.attribute(.imageAttachmentURI, at: 0, effectiveRange: nil) == nil)
+    }
+
+    @Test("a dead-key third backtick fences a mention attachment without losing its URI")
+    func deadKeyTripleBackticksFenceMentionAttachment() throws {
+        let uri = "file:///tmp/File.swift"
+        let textView = makeChipTextView(attributes: [.attachmentURI: uri])
+        let cell = try #require(
+            textView.textStorage?.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment
+        )
+
+        for _ in 0..<3 {
+            textView.typingAttributes = Self.baseTypingAttributes
+            textView.setMarkedText(
+                "`",
+                selectedRange: NSRange(location: 1, length: 0),
+                replacementRange: NSRange(location: NSNotFound, length: 0)
+            )
+            textView.typingAttributes = Self.baseTypingAttributes
+            textView.performKeyboardTextInsertion {
+                textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+            }
+        }
+
+        #expect(textView.string == "```\n\u{fffc}\n```")
+        let storage = try #require(textView.textStorage)
+        #expect(storage.attribute(.attachmentURI, at: 4, effectiveRange: nil) as? String == uri)
+        #expect(storage.attribute(.attachment, at: 4, effectiveRange: nil) as? NSTextAttachment === cell)
+        #expect(storage.attribute(.attachmentURI, at: 0, effectiveRange: nil) == nil)
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 1))
+    }
+
+    /// The attributes `ACPNSTextView.keyDown` installs before every keystroke.
+    /// Setting them explicitly keeps a test from passing by accident: AppKit
+    /// derives `typingAttributes` from the character next to the selection, so
+    /// a chip's own attributes would otherwise be smeared over anything the
+    /// editor types on the user's behalf.
+    private static let baseTypingAttributes: [NSAttributedString.Key: Any] = [
+        .font: ACPChatTypography.default.appKitFont(),
+        .foregroundColor: NSColor.labelColor,
+    ]
+
+    private func makeChipTextView(attributes: [NSAttributedString.Key: Any]) -> ACPNSTextView {
+        let chip = NSMutableAttributedString(attachment: NSTextAttachment())
+        chip.addAttributes(attributes, range: NSRange(location: 0, length: chip.length))
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 120))
+        textView.markdownFencesEnabled = true
+        textView.textStorage?.setAttributedString(chip)
+        textView.setSelectedRange(NSRange(location: 0, length: chip.length))
+        return textView
+    }
+
+    private func typeBackticks(_ count: Int, into textView: ACPNSTextView) {
+        for _ in 0..<count {
+            textView.typingAttributes = Self.baseTypingAttributes
+            textView.performKeyboardTextInsertion {
+                textView.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+            }
+        }
+    }
+
     @Test("opening delimiter inserts an empty pair")
     func openingDelimiterInsertsEmptyPair() {
         let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 120))

--- a/AlasTests/CommitMessageEditorViewTests.swift
+++ b/AlasTests/CommitMessageEditorViewTests.swift
@@ -141,6 +141,24 @@ struct CommitMessageEditorViewTests {
         #expect(model.body == "`body`")
     }
 
+    @Test func bodyEditorWiresCodeBlockStyle() async throws {
+        let theme = currentTheme()
+        let model = CommitComposerModel(subject: "subject", body: "body")
+        let controller = NSHostingController(rootView: CommitComposerHarness(model: model, theme: theme))
+        let window = attach(controller)
+        defer { window.orderOut(nil) }
+        await drain(controller.view)
+
+        let body = try #require(firstSubview(of: PairedDelimiterTextView.self, in: controller.view))
+        #expect(body.markdownFencesEnabled)
+
+        let style = try #require(body.markdownCodeBlockStyle)
+        let expectedFont = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+        #expect(style.baseFont == expectedFont)
+        #expect(style.monoFont == expectedFont)
+        #expect(style.baseColor == NSColor(theme.color("fg")))
+    }
+
     @Test func subjectKeepsFocusAcrossRepeatedTextUpdates() async throws {
         let model = CommitComposerModel(subject: "", body: "")
         let controller = NSHostingController(rootView: CommitComposerHarness(model: model, theme: currentTheme()))

--- a/AlasTests/PairedDelimiterDeadKeyTests.swift
+++ b/AlasTests/PairedDelimiterDeadKeyTests.swift
@@ -177,6 +177,71 @@ struct PairedDelimiterDeadKeyTests {
         #expect(textView.string == "`value```")
     }
 
+    // MARK: - Markdown fences
+
+    @Test func deadKeyThreeBackticksOpenBox() {
+        let textView = makePairedTextView(fencesEnabled: true)
+        typeDeadKeys("```", in: textView)
+
+        #expect(textView.string == "```\n\n```")
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 0))
+    }
+
+    @Test func deadKeyThreeBackticksFenceTheSelection() {
+        let textView = makePairedTextView(text: "value", fencesEnabled: true)
+        textView.setSelectedRange(NSRange(location: 0, length: 5))
+        typeDeadKeys("```", in: textView)
+
+        #expect(textView.string == "```\nvalue\n```")
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 5))
+    }
+
+    @Test func deadKeyBacktickReachingTheOpenersWidthLosesItsPartner() {
+        // The partner would take the body line from three backticks to five,
+        // the opener's own width, and close the block early. Unpaired it stops
+        // at four and the block survives.
+        let textView = makePairedTextView(text: "`````\n```\n`````", fencesEnabled: true)
+        textView.setSelectedRange(NSRange(location: 9, length: 0))
+        typeDeadKeys("`", in: textView)
+
+        #expect(textView.string == "`````\n````\n`````")
+        #expect(textView.selectedRange() == NSRange(location: 10, length: 0))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test func deadKeyQuoteOnAClosingFenceIsSwallowed() {
+        // Pairing a quote onto the closing fence line gives it an info string,
+        // which CommonMark refuses to read as a closer — so the block would
+        // swallow the rest of the document.
+        let textView = makePairedTextView(text: "```\n\n```", fencesEnabled: true)
+        textView.setSelectedRange(NSRange(location: 8, length: 0))
+        typeDeadKeys("\"", in: textView)
+
+        #expect(textView.string == "```\n\n```")
+        #expect(textView.selectedRange() == NSRange(location: 8, length: 0))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).first?.closeFenceRange != nil)
+    }
+
+    @Test func deadKeySwallowRestoresTheSelectionTheCompositionAte() {
+        // The composition replaces the selection before the commit lands, so a
+        // swallowed keystroke has to put it back rather than merely dropping
+        // the marked text.
+        let textView = makePairedTextView(text: "```\nxx``\n``\n```", fencesEnabled: true)
+        textView.setSelectedRange(NSRange(location: 8, length: 1))
+        typeDeadKeys("`", in: textView)
+
+        #expect(textView.string == "```\nxx``\n``\n```")
+        #expect(textView.selectedRange() == NSRange(location: 8, length: 1))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test func deadKeyBacktickPairingIsUntouchedWhenFencesAreDisabled() {
+        let textView = makePairedTextView()
+        typeDeadKeys("```", in: textView)
+
+        #expect(textView.string == "````")
+    }
+
     // MARK: - CodeTextView
 
     @Test func codeEditorDeadKeyCommitInsertsPair() {
@@ -234,8 +299,22 @@ struct PairedDelimiterDeadKeyTests {
         }
     }
 
-    private func makePairedTextView(text: String = "") -> PairedDelimiterTextView {
-        makePairedTextView(storage: NSTextStorage(string: text))
+    /// Drives one dead-key composition per character, in sequence — the
+    /// layout-level equivalent of typing them on a keyboard where `` ` ``,
+    /// `"` and `'` are dead keys.
+    private func typeDeadKeys(_ characters: String, in textView: PairedDelimiterTextView) {
+        for character in characters {
+            commitDeadKey(String(character), in: textView)
+        }
+    }
+
+    private func makePairedTextView(
+        text: String = "",
+        fencesEnabled: Bool = false
+    ) -> PairedDelimiterTextView {
+        let textView = makePairedTextView(storage: NSTextStorage(string: text))
+        textView.markdownFencesEnabled = fencesEnabled
+        return textView
     }
 
     private func makePairedTextView(storage: NSTextStorage) -> PairedDelimiterTextView {

--- a/AlasTests/PairedDelimiterDeadKeyTests.swift
+++ b/AlasTests/PairedDelimiterDeadKeyTests.swift
@@ -260,6 +260,22 @@ struct PairedDelimiterDeadKeyTests {
         #expect(blocks.first?.closeFenceRange != nil)
     }
 
+    @Test func deadKeyWrapsSelectionBeginningWithEmbeddedFenceRun() {
+        // The dead-key equivalent of the Codex repro: the selected body is
+        // itself nothing but a bare three-backtick run. A hardcoded
+        // three-wide fence would read that run, once relocated onto its own
+        // line by the expansion's leading newline, as its own closer.
+        let textView = makePairedTextView(text: "prefix ```", fencesEnabled: true)
+        textView.setSelectedRange(NSRange(location: 7, length: 3))
+        typeDeadKeys("```", in: textView)
+
+        #expect(textView.string == "prefix \n````\n```\n````")
+        #expect(textView.selectedRange() == NSRange(location: 13, length: 3))
+        let blocks = MarkdownFenceEditing.blocks(in: textView.string)
+        #expect(blocks.count == 1)
+        #expect(blocks.first?.closeFenceRange != nil)
+    }
+
     @Test func deadKeyBacktickPairingIsUntouchedWhenFencesAreDisabled() {
         let textView = makePairedTextView()
         typeDeadKeys("```", in: textView)

--- a/AlasTests/PairedDelimiterDeadKeyTests.swift
+++ b/AlasTests/PairedDelimiterDeadKeyTests.swift
@@ -187,6 +187,15 @@ struct PairedDelimiterDeadKeyTests {
         #expect(textView.selectedRange() == NSRange(location: 4, length: 0))
     }
 
+    @Test func deadKeyThreeBackticksAfterLeadingSpacesKeepIndentation() {
+        let textView = makePairedTextView(text: "  ", fencesEnabled: true)
+        textView.setSelectedRange(NSRange(location: 2, length: 0))
+        typeDeadKeys("```", in: textView)
+
+        #expect(textView.string == "  ```\n\n  ```")
+        #expect(textView.selectedRange() == NSRange(location: 6, length: 0))
+    }
+
     @Test func deadKeyThreeBackticksFenceTheSelection() {
         let textView = makePairedTextView(text: "value", fencesEnabled: true)
         textView.setSelectedRange(NSRange(location: 0, length: 5))

--- a/AlasTests/PairedDelimiterDeadKeyTests.swift
+++ b/AlasTests/PairedDelimiterDeadKeyTests.swift
@@ -244,6 +244,22 @@ struct PairedDelimiterDeadKeyTests {
         #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
     }
 
+    @Test func deadKeyCaretInsideAClosingFenceMarkerDoesNotOpenABox() {
+        // The dead-key commit resolves against the pre-composition document,
+        // so it reaches the same decision the plain keystroke does: a caret
+        // part-way through a closing fence's own backticks must step over,
+        // not rewrite the marker into a new block.
+        let textView = makePairedTextView(text: "```\ncode\n```", fencesEnabled: true)
+        textView.setSelectedRange(NSRange(location: 11, length: 0))
+        typeDeadKeys("`", in: textView)
+
+        #expect(textView.string == "```\ncode\n```")
+        #expect(textView.selectedRange() == NSRange(location: 12, length: 0))
+        let blocks = MarkdownFenceEditing.blocks(in: textView.string)
+        #expect(blocks.count == 1)
+        #expect(blocks.first?.closeFenceRange != nil)
+    }
+
     @Test func deadKeyBacktickPairingIsUntouchedWhenFencesAreDisabled() {
         let textView = makePairedTextView()
         typeDeadKeys("```", in: textView)

--- a/AlasTests/PairedReviewComposerSurfaceTests.swift
+++ b/AlasTests/PairedReviewComposerSurfaceTests.swift
@@ -59,6 +59,142 @@ struct PairedReviewComposerSurfaceTests {
         #expect(model.cancelCount == 1)
     }
 
+    @Test func reviewDraftComposerDefaultsLeaveFencesPlain() async throws {
+        let model = ReviewDraftComposerCapture(text: "")
+        let controller = NSHostingController(
+            rootView: ReviewDraftComposerCaptureHarness(model: model, theme: try! ThemeStore().current)
+        )
+        let window = attach(controller)
+        defer { window.orderOut(nil) }
+        await drain(controller.view)
+
+        let composer = try #require(
+            textView(containing: model.text, in: controller.view) as? PairedDelimiterTextView
+        )
+        #expect(composer.markdownFencesEnabled == false)
+        #expect(composer.markdownCodeBlockStyle == nil)
+
+        composer.performKeyboardTextInsertion {
+            composer.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+        composer.performKeyboardTextInsertion {
+            composer.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+        composer.performKeyboardTextInsertion {
+            composer.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
+        }
+
+        // Matches the pre-fix behaviour: `PairedDelimiterTextView`'s ordinary
+        // paired-backtick logic (unrelated to fences) still auto-closes each
+        // backtick, so three keystrokes yield four stray backticks and no box.
+        #expect(model.text == "````")
+        #expect(composer.codeBlockBackgroundRects().isEmpty)
+    }
+
+    @Test func reviewDraftComposerWiresCodeBlockStyleWhenProvided() async throws {
+        let theme = try! ThemeStore().current
+        let style = MarkdownCodeBlockStyle.standard(
+            theme: theme,
+            baseFont: .systemFont(ofSize: 12),
+            baseColor: NSColor(theme.color("fg")),
+            monoSize: 12
+        )
+        let model = ReviewDraftComposerCapture(text: "", codeBlockStyle: style)
+        let controller = NSHostingController(
+            rootView: ReviewDraftComposerCaptureHarness(model: model, theme: theme)
+        )
+        let window = attach(controller)
+        defer { window.orderOut(nil) }
+        await drain(controller.view)
+
+        let composer = try #require(
+            textView(containing: model.text, in: controller.view) as? PairedDelimiterTextView
+        )
+        #expect(composer.markdownFencesEnabled)
+        #expect(composer.markdownCodeBlockStyle == style)
+    }
+
+    @Test func reviewDraftComposerTypingTripleBacktickOpensABoxWhenEnabled() async throws {
+        let theme = try! ThemeStore().current
+        let style = MarkdownCodeBlockStyle.standard(
+            theme: theme,
+            baseFont: .systemFont(ofSize: 12),
+            baseColor: NSColor(theme.color("fg")),
+            monoSize: 12
+        )
+        let model = ReviewDraftComposerCapture(text: "", codeBlockStyle: style)
+        let controller = NSHostingController(
+            rootView: ReviewDraftComposerCaptureHarness(model: model, theme: theme)
+        )
+        let window = attach(controller)
+        defer { window.orderOut(nil) }
+        await drain(controller.view)
+
+        let composer = try #require(
+            textView(containing: model.text, in: controller.view) as? PairedDelimiterTextView
+        )
+
+        for character in ["`", "`", "`"] {
+            composer.performKeyboardTextInsertion {
+                composer.insertText(character, replacementRange: NSRange(location: NSNotFound, length: 0))
+            }
+        }
+        await drain(controller.view)
+
+        #expect(model.text == "```\n\n```")
+        #expect(!composer.codeBlockBackgroundRects().isEmpty)
+    }
+
+    @Test func reviewDraftComposerRestylesAFencedDraftRestoredOnMount() async throws {
+        let theme = try! ThemeStore().current
+        let style = MarkdownCodeBlockStyle.standard(
+            theme: theme,
+            baseFont: .systemFont(ofSize: 12),
+            baseColor: NSColor(theme.color("fg")),
+            monoSize: 12
+        )
+        let persistedDraft = "before\n```\ncode\n```\nafter"
+        let model = ReviewDraftComposerCapture(text: persistedDraft, codeBlockStyle: style)
+        let controller = NSHostingController(
+            rootView: ReviewDraftComposerCaptureHarness(model: model, theme: theme)
+        )
+        let window = attach(controller)
+        defer { window.orderOut(nil) }
+        await drain(controller.view)
+
+        let composer = try #require(
+            textView(containing: persistedDraft, in: controller.view) as? PairedDelimiterTextView
+        )
+        #expect(!composer.codeBlockBackgroundRects().isEmpty)
+    }
+
+    @Test func reviewDraftComposerRestylesAfterAnExternalTextReset() async throws {
+        let theme = try! ThemeStore().current
+        let style = MarkdownCodeBlockStyle.standard(
+            theme: theme,
+            baseFont: .systemFont(ofSize: 12),
+            baseColor: NSColor(theme.color("fg")),
+            monoSize: 12
+        )
+        let model = ReviewDraftComposerCapture(text: "", codeBlockStyle: style)
+        let controller = NSHostingController(
+            rootView: ReviewDraftComposerCaptureHarness(model: model, theme: theme)
+        )
+        let window = attach(controller)
+        defer { window.orderOut(nil) }
+        await drain(controller.view)
+
+        // Simulate a store reload replacing the bound text wholesale, the way
+        // a persisted draft loaded after the composer already mounted would.
+        model.text = "before\n```\ncode\n```\nafter"
+        await drain(controller.view)
+
+        let composer = try #require(
+            textView(containing: model.text, in: controller.view) as? PairedDelimiterTextView
+        )
+        #expect(!composer.codeBlockBackgroundRects().isEmpty)
+    }
+
     @Test func inlineReplyAndEditBindingsReceiveWrappedSelections() async throws {
         let model = InlineCommentCardCapture()
         let controller = NSHostingController(rootView: InlineCommentCardCaptureHarness(model: model))
@@ -241,12 +377,14 @@ private final class ReviewDraftComposerCapture: ObservableObject {
     @Published var text: String
     @Published var quoteInsertionGeneration = 0
     let quoteMarkdown: String?
+    let codeBlockStyle: MarkdownCodeBlockStyle?
     var saveCount = 0
     var cancelCount = 0
 
-    init(text: String, quoteMarkdown: String? = nil) {
+    init(text: String, quoteMarkdown: String? = nil, codeBlockStyle: MarkdownCodeBlockStyle? = nil) {
         self.text = text
         self.quoteMarkdown = quoteMarkdown
+        self.codeBlockStyle = codeBlockStyle
     }
 }
 
@@ -263,6 +401,7 @@ private struct ReviewDraftComposerCaptureHarness: View {
             isFocused: $isFocused,
             quoteMarkdown: model.quoteMarkdown,
             quoteInsertionGeneration: model.quoteInsertionGeneration,
+            codeBlockStyle: model.codeBlockStyle,
             onSave: { model.saveCount += 1 },
             onCancel: { model.cancelCount += 1 }
         )

--- a/AlasTests/UI/MarkdownCodeBlockStylerTests.swift
+++ b/AlasTests/UI/MarkdownCodeBlockStylerTests.swift
@@ -1,0 +1,73 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@Suite("Markdown code block styler")
+@MainActor
+struct MarkdownCodeBlockStylerTests {
+    private let style = MarkdownCodeBlockStyle(
+        baseFont: .systemFont(ofSize: 13),
+        baseColor: .labelColor,
+        monoFont: .monospacedSystemFont(ofSize: 12, weight: .regular),
+        bodyColor: .textColor,
+        fenceColor: .secondaryLabelColor,
+        backgroundColor: .windowBackgroundColor,
+        borderColor: .separatorColor
+    )
+
+    private func storage(_ text: String) -> NSTextStorage {
+        let storage = NSTextStorage(string: text)
+        storage.setAttributes(
+            [.font: NSFont.systemFont(ofSize: 13), .foregroundColor: NSColor.labelColor],
+            range: NSRange(location: 0, length: (text as NSString).length)
+        )
+        return storage
+    }
+
+    @Test("styles the body monospaced and the fences dimmed")
+    func stylesBlock() throws {
+        // "text\n" = 0..4, fence 5..12 ("```swift"), body 14..23, fence 24..26
+        let storage = storage("text\n```swift\nlet x = 1\n```\nafter")
+        MarkdownCodeBlockStyler.restyle(storage, in: nil, style: style)
+
+        #expect(storage.attribute(.font, at: 16, effectiveRange: nil) as? NSFont == style.monoFont)
+        #expect(storage.attribute(.font, at: 6, effectiveRange: nil) as? NSFont == style.monoFont)
+        #expect(storage.attribute(.foregroundColor, at: 6, effectiveRange: nil) as? NSColor == style.fenceColor)
+        #expect(storage.attribute(.foregroundColor, at: 16, effectiveRange: nil) as? NSColor == style.bodyColor)
+    }
+
+    @Test("leaves text outside a block at the base attributes")
+    func resetsOutsideBlock() {
+        let storage = storage("text\n```swift\nlet x = 1\n```\nafter")
+        MarkdownCodeBlockStyler.restyle(storage, in: nil, style: style)
+
+        #expect(storage.attribute(.font, at: 1, effectiveRange: nil) as? NSFont == style.baseFont)
+        #expect(storage.attribute(.font, at: 29, effectiveRange: nil) as? NSFont == style.baseFont)
+    }
+
+    @Test("removing a fence restores base attributes")
+    func restoresAfterFenceRemoval() {
+        let storage = storage("```\ncode\n```")
+        MarkdownCodeBlockStyler.restyle(storage, in: nil, style: style)
+        #expect(storage.attribute(.font, at: 5, effectiveRange: nil) as? NSFont == style.monoFont)
+
+        storage.replaceCharacters(in: NSRange(location: 0, length: 4), with: "")
+        MarkdownCodeBlockStyler.restyle(storage, in: nil, style: style)
+        #expect(storage.attribute(.font, at: 1, effectiveRange: nil) as? NSFont == style.baseFont)
+    }
+
+    @Test("returns the blocks it found")
+    func returnsBlocks() {
+        let blocks = MarkdownCodeBlockStyler.restyle(storage("```\na\n```"), in: nil, style: style)
+        #expect(blocks.count == 1)
+    }
+
+    @Test("preserves chip attachment attributes")
+    func preservesChips() {
+        let storage = storage("x\n```\na\n```")
+        storage.addAttribute(.attachmentURI, value: "file:///tmp/A.swift", range: NSRange(location: 0, length: 1))
+        MarkdownCodeBlockStyler.restyle(storage, in: nil, style: style)
+
+        #expect(storage.attribute(.attachmentURI, at: 0, effectiveRange: nil) as? String == "file:///tmp/A.swift")
+    }
+}

--- a/AlasTests/UI/MarkdownCodeBoxSurfaceOptInTests.swift
+++ b/AlasTests/UI/MarkdownCodeBoxSurfaceOptInTests.swift
@@ -35,4 +35,30 @@ struct MarkdownCodeBoxSurfaceOptInTests {
         #expect(style.baseFont == base)
         #expect(style.monoFont != base)
     }
+
+    @Test("omitting monoFontFamily keeps today's system-mono behaviour")
+    func defaultMonoFontFamilyStaysSystemMono() {
+        let style = MarkdownCodeBlockStyle.standard(
+            theme: theme,
+            baseFont: .systemFont(ofSize: 12),
+            baseColor: .labelColor,
+            monoSize: 12
+        )
+
+        #expect(style.monoFont == .monospacedSystemFont(ofSize: 12, weight: .regular))
+    }
+
+    @Test("a configured monoFontFamily resolves to that fixed-pitch font")
+    func configuredMonoFontFamilyResolvesToThatFont() {
+        let style = MarkdownCodeBlockStyle.standard(
+            theme: theme,
+            baseFont: .systemFont(ofSize: 12),
+            baseColor: .labelColor,
+            monoSize: 12,
+            monoFontFamily: "Menlo"
+        )
+
+        #expect(style.monoFont == CenterTypography.resolveCodeFont(family: "Menlo", size: 12))
+        #expect(style.monoFont != .monospacedSystemFont(ofSize: 12, weight: .regular))
+    }
 }

--- a/AlasTests/UI/MarkdownCodeBoxSurfaceOptInTests.swift
+++ b/AlasTests/UI/MarkdownCodeBoxSurfaceOptInTests.swift
@@ -1,0 +1,38 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@Suite("Code box surface opt-in")
+@MainActor
+struct MarkdownCodeBoxSurfaceOptInTests {
+    private let theme = Theme(id: "test", name: "Test", tokens: [:])
+
+    @Test("the standard style uses the transcript's code block colours")
+    func standardStyleMatchesTranscript() {
+        let style = MarkdownCodeBlockStyle.standard(
+            theme: theme,
+            baseFont: .systemFont(ofSize: 12),
+            baseColor: .labelColor,
+            monoSize: 12
+        )
+
+        #expect(style.monoFont.isFixedPitch)
+        #expect(style.cornerRadius == 6)
+        #expect(style.borderWidth == 0.5)
+        #expect(style.backgroundColor.alphaComponent < 1)
+    }
+
+    @Test("the standard style keeps the surface's own base font")
+    func standardStyleKeepsBaseFont() {
+        let base = NSFont.systemFont(ofSize: 11)
+        let style = MarkdownCodeBlockStyle.standard(
+            theme: theme,
+            baseFont: base,
+            baseColor: .labelColor,
+            monoSize: 11
+        )
+
+        #expect(style.baseFont == base)
+        #expect(style.monoFont != base)
+    }
+}

--- a/AlasTests/UI/MarkdownFenceEditingTests.swift
+++ b/AlasTests/UI/MarkdownFenceEditingTests.swift
@@ -84,3 +84,96 @@ struct MarkdownFenceEditingTests {
         #expect(MarkdownFenceEditing.blocks(in: "").isEmpty)
     }
 }
+
+@Suite("Markdown fence keystroke resolution")
+struct MarkdownFenceResolveTests {
+    private func resolve(_ inserted: String, _ text: String, _ range: NSRange) -> FenceEditAction {
+        MarkdownFenceEditing.resolve(insertedText: inserted, in: text, selectedRange: range)
+    }
+
+    @Test("the third backtick opens a block")
+    func thirdBacktickOpens() {
+        #expect(resolve("`", "``", NSRange(location: 2, length: 0)) == .openBlock)
+    }
+
+    @Test("fewer than two preceding backticks falls through")
+    func notEnoughBackticks() {
+        #expect(resolve("`", "`", NSRange(location: 1, length: 0)) == .none)
+        #expect(resolve("`", "", NSRange(location: 0, length: 0)) == .none)
+    }
+
+    @Test("more than two preceding backticks falls through")
+    func tooManyBackticks() {
+        #expect(resolve("`", "```", NSRange(location: 3, length: 0)) == .none)
+    }
+
+    @Test("a non-backtick keystroke falls through")
+    func otherCharacter() {
+        #expect(resolve("a", "``", NSRange(location: 2, length: 0)) == .none)
+    }
+
+    @Test("does not open a second block from inside one")
+    func suppressedInsideBlock() {
+        // Caret sits after "x``" on the body line of an open block.
+        #expect(resolve("`", "```\nx``\n```", NSRange(location: 7, length: 0)) == .none)
+    }
+
+    @Test("the third backtick over a flanked selection wraps it")
+    func wrapsFlankedSelection() {
+        #expect(resolve("`", "``value``", NSRange(location: 2, length: 5)) == .wrapSelection)
+    }
+
+    @Test("an unflanked selection falls through to inline pairing")
+    func unflankedSelection() {
+        #expect(resolve("`", "value", NSRange(location: 0, length: 5)) == .none)
+        #expect(resolve("`", "`value`", NSRange(location: 1, length: 5)) == .none)
+    }
+
+    @Test("an out-of-bounds selection falls through")
+    func invalidSelection() {
+        #expect(resolve("`", "``", NSRange(location: 99, length: 0)) == .none)
+    }
+
+    @Test("counts the auto-paired closer parked after the caret")
+    func trailingBacktickRun() {
+        // Typed from an empty line: pair then step-over, nothing left after.
+        #expect(MarkdownFenceEditing.trailingBacktickRun(at: 2, in: "``") == 0)
+        // Typed after a word: the first backtick went native, the second
+        // paired, so a closer sits after the caret.
+        #expect(MarkdownFenceEditing.trailingBacktickRun(at: 5, in: "run```") == 1)
+        #expect(MarkdownFenceEditing.trailingBacktickRun(at: 2, in: "``tail") == 0)
+        #expect(MarkdownFenceEditing.trailingBacktickRun(at: 0, in: "`````") == 2)
+        #expect(MarkdownFenceEditing.trailingBacktickRun(at: 99, in: "``") == 0)
+    }
+}
+
+@Suite("Markdown fence containment")
+struct MarkdownFenceContainmentTests {
+    private let text = "```swift\nlet x = 1\n```"
+
+    @Test("the info-string slot counts as inside")
+    func infoSlotIsInside() {
+        #expect(MarkdownFenceEditing.block(containing: 8, in: text) != nil)
+    }
+
+    @Test("the body counts as inside")
+    func bodyIsInside() {
+        #expect(MarkdownFenceEditing.block(containing: 12, in: text) != nil)
+        #expect(MarkdownFenceEditing.block(containing: 19, in: text) != nil)
+    }
+
+    @Test("before the opening backticks is outside")
+    func beforeOpenIsOutside() {
+        #expect(MarkdownFenceEditing.block(containing: 0, in: text) == nil)
+    }
+
+    @Test("past the closing fence is outside")
+    func afterCloseIsOutside() {
+        #expect(MarkdownFenceEditing.block(containing: 22, in: "```\na\n```\ntail") == nil)
+    }
+
+    @Test("an unclosed block contains everything after it")
+    func unclosedContainsTail() {
+        #expect(MarkdownFenceEditing.block(containing: 8, in: "```\ncode") != nil)
+    }
+}

--- a/AlasTests/UI/MarkdownFenceEditingTests.swift
+++ b/AlasTests/UI/MarkdownFenceEditingTests.swift
@@ -118,6 +118,62 @@ struct MarkdownFenceResolveTests {
         #expect(resolve("`", "```\nx``\n```", NSRange(location: 7, length: 0)) == .none)
     }
 
+    @Test("a caret part-way through a closing fence's own backticks falls through")
+    func caretInsideAClosingFenceMarkerIsRefused() {
+        // "```\ncode\n```": the caret sits between the second and third
+        // backtick of the *closing* fence. Two backticks precede it, and
+        // `block(containing:)` reports it as outside the block on purpose —
+        // a fence's own marker is not its interior. Opening a block here
+        // would rewrite the closer into a fresh empty block and leave the
+        // original opener unclosed.
+        #expect(resolve("`", "```\ncode\n```", NSRange(location: 11, length: 0)) == .none)
+    }
+
+    @Test("a caret part-way through an opening fence's own backticks falls through")
+    func caretInsideAnOpeningFenceMarkerIsRefused() {
+        // Same gap from the other end: the caret sits between the second and
+        // third backtick of the *opening* fence, which is likewise ahead of
+        // the block's interior.
+        #expect(resolve("`", "```\ncode\n```", NSRange(location: 2, length: 0)) == .none)
+    }
+
+    @Test("a caret inside a wider fence's marker falls through too")
+    func caretInsideAWiderFenceMarkerIsRefused() {
+        // Four-wide fences: the caret sits two backticks into each marker,
+        // with two more still to its right. Nothing about the gap depends on
+        // a fence being exactly three wide.
+        #expect(resolve("`", "````\ncode\n````", NSRange(location: 2, length: 0)) == .none)
+        #expect(resolve("`", "````\ncode\n````", NSRange(location: 12, length: 0)) == .none)
+    }
+
+    @Test("a caret inside an indented fence's marker falls through")
+    func caretInsideAnIndentedFenceMarkerIsRefused() {
+        // "```\nc\n  ```": the closer carries two spaces of indent, which
+        // `outerRange` does not cover — only the marker itself does.
+        #expect(resolve("`", "```\nc\n  ```", NSRange(location: 10, length: 0)) == .none)
+    }
+
+    @Test("a caret inside an unclosed block's opening marker falls through")
+    func caretInsideAnUnclosedOpenerIsRefused() {
+        #expect(resolve("`", "```\ncode", NSRange(location: 2, length: 0)) == .none)
+    }
+
+    @Test("a caret buried in a wide opener's marker falls through")
+    func caretInsideAWideOpenerMarkerIsRefused() {
+        // "``````\nx\n```": a six-wide opener that the three-wide line below
+        // cannot close, so the block runs unclosed to the end. The caret sits
+        // two backticks in, with four more to its right — the expansion would
+        // eat part of the marker and split the run in two.
+        #expect(resolve("`", "``````\nx\n```", NSRange(location: 2, length: 0)) == .none)
+    }
+
+    @Test("a caret two lines above an untouched block still opens one")
+    func caretAboveABlockStillOpens() {
+        // Counterweight: the span this rewrites is the two backticks on the
+        // first line, which no block goes anywhere near.
+        #expect(resolve("`", "``\n\n```\nx\n```", NSRange(location: 2, length: 0)) == .openBlock)
+    }
+
     @Test("the third backtick over a flanked selection wraps it")
     func wrapsFlankedSelection() {
         #expect(resolve("`", "``value``", NSRange(location: 2, length: 5)) == .wrapSelection)

--- a/AlasTests/UI/MarkdownFenceEditingTests.swift
+++ b/AlasTests/UI/MarkdownFenceEditingTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Markdown fence parsing")
+struct MarkdownFenceEditingTests {
+    @Test("parses a closed block")
+    func closedBlock() throws {
+        let blocks = MarkdownFenceEditing.blocks(in: "```\ncode\n```")
+        #expect(blocks.count == 1)
+        let block = try #require(blocks.first)
+        #expect(block.openFenceRange == NSRange(location: 0, length: 3))
+        #expect(block.bodyRange == NSRange(location: 4, length: 5))
+        #expect(block.closeFenceRange == NSRange(location: 9, length: 3))
+        #expect(block.infoString == "")
+        #expect(block.outerRange == NSRange(location: 0, length: 12))
+    }
+
+    @Test("captures the info string")
+    func infoString() throws {
+        let blocks = MarkdownFenceEditing.blocks(in: "```swift\nlet x = 1\n```")
+        let block = try #require(blocks.first)
+        #expect(block.infoString == "swift")
+        #expect(block.openFenceRange == NSRange(location: 0, length: 8))
+        #expect(block.bodyRange == NSRange(location: 9, length: 10))
+        #expect(block.closeFenceRange == NSRange(location: 19, length: 3))
+    }
+
+    @Test("an unclosed block runs to end of text")
+    func unclosedBlock() throws {
+        let blocks = MarkdownFenceEditing.blocks(in: "```\ncode")
+        let block = try #require(blocks.first)
+        #expect(block.closeFenceRange == nil)
+        #expect(block.bodyRange == NSRange(location: 4, length: 4))
+        #expect(block.outerRange == NSRange(location: 0, length: 8))
+    }
+
+    @Test("a lone fence on the last line yields an empty body")
+    func loneTrailingFence() throws {
+        let blocks = MarkdownFenceEditing.blocks(in: "text\n```")
+        let block = try #require(blocks.first)
+        #expect(block.openFenceRange == NSRange(location: 5, length: 3))
+        #expect(block.bodyRange == NSRange(location: 8, length: 0))
+        #expect(block.closeFenceRange == nil)
+    }
+
+    @Test("parses back-to-back blocks independently")
+    func backToBackBlocks() {
+        let blocks = MarkdownFenceEditing.blocks(in: "```\na\n```\n```\nb\n```")
+        #expect(blocks.count == 2)
+        #expect(blocks.first?.outerRange == NSRange(location: 0, length: 9))
+        #expect(blocks.last?.outerRange == NSRange(location: 10, length: 9))
+    }
+
+    @Test("allows up to three spaces of indent")
+    func indentedFence() throws {
+        let blocks = MarkdownFenceEditing.blocks(in: "  ```\na\n  ```")
+        let block = try #require(blocks.first)
+        #expect(block.openFenceRange == NSRange(location: 0, length: 5))
+        #expect(block.closeFenceRange == NSRange(location: 8, length: 5))
+    }
+
+    @Test("four spaces of indent is not a fence")
+    func overIndentedFence() {
+        #expect(MarkdownFenceEditing.blocks(in: "    ```\na").isEmpty)
+    }
+
+    @Test("an info string containing a backtick is not a fence")
+    func infoStringWithBacktick() {
+        #expect(MarkdownFenceEditing.blocks(in: "``` `x`\ncode").isEmpty)
+    }
+
+    @Test("a fence with an info string cannot close a block")
+    func infoStringCannotClose() throws {
+        let blocks = MarkdownFenceEditing.blocks(in: "```\n```swift\n```")
+        #expect(blocks.count == 1)
+        let block = try #require(blocks.first)
+        #expect(block.closeFenceRange == NSRange(location: 13, length: 3))
+    }
+
+    @Test("plain text has no blocks")
+    func plainText() {
+        #expect(MarkdownFenceEditing.blocks(in: "just prose").isEmpty)
+        #expect(MarkdownFenceEditing.blocks(in: "").isEmpty)
+    }
+}

--- a/AlasTests/UI/MarkdownFenceEditingTests.swift
+++ b/AlasTests/UI/MarkdownFenceEditingTests.swift
@@ -123,6 +123,32 @@ struct MarkdownFenceResolveTests {
         #expect(resolve("`", "``value``", NSRange(location: 2, length: 5)) == .wrapSelection)
     }
 
+    @Test("a selection reaching into a block's interior falls through")
+    func selectionReachingIntoABlockIsRefused() {
+        // "``A\n```\nb``\n```": the selection starts at 2 — outside every
+        // block, since the block's own opener only starts at 4 — but runs
+        // through the opener and into the body. Checking containment at the
+        // selection's start alone sees nothing and wraps, folding the block's
+        // opener into a new outer fence.
+        #expect(resolve("`", "``A\n```\nb``\n```", NSRange(location: 2, length: 7)) == .none)
+    }
+
+    @Test("a selection that swallows a whole block falls through")
+    func selectionContainingAWholeBlockIsRefused() {
+        // "``\n```\ncode\n```\n``": neither endpoint is inside the block —
+        // the selection starts before its opener and ends after its closer —
+        // yet the block sits entirely within the selection, so wrapping would
+        // sweep both of its fence lines into the new outer one.
+        #expect(resolve("`", "``\n```\ncode\n```\n``", NSRange(location: 2, length: 14)) == .none)
+    }
+
+    @Test("a selection next to a block, but not overlapping it, still wraps")
+    func selectionAdjacentToABlockStillWraps() {
+        // Counterweight to the two tests above: the overlap check must not
+        // refuse a selection that merely sits below an existing block.
+        #expect(resolve("`", "```\ncode\n```\n``value``", NSRange(location: 15, length: 5)) == .wrapSelection)
+    }
+
     @Test("an unflanked selection falls through to inline pairing")
     func unflankedSelection() {
         #expect(resolve("`", "value", NSRange(location: 0, length: 5)) == .none)
@@ -154,6 +180,22 @@ struct MarkdownFenceContainmentTests {
     @Test("the info-string slot counts as inside")
     func infoSlotIsInside() {
         #expect(MarkdownFenceEditing.block(containing: 8, in: text) != nil)
+    }
+
+    @Test("a position part-way through the info string counts as inside")
+    func midInfoStringIsInside() {
+        // Caret between 's' and 'w' of "swift" — the author is still typing
+        // the language tag. The whole slot is inside the block, not just the
+        // one position at its end.
+        #expect(MarkdownFenceEditing.block(containing: 4, in: text) != nil)
+        #expect(MarkdownFenceEditing.block(containing: 3, in: text) != nil)
+    }
+
+    @Test("a position inside the opening backticks is still outside")
+    func withinTheOpeningBackticksIsOutside() {
+        // The run of backticks itself is the fence, not its interior.
+        #expect(MarkdownFenceEditing.block(containing: 1, in: text) == nil)
+        #expect(MarkdownFenceEditing.block(containing: 2, in: text) == nil)
     }
 
     @Test("the body counts as inside")

--- a/AlasTests/UI/PairedDelimiterFenceBoxTests.swift
+++ b/AlasTests/UI/PairedDelimiterFenceBoxTests.swift
@@ -1,0 +1,55 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@Suite("Paired delimiter code box drawing")
+@MainActor
+struct PairedDelimiterFenceBoxTests {
+    private func makeTextView(_ text: String) -> PairedDelimiterTextView {
+        let textView = PairedDelimiterTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 200))
+        textView.markdownFencesEnabled = true
+        textView.markdownCodeBlockStyle = MarkdownCodeBlockStyle(
+            baseFont: .systemFont(ofSize: 13),
+            baseColor: .labelColor,
+            monoFont: .monospacedSystemFont(ofSize: 12, weight: .regular),
+            bodyColor: .textColor,
+            fenceColor: .secondaryLabelColor,
+            backgroundColor: .windowBackgroundColor,
+            borderColor: .separatorColor
+        )
+        textView.string = text
+        textView.layoutManager?.ensureLayout(for: textView.textContainer!)
+        return textView
+    }
+
+    @Test("a fenced block yields one full-width rect")
+    func oneRectPerBlock() throws {
+        let textView = makeTextView("```\nlet x = 1\n```")
+        let rects = textView.codeBlockBackgroundRects()
+
+        #expect(rects.count == 1)
+        let rect = try #require(rects.first)
+        #expect(rect.height > 0)
+        let container = try #require(textView.textContainer)
+        let expectedWidth = container.size.width - container.lineFragmentPadding * 2
+        #expect(abs(rect.width - expectedWidth) < 0.5)
+    }
+
+    @Test("two blocks yield two rects")
+    func twoRects() {
+        let textView = makeTextView("```\na\n```\n\n```\nb\n```")
+        #expect(textView.codeBlockBackgroundRects().count == 2)
+    }
+
+    @Test("no fences yields no rects")
+    func noRects() {
+        #expect(makeTextView("just prose").codeBlockBackgroundRects().isEmpty)
+    }
+
+    @Test("no rects when fences are disabled")
+    func disabledYieldsNoRects() {
+        let textView = makeTextView("```\na\n```")
+        textView.markdownFencesEnabled = false
+        #expect(textView.codeBlockBackgroundRects().isEmpty)
+    }
+}

--- a/AlasTests/UI/PairedDelimiterFenceTests.swift
+++ b/AlasTests/UI/PairedDelimiterFenceTests.swift
@@ -151,6 +151,89 @@ struct PairedDelimiterFenceTests {
         #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
     }
 
+    @Test("a caret inside a closing fence's own backticks does not open a box")
+    func caretInsideAClosingFenceMarkerDoesNotOpenABox() {
+        let textView = makeTextView()
+        // Click between the second and third backtick of the closing fence
+        // and type another. Two backticks precede the caret and the position
+        // is outside the block's interior — a fence's marker is not its
+        // interior — so the expansion used to rewrite the closer itself into
+        // a fresh empty block and leave the opener unclosed. Nothing about
+        // the block may move; the keystroke is a plain step-over.
+        textView.string = "```\ncode\n```"
+        textView.setSelectedRange(NSRange(location: 11, length: 0))
+        type("`", into: textView)
+
+        #expect(textView.string == "```\ncode\n```")
+        #expect(textView.selectedRange() == NSRange(location: 12, length: 0))
+        let blocks = MarkdownFenceEditing.blocks(in: textView.string)
+        #expect(blocks.count == 1)
+        #expect(blocks.first?.closeFenceRange != nil)
+    }
+
+    @Test("a caret inside an opening fence's own backticks does not open a box")
+    func caretInsideAnOpeningFenceMarkerDoesNotOpenABox() {
+        let textView = makeTextView()
+        // The same gap at the other marker. Here the damage was worse: the
+        // opener was replaced by a whole empty block, pushing the body out of
+        // the box entirely and leaving the old closer to open a second one.
+        textView.string = "```\ncode\n```"
+        textView.setSelectedRange(NSRange(location: 2, length: 0))
+        type("`", into: textView)
+
+        #expect(textView.string == "```\ncode\n```")
+        #expect(textView.selectedRange() == NSRange(location: 3, length: 0))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("a caret inside a wider fence's marker does not open a box")
+    func caretInsideAWiderFenceMarkerDoesNotOpenABox() {
+        let textView = makeTextView()
+        // Four-wide fences, caret two backticks into the closer with two more
+        // to its right, so the run the expansion would consume covers the
+        // whole marker.
+        textView.string = "````\ncode\n````"
+        textView.setSelectedRange(NSRange(location: 12, length: 0))
+        type("`", into: textView)
+
+        #expect(textView.string == "````\ncode\n````")
+        #expect(textView.selectedRange() == NSRange(location: 13, length: 0))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("a caret inside an indented closer's marker does not open a box")
+    func caretInsideAnIndentedClosingFenceMarkerDoesNotOpenABox() {
+        let textView = makeTextView()
+        // The closer's leading spaces sit outside `outerRange`, so only the
+        // marker's own backticks stand between this caret and the block.
+        textView.string = "```\nc\n  ```"
+        textView.setSelectedRange(NSRange(location: 10, length: 0))
+        type("`", into: textView)
+
+        #expect(textView.string == "```\nc\n  ```")
+        #expect(textView.selectedRange() == NSRange(location: 11, length: 0))
+        let blocks = MarkdownFenceEditing.blocks(in: textView.string)
+        #expect(blocks.count == 1)
+        #expect(blocks.first?.closeFenceRange != nil)
+    }
+
+    @Test("two backticks on the line above a block still open their own box")
+    func backticksAboveABlockStillOpenABox() {
+        let textView = makeTextView()
+        // Counterweight to the marker tests: the span this keystroke rewrites
+        // is the two backticks on the first line, which the block below never
+        // touches. It has to still expand — and leave the block alone.
+        textView.string = "``\n\n```\nx\n```"
+        textView.setSelectedRange(NSRange(location: 2, length: 0))
+        type("`", into: textView)
+
+        #expect(textView.string == "```\n\n```\n\n```\nx\n```")
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 0))
+        let blocks = MarkdownFenceEditing.blocks(in: textView.string)
+        #expect(blocks.count == 2)
+        #expect(blocks.last?.closeFenceRange != nil)
+    }
+
     @Test("backticks that don't start a line are never swallowed")
     func midLineBackticksAreNotSwallowed() {
         let textView = makeTextView()

--- a/AlasTests/UI/PairedDelimiterFenceTests.swift
+++ b/AlasTests/UI/PairedDelimiterFenceTests.swift
@@ -45,6 +45,30 @@ struct PairedDelimiterFenceTests {
         #expect(textView.selectedRange() == NSRange(location: 8, length: 0))
     }
 
+    @Test("a fence opened after up to three leading spaces keeps that indentation",
+        arguments: [1, 2, 3])
+    func fencePreservesLeadingIndent(spaceCount: Int) {
+        let textView = makeTextView()
+        let indent = String(repeating: " ", count: spaceCount)
+        textView.string = indent
+        textView.setSelectedRange(NSRange(location: spaceCount, length: 0))
+        type("```", into: textView)
+
+        #expect(textView.string == "\(indent)```\n\n\(indent)```")
+        #expect(textView.selectedRange() == NSRange(location: spaceCount + 4, length: 0))
+    }
+
+    @Test("a fence opened after more than three leading spaces still starts on its own line")
+    func fenceBeyondIndentToleranceStartsOnOwnLine() {
+        let textView = makeTextView()
+        textView.string = "    "
+        textView.setSelectedRange(NSRange(location: 4, length: 0))
+        type("```", into: textView)
+
+        #expect(textView.string == "    \n```\n\n```")
+        #expect(textView.selectedRange() == NSRange(location: 9, length: 0))
+    }
+
     @Test("following text is pushed past the closing fence")
     func trailingTextGetsItsOwnLine() {
         let textView = makeTextView()
@@ -64,6 +88,17 @@ struct PairedDelimiterFenceTests {
 
         #expect(textView.string == "```\nvalue\n```")
         #expect(textView.selectedRange() == NSRange(location: 4, length: 5))
+    }
+
+    @Test("wrapping a selection after leading spaces keeps that indentation on both fences")
+    func wrapsSelectionPreservingLeadingIndent() {
+        let textView = makeTextView()
+        textView.string = "  value"
+        textView.setSelectedRange(NSRange(location: 2, length: 5))
+        type("```", into: textView)
+
+        #expect(textView.string == "  ```\nvalue\n  ```")
+        #expect(textView.selectedRange() == NSRange(location: 6, length: 5))
     }
 
     @Test("wrapping whole lines does not add a blank line before the closer")

--- a/AlasTests/UI/PairedDelimiterFenceTests.swift
+++ b/AlasTests/UI/PairedDelimiterFenceTests.swift
@@ -589,4 +589,112 @@ struct PairedDelimiterFenceTests {
 
         #expect(textView.string == "````")
     }
+
+    // MARK: - Wrapping a selection whose own body contains a backtick run
+
+    @Test("wrapping a selection that begins with a bare backtick run widens the fence instead of corrupting it")
+    func wrapsSelectionBeginningWithEmbeddedFenceRun() {
+        let textView = makeTextView()
+        // The exact Codex repro: the selected body is itself nothing but a
+        // bare three-backtick run. Relocated onto its own line by the
+        // expansion's leading newline, a hardcoded three-wide fence would read
+        // that run as its own closer — closing the box one line early and
+        // leaving the real closer to open a second, unclosed block.
+        textView.string = "prefix ```"
+        textView.setSelectedRange(NSRange(location: 7, length: 3))
+        type("```", into: textView)
+
+        #expect(textView.string == "prefix \n````\n```\n````")
+        #expect(textView.selectedRange() == NSRange(location: 13, length: 3))
+        let blocks = MarkdownFenceEditing.blocks(in: textView.string)
+        #expect(blocks.count == 1)
+        #expect(blocks.first?.closeFenceRange != nil)
+        if let block = blocks.first {
+            let bodyText = (textView.string as NSString).substring(with: block.bodyRange)
+            #expect(bodyText.contains("```"))
+        }
+    }
+
+    @Test("an embedded fence run at the start of a longer, multi-line body still widens the fence")
+    func wrapsMultiLineSelectionBeginningWithEmbeddedFenceRun() {
+        let textView = makeTextView()
+        // Same failure mode, but the body doesn't end at the embedded run —
+        // there is real content on the lines after it, which the fix must
+        // carry through untouched rather than truncating at the run.
+        let body = "```\nmore\nlines"
+        textView.string = "prefix " + body
+        textView.setSelectedRange(NSRange(location: 7, length: (body as NSString).length))
+        type("```", into: textView)
+
+        let blocks = MarkdownFenceEditing.blocks(in: textView.string)
+        #expect(blocks.count == 1)
+        #expect(blocks.first?.closeFenceRange != nil)
+        if let block = blocks.first {
+            let bodyText = (textView.string as NSString).substring(with: block.bodyRange)
+            #expect(bodyText.contains(body))
+        }
+    }
+
+    @Test("an embedded fence run wider than three backticks still gets a wider wrapping fence")
+    func wrapsSelectionBeginningWithAWiderEmbeddedFenceRun() {
+        let textView = makeTextView()
+        // Four backticks in the body would still close a hardcoded four-wide
+        // fence early; the wrapping fence has to beat whatever is inside it.
+        textView.string = "prefix ````"
+        textView.setSelectedRange(NSRange(location: 7, length: 4))
+        type("```", into: textView)
+
+        #expect(textView.string == "prefix \n`````\n````\n`````")
+        #expect(textView.selectedRange() == NSRange(location: 14, length: 4))
+        let blocks = MarkdownFenceEditing.blocks(in: textView.string)
+        #expect(blocks.count == 1)
+        #expect(blocks.first?.closeFenceRange != nil)
+        if let block = blocks.first {
+            let bodyText = (textView.string as NSString).substring(with: block.bodyRange)
+            #expect(bodyText.contains("````"))
+        }
+    }
+
+    @Test("a body that is itself a complete, closed fenced block is never handed to the width fix at all")
+    func selectingAWholeNestedBlockNeverReachesTheExpansion() {
+        let textView = makeTextView()
+        // A tempting fourth scenario for the width fix would be a body that is
+        // itself a whole, valid, narrower fenced block — "```\nx\n```" — to
+        // prove it nests as inert content once the wrapping fence is wider.
+        // It never gets there: the block's own closer sits right after a real
+        // newline that already exists in the document before this keystroke
+        // ever lands, so `MarkdownFenceEditing.blocks(in:)` already registers
+        // it — as at least an unclosed opener, if nothing else — and
+        // `resolve`'s pre-edit disjointness guard (from the *previous* round
+        // of this fix) refuses `.wrapSelection` outright before
+        // `fencedBlockExpansion` runs at all. The keystroke falls back to
+        // plain character pairing instead, which only ever widens the
+        // existing block's own fence in place — never a second, corrupting
+        // block. This is the guard the width fix is additive to, not a
+        // scenario the width fix itself has to handle.
+        let body = "```\nx\n```"
+        textView.string = "prefix " + body
+        textView.setSelectedRange(NSRange(location: 7, length: (body as NSString).length))
+        type("```", into: textView)
+
+        // Never reaching `.wrapSelection` at all means this keystroke can
+        // only ever widen the pre-existing block's own fence in place, via
+        // plain character pairing — so the original body content ("x") is
+        // untouched, and there is still exactly one block, not two.
+        #expect(textView.string.contains("x"))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("a body with no backticks at all still gets an ordinary three-wide fence")
+    func wrapsOrdinaryBodyWithoutWideningTheFence() {
+        let textView = makeTextView()
+        // The regression guard: nothing about this fix may widen the fence
+        // for a body that never risked closing it early.
+        textView.string = "value"
+        textView.setSelectedRange(NSRange(location: 0, length: 5))
+        type("```", into: textView)
+
+        #expect(textView.string == "```\nvalue\n```")
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 5))
+    }
 }

--- a/AlasTests/UI/PairedDelimiterFenceTests.swift
+++ b/AlasTests/UI/PairedDelimiterFenceTests.swift
@@ -226,6 +226,37 @@ struct PairedDelimiterFenceTests {
         #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
     }
 
+    @Test("a selection reaching into a block from outside is not wrapped into a box")
+    func selectionReachingIntoABlockIsNotWrapped() {
+        let textView = makeTextView()
+        // The selection starts at 2 — ahead of the block, which only opens at
+        // 4 — so no single position of it is inside the block, yet it runs
+        // through the opener and into the body. Wrapping would fold that
+        // opener into a new outer fence and re-cut the document.
+        textView.string = "``A\n```\nb``\n```"
+        textView.setSelectedRange(NSRange(location: 2, length: 7))
+        type("`", into: textView)
+
+        #expect(textView.string == "``A\n```\nb``\n```")
+        #expect(textView.selectedRange() == NSRange(location: 2, length: 7))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("a selection that swallows a whole block is not wrapped into a box")
+    func selectionContainingAWholeBlockIsNotWrapped() {
+        let textView = makeTextView()
+        // Both endpoints sit outside the block — before its opener and after
+        // its closer — but the block itself is entirely inside the selection,
+        // so wrapping would sweep both of its fence lines into the new one.
+        textView.string = "``\n```\ncode\n```\n``"
+        textView.setSelectedRange(NSRange(location: 2, length: 14))
+        type("`", into: textView)
+
+        #expect(textView.string == "``\n```\ncode\n```\n``")
+        #expect(textView.selectedRange() == NSRange(location: 2, length: 14))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
     @Test("a lone body backtick lands without its partner, because pairing would add two more")
     func caretRunOfOneLosesItsPartner() {
         let textView = makeTextView()

--- a/AlasTests/UI/PairedDelimiterFenceTests.swift
+++ b/AlasTests/UI/PairedDelimiterFenceTests.swift
@@ -105,15 +105,19 @@ struct PairedDelimiterFenceTests {
         #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
     }
 
-    @Test("the swallow still applies inside a block opened with a wider fence")
-    func noNestedBoxInsideWiderFence() {
+    @Test("inside a block opened with a wider fence, the third backtick lands unpaired")
+    func thirdBacktickLandsUnpairedInsideWiderFence() {
         let textView = makeTextView()
+        // Pairing the third keystroke would take the body line to four, the
+        // opener's own width, and close it early. The bare keystroke stops at
+        // three, which a four-wide block simply contains — so the author gets
+        // the literal fence line they were typing.
         textView.string = "````\n\n````"
         textView.setSelectedRange(NSRange(location: 5, length: 0))
         type("```", into: textView)
 
-        #expect(textView.string == "````\n``\n````")
-        #expect(textView.selectedRange() == NSRange(location: 7, length: 0))
+        #expect(textView.string == "````\n```\n````")
+        #expect(textView.selectedRange() == NSRange(location: 8, length: 0))
         #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
     }
 
@@ -198,16 +202,17 @@ struct PairedDelimiterFenceTests {
     }
 
     @Test("a lone body backtick is caught, because auto-pairing adds two more")
-    func caretRunOfOneIsSwallowed() {
+    func caretRunOfOneLosesItsPartner() {
         let textView = makeTextView()
         // Only one backtick precedes the caret, but `.insertPair` writes two
-        // characters, so the line still lands on a full three-wide fence.
+        // characters, so pairing would land a full three-wide fence. Dropping
+        // the partner leaves two, which is no fence at all.
         textView.string = "```\n`\n```"
         textView.setSelectedRange(NSRange(location: 5, length: 0))
         type("`", into: textView)
 
-        #expect(textView.string == "```\n`\n```")
-        #expect(textView.selectedRange() == NSRange(location: 5, length: 0))
+        #expect(textView.string == "```\n``\n```")
+        #expect(textView.selectedRange() == NSRange(location: 6, length: 0))
         #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
     }
 
@@ -254,17 +259,18 @@ struct PairedDelimiterFenceTests {
         #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
     }
 
-    @Test("a body line that reaches its opener's width is swallowed")
-    func runMatchingTheOpenerIsSwallowed() {
+    @Test("a body line that would reach its opener's width loses its partner")
+    func runMatchingTheOpenerLosesItsPartner() {
         let textView = makeTextView()
-        // One backtick further along than the case above: the pair takes the
-        // run from three to five, exactly the opener's width, so it closes.
+        // One backtick further along than the case above: the pair would take
+        // the run from three to five, exactly the opener's width, so it would
+        // close. Unpaired it stops at four, one short, and the block survives.
         textView.string = "`````\n```\n`````"
         textView.setSelectedRange(NSRange(location: 9, length: 0))
         type("`", into: textView)
 
-        #expect(textView.string == "`````\n```\n`````")
-        #expect(textView.selectedRange() == NSRange(location: 9, length: 0))
+        #expect(textView.string == "`````\n````\n`````")
+        #expect(textView.selectedRange() == NSRange(location: 10, length: 0))
         #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
     }
 
@@ -312,6 +318,72 @@ struct PairedDelimiterFenceTests {
         #expect(textView.string == "```\nB\n``\n```")
         #expect(textView.selectedRange() == NSRange(location: 4, length: 3))
         #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("a quote pairing onto a closing fence is caught too")
+    func quotePairingOnAClosingFenceIsSwallowed() {
+        let textView = makeTextView()
+        // Nothing to do with backticks: pairing a quote onto the closing
+        // fence line gives it an info string, and CommonMark only accepts a
+        // closer whose info string is empty — so the block would lose its
+        // closer and swallow the rest of the document. Note the block count
+        // stays 1 either way; only the string tells the two apart.
+        textView.string = "```\n\n```"
+        textView.setSelectedRange(NSRange(location: 8, length: 0))
+        type("\"", into: textView)
+
+        #expect(textView.string == "```\n\n```")
+        #expect(textView.selectedRange() == NSRange(location: 8, length: 0))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).first?.closeFenceRange != nil)
+    }
+
+    @Test("a quote inside a block body pairs as usual")
+    func quotePairingInsideABlockBodyIsUntouched() {
+        let textView = makeTextView()
+        // The counterweight to the test above: a body line can never be a
+        // fence line, so ordinary pairing there has to keep working.
+        textView.string = "```\n\n```"
+        textView.setSelectedRange(NSRange(location: 4, length: 0))
+        type("\"", into: textView)
+
+        #expect(textView.string == "```\n\"\"\n```")
+        #expect(textView.selectedRange() == NSRange(location: 5, length: 0))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("widening an opening fence past its closer is caught")
+    func wideningAnOpenerPastItsCloserIsSwallowed() {
+        let textView = makeTextView()
+        // Pairing takes the opener to five and the bare keystroke to four;
+        // either way the three-wide closer stops matching and the block runs
+        // off the end of the document. The block count is 1 before and after,
+        // so this only fails if the fingerprint notices the closer going away.
+        textView.string = "```\nA\n```"
+        textView.setSelectedRange(NSRange(location: 3, length: 0))
+        type("`", into: textView)
+
+        #expect(textView.string == "```\nA\n```")
+        #expect(textView.selectedRange() == NSRange(location: 3, length: 0))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).first?.closeFenceRange != nil)
+    }
+
+    @Test("an unclosed block can still be closed by typing")
+    func unclosedBlockCanBeClosedByTyping() {
+        let textView = makeTextView()
+        // A block left open — by deleting a closer, or by pasting malformed
+        // markdown. Typing its closing fence has to work: the caret sits
+        // inside the block, so every keystroke goes through the collision
+        // check, and refusing the one that finally closes it would leave the
+        // block unclosable from the keyboard forever.
+        textView.string = "```\nfoo\n"
+        textView.setSelectedRange(NSRange(location: 8, length: 0))
+        type("```", into: textView)
+
+        #expect(textView.string == "```\nfoo\n```")
+        #expect(textView.selectedRange() == NSRange(location: 11, length: 0))
+        let blocks = MarkdownFenceEditing.blocks(in: textView.string)
+        #expect(blocks.count == 1)
+        #expect(blocks.first?.closeFenceRange != nil)
     }
 
     @Test("expansion is a single undo group")

--- a/AlasTests/UI/PairedDelimiterFenceTests.swift
+++ b/AlasTests/UI/PairedDelimiterFenceTests.swift
@@ -201,7 +201,7 @@ struct PairedDelimiterFenceTests {
         #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
     }
 
-    @Test("a lone body backtick is caught, because auto-pairing adds two more")
+    @Test("a lone body backtick lands without its partner, because pairing would add two more")
     func caretRunOfOneLosesItsPartner() {
         let textView = makeTextView()
         // Only one backtick precedes the caret, but `.insertPair` writes two

--- a/AlasTests/UI/PairedDelimiterFenceTests.swift
+++ b/AlasTests/UI/PairedDelimiterFenceTests.swift
@@ -148,6 +148,38 @@ struct PairedDelimiterFenceTests {
         #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
     }
 
+    @Test("a dangerous right flank is caught even when the left flank has no preceding backticks at all")
+    func rightFlankDangerDoesNotDependOnLeftFlankBacktickCount() {
+        let textView = makeTextView()
+        // The selection is preceded by "\n" — zero backticks, not merely "not
+        // exactly two" — so the left flank can never be mistaken for
+        // dangerous. Only an independent check of the right flank ("``" alone
+        // on its own line) catches this.
+        textView.string = "```\nX\n``\n```"
+        textView.setSelectedRange(NSRange(location: 4, length: 2))
+        type("`", into: textView)
+
+        #expect(textView.string == "```\nX\n``\n```")
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 2))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("a dangerous right flank is caught even when the selection starts outside any block")
+    func rightFlankDangerDoesNotDependOnLeftFlankBlockContainment() {
+        let textView = makeTextView()
+        // The selection starts before the block even opens, so checking
+        // block containment only at the selection's start would miss that
+        // the selection's end — where the right flank actually sits — is
+        // inside the block, flanked by a bare "``" line about to complete.
+        textView.string = "X\n```\n``\n```"
+        textView.setSelectedRange(NSRange(location: 0, length: 6))
+        type("`", into: textView)
+
+        #expect(textView.string == "X\n```\n``\n```")
+        #expect(textView.selectedRange() == NSRange(location: 0, length: 6))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
     @Test("expansion is a single undo group")
     func singleUndoGroup() throws {
         let textView = makeTextView()

--- a/AlasTests/UI/PairedDelimiterFenceTests.swift
+++ b/AlasTests/UI/PairedDelimiterFenceTests.swift
@@ -66,6 +66,31 @@ struct PairedDelimiterFenceTests {
         #expect(textView.selectedRange() == NSRange(location: 4, length: 5))
     }
 
+    @Test("wrapping whole lines does not add a blank line before the closer")
+    func wrapsWholeLinesWithoutASpuriousBlankLine() {
+        let textView = makeTextView()
+        // Selecting a whole line takes its terminator with it, so the body
+        // already ends on a line of its own. The expansion must not add a
+        // second newline and push a blank line into the author's content.
+        textView.string = "value\nmore"
+        textView.setSelectedRange(NSRange(location: 0, length: 6))
+        type("```", into: textView)
+
+        #expect(textView.string == "```\nvalue\n```\nmore")
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 6))
+    }
+
+    @Test("wrapping several whole lines keeps exactly one newline before the closer")
+    func wrapsSeveralWholeLinesWithoutASpuriousBlankLine() {
+        let textView = makeTextView()
+        textView.string = "one\ntwo\n"
+        textView.setSelectedRange(NSRange(location: 0, length: 8))
+        type("```", into: textView)
+
+        #expect(textView.string == "```\none\ntwo\n```")
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 8))
+    }
+
     @Test("backticks inside a block do not open a nested box")
     func noNestedBox() {
         let textView = makeTextView()

--- a/AlasTests/UI/PairedDelimiterFenceTests.swift
+++ b/AlasTests/UI/PairedDelimiterFenceTests.swift
@@ -180,6 +180,140 @@ struct PairedDelimiterFenceTests {
         #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
     }
 
+    @Test("a selection that starts inside a block and ends below it is caught too")
+    func selectionLeavingABlockIsSwallowed() {
+        let textView = makeTextView()
+        // Mirror image of the "starts outside, ends inside" case: the
+        // selection runs from the middle of the body, through the closing
+        // fence, down to a bare "``" line under the block. Wrapping it
+        // completes that line into a fence, closing the block early and
+        // sweeping the trailing text into a second, unclosed one.
+        textView.string = "```\nxx``\n```\n``\nZ"
+        textView.setSelectedRange(NSRange(location: 8, length: 5))
+        type("`", into: textView)
+
+        #expect(textView.string == "```\nxx``\n```\n``\nZ")
+        #expect(textView.selectedRange() == NSRange(location: 8, length: 5))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("a lone body backtick is caught, because auto-pairing adds two more")
+    func caretRunOfOneIsSwallowed() {
+        let textView = makeTextView()
+        // Only one backtick precedes the caret, but `.insertPair` writes two
+        // characters, so the line still lands on a full three-wide fence.
+        textView.string = "```\n`\n```"
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+        type("`", into: textView)
+
+        #expect(textView.string == "```\n`\n```")
+        #expect(textView.selectedRange() == NSRange(location: 5, length: 0))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("a three-backtick body line inside a four-wide block is caught")
+    func caretRunOfThreeIsSwallowedInsideAWiderFence() {
+        let textView = makeTextView()
+        // The documenting-a-fence shape: a four-wide block whose body is a
+        // three-backtick line. Auto-pairing would widen it to five, which
+        // closes the four-wide opener early.
+        textView.string = "````\n```\n````"
+        textView.setSelectedRange(NSRange(location: 8, length: 0))
+        type("`", into: textView)
+
+        #expect(textView.string == "````\n```\n````")
+        #expect(textView.selectedRange() == NSRange(location: 8, length: 0))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("a selection flanked by a three-backtick line inside a four-wide block is caught")
+    func selectionFlankOfThreeIsSwallowedInsideAWiderFence() {
+        let textView = makeTextView()
+        // Same width collision from the selection path: wrapping takes the
+        // body's three-backtick line to four, matching the opener.
+        textView.string = "````\n```\nabc\n````"
+        textView.setSelectedRange(NSRange(location: 8, length: 4))
+        type("`", into: textView)
+
+        #expect(textView.string == "````\n```\nabc\n````")
+        #expect(textView.selectedRange() == NSRange(location: 8, length: 4))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("a body line that stays narrower than its opener is left alone")
+    func runNarrowerThanTheOpenerIsNotSwallowed() {
+        let textView = makeTextView()
+        // Four backticks inside a five-wide block cannot close it, so this
+        // keystroke is harmless and has to land.
+        textView.string = "`````\n``\n`````"
+        textView.setSelectedRange(NSRange(location: 8, length: 0))
+        type("`", into: textView)
+
+        #expect(textView.string == "`````\n````\n`````")
+        #expect(textView.selectedRange() == NSRange(location: 9, length: 0))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("a body line that reaches its opener's width is swallowed")
+    func runMatchingTheOpenerIsSwallowed() {
+        let textView = makeTextView()
+        // One backtick further along than the case above: the pair takes the
+        // run from three to five, exactly the opener's width, so it closes.
+        textView.string = "`````\n```\n`````"
+        textView.setSelectedRange(NSRange(location: 9, length: 0))
+        type("`", into: textView)
+
+        #expect(textView.string == "`````\n```\n`````")
+        #expect(textView.selectedRange() == NSRange(location: 9, length: 0))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("a selection spanning two different blocks is caught")
+    func selectionAcrossTwoBlocksIsSwallowed() {
+        let textView = makeTextView()
+        // The two flanks sit in different blocks — the left in the first, the
+        // right in the second — so no single enclosing block explains the
+        // damage: wrapping turns two blocks into three.
+        textView.string = "```\n``\n```\n```\n``\n```"
+        textView.setSelectedRange(NSRange(location: 6, length: 9))
+        type("`", into: textView)
+
+        #expect(textView.string == "```\n``\n```\n```\n``\n```")
+        #expect(textView.selectedRange() == NSRange(location: 6, length: 9))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 2)
+    }
+
+    @Test("a run that continues into the selection is caught")
+    func runMergingIntoTheSelectionIsSwallowed() {
+        let textView = makeTextView()
+        // The body line is "``" and the selection starts between the two, so
+        // the wrap's opening backtick joins one on each side: a one-backtick
+        // left flank still ends up a three-wide bare fence line. Counting
+        // only the backticks before the selection sees two and stops.
+        textView.string = "```\n``\nB\n```"
+        textView.setSelectedRange(NSRange(location: 5, length: 3))
+        type("`", into: textView)
+
+        #expect(textView.string == "```\n``\nB\n```")
+        #expect(textView.selectedRange() == NSRange(location: 5, length: 3))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("a run that continues out of the selection is caught")
+    func runMergingOutOfTheSelectionIsSwallowed() {
+        let textView = makeTextView()
+        // Mirror of the above: the selection ends on the first of the body
+        // line's two backticks, so the wrap's closing backtick lands between
+        // them and the line still completes to three.
+        textView.string = "```\nB\n``\n```"
+        textView.setSelectedRange(NSRange(location: 4, length: 3))
+        type("`", into: textView)
+
+        #expect(textView.string == "```\nB\n``\n```")
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 3))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
     @Test("expansion is a single undo group")
     func singleUndoGroup() throws {
         let textView = makeTextView()

--- a/AlasTests/UI/PairedDelimiterFenceTests.swift
+++ b/AlasTests/UI/PairedDelimiterFenceTests.swift
@@ -1,0 +1,109 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@Suite("Paired delimiter code fences")
+@MainActor
+struct PairedDelimiterFenceTests {
+    private func makeTextView(fencesEnabled: Bool = true) -> PairedDelimiterTextView {
+        let textView = PairedDelimiterTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 120))
+        textView.markdownFencesEnabled = fencesEnabled
+        return textView
+    }
+
+    private func type(_ characters: String, into textView: PairedDelimiterTextView) {
+        for character in characters {
+            textView.performKeyboardTextInsertion {
+                textView.insertText(String(character), replacementRange: NSRange(location: NSNotFound, length: 0))
+            }
+        }
+    }
+
+    @Test("three backticks open an empty code box")
+    func threeBackticksOpenBox() {
+        let textView = makeTextView()
+        type("```", into: textView)
+
+        #expect(textView.string == "```\n\n```")
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 0))
+    }
+
+    @Test("three backticks no longer leave a stray fourth")
+    func noStrayFourthBacktick() {
+        let textView = makeTextView()
+        type("```", into: textView)
+
+        #expect(!textView.string.contains("````"))
+    }
+
+    @Test("a fence opened mid-line starts on its own line")
+    func fenceStartsOnOwnLine() {
+        let textView = makeTextView()
+        type("run```", into: textView)
+
+        #expect(textView.string == "run\n```\n\n```")
+        #expect(textView.selectedRange() == NSRange(location: 8, length: 0))
+    }
+
+    @Test("following text is pushed past the closing fence")
+    func trailingTextGetsItsOwnLine() {
+        let textView = makeTextView()
+        textView.string = "tail"
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+        type("```", into: textView)
+
+        #expect(textView.string == "```\n\n```\ntail")
+    }
+
+    @Test("three backticks over a selection fence it")
+    func wrapsSelection() {
+        let textView = makeTextView()
+        textView.string = "value"
+        textView.setSelectedRange(NSRange(location: 0, length: 5))
+        type("```", into: textView)
+
+        #expect(textView.string == "```\nvalue\n```")
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 5))
+    }
+
+    @Test("backticks inside a block do not open a nested box")
+    func noNestedBox() {
+        let textView = makeTextView()
+        textView.string = "```\n\n```"
+        textView.setSelectedRange(NSRange(location: 4, length: 0))
+        type("```", into: textView)
+
+        #expect(textView.string.hasPrefix("```\n"))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("expansion is a single undo group")
+    func singleUndoGroup() throws {
+        let textView = makeTextView()
+        // NSTextView's undo manager comes from the responder chain, so the
+        // view needs a window before typing or no undo actions get recorded.
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 120),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = textView
+        #expect(window.makeFirstResponder(textView))
+        textView.allowsUndo = true
+        type("```", into: textView)
+        #expect(textView.string == "```\n\n```")
+
+        let undoManager = try #require(textView.undoManager)
+        undoManager.undo()
+        #expect(!textView.string.contains("\n"))
+    }
+
+    @Test("disabled by default, leaving existing pairing untouched")
+    func disabledByDefault() {
+        let textView = makeTextView(fencesEnabled: false)
+        type("```", into: textView)
+
+        #expect(textView.string == "````")
+    }
+}

--- a/AlasTests/UI/PairedDelimiterFenceTests.swift
+++ b/AlasTests/UI/PairedDelimiterFenceTests.swift
@@ -117,6 +117,37 @@ struct PairedDelimiterFenceTests {
         #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
     }
 
+    @Test("a selection wrap can also corrupt the block via its right flank")
+    func noNestedBoxFromRightFlankOfSelection() {
+        let textView = makeTextView()
+        // The left flank "xx``" is mid-line (safe on its own), but the right
+        // flank "``" sits alone on its own line — bare and line-starting —
+        // so completing it would still split the block. The guard has to
+        // catch the right flank even though the left one is harmless.
+        textView.string = "```\nxx``\n``\n```"
+        textView.setSelectedRange(NSRange(location: 8, length: 1))
+        type("`", into: textView)
+
+        #expect(textView.string == "```\nxx``\n``\n```")
+        #expect(textView.selectedRange() == NSRange(location: 8, length: 1))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("a selection flanked by mid-line backtick runs on both sides is left alone")
+    func midLineFlanksOnBothSidesAreNotSwallowed() {
+        let textView = makeTextView()
+        // Both "xx``" and "``yy" are mid-line — a fence line can never form
+        // on either side, so completing the wrap is safe and must not be
+        // swallowed.
+        textView.string = "```\nxx``Z``yy\n```"
+        textView.setSelectedRange(NSRange(location: 8, length: 1))
+        type("`", into: textView)
+
+        #expect(textView.string == "```\nxx```Z```yy\n```")
+        #expect(textView.selectedRange() == NSRange(location: 9, length: 1))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
     @Test("expansion is a single undo group")
     func singleUndoGroup() throws {
         let textView = makeTextView()

--- a/AlasTests/UI/PairedDelimiterFenceTests.swift
+++ b/AlasTests/UI/PairedDelimiterFenceTests.swift
@@ -77,6 +77,46 @@ struct PairedDelimiterFenceTests {
         #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
     }
 
+    @Test("a multi-line selection inside a block does not open a nested box either")
+    func noNestedBoxAcrossMultilineSelection() {
+        let textView = makeTextView()
+        textView.string = "```\n\nfoo\n```"
+        // Covers the blank body line's own newline plus "foo" — wrapping this
+        // twice already leaves a bare, would-be-closing run one keystroke away.
+        textView.setSelectedRange(NSRange(location: 4, length: 4))
+        type("```", into: textView)
+
+        #expect(textView.string == "```\n``\nfoo``\n```")
+        #expect(textView.selectedRange() == NSRange(location: 6, length: 4))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("backticks that don't start a line are never swallowed")
+    func midLineBackticksAreNotSwallowed() {
+        let textView = makeTextView()
+        // "x``" sits mid-line: no run starting there can ever parse as a
+        // fence line, so the completing keystroke must land normally.
+        textView.string = "```\nx``\n```"
+        textView.setSelectedRange(NSRange(location: 7, length: 0))
+        type("`", into: textView)
+
+        #expect(textView.string == "```\nx````\n```")
+        #expect(textView.selectedRange() == NSRange(location: 8, length: 0))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
+    @Test("the swallow still applies inside a block opened with a wider fence")
+    func noNestedBoxInsideWiderFence() {
+        let textView = makeTextView()
+        textView.string = "````\n\n````"
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+        type("```", into: textView)
+
+        #expect(textView.string == "````\n``\n````")
+        #expect(textView.selectedRange() == NSRange(location: 7, length: 0))
+        #expect(MarkdownFenceEditing.blocks(in: textView.string).count == 1)
+    }
+
     @Test("expansion is a single undo group")
     func singleUndoGroup() throws {
         let textView = makeTextView()

--- a/AlasTests/UI/PairedTextEditorMarkdownStylingTests.swift
+++ b/AlasTests/UI/PairedTextEditorMarkdownStylingTests.swift
@@ -1,0 +1,48 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@Suite("PairedTextEditor markdown styling")
+@MainActor
+struct PairedTextEditorMarkdownStylingTests {
+    private let style = MarkdownCodeBlockStyle(
+        baseFont: .systemFont(ofSize: 13),
+        baseColor: .labelColor,
+        monoFont: .monospacedSystemFont(ofSize: 12, weight: .regular),
+        bodyColor: .textColor,
+        fenceColor: .secondaryLabelColor,
+        backgroundColor: .windowBackgroundColor,
+        borderColor: .separatorColor
+    )
+
+    @Test("styling off leaves the storage unstyled and fences inert")
+    func stylingOffIsPlain() {
+        var text = "```\ncode\n```"
+        let editor = PairedTextEditor(text: Binding(get: { text }, set: { text = $0 }))
+        let (_, textView) = editor.makeBackingView()
+        editor.applyConfigurationForTesting(to: textView)
+
+        #expect(textView.markdownFencesEnabled == false)
+        #expect(textView.markdownCodeBlockStyle == nil)
+        #expect(textView.codeBlockBackgroundRects().isEmpty)
+        // Nothing was styled: the whole storage keeps the editor's own font.
+        let storage = textView.textStorage
+        #expect(storage?.attribute(.font, at: 5, effectiveRange: nil) as? NSFont != style.monoFont)
+    }
+
+    @Test("styling on enables fences and applies block attributes")
+    func stylingOnStylesBlocks() throws {
+        var text = "```\ncode\n```"
+        let editor = PairedTextEditor(
+            text: Binding(get: { text }, set: { text = $0 }),
+            codeBlockStyle: style
+        )
+        let (_, textView) = editor.makeBackingView()
+        editor.applyConfigurationForTesting(to: textView)
+
+        #expect(textView.markdownFencesEnabled)
+        let storage = try #require(textView.textStorage)
+        #expect(storage.attribute(.font, at: 5, effectiveRange: nil) as? NSFont == style.monoFont)
+    }
+}


### PR DESCRIPTION
## What

Typing three backticks in a markdown-producing editable surface now expands into a fenced code box — a tinted, bordered, monospaced block that matches how the same fence renders once sent, instead of leaving four stray backticks behind.

Covers:
- The ACP chat composer (with Enter staying inside the box instead of submitting, and ⌘⏎ added as an always-works send shortcut)
- The commit message body editor
- Review comment editors (inline diff comments, reply drafts, the review summary rail, the verdict sheet, the publish confirmation dialog)
- The Settings prompt editor (Commit / Merge-Resolve AI prompts)

Deliberately out of scope: syntax highlighting inside the box, hiding/replacing the fence markers, a language picker, and any change to how the transcript itself renders fenced blocks.

## How

- `MarkdownFenceEditing` (new) parses fenced blocks from plain text and decides what a given keystroke should do to them.
- `MarkdownCodeBlockStyler` (new) applies the box's text attributes; `PairedDelimiterTextView` (existing AppKit base class shared by the composer and every other editor here) draws the box itself via `drawBackground(in:)`, since `.backgroundColor` paints behind glyphs only.
- The trickiest part — deciding whether a keystroke should be swallowed to prevent it from re-cutting an existing fence's structure — ended up going through a few iterations before landing on the right shape: instead of hand-checking backtick counts and line positions per case, it now simulates the exact edit AppKit's own pairing logic would make and asks the real parser whether the result would change the document's fence structure. That's a small function, but it's carrying the weight of the whole feature's safety guarantee, so it got adversarial review from a few different angles (selection edges, dead-key keyboard layouts, non-backtick auto-paired characters) before settling.

## Testing

Local focused suites are green (180+ tests across the touched areas). Full sweep left to CI per this repo's convention — this machine is slow for `xcodebuild test` unfiltered.

One pre-existing, unrelated failure exists on `main` and is unaffected by this branch: `CommitMessageEditorViewTests.pairedSubjectAndBodyWrapSelectedText()`. Verified independently two ways — reverting this branch's changes in place reproduces the identical failure, and the diff to both files it touches is purely additive (no existing line changed), so it couldn't be the cause.

## Known follow-up (not in this PR)

`ReviewDraftComposerNSTextView` — the actual "leave a comment on this diff line" composer used in `DiffTabView.swift` / `DiffReviewFileSection.swift` / `AppKitDiffReviewRowPlan.swift` — is a bespoke subclass of the same base class the rest of this feature builds on, and it was missed from this PR's scope (the surface inventory was assembled by grepping for the convenience wrapper this feature hooks into, which this class doesn't use). Its sibling reply editor gets the feature; this one doesn't yet. Tracking as a follow-up rather than expanding this PR.
