### PR TITLE
feat(remote): web worktree creation

### DIFF
--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -44,6 +44,8 @@ let createState = {
   busy: false,
   error: ""
 };
+const worktreeCreation = RemoteWorktreeCreation.createFlow(send);
+worktreeCreation.subscribe(() => renderCreateSheet());
 const ATTACH_CAP = 10 * 1000 * 1000;   // 10 MB running total — matches the server's maxAttachmentsBytes
 
 // state ∈ {connecting, ok, bad} drives the chip's dot/border color via [data-state].
@@ -198,6 +200,7 @@ async function connect() {
     if (createState.open) {
       createState.error = "";
       requestCreateLists();
+      reloadNewWorktreeCatalog();
       renderCreateSheet();
     }
   };
@@ -229,7 +232,10 @@ function send(obj) { ws && ws.readyState === 1 && ws.send(JSON.stringify(obj)); 
 
 function handle(msg) {
   switch (msg.type) {
-    case "sessionList": renderSessions(msg.sessions); break;
+    case "sessionList":
+      renderSessions(msg.sessions);
+      worktreeCreation.markRecoveryListLoaded("sessions");
+      break;
     case "transcriptSnapshot": applySnapshot(msg); break;
     case "transcriptDelta": applyDelta(msg); break;
     case "transcriptPage": applyPage(msg); break;
@@ -248,7 +254,13 @@ function handle(msg) {
     case "sessionRenamed": applySessionRenamed(msg.sessionId, msg.title); break;
     case "worktreeList":
       createState.worktrees = msg.worktrees || [];
-      if (!createState.worktrees.some(w => w.id === createState.selectedWorktreeId)) createState.selectedWorktreeId = null;
+      const recoveredWorktreeId = worktreeCreation.snapshot().selectedWorktreeId;
+      if (recoveredWorktreeId && createState.worktrees.some(w => w.id === recoveredWorktreeId)) {
+        createState.selectedWorktreeId = recoveredWorktreeId;
+      } else if (!createState.worktrees.some(w => w.id === createState.selectedWorktreeId)) {
+        createState.selectedWorktreeId = null;
+      }
+      worktreeCreation.markRecoveryListLoaded("worktrees");
       renderCreateSheet();
       break;
     case "agentList":
@@ -257,6 +269,7 @@ function handle(msg) {
         const preferred = createState.agents.find(a => a.isDefault) || createState.agents[0];
         createState.selectedAgentId = preferred ? preferred.id : null;
       }
+      worktreeCreation.reconcileAgents(createState.agents);
       renderCreateSheet();
       break;
     case "sessionCreated":
@@ -266,6 +279,21 @@ function handle(msg) {
       createState.busy = false;
       createState.error = msg.message || "Could not create session.";
       renderCreateSheet();
+      break;
+    case "projectList":
+    case "branchList":
+    case "branchListFailed":
+      worktreeCreation.receive(msg);
+      break;
+    case "worktreeSessionCreated":
+      if (worktreeCreation.receive(msg)) applyCreatedSession(msg.session);
+      break;
+    case "worktreeSessionCreationFailed":
+      if (worktreeCreation.receive(msg)) {
+        const state = worktreeCreation.snapshot();
+        if (state.selectedWorktreeId) createState.selectedWorktreeId = state.selectedWorktreeId;
+        renderCreateSheet();
+      }
       break;
     case "sessionClosed": if (msg.sessionId === currentSession) showSessions(); break;
     case "promptRejected": if (msg.sessionId === currentSession) restoreRejectedPrompt(); break;
@@ -457,6 +485,8 @@ function applySessionRenamed(sessionId, title) {
 }
 
 function showCreateSheet() {
+  const preserveRecovery = worktreeCreation.snapshot().outcomeUnknown && !worktreeCreation.canRetry();
+  if (!preserveRecovery) worktreeCreation.reset();
   createState = {
     ...createState,
     open: true,
@@ -481,13 +511,27 @@ function requestCreateLists() {
   send({ type: "listAgents" });
 }
 
+function reloadNewWorktreeCatalog() {
+  if (worktreeCreation.snapshot().mode !== "new") return;
+  worktreeCreation.reloadCatalog();
+}
+
+function startNewWorktree() {
+  if (!worktreeCreation.startNewWorktree()) return;
+  worktreeCreation.loadProjects();
+  requestAnimationFrame(() => $("project-select").focus());
+}
+
 function hideCreateSheet(force) {
   const forced = force === true;
-  if (createState.busy && !forced) return;
+  const creationState = worktreeCreation.snapshot();
+  const recoveryPending = creationState.outcomeUnknown && !worktreeCreation.canRetry();
+  if (recoveryPending || ((createState.busy || creationState.submitting) && !forced)) return;
   createState.open = false;
   createState.busy = false;
   createState.error = "";
   $("new-session-sheet").classList.add("hidden");
+  worktreeCreation.reset();
   if (forced) {
     deferredCreatePrompt = null;
   } else {
@@ -496,7 +540,9 @@ function hideCreateSheet(force) {
 }
 
 function failCreateOnDisconnect() {
+  const disconnectedWorktreeCreation = worktreeCreation.disconnect();
   if (!createState.open) return;
+  if (disconnectedWorktreeCreation) return;
   const wasBusy = createState.busy;
   createState.busy = false;
   createState.error = wasBusy ? "Connection lost. Reconnect and try again." : "Connection lost. Reconnecting...";
@@ -518,28 +564,106 @@ function visibleCreateWorktrees() {
 function renderCreateSheet() {
   if (!createState.open) return;
 
-  const inWorktreeStep = createState.step === "worktree";
+  const creationState = worktreeCreation.snapshot();
+  const isNewWorktree = creationState.mode === "new";
+  const busy = createState.busy || creationState.submitting;
+  const recoveryPending = creationState.outcomeUnknown && !worktreeCreation.canRetry();
+  const inWorktreeStep = isNewWorktree ? creationState.step === "worktree" : createState.step === "worktree";
   $("worktree-step").classList.toggle("hidden", !inWorktreeStep);
   $("agent-step").classList.toggle("hidden", inWorktreeStep);
-  $("create-back").classList.toggle("hidden", inWorktreeStep);
-  $("create-back").disabled = createState.busy;
-  $("create-cancel").disabled = createState.busy;
-  $("worktree-search").disabled = createState.busy;
+  $("existing-worktree-picker").classList.toggle("hidden", isNewWorktree);
+  $("new-worktree-form").classList.toggle("hidden", !isNewWorktree);
+  $("create-back").classList.toggle("hidden", inWorktreeStep && !isNewWorktree);
+  $("create-back").disabled = busy || recoveryPending;
+  $("create-cancel").disabled = busy || recoveryPending;
+  $("worktree-search").disabled = busy;
 
   const error = $("create-error");
-  error.textContent = createState.error;
-  error.classList.toggle("hidden", !createState.error);
+  const creationError = creationState.error && creationState.error.stage !== "branches"
+    ? creationState.error
+    : null;
+  const errorMessage = creationError
+    ? creationError.message
+    : createState.error;
+  error.textContent = errorMessage;
+  error.classList.toggle("hidden", !errorMessage);
 
-  renderCreateWorktrees();
-  renderCreateAgents();
+  renderCreateWorktrees(busy);
+  renderNewWorktreeForm(creationState, busy);
+  renderCreateAgents(creationState, isNewWorktree, busy);
+  renderNewWorktreeReview(creationState, isNewWorktree && !inWorktreeStep);
 
-  const canSubmit = inWorktreeStep ? !!createState.selectedWorktreeId : !!createState.selectedWorktreeId && !!createState.selectedAgentId;
   const next = $("create-next");
-  next.disabled = createState.busy || !canSubmit;
-  next.textContent = inWorktreeStep ? "Next" : (createState.busy ? "Creating..." : "Create");
+  const canProceed = isNewWorktree
+    ? (inWorktreeStep ? worktreeCreation.canAdvance() : worktreeCreation.canSubmit())
+    : (inWorktreeStep ? !!createState.selectedWorktreeId : !!createState.selectedWorktreeId && !!createState.selectedAgentId);
+  next.disabled = busy || !canProceed;
+  next.textContent = inWorktreeStep
+    ? "Next"
+    : (busy ? "Creating..." : (isNewWorktree ? "Create worktree and session" : "Create"));
 }
 
-function renderCreateWorktrees() {
+function renderNewWorktreeForm(state, busy) {
+  const projectSelect = $("project-select");
+  projectSelect.innerHTML = "";
+  const placeholder = document.createElement("option");
+  placeholder.value = "";
+  placeholder.disabled = true;
+  placeholder.textContent = state.projectsLoading ? "Loading repositories..." : "Choose a repository";
+  projectSelect.append(placeholder);
+  state.projects.forEach(project => {
+    const option = document.createElement("option");
+    option.value = project.id;
+    option.textContent = project.name || project.id;
+    projectSelect.append(option);
+  });
+  projectSelect.value = state.projectId || "";
+  projectSelect.disabled = busy || state.projectsLoading || state.projects.length === 0;
+  $("project-guidance").textContent = state.projectsLoading
+    ? "Loading repositories..."
+    : (state.projects.length === 0 ? "No repositories are available." : "Choose the repository for the new worktree.");
+
+  const baseSelect = $("base-select");
+  baseSelect.innerHTML = "";
+  const basePlaceholder = document.createElement("option");
+  basePlaceholder.value = "";
+  basePlaceholder.disabled = true;
+  basePlaceholder.textContent = state.branchStatus === "loading" ? "Loading branches..." : "Choose a base branch";
+  baseSelect.append(basePlaceholder);
+  state.branches.forEach(branch => {
+    const option = document.createElement("option");
+    option.value = branch;
+    option.textContent = branch;
+    baseSelect.append(option);
+  });
+  baseSelect.value = state.base || "";
+  baseSelect.disabled = busy || state.branchStatus !== "loaded";
+  const branchStatus = $("branch-status");
+  branchStatus.textContent = state.branchStatus === "loading"
+    ? "Loading branches..."
+    : (state.branchStatus === "failed" ? state.branchError || "Could not load branches."
+      : (state.branchStatus === "loaded" ? "Choose the branch to base this worktree on." : "Choose a repository to load branches."));
+  $("retry-branches").classList.toggle("hidden", state.branchStatus !== "failed");
+  $("retry-branches").disabled = busy;
+
+  const branchInput = $("new-branch");
+  if (branchInput.value !== state.branch) branchInput.value = state.branch;
+  branchInput.disabled = busy;
+}
+
+function renderNewWorktreeReview(state, visible) {
+  const review = $("new-worktree-review");
+  review.classList.toggle("hidden", !visible);
+  review.innerHTML = "";
+  if (!visible) return;
+  const project = state.projects.find(candidate => candidate.id === state.projectId);
+  review.append(el("strong", "", "Review"));
+  review.append(el("div", "", project ? project.name || project.id : "Repository not selected"));
+  review.append(el("div", "", state.base || "Base branch not selected"));
+  review.append(el("div", "", state.branch || "New branch not entered"));
+}
+
+function renderCreateWorktrees(busy) {
   const list = $("worktree-list");
   list.innerHTML = "";
   const worktrees = visibleCreateWorktrees();
@@ -551,10 +675,11 @@ function renderCreateWorktrees() {
   worktrees.forEach(worktree => {
     const row = el("button", "create-row");
     row.type = "button";
-    row.disabled = createState.busy;
+    row.disabled = busy;
     row.classList.toggle("is-selected", worktree.id === createState.selectedWorktreeId);
+    row.setAttribute("aria-pressed", String(worktree.id === createState.selectedWorktreeId));
     row.onclick = () => {
-      if (createState.busy) return;
+      if (busy) return;
       createState.selectedWorktreeId = worktree.id;
       createState.error = "";
       renderCreateSheet();
@@ -588,7 +713,7 @@ function createWorktreeMeta(worktree) {
   return parts.length ? parts : ["clean"];
 }
 
-function renderCreateAgents() {
+function renderCreateAgents(creationState, isNewWorktree, busy) {
   const list = $("agent-list");
   list.innerHTML = "";
   if (createState.agents.length === 0) {
@@ -599,13 +724,19 @@ function renderCreateAgents() {
   createState.agents.forEach(agent => {
     const row = el("button", "create-row");
     row.type = "button";
-    row.disabled = createState.busy;
-    row.classList.toggle("is-selected", agent.id === createState.selectedAgentId);
+    const selectedAgentId = isNewWorktree ? creationState.agentId : createState.selectedAgentId;
+    row.disabled = busy;
+    row.classList.toggle("is-selected", agent.id === selectedAgentId);
+    row.setAttribute("aria-pressed", String(agent.id === selectedAgentId));
     row.onclick = () => {
-      if (createState.busy) return;
-      createState.selectedAgentId = agent.id;
-      createState.error = "";
-      renderCreateSheet();
+      if (busy) return;
+      if (isNewWorktree) {
+        worktreeCreation.setAgent(agent.id);
+      } else {
+        createState.selectedAgentId = agent.id;
+        createState.error = "";
+        renderCreateSheet();
+      }
     };
     row.append(el("div", "create-row-title", agent.name || agent.id));
     if (agent.isDefault) row.append(el("div", "create-row-detail", "Default agent"));
@@ -614,7 +745,13 @@ function renderCreateAgents() {
 }
 
 function advanceCreateSheet() {
-  if (createState.busy) return;
+  const creationState = worktreeCreation.snapshot();
+  if (createState.busy || creationState.submitting) return;
+  if (creationState.mode === "new") {
+    if (creationState.step === "worktree") worktreeCreation.next();
+    else worktreeCreation.submit();
+    return;
+  }
   createState.error = "";
 
   if (createState.step === "worktree") {
@@ -631,7 +768,14 @@ function advanceCreateSheet() {
 }
 
 function backCreateSheet() {
-  if (createState.busy) return;
+  const creationState = worktreeCreation.snapshot();
+  if (createState.busy || creationState.submitting) return;
+  if (creationState.mode === "new") {
+    if (worktreeCreation.back() && worktreeCreation.snapshot().mode === "existing") {
+      requestAnimationFrame(() => $("worktree-search").focus());
+    }
+    return;
+  }
   createState.step = "worktree";
   createState.error = "";
   renderCreateSheet();
@@ -2413,11 +2557,16 @@ $("new-session").onclick = showCreateSheet;
 $("create-cancel").onclick = hideCreateSheet;
 $("create-next").onclick = advanceCreateSheet;
 $("create-back").onclick = backCreateSheet;
+$("create-new-worktree").onclick = startNewWorktree;
+$("retry-branches").onclick = () => worktreeCreation.retryBranches();
 $("new-session-sheet").onclick = (e) => { if (e.target.id === "new-session-sheet" && !createState.busy) hideCreateSheet(); };
 listen("worktree-search", "input", (e) => {
   createState.filter = e.target.value || "";
   renderCreateSheet();
 });
+listen("project-select", "change", (e) => worktreeCreation.selectProject(e.target.value));
+listen("base-select", "change", (e) => worktreeCreation.setBase(e.target.value));
+listen("new-branch", "input", (e) => worktreeCreation.setBranch(e.target.value));
 $("config").onclick = showConfig;
 $("cfg-close").onclick = hideConfig;
 $("cfg").onclick = (e) => { if (e.target.id === "cfg") hideConfig(); };

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/icon.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/icon-180.png" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=40" />
+  <link rel="stylesheet" href="/style.css?v=41" />
 </head>
 <body>
   <header id="bar">
@@ -118,13 +118,31 @@
   <div id="new-session-sheet" class="sheet hidden" role="dialog" aria-modal="true" aria-labelledby="new-session-title">
     <div class="sheet-card create-sheet">
       <p id="new-session-title" class="sheet-title">New session</p>
-      <div id="create-error" class="sheet-error hidden"></div>
+      <div id="create-error" class="sheet-error hidden" role="alert" aria-live="assertive"></div>
       <div id="worktree-step">
-        <input id="worktree-search" class="sheet-input" type="search" autocomplete="off" placeholder="Search worktrees" aria-label="Search worktrees" />
-        <div id="worktree-list" class="create-list"></div>
+        <div id="existing-worktree-picker">
+          <button id="create-new-worktree" class="option-btn" type="button">Create new worktree</button>
+          <label class="sheet-label" for="worktree-search">Existing worktree</label>
+          <input id="worktree-search" class="sheet-input" type="search" autocomplete="off" placeholder="Search worktrees" aria-label="Search worktrees" />
+          <div id="worktree-list" class="create-list"></div>
+        </div>
+        <div id="new-worktree-form" class="hidden">
+          <label class="sheet-label" for="project-select">Repository</label>
+          <select id="project-select" class="sheet-input" aria-describedby="project-guidance"></select>
+          <p id="project-guidance" class="form-guidance"></p>
+          <label class="sheet-label" for="base-select">Base branch</label>
+          <select id="base-select" class="sheet-input" aria-describedby="branch-status"></select>
+          <p id="branch-status" class="form-guidance" role="status"></p>
+          <button id="retry-branches" class="sheet-close hidden" type="button">Retry branches</button>
+          <label class="sheet-label" for="new-branch">New branch</label>
+          <input id="new-branch" class="sheet-input" type="text" autocomplete="off" autocapitalize="none" spellcheck="false" placeholder="feature/new-worktree" aria-describedby="new-branch-guidance" />
+          <p id="new-branch-guidance" class="form-guidance">Use a valid Git branch name.</p>
+        </div>
       </div>
       <div id="agent-step" class="hidden">
-        <div id="agent-list" class="create-list"></div>
+        <div id="new-worktree-review" class="create-review hidden" aria-live="polite"></div>
+        <p id="agent-picker-label" class="sheet-label">Agent</p>
+        <div id="agent-list" class="create-list" role="group" aria-labelledby="agent-picker-label"></div>
       </div>
       <div class="create-actions">
         <button id="create-back" class="sheet-close hidden">Back</button>
@@ -152,7 +170,8 @@
   <script src="/marked.min.js?v=28"></script>
   <script src="/purify.min.js?v=28"></script>
   <script src="/session-ordering.js?v=1"></script>
-  <script src="/app.js?v=62"></script>
+  <script src="/worktree-creation.js?v=1"></script>
+  <script src="/app.js?v=63"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -231,8 +231,16 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 .sheet-title { margin: 0 0 12px; font-size: 15px; font-weight: 600; color: var(--fg); }
 .sheet-input { width: 100%; margin: 0 0 10px; padding: 12px 13px; border: 1px solid var(--bg-4); border-radius: 10px; background: var(--bg-0); color: var(--fg); font: inherit; font-size: 16px; outline: none; }
 .sheet-input:focus { border-color: color-mix(in oklab, var(--accent) 65%, var(--bg-4)); }
+.sheet-label { display: block; margin: 10px 0 6px; color: var(--fg-muted); font-size: 13px; font-weight: 600; }
+.sheet-label:first-child { margin-top: 0; }
+select.sheet-input { appearance: auto; }
+.form-guidance { min-height: 18px; margin: -3px 0 9px; color: var(--fg-dim); font-size: 12px; line-height: 1.35; }
+#retry-branches { margin: -3px 0 10px; }
 .create-sheet { max-height: min(78vh, 620px); display: flex; flex-direction: column; }
+#worktree-step, #agent-step { min-height: 0; overflow-y: auto; -webkit-overflow-scrolling: touch; }
 .create-list { min-height: 0; max-height: 44vh; overflow-y: auto; -webkit-overflow-scrolling: touch; display: flex; flex-direction: column; gap: 8px; padding: 1px 0 4px; }
+.create-review { margin: 0 0 10px; padding: 10px 12px; border: 1px solid var(--line); border-radius: 8px; background: var(--bg-1); color: var(--fg-muted); font-size: 13px; line-height: 1.4; }
+.create-review strong { display: block; margin-bottom: 4px; color: var(--fg); font-size: 14px; }
 button.create-row { display: block; width: 100%; padding: 11px 12px; margin: 0; border: 1px solid var(--bg-4); border-radius: 10px; background: var(--bg-1); color: var(--fg); font: inherit; text-align: left; cursor: pointer; -webkit-tap-highlight-color: transparent; }
 button.create-row:disabled { cursor: not-allowed; opacity: .72; }
 button.create-row.is-selected { border-color: var(--accent); background: color-mix(in oklab, var(--accent) 17%, var(--bg-1)); }

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,10 +1,11 @@
-const CACHE_NAME = "alas-remote-shell-v40";
+const CACHE_NAME = "alas-remote-shell-v41";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
-  "/style.css?v=40",
+  "/style.css?v=41",
   "/session-ordering.js?v=1",
-  "/app.js?v=62",
+  "/worktree-creation.js?v=1",
+  "/app.js?v=63",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/worktree-creation.js
+++ b/Alas/Resources/RemoteWeb/worktree-creation.js
@@ -122,7 +122,13 @@ function createFlow(sendCommand) {
     return state.error ? { error: null } : {};
   }
 
-  function loadBranches(projectId) {
+  function clearMutableError() {
+    return state.outcomeUnknown ? {} : clearError();
+  }
+
+  function loadBranches(projectId, options = {}) {
+    const preserveBase = options.preserveBase === true;
+    const preserveError = options.preserveError === true || state.outcomeUnknown;
     const selectedProjectId = hasText(projectId) ? projectId : null;
     if (!selectedProjectId) {
       return update({
@@ -133,7 +139,7 @@ function createFlow(sendCommand) {
         preferredBase: "",
         branchError: "",
         base: "",
-        ...clearError(),
+        ...(preserveError ? {} : clearError()),
       });
     }
 
@@ -146,9 +152,9 @@ function createFlow(sendCommand) {
       branches: [],
       preferredBase: "",
       branchError: "",
-      base: "",
+      base: preserveBase ? state.base : "",
       result: null,
-      ...clearError(),
+      ...(preserveError ? {} : clearError()),
     });
     if (state.projectId === selectedProjectId &&
         state.branchesLoading &&
@@ -163,10 +169,21 @@ function createFlow(sendCommand) {
     return loadBranches(projectId);
   }
 
-  function loadProjects() {
-    const next = update({ projectsLoading: true, ...clearError() });
+  function loadProjects(options = {}) {
+    const preserveError = options.preserveError === true || state.outcomeUnknown;
+    const next = update({ projectsLoading: true, ...(preserveError ? {} : clearError()) });
     emit({ type: "listProjects" });
     return next;
+  }
+
+  function reloadCatalog() {
+    const selectedProjectId = state.projectId;
+    const preserveError = state.outcomeUnknown;
+    loadProjects({ preserveError });
+    if (selectedProjectId && state.projectId === selectedProjectId) {
+      return loadBranches(selectedProjectId, { preserveBase: true, preserveError });
+    }
+    return snapshot();
   }
 
   function retryBranches() {
@@ -174,15 +191,27 @@ function createFlow(sendCommand) {
   }
 
   function setBase(base) {
-    return update({ base: stringValue(base), ...clearError() });
+    return update({ base: stringValue(base), ...clearMutableError() });
   }
 
   function setBranch(branch) {
-    return update({ branch: stringValue(branch), ...clearError() });
+    return update({ branch: stringValue(branch), ...clearMutableError() });
   }
 
   function setAgent(agentId) {
-    return update({ agentId: hasText(agentId) ? agentId : null, ...clearError() });
+    return update({ agentId: hasText(agentId) ? agentId : null, ...clearMutableError() });
+  }
+
+  function reconcileAgents(agents) {
+    if (!state.agentId) return false;
+    const availableAgentIds = new Set(
+      Array.isArray(agents)
+        ? agents.filter((agent) => agent && hasText(agent.id)).map((agent) => agent.id)
+        : []
+    );
+    if (availableAgentIds.has(state.agentId)) return false;
+    update({ agentId: null });
+    return true;
   }
 
   function worktreeValidationError() {
@@ -197,6 +226,10 @@ function createFlow(sendCommand) {
     if (worktreeError) return worktreeError;
     if (!hasText(state.agentId)) return "Choose an agent.";
     return "";
+  }
+
+  function canAdvance() {
+    return !state.submitting && !state.outcomeUnknown && !worktreeValidationError();
   }
 
   function startNewWorktree() {
@@ -220,7 +253,7 @@ function createFlow(sendCommand) {
   }
 
   function back() {
-    if (state.submitting) return false;
+    if (state.submitting || state.outcomeUnknown) return false;
     if (state.step === "agent") {
       update({ step: "worktree", error: null });
       return true;
@@ -282,7 +315,7 @@ function createFlow(sendCommand) {
       ? message.branches.filter((branch) => hasText(branch))
       : [];
     const preferredBase = branches.includes(message.preferredBase) ? message.preferredBase : "";
-    const base = preferredBase || (branches.includes(state.base) ? state.base : branches[0] || "");
+    const base = branches.includes(state.base) ? state.base : preferredBase || branches[0] || "";
     update({
       branchesLoading: false,
       branchStatus: "loaded",
@@ -290,7 +323,7 @@ function createFlow(sendCommand) {
       preferredBase,
       branchError: "",
       base,
-      ...clearError(),
+      ...clearMutableError(),
     });
     return true;
   }
@@ -300,6 +333,9 @@ function createFlow(sendCommand) {
 
     const branchError = stringValue(message.message);
 
+    const errorChanges = state.outcomeUnknown
+      ? {}
+      : { error: { stage: "branches", message: branchError, worktreeId: null } };
     update({
       branchesLoading: false,
       branchStatus: "failed",
@@ -307,7 +343,7 @@ function createFlow(sendCommand) {
       preferredBase: "",
       branchError,
       base: "",
-      error: { stage: "branches", message: branchError, worktreeId: null },
+      ...errorChanges,
     });
     return true;
   }
@@ -374,21 +410,30 @@ function createFlow(sendCommand) {
     return true;
   }
 
+  function reset() {
+    if (state.outcomeUnknown && !canRetry(state)) return snapshot();
+    return publish(initialState());
+  }
+
   return {
     loadProjects,
+    reloadCatalog,
     selectProject,
     retryBranches,
     setBase,
     setBranch,
     setAgent,
+    reconcileAgents,
     startNewWorktree,
     next,
     back,
+    canAdvance,
     canSubmit: () => canSubmit(state),
     canRetry: () => canRetry(state),
     submit,
     disconnect,
     markRecoveryListLoaded,
+    reset,
     receive,
     snapshot,
     subscribe,

--- a/Alas/Resources/RemoteWeb/worktree-creation.js
+++ b/Alas/Resources/RemoteWeb/worktree-creation.js
@@ -1,0 +1,398 @@
+function initialState() {
+  return {
+    mode: "existing",
+    step: "worktree",
+    projectsLoading: false,
+    projects: [],
+    projectId: null,
+    branchesLoading: false,
+    branchStatus: "idle",
+    branches: [],
+    preferredBase: "",
+    branchError: "",
+    base: "",
+    branch: "",
+    agentId: null,
+    submitting: false,
+    error: null,
+    result: null,
+    outcomeUnknown: false,
+    recovery: { sessions: false, worktrees: false },
+    createdWorktreeId: null,
+    selectedWorktreeId: null,
+  };
+}
+
+function stringValue(value) {
+  return typeof value === "string" ? value : "";
+}
+
+function hasText(value) {
+  return stringValue(value).trim().length > 0;
+}
+
+function isValidBranchName(value) {
+  const name = stringValue(value);
+  if (!hasText(name) || name.length > 250 || name.includes(" ") || /[\x00-\x1f\x7f]/.test(name)) return false;
+  if (name.startsWith("/") || name.endsWith("/") || name.includes("//") || name.includes("@{") || name === "@" || name.startsWith("-")) return false;
+
+  return name.split("/").every((component, index, components) => {
+    if (!component || component === "." || component === ".." || component.startsWith(".")) return false;
+    if (component.includes("..") || component.endsWith(".lock")) return false;
+    if (index === components.length - 1 && component.endsWith(".")) return false;
+    return !/[~^:\\?*\[\t\r\n]/.test(component);
+  });
+}
+
+function canRetry(state) {
+  return state.outcomeUnknown &&
+    !state.submitting &&
+    state.recovery.sessions &&
+    state.recovery.worktrees;
+}
+
+function canSubmit(state) {
+  return !state.submitting &&
+    (!state.outcomeUnknown || canRetry(state)) &&
+    hasText(state.projectId) &&
+    state.branchStatus === "loaded" &&
+    state.branches.includes(state.base) &&
+    isValidBranchName(state.branch) &&
+    hasText(state.agentId);
+}
+
+function copyValue(value) {
+  if (Array.isArray(value)) return value.map(copyValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, copyValue(entry)]));
+  }
+  return value;
+}
+
+function isUsableSession(session) {
+  return session && typeof session === "object" && !Array.isArray(session) && hasText(session.id);
+}
+
+function isCreationFailure(message) {
+  return (message.stage === "worktree" || message.stage === "session") && hasText(message.message);
+}
+
+function snapshotOf(state) {
+  return {
+    ...state,
+    projects: copyValue(state.projects),
+    branches: [...state.branches],
+    error: state.error ? { ...state.error } : null,
+    result: copyValue(state.result),
+    recovery: { ...state.recovery },
+  };
+}
+
+function createFlow(sendCommand) {
+  const send = typeof sendCommand === "function" ? sendCommand : () => {};
+  let state = initialState();
+  let branchRequestGeneration = 0;
+  const subscribers = new Set();
+
+  function snapshot() {
+    return snapshotOf(state);
+  }
+
+  function publish(nextState) {
+    state = nextState;
+    [...subscribers].forEach((subscriber) => {
+      try {
+        subscriber(snapshot());
+      } catch (_) {
+        // A rendering callback must not block the state transition or transport command.
+      }
+    });
+    return snapshot();
+  }
+
+  function update(changes) {
+    return publish({ ...state, ...changes });
+  }
+
+  function emit(command) {
+    send({ ...command });
+  }
+
+  function clearError() {
+    return state.error ? { error: null } : {};
+  }
+
+  function loadBranches(projectId) {
+    const selectedProjectId = hasText(projectId) ? projectId : null;
+    if (!selectedProjectId) {
+      return update({
+        projectId: null,
+        branchesLoading: false,
+        branchStatus: "idle",
+        branches: [],
+        preferredBase: "",
+        branchError: "",
+        base: "",
+        ...clearError(),
+      });
+    }
+
+    const requestGeneration = ++branchRequestGeneration;
+    const command = { type: "listBranches", projectId: selectedProjectId };
+    const next = update({
+      projectId: selectedProjectId,
+      branchesLoading: true,
+      branchStatus: "loading",
+      branches: [],
+      preferredBase: "",
+      branchError: "",
+      base: "",
+      result: null,
+      ...clearError(),
+    });
+    if (state.projectId === selectedProjectId &&
+        state.branchesLoading &&
+        state.branchStatus === "loading" &&
+        branchRequestGeneration === requestGeneration) {
+      emit(command);
+    }
+    return next;
+  }
+
+  function selectProject(projectId) {
+    return loadBranches(projectId);
+  }
+
+  function loadProjects() {
+    const next = update({ projectsLoading: true, ...clearError() });
+    emit({ type: "listProjects" });
+    return next;
+  }
+
+  function retryBranches() {
+    return loadBranches(state.projectId);
+  }
+
+  function setBase(base) {
+    return update({ base: stringValue(base), ...clearError() });
+  }
+
+  function setBranch(branch) {
+    return update({ branch: stringValue(branch), ...clearError() });
+  }
+
+  function setAgent(agentId) {
+    return update({ agentId: hasText(agentId) ? agentId : null, ...clearError() });
+  }
+
+  function worktreeValidationError() {
+    if (!hasText(state.projectId)) return "Choose a repository.";
+    if (state.branchStatus !== "loaded" || !state.branches.includes(state.base)) return "Choose a base branch.";
+    if (!isValidBranchName(state.branch)) return "Enter a valid branch name.";
+    return "";
+  }
+
+  function validationError() {
+    const worktreeError = worktreeValidationError();
+    if (worktreeError) return worktreeError;
+    if (!hasText(state.agentId)) return "Choose an agent.";
+    return "";
+  }
+
+  function startNewWorktree() {
+    if (state.submitting || state.outcomeUnknown) return false;
+    update({ mode: "new", step: "worktree", error: null, result: null });
+    return true;
+  }
+
+  function next() {
+    if (state.submitting || state.outcomeUnknown) return false;
+    if (state.step === "agent") return true;
+
+    const message = worktreeValidationError();
+    if (message) {
+      update({ error: { stage: "validation", message, worktreeId: null } });
+      return false;
+    }
+
+    update({ mode: "new", step: "agent", error: null });
+    return true;
+  }
+
+  function back() {
+    if (state.submitting) return false;
+    if (state.step === "agent") {
+      update({ step: "worktree", error: null });
+      return true;
+    }
+    if (state.mode === "new") {
+      update({ mode: "existing", error: null });
+      return true;
+    }
+    return false;
+  }
+
+  function submit() {
+    if (state.submitting) return false;
+    if (state.outcomeUnknown && !canRetry(state)) return false;
+
+    const message = validationError();
+    if (message) {
+      update({ error: { stage: "validation", message, worktreeId: null }, result: null });
+      return false;
+    }
+
+    const command = {
+      type: "createWorktreeSession",
+      projectId: state.projectId,
+      base: state.base,
+      branch: state.branch,
+      agentId: state.agentId,
+    };
+    update({
+      submitting: true,
+      error: null,
+      result: null,
+      outcomeUnknown: false,
+      recovery: { sessions: false, worktrees: false },
+    });
+    emit(command);
+    return true;
+  }
+
+  function applyProjectList(projects) {
+    const normalizedProjects = Array.isArray(projects)
+      ? projects.filter((project) => project && hasText(project.id)).map(copyValue)
+      : [];
+    const currentProjectExists = normalizedProjects.some((project) => project.id === state.projectId);
+    const selectedProjectId = currentProjectExists ? state.projectId : normalizedProjects[0]?.id || null;
+
+    update({ projectsLoading: false, projects: normalizedProjects });
+    if (selectedProjectId && selectedProjectId !== state.projectId) {
+      loadBranches(selectedProjectId);
+    } else if (!selectedProjectId && state.projectId) {
+      loadBranches(null);
+    }
+  }
+
+  function applyBranchList(message) {
+    if (!hasText(message.projectId) || message.projectId !== state.projectId || !state.branchesLoading || state.branchStatus !== "loading") return false;
+
+    const branches = Array.isArray(message.branches)
+      ? message.branches.filter((branch) => hasText(branch))
+      : [];
+    const preferredBase = branches.includes(message.preferredBase) ? message.preferredBase : "";
+    const base = preferredBase || (branches.includes(state.base) ? state.base : branches[0] || "");
+    update({
+      branchesLoading: false,
+      branchStatus: "loaded",
+      branches,
+      preferredBase,
+      branchError: "",
+      base,
+      ...clearError(),
+    });
+    return true;
+  }
+
+  function applyBranchListFailure(message) {
+    if (!hasText(message.projectId) || message.projectId !== state.projectId || !state.branchesLoading || state.branchStatus !== "loading") return false;
+
+    const branchError = stringValue(message.message);
+
+    update({
+      branchesLoading: false,
+      branchStatus: "failed",
+      branches: [],
+      preferredBase: "",
+      branchError,
+      base: "",
+      error: { stage: "branches", message: branchError, worktreeId: null },
+    });
+    return true;
+  }
+
+  function receive(message) {
+    if (!message || typeof message.type !== "string") return false;
+
+    switch (message.type) {
+      case "projectList":
+        applyProjectList(message.projects);
+        return true;
+      case "branchList":
+        return applyBranchList(message);
+      case "branchListFailed":
+        return applyBranchListFailure(message);
+      case "worktreeSessionCreated":
+        if (!state.submitting || state.outcomeUnknown) return false;
+        if (!isUsableSession(message.session)) return false;
+        update({ submitting: false, error: null, result: copyValue(message.session) });
+        return true;
+      case "worktreeSessionCreationFailed":
+        if (!state.submitting || state.outcomeUnknown) return false;
+        if (!isCreationFailure(message)) return false;
+        const isSessionFailure = message.stage === "session" && hasText(message.worktreeId);
+        update({
+          submitting: false,
+          result: null,
+          mode: isSessionFailure ? "existing" : state.mode,
+          step: isSessionFailure || message.stage === "worktree" ? "worktree" : state.step,
+          createdWorktreeId: isSessionFailure ? message.worktreeId : state.createdWorktreeId,
+          selectedWorktreeId: isSessionFailure ? message.worktreeId : state.selectedWorktreeId,
+          error: {
+            stage: stringValue(message.stage),
+            message: stringValue(message.message),
+            worktreeId: hasText(message.worktreeId) ? message.worktreeId : null,
+          },
+        });
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  function subscribe(subscriber) {
+    if (typeof subscriber !== "function") return () => {};
+    subscribers.add(subscriber);
+    return () => subscribers.delete(subscriber);
+  }
+
+  function disconnect() {
+    if (!state.submitting) return false;
+    update({
+      submitting: false,
+      outcomeUnknown: true,
+      recovery: { sessions: false, worktrees: false },
+      error: { stage: "unknown", message: "Connection lost while creating the worktree.", worktreeId: null },
+    });
+    return true;
+  }
+
+  function markRecoveryListLoaded(list) {
+    if (!state.outcomeUnknown || (list !== "sessions" && list !== "worktrees")) return false;
+    update({ recovery: { ...state.recovery, [list]: true } });
+    return true;
+  }
+
+  return {
+    loadProjects,
+    selectProject,
+    retryBranches,
+    setBase,
+    setBranch,
+    setAgent,
+    startNewWorktree,
+    next,
+    back,
+    canSubmit: () => canSubmit(state),
+    canRetry: () => canRetry(state),
+    submit,
+    disconnect,
+    markRecoveryListLoaded,
+    receive,
+    snapshot,
+    subscribe,
+  };
+}
+
+globalThis.RemoteWorktreeCreation = { createFlow, initialState, canSubmit, canRetry, isValidBranchName };

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7472,6 +7472,28 @@ extension AppState: RemoteSessionsProvider {
         return out
     }
 
+    func remoteProjects() async -> [RemoteProjectOption] {
+        projects.map { RemoteProjectOption(id: $0.id, name: $0.name) }
+    }
+
+    func remoteBranches(projectId: String) async -> RemoteBranchListResult {
+        guard let project = projects.first(where: { $0.id == projectId }) else {
+            return .failure("Repository is no longer available.")
+        }
+
+        do {
+            let branches = try await GitService().branches(at: URL(fileURLWithPath: project.path))
+            let preferredBase = NewWorktreeDialog.preferredBaseBranch(
+                availableBranches: branches,
+                configuredDefault: config.worktrees.baseBranch
+            )
+            return .success(branches: branches, preferredBase: preferredBase)
+        } catch {
+            Self.logger.error("Could not load remote branches for project \(project.id, privacy: .private): \(String(describing: error), privacy: .private)")
+            return .failure("Could not load branches.")
+        }
+    }
+
     func remoteAgents() -> [RemoteAgentOption] {
         let enabledById = Dictionary(uniqueKeysWithValues: agentRegistry.enabled().map { ($0.id, $0) })
         let ordered = ACPLaunchCatalog.specs.compactMap { enabledById[$0.agentID] }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -34,6 +34,8 @@ enum ReviewSessionConsolidation {
     }
 }
 
+private struct RemoteWorktreeDestinationCheckError: Error {}
+
 @Observable
 @MainActor
 final class AppState {
@@ -160,6 +162,14 @@ final class AppState {
     private(set) var remoteConnectedDeviceCountsSnapshot: [String: Int] = [:]
     @ObservationIgnored
     var remoteSessionAttachScheduler: (@MainActor (ACPSessionManager, ACPSession.ID) -> Void)?
+    @ObservationIgnored
+    var remoteWorktreeBranchLoader: (@MainActor (URL) async throws -> [String])?
+    @ObservationIgnored
+    var remoteWorktreeDestinationPreparer: (@MainActor (URL, URL) async throws -> URL)?
+    @ObservationIgnored
+    var remoteWorktreeCommandRunner: (@MainActor (String, String?, String) async throws -> ProcessResult)?
+    @ObservationIgnored
+    var remoteSessionCreator: (@MainActor (String, String) async -> RemoteCreateSessionResult)?
 
     private func makeRemoteInterfaces() -> [RemoteNetworkInterface] {
         RemoteNetwork.interfaces()
@@ -1289,7 +1299,8 @@ final class AppState {
         runStartup: Bool,
         launchSurface: WorktreeLaunchSurface,
         ggWorktreeMode: GGWorktreeMode = .inherit,
-        issueAttachment: IssueAttachment? = nil
+        issueAttachment: IssueAttachment? = nil,
+        destinationAlreadyPrepared: Bool = false
     ) async -> String {
         guard let project = projects.first(where: { $0.id == projectId }) else {
             // Should not happen if the dialog validated the project; fail silently.
@@ -1306,14 +1317,18 @@ final class AppState {
         // that exist on disk; the leaf doesn't exist yet, so resolve the
         // parent (which does) and reattach the leaf.
         let canonicalDestination: URL
-        do {
-            canonicalDestination = try await Self.preparedCreateWorktreeDestination(
-                repoPath: repoPath,
-                destination: destination
-            )
-        } catch {
-            showFileActionError(title: "Create Worktree Failed", message: error.localizedDescription)
-            return ""
+        if destinationAlreadyPrepared {
+            canonicalDestination = destination
+        } else {
+            do {
+                canonicalDestination = try await Self.preparedCreateWorktreeDestination(
+                    repoPath: repoPath,
+                    destination: destination
+                )
+            } catch {
+                showFileActionError(title: "Create Worktree Failed", message: error.localizedDescription)
+                return ""
+            }
         }
         let optimisticId = Worktree.makeId(path: canonicalDestination)
         if projectsManager.worktrees(projectId: projectId).contains(where: { $0.id == optimisticId }) {
@@ -1556,7 +1571,8 @@ final class AppState {
         branch: String,
         destination: URL,
         runStartup: Bool,
-        ggWorktreeMode: GGWorktreeMode = .inherit
+        ggWorktreeMode: GGWorktreeMode = .inherit,
+        destinationAlreadyPrepared: Bool = false
     ) async -> Result<Worktree, WorktreeCreationFailure> {
         let id = await createWorktree(
             projectId: projectId,
@@ -1565,7 +1581,8 @@ final class AppState {
             destination: destination,
             runStartup: runStartup,
             launchSurface: .delegated,
-            ggWorktreeMode: ggWorktreeMode
+            ggWorktreeMode: ggWorktreeMode,
+            destinationAlreadyPrepared: destinationAlreadyPrepared
         )
         guard !id.isEmpty else {
             return .failure(.init(message: "Could not start worktree creation."))
@@ -7540,6 +7557,138 @@ extension AppState: RemoteSessionsProvider {
 
         let worktreeSummary = remoteWorktreeSummaryWithoutMetrics(project: resolved.project, worktree: resolved.worktree)
         return .success(remoteSessionSummary(session: session, manager: manager, worktreeSummary: worktreeSummary))
+    }
+
+    func createRemoteWorktreeSession(
+        projectId: String,
+        base: String,
+        branch: String,
+        agentId: String
+    ) async -> RemoteCreateWorktreeSessionResult {
+        guard let project = projects.first(where: { $0.id == projectId }) else {
+            return .failure(
+                stage: .worktree,
+                message: "Repository is no longer available.",
+                worktreeId: nil
+            )
+        }
+
+        let acpIDs = Set(ACPLaunchCatalog.specs.map(\.agentID))
+        guard agentRegistry.enabled().contains(where: { $0.id == agentId && acpIDs.contains($0.id) }) else {
+            return .failure(stage: .worktree, message: "Could not create worktree.", worktreeId: nil)
+        }
+
+        guard case .valid = GitNameValidator.validateBranchName(branch) else {
+            return .failure(stage: .worktree, message: "Could not create worktree.", worktreeId: nil)
+        }
+
+        do {
+            let repoPath = URL(fileURLWithPath: project.path)
+            let branches = if let remoteWorktreeBranchLoader {
+                try await remoteWorktreeBranchLoader(repoPath)
+            } else {
+                try await GitService().branches(at: repoPath)
+            }
+            guard branches.contains(base) else {
+                return .failure(stage: .worktree, message: "Could not create worktree.", worktreeId: nil)
+            }
+        } catch {
+            Self.logger.error("Could not load branches for remote worktree creation in project \(project.id, privacy: .private): \(String(describing: error), privacy: .private)")
+            return .failure(stage: .worktree, message: "Could not load branches.", worktreeId: nil)
+        }
+
+        let renderedDestination = WorktreePathTemplateRenderer.render(
+            template: config.worktrees.pathTemplate,
+            worktreeRoot: config.worktrees.rootPath,
+            repoName: project.name,
+            branch: branch
+        )
+        let destination: URL
+        do {
+            let repoPath = URL(fileURLWithPath: project.path)
+            destination = if let remoteWorktreeDestinationPreparer {
+                try await remoteWorktreeDestinationPreparer(repoPath, renderedDestination)
+            } else {
+                try await Self.preparedCreateWorktreeDestination(
+                    repoPath: repoPath,
+                    destination: renderedDestination
+                )
+            }
+            if try await remoteCreationDestinationExists(project: project, destination: destination) {
+                return .failure(
+                    stage: .worktree,
+                    message: "A worktree already exists at this path.",
+                    worktreeId: nil
+                )
+            }
+        } catch {
+            Self.logger.error("Could not preflight remote worktree creation for project \(project.id, privacy: .private): \(String(describing: error), privacy: .private)")
+            return .failure(stage: .worktree, message: "Could not create worktree.", worktreeId: nil)
+        }
+
+        let worktreeResult = await createWorktreeAndWait(
+            projectId: project.id,
+            base: base,
+            branch: branch,
+            destination: destination,
+            runStartup: true,
+            ggWorktreeMode: .inherit,
+            destinationAlreadyPrepared: true
+        )
+        switch worktreeResult {
+        case .success(let worktree):
+            let sessionResult = if let remoteSessionCreator {
+                await remoteSessionCreator(worktree.id, agentId)
+            } else {
+                await createRemoteSession(worktreeId: worktree.id, agentId: agentId)
+            }
+            return Self.remoteWorktreeSessionResult(
+                worktree: worktree,
+                sessionResult: sessionResult
+            )
+        case .failure(let error):
+            Self.logger.error("Could not create remote worktree for project \(project.id, privacy: .private): \(error.message, privacy: .private)")
+            return .failure(stage: .worktree, message: "Could not create worktree.", worktreeId: nil)
+        }
+    }
+
+    nonisolated static func remoteWorktreeSessionResult(
+        worktree: Worktree,
+        sessionResult: RemoteCreateSessionResult
+    ) -> RemoteCreateWorktreeSessionResult {
+        switch sessionResult {
+        case .success(let summary):
+            return .success(summary)
+        case .failure:
+            return .failure(
+                stage: .session,
+                message: "Worktree created, but the session could not be created.",
+                worktreeId: worktree.id
+            )
+        }
+    }
+
+    private func remoteCreationDestinationExists(
+        project: ProjectConfig,
+        destination: URL
+    ) async throws -> Bool {
+        guard let host = project.host ?? RemoteHostRegistry.shared.host(forPath: project.path) else {
+            return FileManager.default.fileExists(atPath: destination.path)
+        }
+        let command = "test -e \(SSHCommand.shellQuote(destination.path))"
+        let result = if let remoteWorktreeCommandRunner {
+            try await remoteWorktreeCommandRunner(host, nil, command)
+        } else {
+            try await RemoteExec.run(host: host, cwd: nil, command: command)
+        }
+        switch result.exitCode {
+        case 0:
+            return true
+        case 1:
+            return false
+        default:
+            throw RemoteWorktreeDestinationCheckError()
+        }
     }
 
     func session(for id: String) -> ACPSession? {

--- a/Alas/Sources/App/WorktreeCreationCompletion.swift
+++ b/Alas/Sources/App/WorktreeCreationCompletion.swift
@@ -18,6 +18,9 @@ enum WorktreeCreationCompletion {
     ) async -> Result<Worktree, WorktreeCreationFailure> {
         var remainingInactivePolls = maxPolls
         while remainingInactivePolls > 0 {
+            guard !Task.isCancelled else {
+                return .failure(.init(message: "Worktree creation was interrupted."))
+            }
             let reconciledWorktree = worktree()
 
             switch operationState() {

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -48,6 +48,8 @@ final class RemoteSessionGateway {
             refreshWorktreeList()
         case .listAgents:
             send(.agentList(agents: provider.remoteAgents()))
+        case .listProjects, .listBranches, .createWorktreeSession:
+            break
         case .createSession(let worktreeId, let agentId):
             let result = await provider.createRemoteSession(worktreeId: worktreeId, agentId: agentId)
             switch result {

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -26,6 +26,10 @@ final class RemoteSessionGateway {
     private var sessionListGeneration = 0
     private var worktreeListRefresh: Task<Void, Never>?
     private var worktreeListGeneration = 0
+    private var projectListRefresh: Task<Void, Never>?
+    private var projectListGeneration = 0
+    private var branchListRefresh: Task<Void, Never>?
+    private var branchListGeneration = 0
     private var syncStates: [String: RemoteTranscriptSync] = [:]
     private var trackedSessions: Set<String> = []
     // Per-session request id of the permission/question prompt we last surfaced,
@@ -48,8 +52,32 @@ final class RemoteSessionGateway {
             refreshWorktreeList()
         case .listAgents:
             send(.agentList(agents: provider.remoteAgents()))
-        case .listProjects, .listBranches, .createWorktreeSession:
-            break
+        case .listProjects:
+            refreshProjectList()
+        case .listBranches(let projectId):
+            refreshBranchList(projectId: projectId)
+        case .createWorktreeSession(let projectId, let base, let branch, let agentId):
+            let result = await provider.createRemoteWorktreeSession(
+                projectId: projectId,
+                base: base,
+                branch: branch,
+                agentId: agentId
+            )
+            switch result {
+            case .success(let summary):
+                send(.worktreeSessionCreated(session: summary))
+                refreshSessionList()
+                refreshWorktreeList()
+            case .failure(let stage, let message, let worktreeId):
+                send(.worktreeSessionCreationFailed(
+                    stage: stage,
+                    message: message,
+                    worktreeId: worktreeId
+                ))
+                if worktreeId != nil {
+                    refreshWorktreeList()
+                }
+            }
         case .createSession(let worktreeId, let agentId):
             let result = await provider.createRemoteSession(worktreeId: worktreeId, agentId: agentId)
             switch result {
@@ -295,6 +323,39 @@ final class RemoteSessionGateway {
         }
     }
 
+    private func refreshProjectList() {
+        projectListGeneration += 1
+        let generation = projectListGeneration
+        projectListRefresh?.cancel()
+        projectListRefresh = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let projects = await provider.remoteProjects()
+            guard !Task.isCancelled, generation == projectListGeneration else { return }
+            send(.projectList(projects: projects))
+        }
+    }
+
+    private func refreshBranchList(projectId: String) {
+        branchListGeneration += 1
+        let generation = branchListGeneration
+        branchListRefresh?.cancel()
+        branchListRefresh = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let result = await provider.remoteBranches(projectId: projectId)
+            guard !Task.isCancelled, generation == branchListGeneration else { return }
+            switch result {
+            case .success(let branches, let preferredBase):
+                send(.branchList(
+                    projectId: projectId,
+                    branches: branches,
+                    preferredBase: preferredBase
+                ))
+            case .failure(let message):
+                send(.branchListFailed(projectId: projectId, message: message))
+            }
+        }
+    }
+
     // MARK: attachment materialization
 
     private static let maxAttachmentsBytes = 10_000_000
@@ -353,6 +414,10 @@ final class RemoteSessionGateway {
         sessionListRefresh = nil
         worktreeListRefresh?.cancel()
         worktreeListRefresh = nil
+        projectListRefresh?.cancel()
+        projectListRefresh = nil
+        branchListRefresh?.cancel()
+        branchListRefresh = nil
         subscriptions.removeAll()
         configSubscriptions.removeAll()
         configCoalesce.values.forEach { $0.cancel() }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
@@ -10,6 +10,12 @@ protocol RemoteSessionsProvider: AnyObject {
     func remoteBranches(projectId: String) async -> RemoteBranchListResult
     func remoteAgents() -> [RemoteAgentOption]
     func createRemoteSession(worktreeId: String, agentId: String) async -> RemoteCreateSessionResult
+    func createRemoteWorktreeSession(
+        projectId: String,
+        base: String,
+        branch: String,
+        agentId: String
+    ) async -> RemoteCreateWorktreeSessionResult
     func session(for id: String) -> ACPSession?
     func permissionPolicy(for id: String) -> ACPPermissionPolicy?
     func hydrateIfNeeded(id: String) async

--- a/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
@@ -6,6 +6,8 @@ import Foundation
 protocol RemoteSessionsProvider: AnyObject {
     func sessionSummaries() async -> [RemoteSessionSummary]
     func remoteWorktrees() async -> [RemoteWorktreeOption]
+    func remoteProjects() async -> [RemoteProjectOption]
+    func remoteBranches(projectId: String) async -> RemoteBranchListResult
     func remoteAgents() -> [RemoteAgentOption]
     func createRemoteSession(worktreeId: String, agentId: String) async -> RemoteCreateSessionResult
     func session(for id: String) -> ACPSession?

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -61,6 +61,30 @@ struct RemoteAgentOption: Codable, Equatable, Sendable {
     let isDefault: Bool
 }
 
+struct RemoteProjectOption: Codable, Equatable, Sendable {
+    let id: String
+    let name: String
+}
+
+enum RemoteWorktreeSessionCreationStage: String, Codable, Equatable, Sendable {
+    case worktree
+    case session
+}
+
+enum RemoteBranchListResult: Equatable, Sendable {
+    case success(branches: [String], preferredBase: String)
+    case failure(String)
+}
+
+enum RemoteCreateWorktreeSessionResult: Equatable, Sendable {
+    case success(RemoteSessionSummary)
+    case failure(
+        stage: RemoteWorktreeSessionCreationStage,
+        message: String,
+        worktreeId: String?
+    )
+}
+
 enum RemoteCreateSessionResult: Equatable, Sendable {
     case success(RemoteSessionSummary)
     case failure(String)

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -26,6 +26,9 @@ enum RemoteClientMessage: Equatable, Sendable {
     case listSessions
     case listWorktrees
     case listAgents
+    case listProjects
+    case listBranches(projectId: String)
+    case createWorktreeSession(projectId: String, base: String, branch: String, agentId: String)
     case createSession(worktreeId: String, agentId: String)
     case subscribe(sessionId: String)
     case unsubscribe(sessionId: String)
@@ -54,7 +57,7 @@ enum RemoteClientMessage: Equatable, Sendable {
 }
 
 extension RemoteClientMessage: Codable {
-    private enum CodingKeys: String, CodingKey { case type, sessionId, requestId, optionId, persistScope, answers, action, content, text, attachments, modelId, modeId, enabled, title, worktreeId, agentId, beforeIndex, limit, itemId, intent }
+    private enum CodingKeys: String, CodingKey { case type, sessionId, requestId, optionId, persistScope, answers, action, content, text, attachments, modelId, modeId, enabled, title, worktreeId, agentId, beforeIndex, limit, itemId, intent, projectId, base, branch }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -62,6 +65,15 @@ extension RemoteClientMessage: Codable {
         case "listSessions": self = .listSessions
         case "listWorktrees": self = .listWorktrees
         case "listAgents": self = .listAgents
+        case "listProjects": self = .listProjects
+        case "listBranches":
+            self = .listBranches(projectId: try c.decode(String.self, forKey: .projectId))
+        case "createWorktreeSession":
+            self = .createWorktreeSession(
+                projectId: try c.decode(String.self, forKey: .projectId),
+                base: try c.decode(String.self, forKey: .base),
+                branch: try c.decode(String.self, forKey: .branch),
+                agentId: try c.decode(String.self, forKey: .agentId))
         case "createSession":
             self = .createSession(
                 worktreeId: try c.decode(String.self, forKey: .worktreeId),
@@ -149,6 +161,17 @@ extension RemoteClientMessage: Codable {
             try c.encode("listWorktrees", forKey: .type)
         case .listAgents:
             try c.encode("listAgents", forKey: .type)
+        case .listProjects:
+            try c.encode("listProjects", forKey: .type)
+        case .listBranches(let projectId):
+            try c.encode("listBranches", forKey: .type)
+            try c.encode(projectId, forKey: .projectId)
+        case .createWorktreeSession(let projectId, let base, let branch, let agentId):
+            try c.encode("createWorktreeSession", forKey: .type)
+            try c.encode(projectId, forKey: .projectId)
+            try c.encode(base, forKey: .base)
+            try c.encode(branch, forKey: .branch)
+            try c.encode(agentId, forKey: .agentId)
         case .createSession(let worktreeId, let agentId):
             try c.encode("createSession", forKey: .type)
             try c.encode(worktreeId, forKey: .worktreeId)
@@ -266,6 +289,11 @@ enum RemoteServerMessage: Equatable, Sendable {
     case sessionList(sessions: [RemoteSessionSummary])
     case worktreeList(worktrees: [RemoteWorktreeOption])
     case agentList(agents: [RemoteAgentOption])
+    case projectList(projects: [RemoteProjectOption])
+    case branchList(projectId: String, branches: [String], preferredBase: String)
+    case branchListFailed(projectId: String, message: String)
+    case worktreeSessionCreated(session: RemoteSessionSummary)
+    case worktreeSessionCreationFailed(stage: RemoteWorktreeSessionCreationStage, message: String, worktreeId: String?)
     case sessionCreated(session: RemoteSessionSummary)
     case createSessionFailed(message: String)
     case transcriptSnapshot(
@@ -296,8 +324,8 @@ enum RemoteServerMessage: Equatable, Sendable {
 
 extension RemoteServerMessage: Codable {
     private enum CodingKeys: String, CodingKey {
-        case type, sessions, sessionId, streamingState, canDrive, messages, upserts, payload, requestId, message
-        case worktrees, agents, session
+        case type, sessions, sessionId, projectId, streamingState, canDrive, messages, upserts, payload, requestId, message
+        case worktrees, agents, session, projects, branches, preferredBase, stage, worktreeId
         case models, modes, currentModel, currentMode, autoRunEnabled, acceptsImages, title
         case firstIndex, totalCount, epoch, revision
         case items, steerUndoAvailable, itemId, text
@@ -311,6 +339,24 @@ extension RemoteServerMessage: Codable {
             self = .worktreeList(worktrees: try c.decode([RemoteWorktreeOption].self, forKey: .worktrees))
         case "agentList":
             self = .agentList(agents: try c.decode([RemoteAgentOption].self, forKey: .agents))
+        case "projectList":
+            self = .projectList(projects: try c.decode([RemoteProjectOption].self, forKey: .projects))
+        case "branchList":
+            self = .branchList(
+                projectId: try c.decode(String.self, forKey: .projectId),
+                branches: try c.decode([String].self, forKey: .branches),
+                preferredBase: try c.decode(String.self, forKey: .preferredBase))
+        case "branchListFailed":
+            self = .branchListFailed(
+                projectId: try c.decode(String.self, forKey: .projectId),
+                message: try c.decode(String.self, forKey: .message))
+        case "worktreeSessionCreated":
+            self = .worktreeSessionCreated(session: try c.decode(RemoteSessionSummary.self, forKey: .session))
+        case "worktreeSessionCreationFailed":
+            self = .worktreeSessionCreationFailed(
+                stage: try c.decode(RemoteWorktreeSessionCreationStage.self, forKey: .stage),
+                message: try c.decode(String.self, forKey: .message),
+                worktreeId: try c.decodeIfPresent(String.self, forKey: .worktreeId))
         case "sessionCreated":
             self = .sessionCreated(session: try c.decode(RemoteSessionSummary.self, forKey: .session))
         case "createSessionFailed":
@@ -409,6 +455,26 @@ extension RemoteServerMessage: Codable {
         case .agentList(let agents):
             try c.encode("agentList", forKey: .type)
             try c.encode(agents, forKey: .agents)
+        case .projectList(let projects):
+            try c.encode("projectList", forKey: .type)
+            try c.encode(projects, forKey: .projects)
+        case .branchList(let projectId, let branches, let preferredBase):
+            try c.encode("branchList", forKey: .type)
+            try c.encode(projectId, forKey: .projectId)
+            try c.encode(branches, forKey: .branches)
+            try c.encode(preferredBase, forKey: .preferredBase)
+        case .branchListFailed(let projectId, let message):
+            try c.encode("branchListFailed", forKey: .type)
+            try c.encode(projectId, forKey: .projectId)
+            try c.encode(message, forKey: .message)
+        case .worktreeSessionCreated(let session):
+            try c.encode("worktreeSessionCreated", forKey: .type)
+            try c.encode(session, forKey: .session)
+        case .worktreeSessionCreationFailed(let stage, let message, let worktreeId):
+            try c.encode("worktreeSessionCreationFailed", forKey: .type)
+            try c.encode(stage, forKey: .stage)
+            try c.encode(message, forKey: .message)
+            try c.encodeIfPresent(worktreeId, forKey: .worktreeId)
         case .sessionCreated(let session):
             try c.encode("sessionCreated", forKey: .type)
             try c.encode(session, forKey: .session)

--- a/Alas/Sources/Remote/Server/RemoteConnection.swift
+++ b/Alas/Sources/Remote/Server/RemoteConnection.swift
@@ -37,13 +37,14 @@ final class RemoteConnection: @unchecked Sendable {
     /// `gateway.handle` awaits the previous one, so messages are processed in
     /// arrival order — clients rely on this (e.g. a `takeOver` must land before
     /// the `sendPrompt` that follows it). Mutated only on `queue`.
-    private var processingTail: Task<Void, Never>?
+    private var processingTail: MessageProcessingTask?
     /// Task of the most recently dispatched `isDriveOrdering` message
     /// (sendPrompt/takeOver). A following `stop` awaits exactly this —
     /// narrower than the full `processingTail` — so it lands after a turn
     /// the user just started without being blocked by unrelated queued read
     /// work (subscribe/fetchOlder/list*/etc). Mutated only on `queue`.
     private var lastDriveActionTail: Task<Void, Never>?
+    private var lastDriveActionID: UUID?
     /// Reassembles fragmented WebSocket messages before they're decoded.
     private var reassembler = WebSocketReassembler()
     /// The device this connection authenticated as, set on `queue` once the WS
@@ -351,20 +352,17 @@ final class RemoteConnection: @unchecked Sendable {
             }
             return
         }
-        let previous = processingTail
-        let task = Task { @MainActor in
-            await previous?.value
-            // Only drive-ordering tasks are ever explicitly cancelled (by a
-            // timed-out stop, above) — this check is a no-op for every other
-            // message type, which nothing cancels.
-            if msg.isDriveOrdering {
-                guard !Task.isCancelled else { return }
+        let task = MessageProcessingTask(previous: processingTail)
+        task.start(
+            operation: { await gateway.handle(msg) },
+            onFinish: { [weak self] id in
+                self?.onQueue { [weak self] in self?.finishProcessingTask(id: id) }
             }
-            await gateway.handle(msg)
-        }
+        )
         processingTail = task
         if msg.isDriveOrdering {
-            lastDriveActionTail = task
+            lastDriveActionTail = task.task
+            lastDriveActionID = task.id
         }
     }
 
@@ -399,12 +397,93 @@ final class RemoteConnection: @unchecked Sendable {
         guard !closed else { return }
         closed = true
         isClosing = true
-        processingTail?.cancel()
+        processingTail?.cancelForTeardown()
         processingTail = nil
+        lastDriveActionTail = nil
+        lastDriveActionID = nil
         if let gateway { Task { @MainActor in gateway.close() } }
         gateway = nil
         conn.cancel()
         onClose(self)
+    }
+
+    private func finishProcessingTask(id: UUID) {
+        guard let tail = processingTail, let completed = tail.task(withID: id) else { return }
+        completed.markFinished()
+        if tail.isFinished {
+            processingTail = nil
+        } else {
+            tail.pruneFinishedPredecessors()
+        }
+        if lastDriveActionID == id {
+            lastDriveActionTail = nil
+            lastDriveActionID = nil
+        }
+    }
+
+    /// Queue-confined node in the ordered message chain. The task only captures
+    /// its predecessor's task handle, never this node, so node/task references
+    /// cannot form a cycle. Completion is reported to `RemoteConnection`, which
+    /// marks and unlinks this node on the connection queue.
+    final class MessageProcessingTask: @unchecked Sendable {
+        let id = UUID()
+        private(set) var task: Task<Void, Never>!
+        private(set) var previous: MessageProcessingTask?
+        private(set) var isFinished = false
+
+        init(previous: MessageProcessingTask?) {
+            self.previous = previous
+        }
+
+        func start(
+            operation: @escaping @MainActor @Sendable () async -> Void,
+            onFinish: @escaping @Sendable (UUID) -> Void = { _ in }
+        ) {
+            precondition(task == nil)
+            let previousTask = previous?.task
+            let id = id
+            task = Task { @MainActor in
+                defer { onFinish(id) }
+                await previousTask?.value
+                guard !Task.isCancelled else { return }
+                await operation()
+            }
+        }
+
+        func cancelForTeardown() {
+            var current: MessageProcessingTask? = self
+            while let node = current, !node.isFinished {
+                node.task.cancel()
+                current = node.previous
+            }
+        }
+
+        func task(withID id: UUID) -> MessageProcessingTask? {
+            var current: MessageProcessingTask? = self
+            while let node = current {
+                if node.id == id { return node }
+                current = node.previous
+            }
+            return nil
+        }
+
+        func markFinished() {
+            isFinished = true
+        }
+
+        func pruneFinishedPredecessors() {
+            var current: MessageProcessingTask? = self
+            while let node = current {
+                while let previous = node.previous, previous.isFinished {
+                    node.previous = previous.previous
+                }
+                current = node.previous
+            }
+        }
+
+        var hasPredecessor: Bool {
+            previous != nil
+        }
     }
 
     static func acceptKey(for key: String) -> String {

--- a/AlasTests/AppStateCreateWorktreeCompletionTests.swift
+++ b/AlasTests/AppStateCreateWorktreeCompletionTests.swift
@@ -140,4 +140,141 @@ struct AppStateCreateWorktreeCompletionTests {
 
         #expect(result == .success(Self.worktree))
     }
+
+    @Test
+    func waiterStopsPollingWhenItsCallerIsCancelled() async {
+        let outcome = WorktreeCreationWaitOutcome()
+        let gate = WorktreeCreationPollGate(outcome: outcome)
+        var state: WorktreeOperationState? = .creating
+        let task = Task { @MainActor in
+            let result = await WorktreeCreationCompletion.wait(
+                id: "pending",
+                maxPolls: 1,
+                operationState: { state },
+                worktree: { nil },
+                sleep: { await gate.wait() }
+            )
+            let interrupted = result == .failure(.init(message: "Worktree creation was interrupted."))
+            await outcome.recordCompletion(interrupted: interrupted)
+            return interrupted
+        }
+
+        guard await gate.waitForFirstEntry() else {
+            Issue.record("waiter did not enter its first poll")
+            task.cancel()
+            await gate.releaseAll()
+            _ = await task.value
+            return
+        }
+        task.cancel()
+        await gate.releaseOne()
+
+        let event = await outcome.waitForEvent()
+
+        // Let the pre-fix waiter leave its second poll rather than leaking it
+        // when this assertion demonstrates that it ignored cancellation.
+        state = nil
+        await gate.releaseAll()
+
+        switch event {
+        case .secondPoll:
+            Issue.record("cancelled waiter started a second poll")
+        case .completed(let interrupted):
+            #expect(interrupted)
+        case .timedOut:
+            Issue.record("cancelled waiter did not complete")
+        }
+        #expect(await task.value)
+    }
+}
+
+private actor WorktreeCreationPollGate {
+    private static let timeoutNanoseconds: UInt64 = 1_000_000_000
+    private let outcome: WorktreeCreationWaitOutcome
+    private var entries = 0
+    private var isOpen = false
+    private var firstEntryContinuation: CheckedContinuation<Bool, Never>?
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    init(outcome: WorktreeCreationWaitOutcome) {
+        self.outcome = outcome
+    }
+
+    func wait() async {
+        entries += 1
+        if entries == 1 {
+            firstEntryContinuation?.resume(returning: true)
+            firstEntryContinuation = nil
+        } else if entries == 2 {
+            await outcome.recordSecondPoll()
+        }
+        if isOpen { return }
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func waitForFirstEntry() async -> Bool {
+        guard entries == 0 else { return true }
+        return await withCheckedContinuation { continuation in
+            firstEntryContinuation = continuation
+            Task {
+                try? await Task.sleep(nanoseconds: Self.timeoutNanoseconds)
+                firstEntryContinuation?.resume(returning: false)
+                firstEntryContinuation = nil
+            }
+        }
+    }
+
+    func releaseOne() {
+        guard !continuations.isEmpty else { return }
+        continuations.removeFirst().resume()
+    }
+
+    func releaseAll() {
+        isOpen = true
+        let pending = continuations
+        continuations.removeAll()
+        for continuation in pending {
+            continuation.resume()
+        }
+    }
+}
+
+private actor WorktreeCreationWaitOutcome {
+    enum Event {
+        case secondPoll
+        case completed(interrupted: Bool)
+        case timedOut
+    }
+
+    private static let timeoutNanoseconds: UInt64 = 1_000_000_000
+    private var event: Event?
+    private var continuation: CheckedContinuation<Event, Never>?
+
+    func recordSecondPoll() {
+        record(.secondPoll)
+    }
+
+    func recordCompletion(interrupted: Bool) {
+        record(.completed(interrupted: interrupted))
+    }
+
+    func waitForEvent() async -> Event {
+        if let event { return event }
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            Task {
+                try? await Task.sleep(nanoseconds: Self.timeoutNanoseconds)
+                record(.timedOut)
+            }
+        }
+    }
+
+    private func record(_ event: Event) {
+        guard self.event == nil else { return }
+        self.event = event
+        continuation?.resume(returning: event)
+        continuation = nil
+    }
 }

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -781,6 +781,226 @@ struct RemoteAppStateAccessTests {
         #expect(result == .failure("Repository is no longer available."))
     }
 
+    @Test func remoteSessionsProviderCreatesWorktreeSessionAndFocusesIt() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        let worktreeRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-remote-create-root-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: worktreeRoot)
+            try? FileManager.default.removeItem(at: repository)
+        }
+        let project = ProjectConfig(
+            id: "project-remote-create",
+            name: "Remote Create",
+            path: repository.path,
+            color: "blue",
+            addedAt: Date()
+        )
+        let state = AppState(store: ProjectMemoryStore(
+            projectsFile: ProjectsFile(projects: [project])
+        ))
+        state.config.worktrees.rootPath = worktreeRoot.path
+        state.config.worktrees.pathTemplate = "{worktreeRoot}/{repo}-{branch}"
+        state.agentRegistry = enabledClaudeRegistry()
+        state.remoteSessionAttachScheduler = { _, _ in }
+
+        let provider: RemoteSessionsProvider = state
+        let result = await provider.createRemoteWorktreeSession(
+            projectId: project.id,
+            base: "main",
+            branch: "feature/phone",
+            agentId: "claude"
+        )
+
+        guard case let .success(summary) = result else {
+            Issue.record("expected combined creation success, got \(result)")
+            return
+        }
+        let worktree = try #require(summary.worktree)
+        let worktreeId = Worktree.makeId(path: URL(fileURLWithPath: worktree.path))
+        defer { cleanupRemoteRenameFiles(worktreeId: worktreeId) }
+        #expect(worktree.branch == "feature/phone")
+        #expect(FileManager.default.fileExists(atPath: worktree.path))
+        #expect(state.selectedWorktreeId == worktreeId)
+        let tab = try #require(firstACPTab(in: state, worktreeId: worktreeId))
+        #expect(tab.sessionId == summary.id)
+        #expect(state.tabs.activeTabId(forWorktree: worktreeId) == tab.id)
+    }
+
+    @Test func remoteCreateWorktreeSessionRejectsMissingProjectAndInvalidBranchSafely() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        let project = ProjectConfig(
+            id: "project-remote-reject",
+            name: "Remote Reject",
+            path: repository.path,
+            color: "blue",
+            addedAt: Date()
+        )
+        let state = AppState(store: ProjectMemoryStore(
+            projectsFile: ProjectsFile(projects: [project])
+        ))
+        state.agentRegistry = enabledClaudeRegistry()
+        var branchLookupCount = 0
+        state.remoteWorktreeBranchLoader = { _ in
+            branchLookupCount += 1
+            return ["main"]
+        }
+
+        let missing = await state.createRemoteWorktreeSession(
+            projectId: "missing",
+            base: "main",
+            branch: "feature/phone",
+            agentId: "claude"
+        )
+        let invalid = await state.createRemoteWorktreeSession(
+            projectId: project.id,
+            base: "main",
+            branch: "bad..branch",
+            agentId: "claude"
+        )
+        let invalidAgent = await state.createRemoteWorktreeSession(
+            projectId: project.id,
+            base: "main",
+            branch: "feature/phone",
+            agentId: "missing-agent"
+        )
+        #expect(branchLookupCount == 0)
+
+        let missingBase = await state.createRemoteWorktreeSession(
+            projectId: project.id,
+            base: "missing-base",
+            branch: "feature/phone",
+            agentId: "claude"
+        )
+        let invalidBase = await state.createRemoteWorktreeSession(
+            projectId: project.id,
+            base: "bad..base",
+            branch: "feature/phone",
+            agentId: "claude"
+        )
+
+        #expect(missing == .failure(
+            stage: .worktree,
+            message: "Repository is no longer available.",
+            worktreeId: nil
+        ))
+        #expect(invalid == .failure(
+            stage: .worktree,
+            message: "Could not create worktree.",
+            worktreeId: nil
+        ))
+        #expect(invalidAgent == .failure(
+            stage: .worktree,
+            message: "Could not create worktree.",
+            worktreeId: nil
+        ))
+        #expect(missingBase == .failure(
+            stage: .worktree,
+            message: "Could not create worktree.",
+            worktreeId: nil
+        ))
+        #expect(invalidBase == .failure(
+            stage: .worktree,
+            message: "Could not create worktree.",
+            worktreeId: nil
+        ))
+    }
+
+    @Test func remoteCreateWorktreeSessionRejectsRemoteDestinationBeforeCreating() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        defer {
+            RemoteHostRegistry.shared.unregister(root: repository.path)
+            try? FileManager.default.removeItem(at: repository)
+        }
+        let project = ProjectConfig(
+            id: "project-remote-collision",
+            name: "Remote Collision",
+            path: repository.path,
+            color: "blue",
+            addedAt: Date(),
+            host: "remote.test"
+        )
+        let state = AppState(store: ProjectMemoryStore(
+            projectsFile: ProjectsFile(projects: [project])
+        ))
+        state.agentRegistry = enabledClaudeRegistry()
+        state.config.worktrees.rootPath = "/remote worktrees"
+        state.config.worktrees.pathTemplate = "{worktreeRoot}/{repo}-{branch}"
+        state.remoteWorktreeBranchLoader = { _ in ["main"] }
+        state.remoteWorktreeDestinationPreparer = { _, destination in destination }
+        var command: (host: String, cwd: String?, command: String)?
+        state.remoteWorktreeCommandRunner = { host, cwd, commandToRun in
+            command = (host, cwd, commandToRun)
+            return ProcessResult(exitCode: 0, stdout: "", stderr: "")
+        }
+        var sessionCreationAttempted = false
+        state.remoteSessionCreator = { _, _ in
+            sessionCreationAttempted = true
+            return .failure("should not be reached")
+        }
+
+        let result = await state.createRemoteWorktreeSession(
+            projectId: project.id,
+            base: "main",
+            branch: "feature/phone",
+            agentId: "claude"
+        )
+
+        #expect(result == .failure(
+            stage: .worktree,
+            message: "A worktree already exists at this path.",
+            worktreeId: nil
+        ))
+        #expect(command?.host == "remote.test")
+        #expect(command?.cwd == nil)
+        #expect(command?.command == "test -e '/remote worktrees/Remote Collision-feature-phone'")
+        #expect(state.projectsManager.visibleWorktrees(projectId: project.id).isEmpty)
+        #expect(!sessionCreationAttempted)
+    }
+
+    @Test func remoteCreateWorktreeSessionPreservesWorktreeWhenSessionCreationFails() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        let worktreeRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-remote-session-failure-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: worktreeRoot)
+            try? FileManager.default.removeItem(at: repository)
+        }
+        let project = ProjectConfig(
+            id: "project-remote-session-failure",
+            name: "Remote Session Failure",
+            path: repository.path,
+            color: "blue",
+            addedAt: Date()
+        )
+        let state = AppState(store: ProjectMemoryStore(
+            projectsFile: ProjectsFile(projects: [project])
+        ))
+        state.config.worktrees.rootPath = worktreeRoot.path
+        state.config.worktrees.pathTemplate = "{worktreeRoot}/{repo}-{branch}"
+        state.agentRegistry = enabledClaudeRegistry()
+        state.remoteSessionCreator = { _, _ in .failure("internal details") }
+
+        let result = await state.createRemoteWorktreeSession(
+            projectId: project.id,
+            base: "main",
+            branch: "feature/phone",
+            agentId: "claude"
+        )
+
+        guard case let .failure(stage, message, worktreeId) = result else {
+            Issue.record("expected session creation failure, got \(result)")
+            return
+        }
+        #expect(stage == .session)
+        #expect(message == "Worktree created, but the session could not be created.")
+        let createdWorktreeId = try #require(worktreeId)
+        defer { cleanupRemoteRenameFiles(worktreeId: createdWorktreeId) }
+        let createdWorktree = try #require(state.worktree(withId: createdWorktreeId))
+        #expect(FileManager.default.fileExists(atPath: createdWorktree.path.path))
+    }
+
     private func statusCode(port: UInt16, host: String, path: String) async throws -> Int? {
         var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)\(path)")!)
         req.setValue(host, forHTTPHeaderField: "Host")
@@ -879,6 +1099,16 @@ struct RemoteAppStateAccessTests {
         _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "initial"], cwd: repository)
         _ = try await Process.git(["branch", "feature/remote"], cwd: repository)
         return repository
+    }
+
+    private func enabledClaudeRegistry() -> AgentRegistry {
+        AgentRegistry(
+            builtinState: [
+                "claude": BuiltinAgentState(isEnabled: true, binaryOverride: nil, extraTerminalArgs: nil),
+            ],
+            customs: [],
+            installedIds: ["claude"]
+        )
     }
 
     private func acpTabs(in state: AppState) -> [ACPSessionTabState] {

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -721,6 +721,66 @@ struct RemoteAppStateAccessTests {
         #expect(nonACP == .failure("Agent is no longer available."))
     }
 
+    @Test func remoteProjectsPreserveConfiguredProjectIDsAndNames() async {
+        let firstProject = ProjectConfig(
+            id: "project-first",
+            name: "First Project",
+            path: "/tmp/first-project",
+            color: "blue",
+            addedAt: Date()
+        )
+        let secondProject = ProjectConfig(
+            id: "project-second",
+            name: "Second Project",
+            path: "/tmp/second-project",
+            color: "green",
+            addedAt: Date()
+        )
+        let state = AppState(store: ProjectMemoryStore(
+            projectsFile: ProjectsFile(projects: [firstProject, secondProject])
+        ))
+
+        let projects = await state.remoteProjects()
+
+        #expect(projects == [
+            RemoteProjectOption(id: "project-first", name: "First Project"),
+            RemoteProjectOption(id: "project-second", name: "Second Project"),
+        ])
+    }
+
+    @Test func remoteBranchesReturnsBranchesAndPrefersMain() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        let project = ProjectConfig(
+            id: "project-branches",
+            name: "Branch Project",
+            path: repository.path,
+            color: "blue",
+            addedAt: Date()
+        )
+        let state = AppState(store: ProjectMemoryStore(
+            projectsFile: ProjectsFile(projects: [project])
+        ))
+
+        let result = await state.remoteBranches(projectId: project.id)
+
+        guard case let .success(branches, preferredBase) = result else {
+            Issue.record("expected branch list success, got \(result)")
+            return
+        }
+        #expect(branches.contains("main"))
+        #expect(branches.contains("feature/remote"))
+        #expect(preferredBase == "main")
+    }
+
+    @Test func remoteBranchesRejectsMissingProject() async {
+        let state = AppState(store: ProjectMemoryStore(projectsFile: ProjectsFile(projects: [])))
+
+        let result = await state.remoteBranches(projectId: "missing-project")
+
+        #expect(result == .failure("Repository is no longer available."))
+    }
+
     private func statusCode(port: UInt16, host: String, path: String) async throws -> Int? {
         var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)\(path)")!)
         req.setValue(host, forHTTPHeaderField: "Host")
@@ -807,6 +867,18 @@ struct RemoteAppStateAccessTests {
             installedIds: ["test-agent"]
         )
         return state
+    }
+
+    private func makeRemoteBranchesRepository() async throws -> URL {
+        let repository = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-remote-branches-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repository, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repository)
+        _ = try await Process.git(["config", "user.email", "test@example.com"], cwd: repository)
+        _ = try await Process.git(["config", "user.name", "Test User"], cwd: repository)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "initial"], cwd: repository)
+        _ = try await Process.git(["branch", "feature/remote"], cwd: repository)
+        return repository
     }
 
     private func acpTabs(in state: AppState) -> [ACPSessionTabState] {

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -8,6 +8,106 @@ struct RemoteProtocolTests {
         return try JSONDecoder().decode(T.self, from: data)
     }
 
+    @Test func worktreeCreationClientMessagesRoundTripAndEncodeRequiredFields() throws {
+        let listProjects = RemoteClientMessage.listProjects
+        #expect(try roundTrip(listProjects) == listProjects)
+
+        let listBranches = RemoteClientMessage.listBranches(projectId: "project-1")
+        #expect(try roundTrip(listBranches) == listBranches)
+
+        let create = RemoteClientMessage.createWorktreeSession(
+            projectId: "project-1", base: "origin/main", branch: "feature/remote-create", agentId: "codex")
+        #expect(try roundTrip(create) == create)
+        let object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(create)) as? [String: Any])
+        #expect(object["type"] as? String == "createWorktreeSession")
+        #expect(object["projectId"] as? String == "project-1")
+        #expect(object["base"] as? String == "origin/main")
+        #expect(object["branch"] as? String == "feature/remote-create")
+        #expect(object["agentId"] as? String == "codex")
+    }
+
+    @Test func worktreeCreationServerMessagesRoundTripAndEncodeRequiredFields() throws {
+        let projects = [RemoteProjectOption(id: "project-1", name: "alas")]
+        #expect(try roundTrip(RemoteServerMessage.projectList(projects: projects)) == .projectList(projects: projects))
+
+        let branchList = RemoteServerMessage.branchList(
+            projectId: "project-1", branches: ["main", "develop"], preferredBase: "main")
+        #expect(try roundTrip(branchList) == branchList)
+
+        let branchFailure = RemoteServerMessage.branchListFailed(
+            projectId: "project-1", message: "Could not load branches.")
+        #expect(try roundTrip(branchFailure) == branchFailure)
+
+        let session = RemoteSessionSummary(id: "s1", title: "New", agentId: "codex", status: "idle", canDrive: true)
+        let created = RemoteServerMessage.worktreeSessionCreated(session: session)
+        #expect(try roundTrip(created) == created)
+
+        let failure = RemoteServerMessage.worktreeSessionCreationFailed(
+            stage: .session,
+            message: "Worktree created, but the session could not be created.",
+            worktreeId: "/tmp/alas-feature")
+        #expect(try roundTrip(failure) == failure)
+
+        let object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(failure)) as? [String: Any])
+        #expect(object["type"] as? String == "worktreeSessionCreationFailed")
+        #expect(object["stage"] as? String == "session")
+        #expect(object["message"] as? String == "Worktree created, but the session could not be created.")
+        #expect(object["worktreeId"] as? String == "/tmp/alas-feature")
+    }
+
+    @Test func worktreeCreationMessagesRejectMissingRequiredFields() throws {
+        let invalidClientPayloads = [
+            #"{"type":"listBranches"}"#,
+            #"{"type":"createWorktreeSession","base":"main","branch":"feature","agentId":"codex"}"#,
+            #"{"type":"createWorktreeSession","projectId":"p","branch":"feature","agentId":"codex"}"#,
+            #"{"type":"createWorktreeSession","projectId":"p","base":"main","agentId":"codex"}"#,
+            #"{"type":"createWorktreeSession","projectId":"p","base":"main","branch":"feature"}"#,
+        ]
+        for payload in invalidClientPayloads {
+            #expect(throws: DecodingError.self) {
+                _ = try JSONDecoder().decode(RemoteClientMessage.self, from: Data(payload.utf8))
+            }
+        }
+
+        let invalidServerPayloads = [
+            #"{"type":"branchList","branches":[],"preferredBase":"main"}"#,
+            #"{"type":"branchListFailed","message":"failed"}"#,
+            #"{"type":"worktreeSessionCreationFailed","message":"failed"}"#,
+            #"{"type":"worktreeSessionCreationFailed","message":"failed","stage":"invalid"}"#,
+        ]
+        for payload in invalidServerPayloads {
+            #expect(throws: DecodingError.self) {
+                _ = try JSONDecoder().decode(RemoteServerMessage.self, from: Data(payload.utf8))
+            }
+        }
+
+        for stage in [RemoteWorktreeSessionCreationStage.worktree, .session] {
+            let withoutWorktreeId = try #require(
+                try? JSONDecoder().decode(
+                    RemoteServerMessage.self,
+                    from: Data(#"{"type":"worktreeSessionCreationFailed","message":"failed","stage":"\#(stage.rawValue)"}"#.utf8)
+                )
+            )
+            #expect(
+                withoutWorktreeId == .worktreeSessionCreationFailed(
+                    stage: stage, message: "failed", worktreeId: nil)
+            )
+            #expect(try roundTrip(withoutWorktreeId) == withoutWorktreeId)
+        }
+    }
+
+    @Test func worktreeCreationClientMessagesAreNotControlOrDriveOrdered() {
+        let messages: [RemoteClientMessage] = [
+            .listProjects,
+            .listBranches(projectId: "project-1"),
+            .createWorktreeSession(projectId: "project-1", base: "main", branch: "feature", agentId: "codex"),
+        ]
+        for message in messages {
+            #expect(!message.isControl)
+            #expect(!message.isDriveOrdering)
+        }
+    }
+
     @Test func clientMessageDecodesSubscribe() throws {
         let json = #"{"type":"subscribe","sessionId":"s1"}"#.data(using: .utf8)!
         let msg = try JSONDecoder().decode(RemoteClientMessage.self, from: json)

--- a/AlasTests/Remote/RemoteServerIntegrationTests.swift
+++ b/AlasTests/Remote/RemoteServerIntegrationTests.swift
@@ -27,6 +27,76 @@ struct RemoteServerIntegrationTests {
         return (server, try #require(server.port))
     }
 
+    @Test func teardownCancelsQueuedPredecessorAndSkipsSuccessor() async {
+        let gate = CancellableTaskGate()
+        let previous = RemoteConnection.MessageProcessingTask(previous: nil)
+        previous.start {
+            await withTaskCancellationHandler(
+                operation: { await gate.waitForRelease() },
+                onCancel: { Task { await gate.recordCancellation() } }
+            )
+            await gate.recordCompletion(wasCancelled: Task.isCancelled)
+        }
+        guard await gate.waitForEntry() else {
+            Issue.record("predecessor did not start")
+            await gate.release()
+            return
+        }
+
+        let successor = RemoteConnection.MessageProcessingTask(previous: previous)
+        successor.start {
+            await gate.recordHandlerRun()
+        }
+        successor.cancelForTeardown()
+
+        let didCancelPredecessor = await gate.waitForCancellation()
+        await gate.release()
+
+        await previous.task.value
+        #expect(didCancelPredecessor)
+        #expect(await gate.completedWhileCancelled())
+        await successor.task.value
+        #expect(await gate.handlerDidRun() == false)
+    }
+
+    @Test func stopTimeoutCancellationDoesNotCancelQueuedPredecessor() async {
+        let gate = CancellableTaskGate()
+        let previous = RemoteConnection.MessageProcessingTask(previous: nil)
+        previous.start {
+            await withTaskCancellationHandler(
+                operation: { await gate.waitForRelease() },
+                onCancel: { Task { await gate.recordCancellation() } }
+            )
+            await gate.recordCompletion(wasCancelled: Task.isCancelled)
+        }
+        guard await gate.waitForEntry() else {
+            Issue.record("predecessor did not start")
+            await gate.release()
+            return
+        }
+
+        let successor = RemoteConnection.MessageProcessingTask(previous: previous)
+        successor.start {}
+        successor.task.cancel()
+        await gate.release()
+
+        await previous.task.value
+        #expect(await gate.completedWhileCancelled() == false)
+        await successor.task.value
+    }
+
+    @Test func completedPredecessorIsPrunedFromSuccessor() async {
+        let predecessor = RemoteConnection.MessageProcessingTask(previous: nil)
+        predecessor.start {}
+        await predecessor.task.value
+        predecessor.markFinished()
+
+        let successor = RemoteConnection.MessageProcessingTask(previous: predecessor)
+        #expect(successor.hasPredecessor)
+        successor.pruneFinishedPredecessors()
+        #expect(successor.hasPredecessor == false)
+    }
+
     @Test func pairThenWebSocketSubscribeReceivesSnapshot() async throws {
         // Provider with one session containing one agent message.
         let provider = FakeSessionsProvider()
@@ -876,5 +946,91 @@ struct RemoteServerIntegrationTests {
             data.append(chunk)
             return data
         }
+    }
+}
+
+private actor CancellableTaskGate {
+    private static let timeoutNanoseconds: UInt64 = 1_000_000_000
+    private var entered = false
+    private var released = false
+    private var cancelled = false
+    private var completedWithCancellation = false
+    private var handlerRan = false
+    private var entryContinuation: CheckedContinuation<Bool, Never>?
+    private var cancellationContinuation: CheckedContinuation<Bool, Never>?
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func waitForRelease() async {
+        entered = true
+        finishEntry(true)
+        guard !released else { return }
+        await withCheckedContinuation { releaseContinuation = $0 }
+    }
+
+    func waitForEntry() async -> Bool {
+        guard !entered else { return true }
+        return await withCheckedContinuation { continuation in
+            entryContinuation = continuation
+            scheduleEntryTimeout()
+        }
+    }
+
+    func recordCancellation() {
+        cancelled = true
+        finishCancellation(true)
+    }
+
+    func waitForCancellation() async -> Bool {
+        guard !cancelled else { return true }
+        return await withCheckedContinuation { continuation in
+            cancellationContinuation = continuation
+            scheduleCancellationTimeout()
+        }
+    }
+
+    func recordCompletion(wasCancelled: Bool) {
+        completedWithCancellation = wasCancelled
+    }
+
+    func completedWhileCancelled() -> Bool {
+        completedWithCancellation
+    }
+
+    func recordHandlerRun() {
+        handlerRan = true
+    }
+
+    func handlerDidRun() -> Bool {
+        handlerRan
+    }
+
+    func release() {
+        released = true
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+
+    private func scheduleEntryTimeout() {
+        Task {
+            try? await Task.sleep(nanoseconds: Self.timeoutNanoseconds)
+            finishEntry(false)
+        }
+    }
+
+    private func scheduleCancellationTimeout() {
+        Task {
+            try? await Task.sleep(nanoseconds: Self.timeoutNanoseconds)
+            finishCancellation(false)
+        }
+    }
+
+    private func finishEntry(_ value: Bool) {
+        entryContinuation?.resume(returning: value)
+        entryContinuation = nil
+    }
+
+    private func finishCancellation(_ value: Bool) {
+        cancellationContinuation?.resume(returning: value)
+        cancellationContinuation = nil
     }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -50,7 +50,9 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var sessionSummariesCallCount = 0
     var remoteWorktreesCallCount = 0
     var remoteProjectsCallCount = 0
+    var remoteProjectsCompletionCount = 0
     var remoteBranchesCallCount = 0
+    var remoteBranchesCompletionCount = 0
     var remoteBranchRequests: [String] = []
     var remoteAgentsCallCount = 0
     var createRequests: [(worktreeId: String, agentId: String)] = []
@@ -66,6 +68,10 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     private var remoteWorktreesContinuation: CheckedContinuation<[RemoteWorktreeOption], Never>?
     private var remoteProjectsContinuation: CheckedContinuation<[RemoteProjectOption], Never>?
     private var remoteBranchesContinuation: CheckedContinuation<RemoteBranchListResult, Never>?
+    private var remoteProjectsCallWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+    private var remoteProjectsCompletionWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+    private var remoteBranchesCallWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+    private var remoteBranchesCompletionWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
     private var fullToolCallContentContinuation: CheckedContinuation<String?, Never>?
     func sessionSummaries() async -> [RemoteSessionSummary] {
         sessionSummariesCallCount += 1
@@ -87,22 +93,34 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     }
     func remoteProjects() async -> [RemoteProjectOption] {
         remoteProjectsCallCount += 1
+        resumeWaiters(&remoteProjectsCallWaiters, through: remoteProjectsCallCount)
+        let result: [RemoteProjectOption]
         if pauseRemoteProjects {
-            return await withCheckedContinuation { continuation in
+            result = await withCheckedContinuation { continuation in
                 remoteProjectsContinuation = continuation
             }
+        } else {
+            result = projects
         }
-        return projects
+        remoteProjectsCompletionCount += 1
+        resumeWaiters(&remoteProjectsCompletionWaiters, through: remoteProjectsCompletionCount)
+        return result
     }
     func remoteBranches(projectId: String) async -> RemoteBranchListResult {
         remoteBranchesCallCount += 1
         remoteBranchRequests.append(projectId)
+        resumeWaiters(&remoteBranchesCallWaiters, through: remoteBranchesCallCount)
+        let result: RemoteBranchListResult
         if pauseRemoteBranches {
-            return await withCheckedContinuation { continuation in
+            result = await withCheckedContinuation { continuation in
                 remoteBranchesContinuation = continuation
             }
+        } else {
+            result = branchResults[projectId] ?? .failure("Could not load branches.")
         }
-        return branchResults[projectId] ?? .failure("Could not load branches.")
+        remoteBranchesCompletionCount += 1
+        resumeWaiters(&remoteBranchesCompletionWaiters, through: remoteBranchesCompletionCount)
+        return result
     }
     func remoteAgents() -> [RemoteAgentOption] {
         remoteAgentsCallCount += 1
@@ -138,6 +156,38 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
             returning: branchResults[projectId] ?? .failure("Could not load branches.")
         )
         remoteBranchesContinuation = nil
+    }
+    func waitForRemoteProjectsCall(_ count: Int) async {
+        guard remoteProjectsCallCount < count else { return }
+        await withCheckedContinuation { continuation in
+            remoteProjectsCallWaiters.append((count, continuation))
+        }
+    }
+    func waitForRemoteProjectsCompletion(_ count: Int) async {
+        guard remoteProjectsCompletionCount < count else { return }
+        await withCheckedContinuation { continuation in
+            remoteProjectsCompletionWaiters.append((count, continuation))
+        }
+    }
+    func waitForRemoteBranchesCall(_ count: Int) async {
+        guard remoteBranchesCallCount < count else { return }
+        await withCheckedContinuation { continuation in
+            remoteBranchesCallWaiters.append((count, continuation))
+        }
+    }
+    func waitForRemoteBranchesCompletion(_ count: Int) async {
+        guard remoteBranchesCompletionCount < count else { return }
+        await withCheckedContinuation { continuation in
+            remoteBranchesCompletionWaiters.append((count, continuation))
+        }
+    }
+    private func resumeWaiters(
+        _ waiters: inout [(count: Int, continuation: CheckedContinuation<Void, Never>)],
+        through count: Int
+    ) {
+        let ready = waiters.filter { $0.count <= count }
+        waiters.removeAll { $0.count <= count }
+        ready.forEach { $0.continuation.resume() }
     }
     func session(for id: String) -> ACPSession? { sessions[id] }
     func permissionPolicy(for id: String) -> ACPPermissionPolicy? { policies[id] }
@@ -371,6 +421,273 @@ struct RemoteSessionGatewayTests {
 
         #expect(provider.remoteAgentsCallCount == 1)
         #expect(sent == [.agentList(agents: provider.agents)])
+    }
+
+    @Test func listProjectsEmitsProjectList() async {
+        let provider = FakeSessionsProvider()
+        provider.projects = [RemoteProjectOption(id: "project-1", name: "Alas")]
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.listProjects)
+        for _ in 0..<10 where sent.isEmpty {
+            await Task.yield()
+        }
+
+        #expect(provider.remoteProjectsCallCount == 1)
+        #expect(sent == [.projectList(projects: provider.projects)])
+    }
+
+    @Test func listProjectsDropsSupersededPausedResponse() async {
+        let provider = FakeSessionsProvider()
+        let oldProjects = [RemoteProjectOption(id: "project-old", name: "Old")]
+        let newProjects = [RemoteProjectOption(id: "project-new", name: "New")]
+        provider.projects = oldProjects
+        provider.pauseRemoteProjects = true
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.listProjects)
+        await provider.waitForRemoteProjectsCall(1)
+
+        provider.pauseRemoteProjects = false
+        provider.projects = newProjects
+        await gw.handle(.listProjects)
+        await provider.waitForRemoteProjectsCompletion(1)
+
+        provider.projects = oldProjects
+        provider.resumeRemoteProjects()
+        await provider.waitForRemoteProjectsCompletion(2)
+
+        #expect(provider.remoteProjectsCallCount == 2)
+        #expect(sent == [.projectList(projects: newProjects)])
+    }
+
+    @Test func listBranchesEmitsRequestedProjectBranches() async {
+        let provider = FakeSessionsProvider()
+        provider.branchResults["project-1"] = .success(
+            branches: ["main", "feature/remote"],
+            preferredBase: "main"
+        )
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.listBranches(projectId: "project-1"))
+        for _ in 0..<10 where sent.isEmpty {
+            await Task.yield()
+        }
+
+        #expect(provider.remoteBranchRequests == ["project-1"])
+        #expect(sent == [
+            .branchList(
+                projectId: "project-1",
+                branches: ["main", "feature/remote"],
+                preferredBase: "main"
+            )
+        ])
+    }
+
+    @Test func listBranchesEmitsRequestedProjectFailure() async {
+        let provider = FakeSessionsProvider()
+        provider.branchResults["project-1"] = .failure("Repository is no longer available.")
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.listBranches(projectId: "project-1"))
+        for _ in 0..<10 where sent.isEmpty {
+            await Task.yield()
+        }
+
+        #expect(provider.remoteBranchRequests == ["project-1"])
+        #expect(sent == [
+            .branchListFailed(projectId: "project-1", message: "Repository is no longer available.")
+        ])
+    }
+
+    @Test func listBranchesDropsSupersededPausedResponse() async {
+        let provider = FakeSessionsProvider()
+        provider.branchResults["project-old"] = .success(
+            branches: ["main", "feature/old"],
+            preferredBase: "main"
+        )
+        provider.branchResults["project-new"] = .failure("Could not load branches.")
+        provider.pauseRemoteBranches = true
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.listBranches(projectId: "project-old"))
+        await provider.waitForRemoteBranchesCall(1)
+
+        provider.pauseRemoteBranches = false
+        await gw.handle(.listBranches(projectId: "project-new"))
+        await provider.waitForRemoteBranchesCompletion(1)
+
+        provider.resumeRemoteBranches(projectId: "project-old")
+        await provider.waitForRemoteBranchesCompletion(2)
+
+        #expect(provider.remoteBranchRequests == ["project-old", "project-new"])
+        #expect(sent == [
+            .branchListFailed(projectId: "project-new", message: "Could not load branches.")
+        ])
+    }
+
+    @Test func closeCancelsPendingProjectListRefresh() async {
+        let provider = FakeSessionsProvider()
+        provider.projects = [RemoteProjectOption(id: "project-1", name: "Alas")]
+        provider.pauseRemoteProjects = true
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.listProjects)
+        await provider.waitForRemoteProjectsCall(1)
+        gw.close()
+        provider.resumeRemoteProjects()
+        await provider.waitForRemoteProjectsCompletion(1)
+
+        #expect(provider.remoteProjectsCallCount == 1)
+        #expect(sent.isEmpty)
+    }
+
+    @Test func closeCancelsPendingBranchListRefresh() async {
+        let provider = FakeSessionsProvider()
+        provider.branchResults["project-1"] = .success(branches: ["main"], preferredBase: "main")
+        provider.pauseRemoteBranches = true
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.listBranches(projectId: "project-1"))
+        await provider.waitForRemoteBranchesCall(1)
+        gw.close()
+        provider.resumeRemoteBranches(projectId: "project-1")
+        await provider.waitForRemoteBranchesCompletion(1)
+
+        #expect(provider.remoteBranchesCallCount == 1)
+        #expect(sent.isEmpty)
+    }
+
+    @Test func createWorktreeSessionEmitsCreatedSessionAndRefreshesLists() async {
+        let provider = FakeSessionsProvider()
+        let summary = RemoteSessionSummary(
+            id: "session-1",
+            title: "Feature remote",
+            agentId: "claude",
+            status: "idle",
+            canDrive: true
+        )
+        provider.createWorktreeSessionResult = .success(summary)
+        provider.summaries = [summary]
+        provider.worktrees = [
+            RemoteWorktreeOption(
+                id: "worktree-1",
+                projectName: "Alas",
+                worktreeName: "Feature remote",
+                branch: "feature/remote",
+                path: "/tmp/alas-feature-remote",
+                metricsAvailable: false,
+                comparisonRef: nil,
+                commitCount: 0,
+                changedFileCount: 0,
+                addedLines: 0,
+                deletedLines: 0,
+                conflictCount: 0
+            )
+        ]
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.createWorktreeSession(
+            projectId: "project-1",
+            base: "main",
+            branch: "feature/remote",
+            agentId: "claude"
+        ))
+        for _ in 0..<10 {
+            if provider.sessionSummariesCallCount == 1, provider.remoteWorktreesCallCount == 1 { break }
+            await Task.yield()
+        }
+
+        #expect(provider.createWorktreeSessionRequests.count == 1)
+        #expect(provider.createWorktreeSessionRequests.first?.projectId == "project-1")
+        #expect(provider.createWorktreeSessionRequests.first?.base == "main")
+        #expect(provider.createWorktreeSessionRequests.first?.branch == "feature/remote")
+        #expect(provider.createWorktreeSessionRequests.first?.agentId == "claude")
+        #expect(sent.first == .worktreeSessionCreated(session: summary))
+        #expect(sent.contains(.sessionList(sessions: [summary])))
+        #expect(sent.contains(.worktreeList(worktrees: provider.worktrees)))
+        #expect(!sent.contains(.sessionCreated(session: summary)))
+    }
+
+    @Test func createWorktreeSessionEmitsWorktreeFailureWithoutRefreshingLists() async {
+        let provider = FakeSessionsProvider()
+        provider.createWorktreeSessionResult = .failure(
+            stage: .worktree,
+            message: "Could not create worktree.",
+            worktreeId: nil
+        )
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.createWorktreeSession(
+            projectId: "project-1",
+            base: "main",
+            branch: "feature/remote",
+            agentId: "claude"
+        ))
+
+        #expect(sent == [
+            .worktreeSessionCreationFailed(
+                stage: .worktree,
+                message: "Could not create worktree.",
+                worktreeId: nil
+            )
+        ])
+        #expect(provider.sessionSummariesCallCount == 0)
+        #expect(provider.remoteWorktreesCallCount == 0)
+    }
+
+    @Test func createWorktreeSessionEmitsSessionFailureAndRefreshesWorktrees() async {
+        let provider = FakeSessionsProvider()
+        provider.createWorktreeSessionResult = .failure(
+            stage: .session,
+            message: "Worktree created, but the session could not be created.",
+            worktreeId: "worktree-1"
+        )
+        provider.worktrees = [
+            RemoteWorktreeOption(
+                id: "worktree-1",
+                projectName: "Alas",
+                worktreeName: "Feature remote",
+                branch: "feature/remote",
+                path: "/tmp/alas-feature-remote",
+                metricsAvailable: false,
+                comparisonRef: nil,
+                commitCount: 0,
+                changedFileCount: 0,
+                addedLines: 0,
+                deletedLines: 0,
+                conflictCount: 0
+            )
+        ]
+        var sent: [RemoteServerMessage] = []
+        let gw = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gw.handle(.createWorktreeSession(
+            projectId: "project-1",
+            base: "main",
+            branch: "feature/remote",
+            agentId: "claude"
+        ))
+        for _ in 0..<10 where provider.remoteWorktreesCallCount == 0 {
+            await Task.yield()
+        }
+
+        #expect(sent.first == .worktreeSessionCreationFailed(
+            stage: .session,
+            message: "Worktree created, but the session could not be created.",
+            worktreeId: "worktree-1"
+        ))
+        #expect(sent.contains(.worktreeList(worktrees: provider.worktrees)))
+        #expect(provider.sessionSummariesCallCount == 0)
     }
 
     @Test func createSessionEmitsCreatedSession() async {

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -10,6 +10,11 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var branchResults: [String: RemoteBranchListResult] = [:]
     var agents: [RemoteAgentOption] = []
     var createResults: [String: RemoteCreateSessionResult] = [:]
+    var createWorktreeSessionResult: RemoteCreateWorktreeSessionResult = .failure(
+        stage: .worktree,
+        message: "Could not create worktree.",
+        worktreeId: nil
+    )
     var sessions: [String: ACPSession] = [:]
     var policies: [String: ACPPermissionPolicy] = [:]
     var lastQuestionResponse: (id: String, requestId: JSONRPCID, response: ACPQuestionResponse)?
@@ -49,6 +54,7 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var remoteBranchRequests: [String] = []
     var remoteAgentsCallCount = 0
     var createRequests: [(worktreeId: String, agentId: String)] = []
+    var createWorktreeSessionRequests: [(projectId: String, base: String, branch: String, agentId: String)] = []
     var pauseSessionSummaries = false
     var pauseRemoteWorktrees = false
     var pauseRemoteProjects = false
@@ -105,6 +111,15 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     func createRemoteSession(worktreeId: String, agentId: String) async -> RemoteCreateSessionResult {
         createRequests.append((worktreeId, agentId))
         return createResults["\(worktreeId)|\(agentId)"] ?? .failure("Could not create session.")
+    }
+    func createRemoteWorktreeSession(
+        projectId: String,
+        base: String,
+        branch: String,
+        agentId: String
+    ) async -> RemoteCreateWorktreeSessionResult {
+        createWorktreeSessionRequests.append((projectId, base, branch, agentId))
+        return createWorktreeSessionResult
     }
     func resumeSessionSummaries() {
         sessionSummariesContinuation?.resume(returning: summaries)

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -6,6 +6,8 @@ import Foundation
 final class FakeSessionsProvider: RemoteSessionsProvider {
     var summaries: [RemoteSessionSummary] = []
     var worktrees: [RemoteWorktreeOption] = []
+    var projects: [RemoteProjectOption] = []
+    var branchResults: [String: RemoteBranchListResult] = [:]
     var agents: [RemoteAgentOption] = []
     var createResults: [String: RemoteCreateSessionResult] = [:]
     var sessions: [String: ACPSession] = [:]
@@ -42,15 +44,22 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var fullToolCallContentCallCount = 0
     var sessionSummariesCallCount = 0
     var remoteWorktreesCallCount = 0
+    var remoteProjectsCallCount = 0
+    var remoteBranchesCallCount = 0
+    var remoteBranchRequests: [String] = []
     var remoteAgentsCallCount = 0
     var createRequests: [(worktreeId: String, agentId: String)] = []
     var pauseSessionSummaries = false
     var pauseRemoteWorktrees = false
+    var pauseRemoteProjects = false
+    var pauseRemoteBranches = false
     /// 1-indexed call number of `fullToolCallContent` to suspend on (nil = never pause).
     /// Lets a test freeze exactly one in-flight fetch while later calls proceed normally.
     var pauseFullToolCallContentOnCall: Int?
     private var sessionSummariesContinuation: CheckedContinuation<[RemoteSessionSummary], Never>?
     private var remoteWorktreesContinuation: CheckedContinuation<[RemoteWorktreeOption], Never>?
+    private var remoteProjectsContinuation: CheckedContinuation<[RemoteProjectOption], Never>?
+    private var remoteBranchesContinuation: CheckedContinuation<RemoteBranchListResult, Never>?
     private var fullToolCallContentContinuation: CheckedContinuation<String?, Never>?
     func sessionSummaries() async -> [RemoteSessionSummary] {
         sessionSummariesCallCount += 1
@@ -70,6 +79,25 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
         }
         return worktrees
     }
+    func remoteProjects() async -> [RemoteProjectOption] {
+        remoteProjectsCallCount += 1
+        if pauseRemoteProjects {
+            return await withCheckedContinuation { continuation in
+                remoteProjectsContinuation = continuation
+            }
+        }
+        return projects
+    }
+    func remoteBranches(projectId: String) async -> RemoteBranchListResult {
+        remoteBranchesCallCount += 1
+        remoteBranchRequests.append(projectId)
+        if pauseRemoteBranches {
+            return await withCheckedContinuation { continuation in
+                remoteBranchesContinuation = continuation
+            }
+        }
+        return branchResults[projectId] ?? .failure("Could not load branches.")
+    }
     func remoteAgents() -> [RemoteAgentOption] {
         remoteAgentsCallCount += 1
         return agents
@@ -85,6 +113,16 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     func resumeRemoteWorktrees() {
         remoteWorktreesContinuation?.resume(returning: worktrees)
         remoteWorktreesContinuation = nil
+    }
+    func resumeRemoteProjects() {
+        remoteProjectsContinuation?.resume(returning: projects)
+        remoteProjectsContinuation = nil
+    }
+    func resumeRemoteBranches(projectId: String) {
+        remoteBranchesContinuation?.resume(
+            returning: branchResults[projectId] ?? .failure("Could not load branches.")
+        )
+        remoteBranchesContinuation = nil
     }
     func session(for id: String) -> ACPSession? { sessions[id] }
     func permissionPolicy(for id: String) -> ACPPermissionPolicy? { policies[id] }

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,13 +49,13 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=62"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=62"#))
-        #expect(html.contains(#"/style.css?v=40"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v40";"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=63"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=63"#))
+        #expect(html.contains(#"/style.css?v=41"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v41";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=62""#))
-        #expect(sw.contains(#""/style.css?v=40""#))
+        #expect(sw.contains(#""/app.js?v=63""#))
+        #expect(sw.contains(#""/style.css?v=41""#))
     }
 
     @Test func remoteWebToolRowsAvoidNativeButtonRenderingOnMobileSafari() throws {
@@ -68,11 +68,11 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=62"#))
-        #expect(html.contains(#"/style.css?v=40"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v40";"#))
-        #expect(sw.contains(#""/app.js?v=62""#))
-        #expect(sw.contains(#""/style.css?v=40""#))
+        #expect(html.contains(#"/app.js?v=63"#))
+        #expect(html.contains(#"/style.css?v=41"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v41";"#))
+        #expect(sw.contains(#""/app.js?v=63""#))
+        #expect(sw.contains(#""/style.css?v=41""#))
     }
 
     @Test func remoteBareURLLinkifierPreservesIndentedCodeBlocks() throws {
@@ -119,8 +119,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=62"))
-        #expect(html.contains("/style.css?v=40"))
+        #expect(html.contains("/app.js?v=63"))
+        #expect(html.contains("/style.css?v=41"))
     }
 
     @Test func remoteWebExposesSessionRenameControls() throws {
@@ -145,8 +145,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=62""#))
-        #expect(sw.contains(#""/style.css?v=40""#))
+        #expect(sw.contains(#""/app.js?v=63""#))
+        #expect(sw.contains(#""/style.css?v=41""#))
     }
 
     @Test func configSheetScrollsWhenModelListOverflows() throws {
@@ -187,6 +187,46 @@ struct RemoteWebAssetTests {
         #expect(js.contains(#"case "agentList""#))
         #expect(js.contains(#"case "sessionCreated""#))
         #expect(js.contains(#"case "createSessionFailed""#))
+    }
+
+    @Test func remoteWebIntegratesWorktreeCreationController() throws {
+        let html = try asset("index.html")
+        let js = try asset("app.js")
+        let creation = try asset("worktree-creation.js")
+        let sw = try asset("sw.js")
+
+        #expect(html.contains(#"/worktree-creation.js?v=1"#))
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=63"#)!.lowerBound)
+        #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
+        #expect(js.contains(#"case "projectList":"#))
+        #expect(js.contains(#"case "branchList":"#))
+        #expect(js.contains(#"case "branchListFailed":"#))
+        #expect(js.contains(#"case "worktreeSessionCreated":"#))
+        #expect(js.contains(#"case "worktreeSessionCreationFailed":"#))
+        #expect(js.contains("worktreeCreation.disconnect();"))
+        #expect(js.contains(#"worktreeCreation.markRecoveryListLoaded("sessions");"#))
+        #expect(js.contains(#"worktreeCreation.markRecoveryListLoaded("worktrees");"#))
+        #expect(js.contains("function reloadNewWorktreeCatalog()"))
+        #expect(js.contains("worktreeCreation.reloadCatalog();"))
+        #expect(js.contains("reloadNewWorktreeCatalog();"))
+        #expect(js.contains("worktreeCreation.reconcileAgents(createState.agents);"))
+        #expect(!js.contains("`Worktree created. ${creationError.message}`"))
+        #expect(creation.contains(#"type: "listProjects""#))
+        #expect(creation.contains(#"type: "createWorktreeSession""#))
+        #expect(creation.contains("function reloadCatalog()"))
+        #expect(creation.contains("function reconcileAgents(agents)"))
+        #expect(sw.contains(#""/worktree-creation.js?v=1""#))
+    }
+
+    @Test func remoteWebScopesBranchFailuresToTheBaseBranchControl() throws {
+        let html = try asset("index.html")
+        let js = try asset("app.js")
+
+        #expect(html.contains(#"id="create-error" class="sheet-error hidden" role="alert" aria-live="assertive""#))
+        #expect(html.contains(#"id="branch-status" class="form-guidance" role="status""#))
+        #expect(html.contains(#"id="retry-branches""#))
+        #expect(js.contains("creationState.error && creationState.error.stage !== \"branches\""))
+        #expect(js.contains("worktreeCreation.canRetry()"))
     }
 
     @Test func remoteWebClearsSessionSheetsWhenOpeningSession() throws {
@@ -294,9 +334,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v40"))
-        #expect(sw.contains("/app.js?v=62"))
-        #expect(html.contains("app.js?v=62"))
+        #expect(sw.contains("alas-remote-shell-v41"))
+        #expect(sw.contains("/app.js?v=63"))
+        #expect(html.contains("app.js?v=63"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -459,11 +499,11 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=61"#))
-        #expect(html.contains(#"/style.css?v=39"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v39";"#))
-        #expect(sw.contains(#""/app.js?v=61""#))
-        #expect(sw.contains(#""/style.css?v=39""#))
+        #expect(html.contains(#"/app.js?v=63"#))
+        #expect(html.contains(#"/style.css?v=41"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v41";"#))
+        #expect(sw.contains(#""/app.js?v=63""#))
+        #expect(sw.contains(#""/style.css?v=41""#))
     }
 
     @Test func remoteWebOffersUndoAfterASteerDiscardsTheQueue() throws {

--- a/AlasTests/SSH/SSHIntegrationTests.swift
+++ b/AlasTests/SSH/SSHIntegrationTests.swift
@@ -83,6 +83,75 @@ struct SSHIntegrationTests {
         #expect(preferredBase == "main")
     }
 
+    @Test @MainActor func remoteWorktreeSessionCreationOverSSHLocalhost() async throws {
+        try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
+
+        let repository = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ssh-worktree-session-\(UUID().uuidString)")
+        let worktreeRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ssh-worktree-root-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repository, withIntermediateDirectories: true)
+        defer {
+            RemoteHostRegistry.shared.unregister(root: repository.path)
+            try? FileManager.default.removeItem(at: worktreeRoot)
+            try? FileManager.default.removeItem(at: repository)
+        }
+
+        _ = try await Process.run("/usr/bin/env", args: ["git", "init", "-q", "-b", "main"], cwd: repository)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "config", "user.email", "test@example.com"], cwd: repository)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "config", "user.name", "Test User"], cwd: repository)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "commit", "-q", "--allow-empty", "-m", "initial"], cwd: repository)
+        let project = ProjectConfig(
+            id: "ssh-worktree-session",
+            name: "SSH Worktree Session",
+            path: repository.path,
+            color: "blue",
+            addedAt: Date(),
+            host: "localhost"
+        )
+        let state = AppState(store: ProjectMemoryStore(
+            projectsFile: ProjectsFile(projects: [project])
+        ))
+        state.config.worktrees.rootPath = worktreeRoot.path
+        state.config.worktrees.pathTemplate = "{worktreeRoot}/{repo}-{branch}"
+        state.agentRegistry = AgentRegistry(
+            builtinState: [
+                "claude": BuiltinAgentState(isEnabled: true, binaryOverride: nil, extraTerminalArgs: nil),
+            ],
+            customs: [],
+            installedIds: ["claude"]
+        )
+        state.remoteSessionAttachScheduler = { _, _ in }
+
+        let result = await state.createRemoteWorktreeSession(
+            projectId: project.id,
+            base: "main",
+            branch: "feature/ssh",
+            agentId: "claude"
+        )
+
+        guard case let .success(summary) = result else {
+            Issue.record("expected remote worktree session creation, got \(result)")
+            return
+        }
+        let worktree = try #require(summary.worktree)
+        let worktreeId = Worktree.makeId(path: URL(fileURLWithPath: worktree.path))
+        defer {
+            RemoteHostRegistry.shared.unregister(root: worktree.path)
+            try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId))
+            let database = Paths.acpSessionsDB(forWorktreeId: worktreeId)
+            try? FileManager.default.removeItem(at: database)
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: database.path + "-wal"))
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: database.path + "-shm"))
+        }
+        #expect(FileManager.default.fileExists(atPath: worktree.path))
+        #expect(state.selectedWorktreeId == worktreeId)
+        #expect(state.tabs.tabs(forWorktree: worktreeId).contains { tab in
+            if case let .acpSession(session) = tab { return session.sessionId == summary.id }
+            return false
+        })
+    }
+
     @Test func remoteValidatorAcceptsAndRejects() async throws {
         try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
 

--- a/AlasTests/SSH/SSHIntegrationTests.swift
+++ b/AlasTests/SSH/SSHIntegrationTests.swift
@@ -5,6 +5,22 @@ import Testing
 /// Enable with ALAS_SSH_INTEGRATION=1 and key-authenticated ssh localhost.
 @Suite(.disabled(if: ProcessInfo.processInfo.environment["ALAS_SSH_INTEGRATION"] != "1"))
 struct SSHIntegrationTests {
+    private struct ProjectMemoryStore: PersistenceStoreProtocol {
+        let projectsFile: ProjectsFile
+
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+
+        func readIfExists<T: Decodable>(_ type: T.Type, from _: URL) throws -> T? {
+            if type == ProjectsFile.self {
+                return projectsFile as? T
+            }
+            if type == AppConfig.self {
+                return AppConfig.defaults as? T
+            }
+            return nil
+        }
+    }
+
     private var enabled: Bool {
         ProcessInfo.processInfo.environment["ALAS_SSH_INTEGRATION"] == "1"
     }
@@ -26,6 +42,45 @@ struct SSHIntegrationTests {
         #expect(status.exitCode == 0)
         let repository = try await Process.git(["rev-parse", "--is-inside-work-tree"], cwd: directory)
         #expect(repository.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "true")
+    }
+
+    @Test @MainActor func remoteBranchesDiscoverOverSSHLocalhost() async throws {
+        try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ssh-branches-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            RemoteHostRegistry.shared.unregister(root: directory.path)
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        _ = try await Process.run("/usr/bin/env", args: ["git", "init", "-q", "-b", "main"], cwd: directory)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "config", "user.email", "test@example.com"], cwd: directory)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "config", "user.name", "Test User"], cwd: directory)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "commit", "-q", "--allow-empty", "-m", "initial"], cwd: directory)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "branch", "feature/remote"], cwd: directory)
+        let project = ProjectConfig(
+            id: "ssh-branches",
+            name: "SSH Branches",
+            path: directory.path,
+            color: "blue",
+            addedAt: Date(),
+            host: "localhost"
+        )
+        let state = AppState(store: ProjectMemoryStore(
+            projectsFile: ProjectsFile(projects: [project])
+        ))
+
+        let result = await state.remoteBranches(projectId: project.id)
+
+        guard case let .success(branches, preferredBase) = result else {
+            Issue.record("expected branch list success, got \(result)")
+            return
+        }
+        #expect(branches.contains("main"))
+        #expect(branches.contains("feature/remote"))
+        #expect(preferredBase == "main")
     }
 
     @Test func remoteValidatorAcceptsAndRejects() async throws {

--- a/docs/plans/2026-09-05-remote-web-worktree-creation-design.md
+++ b/docs/plans/2026-09-05-remote-web-worktree-creation-design.md
@@ -1,0 +1,89 @@
+# Remote Web Worktree Creation Design
+
+## Goal
+
+Let a paired Alas Remote browser create a worktree and immediately start an ACP session in it. The flow must work well on a phone, reuse the Mac app's worktree settings, and leave filesystem and Git policy on the Mac.
+
+## Scope
+
+The first version exposes only the fields needed to start work: repository, base branch, new branch name, and agent. Alas uses the configured worktree path template, worktree root, fetch-before-create setting, startup script, and ACP auto-run default. Stacked-diffs mode, issue attachment, destination editing, and standalone remote worktree management are out of scope.
+
+Creation mirrors the existing remote-session behavior. After success, Alas switches to the new worktree, opens its ACP tab on the Mac, and opens the session in the browser.
+
+## Interaction
+
+The existing **New session** sheet remains the entry point. Its worktree step adds **Create new worktree** above the searchable list of existing worktrees.
+
+Choosing that action opens a compact worktree form:
+
+- Repository picker
+- Lazily loaded base-branch picker
+- New branch name field
+- Back and Next actions
+
+Next opens the existing agent picker. Its primary action reads **Create worktree and session** for this path. Back navigation preserves the repository, base, branch, and agent selections. Closing the sheet clears them.
+
+While creation runs, the sheet stays open, disables navigation, and shows progress. Success closes the sheet and subscribes the browser to the returned session. Failure keeps the sheet open and shows the server's message near the form.
+
+## Protocol
+
+Add these client messages:
+
+- `listProjects`
+- `listBranches(projectId)`
+- `createWorktreeSession(projectId, base, branch, agentId)`
+
+Add matching server messages:
+
+- `projectList(projects)` with stable project IDs and display names
+- `branchList(projectId, branches, preferredBase)`
+- `branchListFailed(projectId, message)`
+- `worktreeSessionCreated(session)`
+- `worktreeSessionCreationFailed(stage, message, worktreeId?)`
+
+The combined-creation failure stage is `worktree` or `session`. A non-nil `worktreeId` means worktree creation completed but session creation did not. Branch-loading failures use the repository-scoped `branchListFailed` response so a late failure cannot overwrite the current repository's state. Existing worktree and agent list messages remain unchanged.
+
+The gateway suppresses superseded asynchronous project or branch-list results with generation checks, matching the existing worktree-list refresh behavior. A branch response includes its project ID so the browser can reject a late response after the user changes repositories.
+
+## App architecture
+
+`RemoteSessionGateway` decodes requests, calls `RemoteSessionsProvider`, and maps provider results to wire messages. It does not construct paths or run Git commands.
+
+`RemoteSessionsProvider` gains methods for remote project options, branches for one project, and combined worktree-session creation. `AppState` implements them with existing services and settings.
+
+For branch listing, `AppState` confirms the project still exists, asks `GitService` for branches at the project's local or SSH-backed path, and chooses a preferred base with `NewWorktreeDialog.preferredBaseBranch`. The browser can select only a branch returned for the current project.
+
+For creation, `AppState` performs all checks again because browser state may be stale:
+
+1. Confirm the project exists and the agent is enabled and ACP-capable.
+2. Validate the new branch with `GitNameValidator`.
+3. Reload or otherwise validate the requested base against the project's branches.
+4. Render the destination with `WorktreePathTemplateRenderer` and reject an existing path.
+5. Call `createWorktreeAndWait` with `runStartup: true` and inherited GG mode. Existing configuration controls fetch-before-create and the startup script.
+6. After reconciliation returns the worktree, call the existing remote-session creation path. That path switches spaces if needed, selects the worktree, appends and activates the ACP tab, schedules attachment, and returns a session summary.
+
+The worktree operation cannot be transactionally rolled back after Git succeeds. If session creation fails, Alas returns the created worktree ID, refreshes the browser's worktree list, and tells the user that the worktree exists but the session could not be created.
+
+## Browser state and concurrency
+
+The browser creation state distinguishes existing-worktree selection, new-worktree entry, agent selection, and active creation. Repository changes clear the old base, request new branches, and tag the request with the selected project ID. Late results for another project do not change the form.
+
+Submission is enabled only when the current project has a loaded branch list, the chosen base occurs in that list, the branch name is non-empty, and an agent is selected. The server remains authoritative for every validation rule.
+
+If the WebSocket disconnects during creation, the browser marks the outcome unknown. After reconnecting, it refreshes sessions and worktrees before enabling retry. A completed session then appears normally. If only the worktree completed, it appears in the existing-worktree list. A retry cannot create a duplicate because the server rechecks the branch and destination.
+
+## Errors
+
+Branch-loading errors stay within the base-branch field and provide Retry. Worktree validation and creation errors appear on the worktree step even if the user submitted from the agent step. Session-stage failures state that the worktree was created and return the user to the existing-worktree list with that worktree selected when it is available.
+
+Error strings remain user-facing English produced by `AppState`. Logs may retain the underlying error for diagnosis, but the protocol must not expose command output, local credentials, or more filesystem detail than existing remote worktree options already reveal.
+
+## Testing
+
+Protocol tests cover round trips for every new message, optional partial-success data, and malformed or missing fields. Gateway tests cover list forwarding, success, each failure stage, stale asynchronous response suppression, and worktree-list refresh after partial success.
+
+`AppState` tests use temporary Git repositories to cover preferred-base selection, branch validation, destination rendering, duplicate rejection, startup configuration, successful reconciliation followed by ACP session creation, partial success when session creation fails, space switching, and SSH-backed projects through the existing remote Git abstractions.
+
+Extract the browser wizard's pure state transitions into a small JavaScript module, following `session-ordering.js`. Node tests cover forward and backward navigation, preserved values, late branch responses, submit enablement, disconnect recovery, and partial success. Swift asset tests verify the controls, protocol message names, script loading order, and coordinated service-worker cache revisions.
+
+Finish with the focused Node test, `xcodegen`, a macOS build, the full test suite, and a manual narrow-phone check of the sheet.

--- a/docs/plans/2026-09-05-remote-web-worktree-creation-implementation-plan.md
+++ b/docs/plans/2026-09-05-remote-web-worktree-creation-implementation-plan.md
@@ -1,0 +1,668 @@
+# Remote Web Worktree Creation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a paired Alas Remote browser create a worktree from configured repository defaults and immediately open an ACP session in it.
+
+**Architecture:** Extend the typed WebSocket protocol with repository, branch, and combined-creation messages. Keep Git, path, startup-script, and agent policy in `AppState`; keep `RemoteSessionGateway` as the asynchronous coordinator; isolate the browser wizard's pure transitions in a testable JavaScript module used by `app.js`.
+
+**Tech Stack:** Swift 5.9, Swift Testing, SwiftUI-hosted static HTML/CSS/JavaScript, Node.js `assert`, Git worktrees over local or SSH-aware existing services.
+
+**Design spec:** `docs/plans/2026-09-05-remote-web-worktree-creation-design.md`
+
+---
+
+## File map
+
+- `Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift`: wire DTOs and provider result enums for repositories, branches, and combined creation.
+- `Alas/Sources/Remote/Protocol/RemoteProtocol.swift`: client/server WebSocket cases and Codable dispatch.
+- `Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift`: app capabilities exposed to a connection gateway.
+- `Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift`: generation-guarded list requests and combined-creation response mapping.
+- `Alas/Sources/App/AppState.swift`: authoritative repository lookup, branch validation, destination rendering, worktree creation, and session creation.
+- `Alas/Resources/RemoteWeb/worktree-creation.js`: pure creation-wizard state transitions.
+- `Alas/Resources/RemoteWeb/app.js`: DOM rendering, WebSocket requests, reconnect recovery, and success/failure handling.
+- `Alas/Resources/RemoteWeb/index.html`: new-worktree form controls and script loading.
+- `Alas/Resources/RemoteWeb/style.css`: compact responsive form styles.
+- `Alas/Resources/RemoteWeb/sw.js`: cache names and new asset revision.
+- `AlasTests/Remote/RemoteProtocolTests.swift`: wire round-trip coverage.
+- `AlasTests/Remote/RemoteAppStateAccessTests.swift`: app policy and orchestration coverage.
+- `AlasTests/Remote/RemoteSessionGatewayTests.swift`: gateway routing, generation, and partial-success coverage.
+- `AlasTests/Remote/RemoteWebAssetTests.swift`: static asset wiring and cache-version assertions.
+- `AlasTests/SSH/SSHIntegrationTests.swift`: opt-in localhost SSH coverage for branch discovery and creation.
+- `scripts/tests/remote-web-worktree-creation/run.sh`: focused JavaScript test runner.
+- `scripts/tests/remote-web-worktree-creation/test-worktree-creation.js`: wizard transition tests.
+
+### Task 1: Add the remote worktree-creation wire contract
+
+**Files:**
+- Modify: `Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift`
+- Modify: `Alas/Sources/Remote/Protocol/RemoteProtocol.swift`
+- Modify: `AlasTests/Remote/RemoteProtocolTests.swift`
+
+- [ ] **Step 1: Write failing protocol round-trip tests**
+
+Add focused tests for all new cases. Assert exact JSON keys, not only enum equality:
+
+```swift
+@Test func worktreeCreationMessagesRoundTrip() throws {
+    let listBranches = RemoteClientMessage.listBranches(projectId: "project-1")
+    #expect(try roundTrip(listBranches) == listBranches)
+
+    let create = RemoteClientMessage.createWorktreeSession(
+        projectId: "project-1",
+        base: "origin/main",
+        branch: "feature/remote-create",
+        agentId: "codex"
+    )
+    #expect(try roundTrip(create) == create)
+    let object = try #require(
+        JSONSerialization.jsonObject(with: JSONEncoder().encode(create)) as? [String: Any]
+    )
+    #expect(object["type"] as? String == "createWorktreeSession")
+    #expect(object["projectId"] as? String == "project-1")
+
+    let projects = [RemoteProjectOption(id: "project-1", name: "alas")]
+    let projectList = RemoteServerMessage.projectList(projects: projects)
+    #expect(try roundTrip(projectList) == projectList)
+    let branchList = RemoteServerMessage.branchList(
+        projectId: "project-1", branches: ["main"], preferredBase: "main"
+    )
+    #expect(try roundTrip(branchList) == branchList)
+    let branchFailure = RemoteServerMessage.branchListFailed(
+        projectId: "project-1", message: "Could not load branches."
+    )
+    #expect(try roundTrip(branchFailure) == branchFailure)
+    let createFailure = RemoteServerMessage.worktreeSessionCreationFailed(
+        stage: .session,
+        message: "Worktree created, but the session could not be created.",
+        worktreeId: "/tmp/alas-feature"
+    )
+    #expect(try roundTrip(createFailure) == createFailure)
+}
+```
+
+Also assert decoding fails when `projectId`, `base`, `branch`, `agentId`, or `stage` is missing or invalid.
+
+- [ ] **Step 2: Run the protocol tests and confirm the new cases fail to compile**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteProtocolTests
+```
+
+Expected: FAIL because the new protocol cases and DTOs do not exist.
+
+- [ ] **Step 3: Add the wire DTOs and result vocabulary**
+
+In `RemoteMessageWireJSON.swift`, add:
+
+```swift
+struct RemoteProjectOption: Codable, Equatable, Sendable {
+    let id: String
+    let name: String
+}
+
+enum RemoteWorktreeSessionCreationStage: String, Codable, Equatable, Sendable {
+    case worktree
+    case session
+}
+
+enum RemoteBranchListResult: Equatable, Sendable {
+    case success(branches: [String], preferredBase: String)
+    case failure(String)
+}
+
+enum RemoteCreateWorktreeSessionResult: Equatable, Sendable {
+    case success(RemoteSessionSummary)
+    case failure(
+        stage: RemoteWorktreeSessionCreationStage,
+        message: String,
+        worktreeId: String?
+    )
+}
+```
+
+Add client cases `listProjects`, `listBranches(projectId:)`, and `createWorktreeSession(projectId:base:branch:agentId:)`. Add server cases `projectList`, `branchList`, `branchListFailed`, `worktreeSessionCreated`, and `worktreeSessionCreationFailed`. Extend coding keys and both Codable switches with the exact lower-camel-case wire names from the spec. Do not classify these as control messages or drive-ordering messages.
+
+- [ ] **Step 4: Run the protocol tests**
+
+Run the command from Step 2.
+
+Expected: PASS with all `RemoteProtocolTests` passing.
+
+- [ ] **Step 5: Commit the protocol contract**
+
+```bash
+git add Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift Alas/Sources/Remote/Protocol/RemoteProtocol.swift AlasTests/Remote/RemoteProtocolTests.swift
+git commit -m "feat(remote): add worktree creation protocol"
+```
+
+### Task 2: Expose remote repository and branch catalogs
+
+**Files:**
+- Modify: `Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift`
+- Modify: `Alas/Sources/App/AppState.swift`
+- Modify: `AlasTests/Remote/RemoteAppStateAccessTests.swift`
+- Modify: `AlasTests/Remote/RemoteSessionGatewayTests.swift`
+- Modify: `AlasTests/SSH/SSHIntegrationTests.swift`
+
+- [ ] **Step 1: Add failing `AppState` catalog tests**
+
+Cover stable project IDs/names, missing projects, branch ordering, preferred-base reuse, local repositories, and SSH-aware dispatch through the existing `Process.git`/`RemoteHostRegistry` path. The core expectations are:
+
+```swift
+let projects = await state.remoteProjects()
+#expect(projects == [RemoteProjectOption(id: project.id, name: project.name)])
+
+let result = await state.remoteBranches(projectId: project.id)
+guard case .success(let branches, let preferredBase) = result else {
+    Issue.record("expected branch list success")
+    return
+}
+#expect(branches.contains("main"))
+#expect(preferredBase == "main")
+
+#expect(await state.remoteBranches(projectId: "missing") == .failure("Repository is no longer available."))
+```
+
+Use a temporary Git repository for the local success case. Add an opt-in test to `SSHIntegrationTests` that creates a temporary repository, registers its path with host `localhost`, builds an `AppState` containing that remote project, and calls `remoteBranches`. The suite already requires `ALAS_SSH_INTEGRATION=1` and key-authenticated localhost SSH. Always unregister the path and remove temporary repositories in `defer`. Combined SSH creation belongs to Task 3, after that API exists.
+
+- [ ] **Step 2: Run the `AppState` remote-access tests and verify failure**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteAppStateAccessTests
+```
+
+Expected: FAIL because `remoteProjects()` and `remoteBranches(projectId:)` are missing.
+
+- [ ] **Step 3: Extend the provider and its test fake**
+
+Add these requirements to `RemoteSessionsProvider`:
+
+```swift
+func remoteProjects() async -> [RemoteProjectOption]
+func remoteBranches(projectId: String) async -> RemoteBranchListResult
+```
+
+Add storage, call counters, optional continuations, and implementations to `FakeSessionsProvider` in `RemoteSessionGatewayTests.swift`. This keeps the test target compiling before gateway routing is added.
+
+- [ ] **Step 4: Implement the `AppState` catalog methods**
+
+Place them beside `remoteWorktrees()`:
+
+```swift
+func remoteProjects() async -> [RemoteProjectOption] {
+    projects.map { RemoteProjectOption(id: $0.id, name: $0.name) }
+}
+
+func remoteBranches(projectId: String) async -> RemoteBranchListResult {
+    guard let project = projects.first(where: { $0.id == projectId }) else {
+        return .failure("Repository is no longer available.")
+    }
+    do {
+        let branches = try await GitService().branches(at: URL(fileURLWithPath: project.path))
+        return .success(
+            branches: branches,
+            preferredBase: NewWorktreeDialog.preferredBaseBranch(
+                availableBranches: branches,
+                configuredDefault: config.worktrees.baseBranch
+            )
+        )
+    } catch {
+        Self.logger.error("Remote branch loading failed: \(String(describing: error), privacy: .public)")
+        return .failure("Could not load branches.")
+    }
+}
+```
+
+Do not duplicate SSH handling. `Process.git` already resolves `RemoteHostRegistry` for the project path. Never put raw Git or SSH stderr in `RemoteBranchListResult`; it may contain host paths or credentials.
+
+- [ ] **Step 5: Run the focused tests**
+
+Run the command from Step 2.
+
+Expected: PASS for local, missing-project, and preferred-base coverage.
+
+When key-authenticated localhost SSH is available, also run:
+
+```bash
+ALAS_SSH_INTEGRATION=1 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/SSHIntegrationTests
+```
+
+Expected: PASS, including remote branch discovery. If localhost SSH is unavailable, record that the opt-in suite was not run; the default full suite keeps it disabled.
+
+- [ ] **Step 6: Commit the catalogs**
+
+```bash
+git add Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift Alas/Sources/App/AppState.swift AlasTests/Remote/RemoteAppStateAccessTests.swift AlasTests/Remote/RemoteSessionGatewayTests.swift AlasTests/SSH/SSHIntegrationTests.swift
+git commit -m "feat(remote): expose repository branch catalogs"
+```
+
+### Task 3: Implement authoritative combined creation in `AppState`
+
+**Files:**
+- Modify: `Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift`
+- Modify: `Alas/Sources/App/AppState.swift`
+- Modify: `AlasTests/Remote/RemoteAppStateAccessTests.swift`
+- Modify: `AlasTests/Remote/RemoteSessionGatewayTests.swift`
+- Modify: `AlasTests/SSH/SSHIntegrationTests.swift`
+
+- [ ] **Step 1: Add failing creation-policy tests**
+
+Add tests that call `createRemoteWorktreeSession(projectId:base:branch:agentId:)` and cover:
+
+- missing project;
+- disabled, missing, or non-ACP agent before Git work starts;
+- invalid branch name;
+- base absent from a freshly loaded branch list;
+- destination already present;
+- destination already present on an SSH host;
+- successful real worktree creation and ACP tab/session activation;
+- configured path rendering and startup enabled;
+- mapping `.failure(.session, ..., worktreeId: newWorktree.id)` without deleting the created worktree.
+
+Use temporary repositories and the existing `remoteSessionAttachScheduler` to avoid launching a real ACP process. Test the partial-success mapping through a small internal result-mapping helper fed a failed `RemoteCreateSessionResult`; gateway-level behavior will also be covered in Task 4.
+
+Extend `SSHIntegrationTests` with an opt-in combined-creation test. Register the temporary repository for `localhost`, configure the path template to another temporary directory, install an enabled ACP agent plus `remoteSessionAttachScheduler`, then assert that the remote worktree exists and the returned summary points at it. This test is disabled unless `ALAS_SSH_INTEGRATION=1` is set.
+
+Example success assertion:
+
+```swift
+let result = await state.createRemoteWorktreeSession(
+    projectId: project.id,
+    base: "main",
+    branch: "feature/from-phone",
+    agentId: "claude"
+)
+
+guard case .success(let summary) = result else {
+    Issue.record("expected combined creation success")
+    return
+}
+#expect(summary.worktree?.branch == "feature/from-phone")
+let path = try #require(summary.worktree?.path)
+#expect(state.selectedWorktreeId == Worktree.makeId(path: URL(fileURLWithPath: path)))
+```
+
+- [ ] **Step 2: Run the focused tests and verify failure**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteAppStateAccessTests
+```
+
+Expected: FAIL because the combined provider method is missing.
+
+- [ ] **Step 3: Add the provider requirement and fake implementation**
+
+```swift
+func createRemoteWorktreeSession(
+    projectId: String,
+    base: String,
+    branch: String,
+    agentId: String
+) async -> RemoteCreateWorktreeSessionResult
+```
+
+Extend `FakeSessionsProvider` with keyed results and captured requests so Task 4 can test gateway routing.
+
+- [ ] **Step 4: Implement validation and creation in `AppState`**
+
+Add the method beside `createRemoteSession`. Its order is important:
+
+1. Resolve the project and validate the ACP-capable agent using the same catalog as `createRemoteSession`.
+2. Validate `branch` through `GitNameValidator`.
+3. Call `GitService().branches` again and require `base` to occur in the returned list.
+4. Render the destination with `config.worktrees.pathTemplate`, `rootPath`, project name, and branch, then normalize it with `preparedCreateWorktreeDestination` so `~` resolves to the SSH user's home for remote projects.
+5. Reject an existing destination before calling `createWorktreeAndWait`. Use `FileManager.fileExists` locally and `RemoteExec.run(..., command: "test -e <shell-quoted-path>")` for an SSH project. Treat a remote existence-check transport failure as a fixed browser-safe worktree error instead of assuming the path is free.
+6. Call `createWorktreeAndWait(..., runStartup: true, ggWorktreeMode: .inherit)`.
+7. On worktree success, call `createRemoteSession(worktreeId:agentId:)` and map its result without deleting the worktree.
+
+Keep the local/SSH existence behavior in one helper:
+
+```swift
+private func remoteCreationDestinationExists(
+    project: ProjectConfig,
+    destination: URL
+) async throws -> Bool {
+    guard let host = project.host ?? RemoteHostRegistry.shared.host(forPath: project.path) else {
+        return FileManager.default.fileExists(atPath: destination.path)
+    }
+    let command = "test -e \(Self.shellQuote(destination.path))"
+    let result = try await RemoteExec.run(host: host, cwd: nil, command: command)
+    switch result.exitCode {
+    case 0: return true
+    case 1: return false
+    default: throw RemoteWorktreeDestinationCheckError()
+    }
+}
+
+private struct RemoteWorktreeDestinationCheckError: LocalizedError {
+    var errorDescription: String? { "Could not check the worktree destination." }
+}
+```
+
+Test that shell metacharacters and spaces in the destination stay inside the quoted `test -e` argument. The opt-in localhost SSH test covers both an absent and an existing remote destination.
+
+Use a pure internal mapper for the non-transactional final step:
+
+```swift
+nonisolated static func remoteWorktreeSessionResult(
+    worktree: Worktree,
+    sessionResult: RemoteCreateSessionResult
+) -> RemoteCreateWorktreeSessionResult {
+    switch sessionResult {
+    case .success(let summary):
+        return .success(summary)
+    case .failure(let message):
+        return .failure(
+            stage: .session,
+            message: "Worktree created, but the session could not be created: \(message)",
+            worktreeId: worktree.id
+        )
+    }
+}
+```
+
+Return `.worktree` failures for every pre-session validation or worktree failure. Keep detailed command output in existing logs and return localized user-facing messages. For an existing destination, return `A worktree already exists at this path.` For an unexpected `createWorktreeAndWait` failure, log `WorktreeCreationFailure.message` and return the fixed text `Could not create worktree.`; do not put the underlying Git message on the wire.
+If the fresh branch lookup itself fails, log the underlying error and return the same fixed `Could not load branches.` text used by `remoteBranches`; do not return raw Git or SSH stderr.
+
+- [ ] **Step 5: Run the focused tests**
+
+Run the command from Step 2.
+
+Expected: PASS, including the real Git worktree and partial-success mapper cases.
+
+When key-authenticated localhost SSH is available, also run:
+
+```bash
+ALAS_SSH_INTEGRATION=1 xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/SSHIntegrationTests
+```
+
+Expected: PASS, including remote branch discovery and combined worktree-session creation. If localhost SSH is unavailable, record that the opt-in suite was not run; the default full suite keeps it disabled.
+
+- [ ] **Step 6: Commit app-side creation**
+
+```bash
+git add Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift Alas/Sources/App/AppState.swift AlasTests/Remote/RemoteAppStateAccessTests.swift AlasTests/Remote/RemoteSessionGatewayTests.swift AlasTests/SSH/SSHIntegrationTests.swift
+git commit -m "feat(remote): create worktree sessions"
+```
+
+### Task 4: Route catalogs and combined creation through the gateway
+
+**Files:**
+- Modify: `Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift`
+- Modify: `AlasTests/Remote/RemoteSessionGatewayTests.swift`
+
+- [ ] **Step 1: Add failing gateway tests**
+
+Cover:
+
+- `listProjects` emits `projectList`;
+- `listBranches` emits `branchList` or `branchListFailed` with the requested project ID;
+- a second project/branch list request suppresses a paused older response;
+- combined creation forwards every field exactly once;
+- success emits `worktreeSessionCreated`, then refreshes session and worktree lists;
+- worktree failure emits the stage and no worktree ID;
+- session failure emits the stage and created worktree ID, then refreshes worktrees.
+
+Use `FakeSessionsProvider` continuations to pause the first request, as current worktree-list generation tests do.
+
+- [ ] **Step 2: Run the gateway tests and verify failure**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteSessionGatewayTests
+```
+
+Expected: FAIL because `RemoteSessionGateway.handle` does not route the new messages.
+
+- [ ] **Step 3: Add generation-guarded refresh methods**
+
+Add separate cancellable tasks and generation counters for project and branch lists. A branch success or failure must carry the captured project ID:
+
+```swift
+private func refreshBranchList(projectId: String) {
+    branchListGeneration += 1
+    let generation = branchListGeneration
+    branchListRefresh?.cancel()
+    branchListRefresh = Task { @MainActor [weak self] in
+        guard let self else { return }
+        let result = await provider.remoteBranches(projectId: projectId)
+        guard !Task.isCancelled, generation == branchListGeneration else { return }
+        switch result {
+        case .success(let branches, let preferredBase):
+            send(.branchList(projectId: projectId, branches: branches, preferredBase: preferredBase))
+        case .failure(let message):
+            send(.branchListFailed(projectId: projectId, message: message))
+        }
+    }
+}
+```
+
+Cancel both new tasks in `close()`.
+
+- [ ] **Step 4: Route combined creation and refresh lists**
+
+In `handle`, call the provider and map its result. On success, send `worktreeSessionCreated`, refresh sessions, and refresh worktrees. On all failures, send `worktreeSessionCreationFailed`; refresh worktrees when `worktreeId != nil`.
+
+- [ ] **Step 5: Run the gateway tests**
+
+Run the command from Step 2.
+
+Expected: PASS with no stale project or branch response emitted.
+
+- [ ] **Step 6: Commit gateway coordination**
+
+```bash
+git add Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift AlasTests/Remote/RemoteSessionGatewayTests.swift
+git commit -m "feat(remote): route worktree session creation"
+```
+
+### Task 5: Build and test the browser wizard state module
+
+**Files:**
+- Create: `Alas/Resources/RemoteWeb/worktree-creation.js`
+- Create: `scripts/tests/remote-web-worktree-creation/run.sh`
+- Create: `scripts/tests/remote-web-worktree-creation/test-worktree-creation.js`
+
+- [ ] **Step 1: Write the failing Node tests**
+
+Test the module's public operations:
+
+```javascript
+const state = creation.initialState();
+const loading = creation.selectProject(state, "project-1");
+const stale = creation.applyBranchList(loading, "project-old", ["old"], "old");
+assert.deepStrictEqual(stale, loading);
+
+const loaded = creation.applyBranchList(loading, "project-1", ["main"], "main");
+assert.equal(creation.canSubmit(loaded, "codex", false), true);
+
+const unknown = creation.disconnect(creation.beginCreate(loaded));
+assert.equal(unknown.outcomeUnknown, true);
+assert.equal(creation.canRetry(unknown), false);
+const recovered = creation.markRecoveryListLoaded(
+  creation.markRecoveryListLoaded(unknown, "sessions"),
+  "worktrees"
+);
+assert.equal(creation.canRetry(recovered), true);
+```
+
+Also cover forward/back step changes preserving values, missing base, branch failure/retry, agent absence, busy state, and session-stage partial success selecting the returned worktree.
+
+- [ ] **Step 2: Run the script and verify failure**
+
+```bash
+scripts/tests/remote-web-worktree-creation/run.sh
+```
+
+Expected: FAIL because `worktree-creation.js` does not exist.
+
+- [ ] **Step 3: Implement the pure module**
+
+Use the existing global-export pattern from `session-ordering.js`. Export immutable operations through `globalThis.RemoteWorktreeCreation`. Keep DOM access and WebSocket sending out of this file; the Node test loads it with `require(...)` and then reads the global.
+
+The state must include:
+
+```javascript
+{
+  mode: "existing", step: "worktree",
+  projectId: null, projects: [], branches: [], base: "", branch: "",
+  branchStatus: "idle", branchError: "",
+  agentId: null, busy: false, error: "",
+  outcomeUnknown: false,
+  recovery: { sessions: false, worktrees: false },
+  createdWorktreeId: null
+}
+```
+
+Return the identical state object for stale project-scoped branch success or failure so callers can skip rendering.
+
+Make `run.sh` executable with `chmod +x scripts/tests/remote-web-worktree-creation/run.sh` before running it directly.
+
+- [ ] **Step 4: Run the Node tests**
+
+```bash
+scripts/tests/remote-web-worktree-creation/run.sh
+```
+
+Expected output: `remote web worktree creation tests passed`.
+
+- [ ] **Step 5: Commit the state module**
+
+```bash
+git add Alas/Resources/RemoteWeb/worktree-creation.js scripts/tests/remote-web-worktree-creation
+git commit -m "feat(remote-web): add worktree creation state"
+```
+
+### Task 6: Integrate the new-worktree flow into the remote web sheet
+
+**Files:**
+- Modify: `Alas/Resources/RemoteWeb/index.html`
+- Modify: `Alas/Resources/RemoteWeb/app.js`
+- Modify: `Alas/Resources/RemoteWeb/style.css`
+- Modify: `Alas/Resources/RemoteWeb/sw.js`
+- Modify: `AlasTests/Remote/RemoteWebAssetTests.swift`
+
+- [ ] **Step 1: Add failing asset integration assertions**
+
+Assert that:
+
+- the worktree list contains a `create-new-worktree` button;
+- repository, base, and branch controls have labels and stable IDs;
+- `worktree-creation.js` loads before `app.js`;
+- `app.js` sends and handles all new message names;
+- reconnect requests sessions and worktrees and marks both recovery lists loaded;
+- `index.html` and `sw.js` use matching new revisions for `app.js`, `style.css`, and `worktree-creation.js`;
+- the service-worker shell cache name is incremented.
+
+- [ ] **Step 2: Run asset and Node tests and verify the asset failure**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteWebAssetTests
+scripts/tests/remote-web-worktree-creation/run.sh
+```
+
+Expected: Swift asset tests FAIL; Node state tests PASS.
+
+- [ ] **Step 3: Add semantic form markup**
+
+In `index.html`, add the create action to `worktree-step` and a hidden `new-worktree-step` containing labeled repository and base `<select>` elements plus a branch `<input>`. Keep the existing agent step. Use the existing action row rather than nesting another sheet or card.
+
+Load `/worktree-creation.js?v=1` after `session-ordering.js` and before `app.js`.
+
+- [ ] **Step 4: Wire state and WebSocket messages in `app.js`**
+
+Use `RemoteWorktreeCreation` for all new-worktree transitions. Keep existing-session creation unchanged.
+
+On sheet open, request worktrees, agents, and projects. Selecting a repository sends `listBranches`. Render loading, inline error with Retry, or branch options. The final action sends exactly one `createWorktreeSession` request.
+
+Handle `worktreeSessionCreated` through the existing `applyCreatedSession`. Handle worktree-stage failures by returning to the worktree form. Handle session-stage failures by selecting `worktreeId`, returning to the existing list, and showing that the worktree exists.
+
+On disconnect during creation, call the pure module's disconnect transition. On reconnect, send `listSessions` and `listWorktrees`; only enable retry after both responses have marked recovery complete. Do not infer success from a matching branch name.
+
+- [ ] **Step 5: Add compact responsive styles**
+
+Reuse `.sheet-input`, `.create-list`, `.create-actions`, and current color variables. Add only layout needed for field labels, selects, loading/error rows, and the full-width create-new action. Verify at 320 CSS pixels that labels, inputs, Back, Create, and Cancel do not overlap or escape the sheet.
+
+- [ ] **Step 6: Rev all cached assets together**
+
+Increment `app.js` from `v=62`, `style.css` from `v=40`, and the shell cache from `v40`. Add `worktree-creation.js?v=1` to `SHELL_ASSETS`. Update every matching assertion in `RemoteWebAssetTests.swift`; do not leave mixed revisions between `index.html`, `sw.js`, and tests.
+
+- [ ] **Step 7: Run focused web tests**
+
+```bash
+scripts/tests/remote-web-worktree-creation/run.sh
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/RemoteWebAssetTests
+```
+
+Expected: Node prints `remote web worktree creation tests passed`; all `RemoteWebAssetTests` pass.
+
+- [ ] **Step 8: Commit the browser integration**
+
+```bash
+git add Alas/Resources/RemoteWeb/index.html Alas/Resources/RemoteWeb/app.js Alas/Resources/RemoteWeb/style.css Alas/Resources/RemoteWeb/sw.js AlasTests/Remote/RemoteWebAssetTests.swift
+git commit -m "feat(remote-web): create worktrees with sessions"
+```
+
+### Task 7: Verify the complete feature
+
+**Files:**
+- Verify only; fix failures in the owning task's files and commit those fixes separately.
+
+- [ ] **Step 1: Run both remote-web Node suites**
+
+```bash
+scripts/tests/remote-web-session-ordering/run.sh
+scripts/tests/remote-web-worktree-creation/run.sh
+```
+
+Expected: both scripts print their passing messages and exit 0.
+
+- [ ] **Step 2: Regenerate the Xcode project**
+
+```bash
+xcodegen
+```
+
+Expected: project generation completes without errors. Because `RemoteWeb` is a folder resource, the new JavaScript file requires no `project.yml` entry.
+
+- [ ] **Step 3: Build the macOS app**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: `** TEST SUCCEEDED **` with no failed tests.
+
+- [ ] **Step 5: Exercise the paired browser flow**
+
+With a disposable repository and an enabled ACP agent:
+
+1. Open Alas Remote at a 320-pixel-wide responsive viewport.
+2. Open **New session**, choose **Create new worktree**, and change repositories while branch loading is active.
+3. Confirm only the final repository's branches appear and Back preserves the entered branch.
+4. Create the worktree and confirm the browser opens the new session.
+5. Confirm Alas switches to the new worktree and activates the matching ACP tab.
+6. Repeat with an invalid branch and an occupied destination; confirm the sheet keeps the input and shows a useful error.
+7. Disconnect during creation, reconnect, and confirm lists refresh before Retry becomes available.
+
+- [ ] **Step 6: Check the final diff and history**
+
+```bash
+git diff --check main...HEAD
+git status --short
+git log --oneline main..HEAD
+```
+
+Expected: no whitespace errors, no unintended files, and focused commits matching the tasks above.

--- a/scripts/tests/remote-web-worktree-creation/run.sh
+++ b/scripts/tests/remote-web-worktree-creation/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+node "$(dirname "$0")/test-worktree-creation.js"

--- a/scripts/tests/remote-web-worktree-creation/test-worktree-creation.js
+++ b/scripts/tests/remote-web-worktree-creation/test-worktree-creation.js
@@ -1,0 +1,375 @@
+const assert = require("node:assert/strict");
+
+require("../../../Alas/Resources/RemoteWeb/worktree-creation.js");
+
+const creation = globalThis.RemoteWorktreeCreation;
+
+function newFlow() {
+  const commands = [];
+  const flow = creation.createFlow((command) => commands.push(command));
+  return { flow, commands };
+}
+
+{
+  const { flow, commands } = newFlow();
+  const snapshots = [];
+  const unsubscribe = flow.subscribe((snapshot) => snapshots.push(snapshot));
+
+  flow.loadProjects();
+  assert.equal(flow.snapshot().projectsLoading, true);
+  assert.deepStrictEqual(commands, [{ type: "listProjects" }]);
+
+  flow.receive({
+    type: "projectList",
+    projects: [{ id: "project-1", name: "First" }, { id: "project-2", name: "Second" }],
+  });
+
+  assert.equal(flow.snapshot().projectId, "project-1");
+  assert.equal(flow.snapshot().branchesLoading, true);
+  assert.deepStrictEqual(commands[1], { type: "listBranches", projectId: "project-1" });
+  assert.ok(snapshots.length >= 2);
+  unsubscribe();
+  const snapshotCount = snapshots.length;
+  flow.setBranch("feature/ignored-after-unsubscribe");
+  assert.equal(snapshots.length, snapshotCount);
+}
+
+{
+  const { flow, commands } = newFlow();
+  flow.receive({
+    type: "projectList",
+    projects: [{ id: "project-1", name: "First" }, { id: "project-2", name: "Second" }],
+  });
+  flow.selectProject("project-2");
+
+  const beforeStaleResponse = flow.snapshot();
+  flow.receive({
+    type: "branchList",
+    projectId: "project-1",
+    branches: ["main"],
+    preferredBase: "main",
+  });
+  assert.deepStrictEqual(flow.snapshot(), beforeStaleResponse);
+
+  flow.receive({
+    type: "branchList",
+    projectId: "project-2",
+    branches: ["main", "release"],
+    preferredBase: "release",
+  });
+  assert.equal(flow.snapshot().base, "release");
+  assert.deepStrictEqual(flow.snapshot().branches, ["main", "release"]);
+
+  const beforeStaleFailure = flow.snapshot();
+  flow.receive({
+    type: "branchListFailed",
+    projectId: "project-1",
+    message: "Old repository failed to load",
+  });
+  assert.deepStrictEqual(flow.snapshot(), beforeStaleFailure);
+
+  flow.setBase("main");
+  flow.selectProject("project-1");
+  flow.receive({
+    type: "branchList",
+    projectId: "project-1",
+    branches: ["trunk"],
+    preferredBase: "missing",
+  });
+  assert.equal(flow.snapshot().base, "trunk");
+  assert.deepStrictEqual(commands.at(-1), { type: "listBranches", projectId: "project-1" });
+}
+
+{
+  const { flow, commands } = newFlow();
+  flow.selectProject("project-1");
+  flow.receive({
+    type: "branchListFailed",
+    projectId: "project-1",
+    message: "Git is unavailable",
+  });
+  assert.equal(flow.snapshot().projectId, "project-1");
+  assert.equal(flow.snapshot().branchesLoading, false);
+  assert.deepStrictEqual(flow.snapshot().error, { stage: "branches", message: "Git is unavailable", worktreeId: null });
+
+  flow.retryBranches();
+  assert.deepStrictEqual(commands.at(-1), { type: "listBranches", projectId: "project-1" });
+  assert.equal(flow.snapshot().branchesLoading, true);
+}
+
+{
+  const { flow, commands } = newFlow();
+  assert.equal(flow.submit(), false);
+  assert.equal(flow.snapshot().error.stage, "validation");
+
+  flow.selectProject("project-1");
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  flow.setBranch("   ");
+  flow.setAgent("agent-1");
+  assert.equal(flow.canSubmit(), false);
+  assert.equal(flow.submit(), false);
+
+  flow.setBranch("feature/new-worktree");
+  assert.equal(flow.canSubmit(), true);
+  assert.equal(flow.submit(), true);
+  assert.equal(flow.submit(), false);
+  assert.equal(flow.snapshot().submitting, true);
+  assert.deepStrictEqual(commands.at(-1), {
+    type: "createWorktreeSession",
+    projectId: "project-1",
+    base: "main",
+    branch: "feature/new-worktree",
+    agentId: "agent-1",
+  });
+  assert.equal(commands.filter(({ type }) => type === "createWorktreeSession").length, 1);
+}
+
+{
+  const { flow, commands } = newFlow();
+  flow.selectProject("project-1");
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  flow.setBranch("feature/validation");
+
+  assert.equal(flow.submit(), false);
+  assert.equal(flow.snapshot().error.stage, "validation");
+  assert.equal(commands.filter(({ type }) => type === "createWorktreeSession").length, 0);
+
+  flow.setAgent("agent-1");
+  flow.setBase("missing");
+  assert.equal(flow.submit(), false);
+  assert.equal(flow.snapshot().error.stage, "validation");
+  assert.equal(commands.filter(({ type }) => type === "createWorktreeSession").length, 0);
+}
+
+assert.equal(creation.isValidBranchName("feature/new-worktree"), true);
+assert.equal(creation.isValidBranchName("feature\u0001broken"), false);
+
+{
+  const { flow, commands } = newFlow();
+  flow.selectProject("project-1");
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  flow.setBranch("feature/ok");
+  flow.setAgent("agent-1");
+  flow.submit();
+  const session = { id: "session-1", title: "New session", worktree: { id: "worktree-1" } };
+  flow.receive({ type: "worktreeSessionCreated", session });
+  assert.equal(flow.snapshot().submitting, false);
+  assert.deepStrictEqual(flow.snapshot().result, session);
+  assert.equal(flow.snapshot().error, null);
+
+  const completedCommands = commands.length;
+  flow.receive({ type: "branchList", projectId: "project-other", branches: ["main"], preferredBase: "main" });
+  assert.equal(commands.length, completedCommands);
+
+  const completedSnapshot = flow.snapshot();
+  completedSnapshot.result.worktree.id = "mutated";
+  assert.equal(flow.snapshot().result.worktree.id, "worktree-1");
+}
+
+{
+  const { flow, commands } = newFlow();
+  const observedBranches = [];
+  flow.subscribe((snapshot) => snapshot.branches.push("mutated"));
+  flow.subscribe((snapshot) => observedBranches.push(snapshot.branches));
+  flow.selectProject("project-1");
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  assert.deepStrictEqual(observedBranches.at(-1), ["main"]);
+}
+
+{
+  const { flow, commands } = newFlow();
+  flow.selectProject("project-1");
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  flow.setBranch("feature/fail");
+  flow.setAgent("agent-1");
+  flow.submit();
+  const commandsBeforeWorktreeFailure = commands.length;
+  flow.receive({ type: "worktreeSessionCreationFailed", stage: "worktree", message: "Branch already exists" });
+  assert.equal(commands.length, commandsBeforeWorktreeFailure);
+  assert.equal(flow.snapshot().submitting, false);
+  assert.deepStrictEqual(flow.snapshot().error, {
+    stage: "worktree", message: "Branch already exists", worktreeId: null,
+  });
+
+  flow.submit();
+  const commandsBeforeSessionFailure = commands.length;
+  flow.receive({
+    type: "worktreeSessionCreationFailed",
+    stage: "session",
+    message: "Agent failed to start",
+    worktreeId: "worktree-1",
+  });
+  assert.equal(commands.length, commandsBeforeSessionFailure);
+  assert.deepStrictEqual(flow.snapshot().error, {
+    stage: "session", message: "Agent failed to start", worktreeId: "worktree-1",
+  });
+  assert.equal(flow.snapshot().result, null);
+}
+
+{
+  const { flow } = newFlow();
+  flow.startNewWorktree();
+  assert.equal(flow.snapshot().mode, "new");
+  assert.equal(flow.snapshot().step, "worktree");
+  flow.selectProject("project-1");
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  flow.setBranch("feature/navigation");
+  assert.equal(flow.next(), true);
+  assert.equal(flow.snapshot().step, "agent");
+  flow.setAgent("agent-1");
+  assert.equal(flow.back(), true);
+  assert.equal(flow.snapshot().step, "worktree");
+  assert.equal(flow.snapshot().branch, "feature/navigation");
+  assert.equal(flow.snapshot().agentId, "agent-1");
+  assert.equal(flow.next(), true);
+  assert.equal(flow.snapshot().step, "agent");
+}
+
+{
+  const { flow } = newFlow();
+  flow.selectProject("project-1");
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  const loaded = flow.snapshot();
+  assert.equal(flow.receive({ type: "branchList", projectId: "project-1", branches: ["other"], preferredBase: "other" }), false);
+  assert.deepStrictEqual(flow.snapshot(), loaded);
+  assert.equal(flow.receive({ type: "branchListFailed", projectId: "project-1", message: "late failure" }), false);
+  assert.deepStrictEqual(flow.snapshot(), loaded);
+}
+
+{
+  const { flow, commands } = newFlow();
+  flow.selectProject("project-1");
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  flow.setBranch("feature/disconnect");
+  flow.setAgent("agent-1");
+  assert.equal(flow.submit(), true);
+  const commandsBeforeDisconnect = commands.length;
+  flow.disconnect();
+  assert.equal(flow.snapshot().outcomeUnknown, true);
+  assert.equal(flow.snapshot().submitting, false);
+  assert.equal(flow.canRetry(), false);
+  assert.equal(flow.submit(), false);
+  assert.equal(commands.length, commandsBeforeDisconnect);
+  assert.equal(flow.receive({ type: "worktreeSessionCreated", session: { id: "late" } }), false);
+  assert.equal(flow.snapshot().result, null);
+  flow.markRecoveryListLoaded("sessions");
+  assert.equal(flow.canRetry(), false);
+  flow.markRecoveryListLoaded("worktrees");
+  assert.equal(flow.canRetry(), true);
+}
+
+{
+  const { flow } = newFlow();
+  flow.startNewWorktree();
+  flow.selectProject("project-1");
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  flow.setBranch("feature/partial");
+  flow.next();
+  flow.setAgent("agent-1");
+  flow.submit();
+  assert.equal(flow.receive({
+    type: "worktreeSessionCreationFailed",
+    stage: "session",
+    message: "Agent failed to start",
+    worktreeId: "worktree-1",
+  }), true);
+  assert.equal(flow.snapshot().mode, "existing");
+  assert.equal(flow.snapshot().step, "worktree");
+  assert.equal(flow.snapshot().createdWorktreeId, "worktree-1");
+  assert.equal(flow.snapshot().selectedWorktreeId, "worktree-1");
+  const partialSuccess = flow.snapshot();
+  assert.equal(flow.receive({ type: "worktreeSessionCreated", session: { id: "duplicate" } }), false);
+  assert.deepStrictEqual(flow.snapshot(), partialSuccess);
+}
+
+{
+  const { flow, commands } = newFlow();
+  const observed = [];
+  flow.subscribe(() => { throw new Error("listener failed"); });
+  flow.subscribe((snapshot) => observed.push(snapshot.projectId));
+  flow.selectProject("project-1");
+  assert.deepStrictEqual(commands, [{ type: "listBranches", projectId: "project-1" }]);
+  assert.deepStrictEqual(observed, ["project-1"]);
+}
+
+{
+  const { flow, commands } = newFlow();
+  let reentered = false;
+  flow.subscribe((snapshot) => {
+    if (snapshot.projectId === "project-1" && !reentered) {
+      reentered = true;
+      flow.selectProject("project-2");
+    }
+  });
+  flow.selectProject("project-1");
+  assert.deepStrictEqual(commands, [{ type: "listBranches", projectId: "project-2" }]);
+  assert.equal(flow.snapshot().projectId, "project-2");
+  assert.equal(flow.snapshot().branchStatus, "loading");
+}
+
+{
+  const { flow } = newFlow();
+  const received = [];
+  flow.subscribe(() => flow.subscribe(() => received.push("late listener")));
+  flow.selectProject("project-1");
+  assert.deepStrictEqual(received, []);
+  flow.setBranch("feature/next-event");
+  assert.deepStrictEqual(received, ["late listener"]);
+}
+
+{
+  const { flow, commands } = newFlow();
+  flow.selectProject("project-1");
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  flow.setBranch("feature/captured");
+  flow.setAgent("agent-1");
+  let reentered = false;
+  flow.subscribe((snapshot) => {
+    if (snapshot.submitting && !reentered) {
+      reentered = true;
+      flow.setBranch("   ");
+    }
+  });
+  assert.equal(flow.submit(), true);
+  assert.deepStrictEqual(commands.at(-1), {
+    type: "createWorktreeSession",
+    projectId: "project-1",
+    base: "main",
+    branch: "feature/captured",
+    agentId: "agent-1",
+  });
+}
+
+{
+  const { flow } = newFlow();
+  flow.selectProject("project-1");
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  flow.setBranch("feature/terminal-validation");
+  flow.setAgent("agent-1");
+  flow.submit();
+  assert.equal(flow.receive({ type: "worktreeSessionCreated", session: {} }), false);
+  assert.equal(flow.snapshot().submitting, true);
+  assert.equal(flow.receive({ type: "worktreeSessionCreationFailed", stage: "unexpected", message: "bad stage" }), false);
+  assert.equal(flow.snapshot().submitting, true);
+  assert.equal(flow.receive({ type: "worktreeSessionCreationFailed", stage: "worktree", message: "   " }), false);
+  assert.equal(flow.snapshot().submitting, true);
+}
+
+{
+  const { flow, commands } = newFlow();
+  flow.selectProject("project-1");
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  flow.setBranch("feature/retry");
+  flow.setAgent("agent-1");
+  flow.submit();
+  flow.disconnect();
+  flow.markRecoveryListLoaded("sessions");
+  flow.markRecoveryListLoaded("worktrees");
+  assert.equal(flow.canRetry(), true);
+  assert.equal(flow.submit(), true);
+  assert.equal(commands.filter(({ type }) => type === "createWorktreeSession").length, 2);
+  assert.equal(flow.snapshot().outcomeUnknown, false);
+  assert.deepStrictEqual(flow.snapshot().recovery, { sessions: false, worktrees: false });
+}
+
+console.log("remote web worktree creation tests passed");

--- a/scripts/tests/remote-web-worktree-creation/test-worktree-creation.js
+++ b/scripts/tests/remote-web-worktree-creation/test-worktree-creation.js
@@ -99,6 +99,57 @@ function newFlow() {
 
 {
   const { flow, commands } = newFlow();
+  flow.startNewWorktree();
+  flow.loadProjects();
+  flow.reloadCatalog();
+  assert.deepStrictEqual(commands, [
+    { type: "listProjects" },
+    { type: "listProjects" },
+  ]);
+
+  flow.receive({ type: "projectList", projects: [{ id: "project-1", name: "First" }] });
+  assert.deepStrictEqual(commands.at(-1), { type: "listBranches", projectId: "project-1" });
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  assert.equal(flow.snapshot().projectsLoading, false);
+  assert.equal(flow.snapshot().branchesLoading, false);
+  assert.equal(flow.snapshot().branchStatus, "loaded");
+}
+
+{
+  const { flow, commands } = newFlow();
+  flow.startNewWorktree();
+  flow.receive({ type: "projectList", projects: [{ id: "project-1", name: "First" }] });
+  flow.reloadCatalog();
+  assert.deepStrictEqual(commands.slice(-2), [
+    { type: "listProjects" },
+    { type: "listBranches", projectId: "project-1" },
+  ]);
+  assert.equal(flow.snapshot().projectsLoading, true);
+  assert.equal(flow.snapshot().branchesLoading, true);
+
+  flow.receive({ type: "projectList", projects: [{ id: "project-1", name: "First" }] });
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  assert.equal(flow.snapshot().projectsLoading, false);
+  assert.equal(flow.snapshot().branchesLoading, false);
+  assert.equal(flow.snapshot().base, "main");
+}
+
+{
+  const { flow, commands } = newFlow();
+  flow.selectProject("project-1");
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  flow.setBranch("feature/stale-agent");
+  flow.setAgent("agent-stale");
+  assert.equal(flow.canSubmit(), true);
+  assert.equal(flow.reconcileAgents([{ id: "agent-current" }]), true);
+  assert.equal(flow.snapshot().agentId, null);
+  assert.equal(flow.canSubmit(), false);
+  assert.equal(flow.submit(), false);
+  assert.equal(commands.filter(({ type }) => type === "createWorktreeSession").length, 0);
+}
+
+{
+  const { flow, commands } = newFlow();
   assert.equal(flow.submit(), false);
   assert.equal(flow.snapshot().error.stage, "validation");
 
@@ -214,6 +265,7 @@ assert.equal(creation.isValidBranchName("feature\u0001broken"), false);
   flow.selectProject("project-1");
   flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
   flow.setBranch("feature/navigation");
+  assert.equal(flow.canAdvance(), true);
   assert.equal(flow.next(), true);
   assert.equal(flow.snapshot().step, "agent");
   flow.setAgent("agent-1");
@@ -223,6 +275,22 @@ assert.equal(creation.isValidBranchName("feature\u0001broken"), false);
   assert.equal(flow.snapshot().agentId, "agent-1");
   assert.equal(flow.next(), true);
   assert.equal(flow.snapshot().step, "agent");
+}
+
+{
+  const { flow } = newFlow();
+  assert.equal(flow.canAdvance(), false);
+  flow.selectProject("project-1");
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  flow.setBranch("feature/advance");
+  assert.equal(flow.canAdvance(), true);
+  flow.startNewWorktree();
+  flow.selectProject("project-1");
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  flow.setBranch("feature/advance");
+  flow.setAgent("agent-1");
+  flow.submit();
+  assert.equal(flow.canAdvance(), false);
 }
 
 {
@@ -256,6 +324,75 @@ assert.equal(creation.isValidBranchName("feature\u0001broken"), false);
   assert.equal(flow.canRetry(), false);
   flow.markRecoveryListLoaded("worktrees");
   assert.equal(flow.canRetry(), true);
+}
+
+{
+  const { flow, commands } = newFlow();
+  flow.startNewWorktree();
+  flow.selectProject("project-1");
+  flow.receive({
+    type: "branchList",
+    projectId: "project-1",
+    branches: ["main", "release"],
+    preferredBase: "main",
+  });
+  flow.setBase("release");
+  flow.setBranch("feature/reload-preserves-base");
+  flow.next();
+  flow.setAgent("agent-1");
+  flow.submit();
+  flow.disconnect();
+  const unknownError = flow.snapshot().error;
+
+  flow.reloadCatalog();
+  assert.equal(flow.snapshot().base, "release");
+  assert.deepStrictEqual(flow.snapshot().error, unknownError);
+  assert.deepStrictEqual(commands.slice(-2), [
+    { type: "listProjects" },
+    { type: "listBranches", projectId: "project-1" },
+  ]);
+
+  flow.receive({ type: "projectList", projects: [{ id: "project-1", name: "First" }] });
+  flow.receive({
+    type: "branchList",
+    projectId: "project-1",
+    branches: ["main", "release"],
+    preferredBase: "main",
+  });
+  assert.equal(flow.snapshot().base, "release");
+  assert.deepStrictEqual(flow.snapshot().error, unknownError);
+
+  flow.markRecoveryListLoaded("sessions");
+  flow.markRecoveryListLoaded("worktrees");
+  assert.equal(flow.submit(), true);
+  assert.deepStrictEqual(commands.at(-1), {
+    type: "createWorktreeSession",
+    projectId: "project-1",
+    base: "release",
+    branch: "feature/reload-preserves-base",
+    agentId: "agent-1",
+  });
+}
+
+{
+  const { flow } = newFlow();
+  flow.startNewWorktree();
+  flow.selectProject("project-1");
+  flow.receive({ type: "branchList", projectId: "project-1", branches: ["main"], preferredBase: "main" });
+  flow.setBranch("feature/recovery-guard");
+  flow.next();
+  flow.setAgent("agent-1");
+  flow.submit();
+  flow.disconnect();
+
+  const recoveryPending = flow.snapshot();
+  assert.equal(flow.back(), false);
+  assert.deepStrictEqual(flow.reset(), recoveryPending);
+
+  flow.markRecoveryListLoaded("sessions");
+  flow.markRecoveryListLoaded("worktrees");
+  assert.equal(flow.canRetry(), true);
+  assert.deepStrictEqual(flow.reset(), creation.initialState());
 }
 
 {
@@ -370,6 +507,16 @@ assert.equal(creation.isValidBranchName("feature\u0001broken"), false);
   assert.equal(commands.filter(({ type }) => type === "createWorktreeSession").length, 2);
   assert.equal(flow.snapshot().outcomeUnknown, false);
   assert.deepStrictEqual(flow.snapshot().recovery, { sessions: false, worktrees: false });
+}
+
+{
+  const { flow } = newFlow();
+  flow.startNewWorktree();
+  flow.selectProject("project-1");
+  flow.setBranch("feature/clear-on-close");
+  flow.setAgent("agent-1");
+  flow.reset();
+  assert.deepStrictEqual(flow.snapshot(), creation.initialState());
 }
 
 console.log("remote web worktree creation tests passed");


### PR DESCRIPTION
## Summary

- Add remote project and branch catalogs plus remote-safe worktree and ACP session creation.
- Route worktree-session creation through the remote gateway.
- Add the staged remote web flow with reconnect recovery and focused coverage.

## Verification

- `xcodegen`
- macOS build
- Focused remote Swift tests
- Remote-web Node test suites
- GitHub Actions `build-test`