### PR TITLE
feat(remote): read-only Changes and Files tabs for remote web

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -844,6 +844,7 @@
 		881AE2B2D456B36573346AD6 /* DraftCommitTabsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB0C89AA6E07A2402934FD2 /* DraftCommitTabsManagerTests.swift */; };
 		881EB8E37CE9D947A2C74564 /* GitRefNameInputFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D6BBD77A210BB378E217FC /* GitRefNameInputFilterTests.swift */; };
 		8824EFBA6EA3673F13244C6D /* MergeSingleResolvePromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 749E3289E4C70DA7E4DD80E6 /* MergeSingleResolvePromptEditorWindow.swift */; };
+		88410E03F4A1760992C58AE3 /* GitService+RemoteChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB8C5E87A22F4A12518D4893 /* GitService+RemoteChanges.swift */; };
 		884F7EB87029E537B923191E /* DefinitionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */; };
 		887B90FE9E87033A31567CC0 /* WorktreeSortMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3F4EE1590F6355AF2AD9DA /* WorktreeSortMenuTests.swift */; };
 		88A139C7B3C3C9F20EF5945A /* ACPChangeNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419EF533C4D29448483045DA /* ACPChangeNotifier.swift */; };
@@ -1450,6 +1451,7 @@
 		E551A81EBC839478D6999A97 /* ACPComposerDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */; };
 		E5648509F3F1EA4297E856A1 /* GGStackCreateMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B7A6EC8A1372E76F0B934D /* GGStackCreateMode.swift */; };
 		E5D32C15B08F30DF3B46CA74 /* DiffReviewScrollSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D73C433B373577FD515FECD3 /* DiffReviewScrollSpy.swift */; };
+		E5E4D7897CF6ED1FB497E11E /* GitServiceRemoteChangesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4441571BD0882A31CF1C8F /* GitServiceRemoteChangesTests.swift */; };
 		E5E6CB61C4776CD48C3AF563 /* ACPDictationRegionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD3B4EB4344DFAF081D72D5 /* ACPDictationRegionTests.swift */; };
 		E6119C80C9AFF38EB308301A /* GGMCPInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1E93FE66457A82A3348EDA /* GGMCPInjection.swift */; };
 		E6426E94A57602E76D401D21 /* AlasActionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005F92E45C7D391D8BD5A3FD /* AlasActionService.swift */; };
@@ -3091,6 +3093,7 @@
 		EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerActionTests.swift; sourceTree = "<group>"; };
 		EE0C0029F439C282D474ED77 /* ACPFileWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileWriter.swift; sourceTree = "<group>"; };
 		EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParserTests.swift; sourceTree = "<group>"; };
+		EE4441571BD0882A31CF1C8F /* GitServiceRemoteChangesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceRemoteChangesTests.swift; sourceTree = "<group>"; };
 		EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRow.swift; sourceTree = "<group>"; };
 		EE6F36C31DB1C13D86416B4B /* PiACPInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiACPInstaller.swift; sourceTree = "<group>"; };
 		EE91017BB71AB08265C7B56E /* ACPComposerControlPresentationDictationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerControlPresentationDictationTests.swift; sourceTree = "<group>"; };
@@ -3174,6 +3177,7 @@
 		FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerTests.swift; sourceTree = "<group>"; };
 		FB73E99357B77163006FA511 /* ACPManagedAdapterDescriptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPManagedAdapterDescriptorTests.swift; sourceTree = "<group>"; };
 		FB86F9BBBDDEF3D9BB3B9F0D /* CommitPublishModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPublishModels.swift; sourceTree = "<group>"; };
+		FB8C5E87A22F4A12518D4893 /* GitService+RemoteChanges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+RemoteChanges.swift"; sourceTree = "<group>"; };
 		FB9E78C70091168556C9669B /* ReviewChangesTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesTabViewTests.swift; sourceTree = "<group>"; };
 		FBB8BF6C61840B9F972ABACC /* RemoteFileStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileStats.swift; sourceTree = "<group>"; };
 		FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextView.swift; sourceTree = "<group>"; };
@@ -3609,6 +3613,7 @@
 				38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */,
 				B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */,
 				1BB00E2F151520DC02B80BD4 /* GitServicePullTests.swift */,
+				EE4441571BD0882A31CF1C8F /* GitServiceRemoteChangesTests.swift */,
 				FFB1CCDE2E4D85A46E6CFB1A /* GitServiceReviewRequestDraftTests.swift */,
 				DB1415E5F17DB2DF2038EE54 /* GitServiceStackCommitTests.swift */,
 				C2CA853E91C240B7B5551859 /* GitServiceStagedTests.swift */,
@@ -3971,6 +3976,7 @@
 				7F4A17C42833BE6190A45AF3 /* GitService+CommitEditing.swift */,
 				90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */,
 				5B9583B34B9AAD4454C558E5 /* GitService+Pull.swift */,
+				FB8C5E87A22F4A12518D4893 /* GitService+RemoteChanges.swift */,
 				764489A630CC6D79FCE0A26A /* GitService+ReviewLoop.swift */,
 				0EE97D2D6875CD6A1DBF4DE9 /* GitService+ReviewRequestDraft.swift */,
 				2DCCB2F0B68844EA336A5433 /* GitService+StackCommits.swift */,
@@ -6578,6 +6584,7 @@
 				DF8CAD5714483408B8BD72F7 /* GitService+Discard.swift in Sources */,
 				E703B4895A0337310A17FED6 /* GitService+ImageDiff.swift in Sources */,
 				74F193BC4B2A1BD5AD58C6DA /* GitService+Pull.swift in Sources */,
+				88410E03F4A1760992C58AE3 /* GitService+RemoteChanges.swift in Sources */,
 				5846A180EB68D905E9775401 /* GitService+ReviewLoop.swift in Sources */,
 				C70D6BEC5321C16B70301CBF /* GitService+ReviewRequestDraft.swift in Sources */,
 				2DA2C2F546AF919D2DE4A41D /* GitService+StackCommits.swift in Sources */,
@@ -7382,6 +7389,7 @@
 				1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */,
 				7BD8965290B1F007B0E99BCF /* GitServiceMergeTests.swift in Sources */,
 				B8BF059C5C2090AFBB56A5BC /* GitServicePullTests.swift in Sources */,
+				E5E4D7897CF6ED1FB497E11E /* GitServiceRemoteChangesTests.swift in Sources */,
 				4D9A57C74B314FA3570B0406 /* GitServiceReviewRequestDraftTests.swift in Sources */,
 				9FE6B05DF450CFD427AD24A2 /* GitServiceStackCommitTests.swift in Sources */,
 				478863759224A2278123B7B9 /* GitServiceStagedTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		0575E49BE44BEB8AB9D4977F /* MergeConflictAgentProposalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECD5B53A23694EF60F63041 /* MergeConflictAgentProposalView.swift */; };
 		0585FDF4437997020A1D1579 /* MergeConflictAnnotationStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5848B9AAD7985BF7BFB87F6 /* MergeConflictAnnotationStrip.swift */; };
 		05AD50E71FED22187F67D33F /* ACPUserInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955B9084309744F3B9A44CBC /* ACPUserInput.swift */; };
+		05F40FE81621967A389B2E89 /* RemoteWorktreeFileAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A5662DEEA883E342579177 /* RemoteWorktreeFileAccess.swift */; };
 		0657FD1930271CA4C1F698DD /* RangeReviewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43B2247BD2DC3FE9E1EA2CC /* RangeReviewLoader.swift */; };
 		065F01BB553C415040414D37 /* ImageDiffSwipeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802EF6C18E2E27F68F6B770E /* ImageDiffSwipeView.swift */; };
 		065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */; };
@@ -490,6 +491,7 @@
 		4A99239BAD338EDCE7BE5F0E /* GGMutationModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1276253D1FB205BC9B5AEDF1 /* GGMutationModelsTests.swift */; };
 		4AFE4A55AF808EEFE3AA4DE2 /* ACPDelegatedSessionsPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0235A58C8825D42F1C406C /* ACPDelegatedSessionsPolicyTests.swift */; };
 		4B2031FB61782327D5279F98 /* FileTreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */; };
+		4B5BCD3E5E98FA998B1CC0D5 /* RemoteWorktreeFileAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CBFA79128A3F134EA7C5BDD /* RemoteWorktreeFileAccessTests.swift */; };
 		4B88A05E99FBAA788CAA4394 /* ClosedTabHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75D19208F2DE728FB5D6F8FF /* ClosedTabHistoryTests.swift */; };
 		4B8A7F326E4DBD17C9D95E1E /* CommitHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02E429B37288215EBC89571 /* CommitHeaderView.swift */; };
 		4B8BD1280C2DFF3CE1FD3C4B /* ACPTranscriptCurrentPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7FA2ABE27A4CC2EB0BCA18 /* ACPTranscriptCurrentPlanTests.swift */; };
@@ -2088,6 +2090,7 @@
 		4C407678AABCFACDBB04B339 /* GGInboxHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxHelpersTests.swift; sourceTree = "<group>"; };
 		4C4B9AC0713D961FC7E1DE22 /* RunScriptPaletteEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptPaletteEnvironment.swift; sourceTree = "<group>"; };
 		4C6641006D2208E28C46AAB2 /* PiACPInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiACPInstallerTests.swift; sourceTree = "<group>"; };
+		4CBFA79128A3F134EA7C5BDD /* RemoteWorktreeFileAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreeFileAccessTests.swift; sourceTree = "<group>"; };
 		4CE0FF00CB2F81000FB09A72 /* LegacyHookSweep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHookSweep.swift; sourceTree = "<group>"; };
 		4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopeRow.swift; sourceTree = "<group>"; };
 		4D20C843AB88A6EB14D2A1BD /* ACPStdioClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStdioClient.swift; sourceTree = "<group>"; };
@@ -3129,6 +3132,7 @@
 		F40A1779F98074142F57210B /* PiMCPAdapterInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiMCPAdapterInspectorTests.swift; sourceTree = "<group>"; };
 		F4120556B9870D6246D0F30A /* ReviewSessionTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionTabViewTests.swift; sourceTree = "<group>"; };
 		F4526714086C04ED5B472C90 /* DiffInlineCommentCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineCommentCard.swift; sourceTree = "<group>"; };
+		F4A5662DEEA883E342579177 /* RemoteWorktreeFileAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreeFileAccess.swift; sourceTree = "<group>"; };
 		F55C4A7D3820C97CB1CD980D /* IssueResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueResolver.swift; sourceTree = "<group>"; };
 		F56A35888F0783BA6F296CED /* MermaidDiagramViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidDiagramViewer.swift; sourceTree = "<group>"; };
 		F59AAA1AFFBA04A837BCBA13 /* ACPBareURLLinkifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBareURLLinkifierTests.swift; sourceTree = "<group>"; };
@@ -3262,6 +3266,7 @@
 				A79A06E48E215BF7B9EC2408 /* RemoteServerIntegrationTests.swift */,
 				37011506F459800FFF6D12A9 /* RemoteSessionGatewayTests.swift */,
 				5AA5809066E33EB30E09E0D8 /* RemoteWebAssetTests.swift */,
+				4CBFA79128A3F134EA7C5BDD /* RemoteWorktreeFileAccessTests.swift */,
 				20A5D6E7C4527B459EFC2CBB /* RemoteWorktreeSummaryBuilderTests.swift */,
 				DF919734A34EEB87FA61FE07 /* WebSocketFrameTests.swift */,
 			);
@@ -3392,6 +3397,7 @@
 				CDE49D2437D7E6AC9D67F136 /* RemoteSessionGateway.swift */,
 				33EBE6A3E0CA30D8910E68F8 /* RemoteSessionsProvider.swift */,
 				88DCE75EFAA8F6E576343CE5 /* RemoteTranscriptSync.swift */,
+				F4A5662DEEA883E342579177 /* RemoteWorktreeFileAccess.swift */,
 				9DD81682586D187AB70D1CDB /* RemoteWorktreeSummaryBuilder.swift */,
 			);
 			path = Gateway;
@@ -6789,6 +6795,7 @@
 				31CB9FBE16CECDE2C6D94EC6 /* RemoteStatusFingerprint.swift in Sources */,
 				FD4196C9F558CE954D94E060 /* RemoteTerminalScript.swift in Sources */,
 				BB7A00188B3BD4C729E0D8E6 /* RemoteTranscriptSync.swift in Sources */,
+				05F40FE81621967A389B2E89 /* RemoteWorktreeFileAccess.swift in Sources */,
 				F2983AF4C5674B906BEF2E88 /* RemoteWorktreePoll.swift in Sources */,
 				8C492CBACC6D6DACE56DADA9 /* RemoteWorktreeSummaryBuilder.swift in Sources */,
 				1F860C66D658B0DA5A0599F6 /* RemoteZmxInstaller.swift in Sources */,
@@ -7544,6 +7551,7 @@
 				0C7A044AC34BF225A4149556 /* RemoteTerminalLaunchTests.swift in Sources */,
 				78D49DF401553D2A9BCE1EE5 /* RemoteTerminalScriptTests.swift in Sources */,
 				0C0C65E3012A722B10816F8D /* RemoteWebAssetTests.swift in Sources */,
+				4B5BCD3E5E98FA998B1CC0D5 /* RemoteWorktreeFileAccessTests.swift in Sources */,
 				CA7269D9237C925D7C1358D7 /* RemoteWorktreePollTests.swift in Sources */,
 				9666162EC5BE3445EEBCDEA1 /* RemoteWorktreeSummaryBuilderTests.swift in Sources */,
 				FCC6BC72DF062AA572F5535F /* RemoteZmxInstallerTests.swift in Sources */,

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -301,6 +301,55 @@ function handle(msg) {
       break;
     case "sessionClosed": if (msg.sessionId === currentSession) showSessions(); break;
     case "promptRejected": if (msg.sessionId === currentSession) restoreRejectedPrompt(); break;
+    case "changeList":
+      if (msg.sessionId !== currentSession) break;
+      $("changes-error").classList.add("hidden");
+      changesState = {
+        comparisonRef: msg.comparisonRef || null,
+        metricsAvailable: msg.metricsAvailable !== false,
+        files: msg.files || [],
+        truncated: !!msg.truncated,
+        loaded: true
+      };
+      renderChanges();
+      break;
+    case "changeListFailed":
+      if (msg.sessionId !== currentSession) break;
+      changesState.loaded = true;
+      showChangesError(fileAccessMessage(msg.reason, null));
+      break;
+    case "fileDiffResult":
+      if (msg.sessionId !== currentSession) break;
+      renderDiff(msg.path, msg.hunks || [], !!msg.truncated);
+      break;
+    case "fileDiffFailed":
+      if (msg.sessionId !== currentSession) break;
+      if ($("diff-path").textContent === msg.path) {
+        $("diff-rows").innerHTML = "";
+        $("diff-rows").append(el("p", "placeholder-card", fileAccessMessage(msg.reason, null)));
+      }
+      break;
+    case "fileTree":
+      if (msg.sessionId !== currentSession) break;
+      $("file-error").classList.add("hidden");
+      changesTree.applyNodes(msg.path === undefined ? null : msg.path, msg.nodes || []);
+      renderFileTree();
+      break;
+    case "fileTreeFailed":
+      if (msg.sessionId !== currentSession) break;
+      showFileError(fileAccessMessage(msg.reason, null));
+      break;
+    case "fileContents":
+      if (msg.sessionId !== currentSession) break;
+      renderFileContents(msg.path, msg.text || "", !!msg.truncated);
+      break;
+    case "fileUnavailable":
+      if (msg.sessionId !== currentSession) break;
+      if ($("file-view-path").textContent === msg.path) {
+        $("file-view-body").innerHTML = "";
+        $("file-view-body").append(el("p", "placeholder-card", fileAccessMessage(msg.reason, msg.byteSize)));
+      }
+      break;
     case "error": setStatus("Error", "bad"); $("status").title = msg.message ?? ""; break;
     default: console.warn("unknown message type", msg.type);
   }
@@ -431,6 +480,162 @@ $("tab-chat").addEventListener("click", () => showTab("chat"));
 $("tab-changes").addEventListener("click", () => showTab("changes"));
 $("tab-files").addEventListener("click", () => showTab("files"));
 $("changes-refresh").addEventListener("click", requestChanges);
+
+function renderChanges() {
+  const list = $("changes-list");
+  list.innerHTML = "";
+  $("changes-summary").textContent = changesState.loaded
+    ? RemoteChangesView.formatSummary(changesState)
+    : "Loading changes…";
+
+  if (changesState.loaded && !changesState.metricsAvailable) {
+    list.append(el("p", "placeholder-card", "Change metrics are unavailable for this worktree."));
+    return;
+  }
+
+  if (changesState.loaded && changesState.files.length === 0) {
+    list.append(el("p", "placeholder-card", "No changes yet."));
+    return;
+  }
+
+  for (const file of RemoteChangesView.sortFiles(changesState.files)) {
+    const parts = RemoteChangesView.splitPath(file.path);
+    const row = document.createElement("button");
+    row.type = "button";
+    row.className = "change-row";
+    row.onclick = () => openDiff(file.path);
+
+    row.append(el("span", "change-dir", parts.dir), el("span", "change-name", parts.name));
+    if (file.conflict) row.append(el("span", "change-conflict", "conflict"));
+    row.append(el("span", "change-counts", RemoteChangesView.formatFileCounts(file)));
+    list.appendChild(row);
+  }
+
+  const notice = RemoteChangesView.truncationNotice(changesState.truncated, "files");
+  if (notice) list.append(el("p", "placeholder-card", notice));
+}
+
+function openDiff(path) {
+  detailStack.push({ tab: "changes", path });
+  $("changes-list").classList.add("hidden");
+  $("changes-header").classList.add("hidden");
+  $("diff-view").classList.remove("hidden");
+  $("diff-path").textContent = path;
+  $("diff-rows").innerHTML = "";
+  send({ type: "fileDiff", sessionId: currentSession, path });
+}
+
+function closeDetailLevel() {
+  detailStack.pop();
+  $("diff-view").classList.add("hidden");
+  $("file-view").classList.add("hidden");
+  $("changes-list").classList.remove("hidden");
+  $("changes-header").classList.remove("hidden");
+  $("file-list").classList.remove("hidden");
+}
+
+function renderDiff(path, hunks, truncated) {
+  if ($("diff-path").textContent !== path) return;   // a newer file is open
+  const container = $("diff-rows");
+  container.innerHTML = "";
+  for (const row of RemoteChangesView.diffRows(hunks)) {
+    if (row.type === "hunk") {
+      container.append(el("div", "diff-hunk", row.text));
+      continue;
+    }
+    const line = el("div", "diff-line " + row.kind);
+    line.append(
+      el("span", "diff-gutter", row.oldNumber === null ? "" : String(row.oldNumber)),
+      el("span", "diff-gutter", row.newNumber === null ? "" : String(row.newNumber)),
+      el("span", "", row.text));
+    container.appendChild(line);
+  }
+  const notice = RemoteChangesView.truncationNotice(truncated, "diff");
+  if (notice) container.append(el("p", "placeholder-card", notice));
+}
+
+function renderFileTree() {
+  const list = $("file-list");
+  list.innerHTML = "";
+  for (const row of changesTree.visibleRows()) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "file-row";
+    button.style.paddingLeft = 12 + row.depth * 14 + "px";
+
+    const label = row.node.kind === "dir"
+      ? (row.expanded ? "▾ " : "▸ ") + row.node.name
+      : row.node.name;
+    button.append(el("span", "", label));
+    if (row.node.badge) button.append(el("span", "change-counts", row.node.badge));
+
+    button.onclick = () => {
+      if (row.node.kind === "dir") {
+        if (changesTree.toggle(row.node.path)) {
+          send({ type: "listFiles", sessionId: currentSession, path: row.node.path });
+        }
+        renderFileTree();
+        return;
+      }
+      openFileView(row.node.path);
+    };
+    list.appendChild(button);
+  }
+}
+
+function openFileView(path) {
+  detailStack.push({ tab: "files", path });
+  $("file-list").classList.add("hidden");
+  $("file-view").classList.remove("hidden");
+  $("file-view-path").textContent = path;
+  $("file-view-body").textContent = "Loading…";
+  send({ type: "readFile", sessionId: currentSession, path });
+}
+
+function renderFileContents(path, text, truncated) {
+  if ($("file-view-path").textContent !== path) return;
+  const body = $("file-view-body");
+  body.innerHTML = "";
+  text.split("\n").forEach((line, index) => {
+    const row = el("div", "diff-line");
+    row.append(el("span", "diff-gutter", String(index + 1)), el("span", "", line));
+    body.appendChild(row);
+  });
+  if (truncated) body.append(el("p", "placeholder-card", "File truncated."));
+}
+
+function fileAccessMessage(reason, byteSize) {
+  switch (reason) {
+    case "binary": return "Binary file — not shown.";
+    case "tooLarge": return byteSize
+      ? "File is " + Math.round(byteSize / 1024) + " KB — too large to view."
+      : "File is too large to view.";
+    case "pathRejected": return "That path is outside this worktree.";
+    case "notFound": return "File not found.";
+    case "worktreeUnavailable": return "This session's worktree is unavailable.";
+    case "sessionUnknown": return "This session is no longer open on the host.";
+    default: return "Could not read this file.";
+  }
+}
+
+function showChangesError(text) {
+  const error = $("changes-error");
+  error.textContent = text;
+  error.classList.remove("hidden");
+}
+
+function showFileError(text) {
+  const error = $("file-error");
+  error.textContent = text;
+  error.classList.remove("hidden");
+}
+
+/// Re-fetch the change list when the agent stops, but only while the tab is
+/// open — the server keeps no per-tab state.
+function noteStreamingStateForChanges(state) {
+  if (state !== "idle") return;
+  if (activeTab === "changes" && detailStack.length === 0) requestChanges();
+}
 
 function clearSessionSheetsForOpen() {
   hidePermission();
@@ -2450,6 +2655,7 @@ function markStopping(on) {
 function syncStreamingState(streamingState) {
   if (streamingState === "idle" && stopPending) markStopping(false);
   renderDriveBar(streamingState);
+  noteStreamingStateForChanges(streamingState);
 }
 
 // takeOver seizes the lease synchronously server-side and messages are ordered,
@@ -2683,7 +2889,10 @@ $("question").onclick = (e) => { if (e.target.id === "question") dismissQuestion
 $("permission").onclick = (e) => { if (e.target.id === "permission") hidePermission(); };
 $("elicitation").onclick = (e) => { if (e.target.id === "elicitation") resolveElicitation("cancel"); };
 
-$("back").onclick = showSessions;
+$("back").onclick = () => {
+  if (detailStack.length > 0) { closeDetailLevel(); return; }
+  showSessions();
+};
 $("gate-retry").onclick = retryConnection;
 
 // iOS overlays the keyboard without shrinking the layout viewport, so a

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -46,6 +46,10 @@ let createState = {
 };
 const worktreeCreation = RemoteWorktreeCreation.createFlow(send);
 worktreeCreation.subscribe(() => renderCreateSheet());
+const changesTree = RemoteFileBrowser.createTree();
+let activeTab = "chat";
+let changesState = { comparisonRef: null, metricsAvailable: true, files: [], truncated: false, loaded: false };
+let detailStack = [];   // [{ tab, path }] for the in-tab list → detail level
 const ATTACH_CAP = 10 * 1000 * 1000;   // 10 MB running total — matches the server's maxAttachmentsBytes
 
 // state ∈ {connecting, ok, bad} drives the chip's dot/border color via [data-state].
@@ -393,7 +397,40 @@ function openSession(id) {
   $("messages").innerHTML = ""; renderConfigAffordances();
   queueItems = []; steerUndoAvailable = false; renderQueue();
   renderDriveBar("idle"); send({ type: "subscribe", sessionId: id });
+  changesTree.reset();
+  changesState = { comparisonRef: null, metricsAvailable: true, files: [], truncated: false, loaded: false };
+  detailStack = [];
+  const summary = listedSessions.get(id);
+  $("detail-tabs").classList.toggle("hidden", !summary || !summary.worktree);
+  showTab("chat");
 }
+
+function showTab(name) {
+  activeTab = name;
+  detailStack = [];
+  $("diff-view").classList.add("hidden");
+  $("file-view").classList.add("hidden");
+  for (const [id, tab] of [["tab-chat", "chat"], ["tab-changes", "changes"], ["tab-files", "files"]]) {
+    $(id).classList.toggle("is-active", tab === name);
+  }
+  $("transcript").classList.toggle("hidden", name !== "chat");
+  $("changes").classList.toggle("hidden", name !== "changes");
+  $("files").classList.toggle("hidden", name !== "files");
+  if (name === "changes") requestChanges();
+  if (name === "files" && changesTree.needsChildren(null)) {
+    send({ type: "listFiles", sessionId: currentSession });
+  }
+}
+
+function requestChanges() {
+  if (!currentSession) return;
+  send({ type: "listChanges", sessionId: currentSession });
+}
+
+$("tab-chat").addEventListener("click", () => showTab("chat"));
+$("tab-changes").addEventListener("click", () => showTab("changes"));
+$("tab-files").addEventListener("click", () => showTab("files"));
+$("changes-refresh").addEventListener("click", requestChanges);
 
 function clearSessionSheetsForOpen() {
   hidePermission();
@@ -414,6 +451,13 @@ function showSessions() {
   $("detail-title").classList.add("hidden"); $("detail-rename").classList.add("hidden");
   $("drivebar").classList.add("hidden");
   $("transcript").classList.add("hidden"); $("sessions").classList.remove("hidden");
+  changesTree.reset();
+  changesState = { comparisonRef: null, metricsAvailable: true, files: [], truncated: false, loaded: false };
+  detailStack = [];
+  activeTab = "chat";
+  $("detail-tabs").classList.add("hidden");
+  $("changes").classList.add("hidden");
+  $("files").classList.add("hidden");
   send({ type: "listSessions" });
 }
 

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -582,14 +582,21 @@ function renderFileTree() {
     button.className = "file-row";
     button.style.paddingLeft = 12 + row.depth * 14 + "px";
 
+    const isSubmodule = row.node.kind === "dir" && row.node.isSubmodule === true;
     const label = row.node.kind === "dir"
-      ? (row.expanded ? "▾ " : "▸ ") + row.node.name
+      ? (isSubmodule ? "◇ " : (row.expanded ? "▾ " : "▸ ")) + row.node.name
       : row.node.name;
     button.append(el("span", "", label));
-    if (row.node.badge) button.append(el("span", "change-counts", row.node.badge));
+    if (isSubmodule) button.append(el("span", "change-counts", "submodule"));
+    else if (row.node.badge) button.append(el("span", "change-counts", row.node.badge));
 
     button.onclick = () => {
       if (row.node.kind === "dir") {
+        // Submodules are a separate git repo: `git check-ignore` / the
+        // server's `listFiles` walk fail on paths inside one ("Pathspec ...
+        // is in submodule"). Treat the row as a non-expandable leaf instead
+        // of sending a `listFiles` request that can only fail.
+        if (isSubmodule) return;
         if (changesTree.toggle(row.node.path)) {
           send({ type: "listFiles", sessionId: currentSession, path: row.node.path });
         }

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -26,6 +26,12 @@ let everConnected = false;      // has any onopen fired this page load? separate
 let escalationTimer = null;     // fires after a continuous not-connected grace window, then shows the alarming gate
 let escalated = false;          // true once the grace window elapsed and the alarming gate is showing
 const GRACE_MS = 5000;          // total not-connected budget before escalating "Connecting…" → "Can't reach Alas"
+// A file within the server's byte cap can still contain an enormous NUMBER
+// of (short or empty) lines — one DOM row per line would freeze the browser
+// or exhaust memory on a phone. 5000 rows is comfortably more than a human
+// scrolls through in the file viewer while staying well short of causing
+// jank on mobile Safari.
+const MAX_RENDERED_FILE_LINES = 5000;
 let dismissedQuestion = null;   // {sessionId, requestId} the user closed; suppress re-shows of that exact prompt (ids aren't unique across sessions)
 let lastSentText = null;        // text of the most recent sendPrompt, kept so a server promptRejected can restore it instead of losing the message
 let lastSentAttachments = [];   // images of the most recent sendPrompt, restored alongside the text on promptRejected
@@ -622,12 +628,20 @@ function renderFileContents(path, text, truncated) {
   if ($("file-view-path").textContent !== path) return;
   const body = $("file-view-body");
   body.innerHTML = "";
-  text.split("\n").forEach((line, index) => {
+  const lines = text.split("\n");
+  const linesTruncated = lines.length > MAX_RENDERED_FILE_LINES;
+  const shown = linesTruncated ? lines.slice(0, MAX_RENDERED_FILE_LINES) : lines;
+  shown.forEach((line, index) => {
     const row = el("div", "diff-line");
     row.append(el("span", "diff-gutter", String(index + 1)), el("span", "", line));
     body.appendChild(row);
   });
   if (truncated) body.append(el("p", "placeholder-card", "File truncated."));
+  // Distinct from the byte-based `truncated` flag above: a file can be under
+  // the server's byte cap (so `truncated` is false) yet still have more
+  // lines than we're willing to render as individual DOM rows.
+  const notice = RemoteChangesView.truncationNotice(linesTruncated, "lines");
+  if (notice) body.append(el("p", "placeholder-card", notice));
 }
 
 function fileAccessMessage(reason, byteSize) {

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -435,6 +435,16 @@ function plural(count, singular) {
   return `${count} ${singular}${count === 1 ? "" : "s"}`;
 }
 
+function resetChangesAndFilesDOM() {
+  $("changes-list").innerHTML = "";
+  $("changes-summary").textContent = "";
+  $("changes-error").textContent = ""; $("changes-error").classList.add("hidden");
+  $("file-list").innerHTML = "";
+  $("file-error").textContent = ""; $("file-error").classList.add("hidden");
+  $("diff-rows").innerHTML = ""; $("diff-path").textContent = "";
+  $("file-view-body").innerHTML = ""; $("file-view-path").textContent = "";
+}
+
 function openSession(id) {
   clearSessionSheetsForOpen();
   currentSession = id; messages = new Map(); messageNodes = new Map(); transcriptMeta = null; olderFetchInFlight = false;
@@ -449,9 +459,18 @@ function openSession(id) {
   changesTree.reset();
   changesState = { comparisonRef: null, metricsAvailable: true, files: [], truncated: false, loaded: false };
   detailStack = [];
+  resetChangesAndFilesDOM();
+  if (changesRefreshDebounceTimer) { clearTimeout(changesRefreshDebounceTimer); changesRefreshDebounceTimer = null; }
+  previousChangesStreamingState = "idle";
   const summary = listedSessions.get(id);
   $("detail-tabs").classList.toggle("hidden", !summary || !summary.worktree);
   showTab("chat");
+}
+
+function showTabListLevel() {
+  $("changes-list").classList.remove("hidden");
+  $("changes-header").classList.remove("hidden");
+  $("file-list").classList.remove("hidden");
 }
 
 function showTab(name) {
@@ -459,6 +478,7 @@ function showTab(name) {
   detailStack = [];
   $("diff-view").classList.add("hidden");
   $("file-view").classList.add("hidden");
+  showTabListLevel();
   for (const [id, tab] of [["tab-chat", "chat"], ["tab-changes", "changes"], ["tab-files", "files"]]) {
     $(id).classList.toggle("is-active", tab === name);
   }
@@ -507,6 +527,7 @@ function renderChanges() {
 
     row.append(el("span", "change-dir", parts.dir), el("span", "change-name", parts.name));
     if (file.conflict) row.append(el("span", "change-conflict", "conflict"));
+    row.append(el("span", "change-status", file.status));
     row.append(el("span", "change-counts", RemoteChangesView.formatFileCounts(file)));
     list.appendChild(row);
   }
@@ -529,9 +550,7 @@ function closeDetailLevel() {
   detailStack.pop();
   $("diff-view").classList.add("hidden");
   $("file-view").classList.add("hidden");
-  $("changes-list").classList.remove("hidden");
-  $("changes-header").classList.remove("hidden");
-  $("file-list").classList.remove("hidden");
+  showTabListLevel();
 }
 
 function renderDiff(path, hunks, truncated) {
@@ -630,11 +649,26 @@ function showFileError(text) {
   error.classList.remove("hidden");
 }
 
-/// Re-fetch the change list when the agent stops, but only while the tab is
-/// open — the server keeps no per-tab state.
+let previousChangesStreamingState = "idle";   // so we can edge-trigger on the idle TRANSITION only
+let changesRefreshDebounceTimer = null;
+const CHANGES_REFRESH_DEBOUNCE_MS = 500;
+
+/// Re-fetch the change list when the agent stops, but only on the actual
+/// transition into idle (not on every idle delta, and not on an
+/// already-idle first delta) and only while the tab is open — the server
+/// keeps no per-tab state. Debounced as defense in depth: the gateway
+/// serializes non-control messages per-connection, so a burst of
+/// transitions must not queue up a pile of listChanges calls.
 function noteStreamingStateForChanges(state) {
-  if (state !== "idle") return;
-  if (activeTab === "changes" && detailStack.length === 0) requestChanges();
+  const wasIdle = previousChangesStreamingState === "idle";
+  previousChangesStreamingState = state;
+  if (state !== "idle" || wasIdle) return;
+  if (activeTab !== "changes" || detailStack.length !== 0) return;
+  if (changesRefreshDebounceTimer) clearTimeout(changesRefreshDebounceTimer);
+  changesRefreshDebounceTimer = setTimeout(() => {
+    changesRefreshDebounceTimer = null;
+    requestChanges();
+  }, CHANGES_REFRESH_DEBOUNCE_MS);
 }
 
 function clearSessionSheetsForOpen() {
@@ -659,6 +693,9 @@ function showSessions() {
   changesTree.reset();
   changesState = { comparisonRef: null, metricsAvailable: true, files: [], truncated: false, loaded: false };
   detailStack = [];
+  resetChangesAndFilesDOM();
+  if (changesRefreshDebounceTimer) { clearTimeout(changesRefreshDebounceTimer); changesRefreshDebounceTimer = null; }
+  previousChangesStreamingState = "idle";
   activeTab = "chat";
   $("detail-tabs").classList.add("hidden");
   $("changes").classList.add("hidden");

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -207,6 +207,7 @@ async function connect() {
     reconnectDelay = initialReconnectDelay;   // reset back-off after a good connection
     send({ type: "listSessions" });
     if (currentSession) send({ type: "subscribe", sessionId: currentSession });   // re-sync after reconnect
+    replayActiveDetailRequest();   // the file/diff request itself doesn't survive a dropped socket
     if (createState.open) {
       createState.error = "";
       requestCreateLists();
@@ -557,6 +558,25 @@ function closeDetailLevel() {
   $("diff-view").classList.add("hidden");
   $("file-view").classList.add("hidden");
   showTabListLevel();
+}
+
+// If the socket drops while a file or diff detail view is open, `onopen`'s
+// `subscribe` only re-syncs the session's transcript — the `readFile`/
+// `fileDiff` request itself was in flight on the OLD socket and is gone
+// with it, so without this the viewer is stuck on "Loading…" (files) or an
+// empty diff (changes) indefinitely, until the user backs out and reopens
+// it. `detailStack`'s top entry is whichever detail view is currently
+// showing (or none, if the user is at a list level), so replaying its
+// request on every reconnect (a no-op when the stack is empty) covers both
+// "dropped mid-request" and "dropped while idly viewing" the same way.
+function replayActiveDetailRequest() {
+  if (!currentSession || detailStack.length === 0) return;
+  const top = detailStack[detailStack.length - 1];
+  if (top.tab === "files") {
+    send({ type: "readFile", sessionId: currentSession, path: top.path });
+  } else if (top.tab === "changes") {
+    send({ type: "fileDiff", sessionId: currentSession, path: top.path });
+  }
 }
 
 function renderDiff(path, hunks, truncated) {

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -350,11 +350,25 @@ function handle(msg) {
       if (msg.truncated) fileTreeTruncatedPaths.add(treeKey);
       else fileTreeTruncatedPaths.delete(treeKey);
       changesTree.applyNodes(msg.path === undefined ? null : msg.path, msg.nodes || []);
+      // Only AFTER applying the root response — not synchronously alongside
+      // the root request in `refreshFileTree()` — does `expandedPaths()`
+      // reflect any directory that response just pruned (deleted/renamed
+      // since the last listing). Requesting descendants any earlier would
+      // still include a since-vanished path, which the server processes
+      // right after the (by-then-already-superseded) root response and
+      // fails, leaving a stale error banner over the freshly refreshed tree.
+      if (treeKey === "" && pendingExpandedPathsRefresh) {
+        pendingExpandedPathsRefresh = false;
+        for (const path of changesTree.expandedPaths()) {
+          send({ type: "listFiles", sessionId: currentSession, path });
+        }
+      }
       renderFileTree();
       break;
     }
     case "fileTreeFailed":
       if (msg.sessionId !== currentSession) break;
+      if (msg.path === undefined || msg.path === null) pendingExpandedPathsRefresh = false;
       showFileError(fileAccessMessage(msg.reason, null));
       break;
     case "fileContents":
@@ -482,6 +496,7 @@ function openSession(id) {
   if (changesRefreshDebounceTimer) { clearTimeout(changesRefreshDebounceTimer); changesRefreshDebounceTimer = null; }
   previousChangesStreamingState = "idle";
   pendingListRefresh = false;
+  pendingExpandedPathsRefresh = false;
   const summary = listedSessions.get(id);
   $("detail-tabs").classList.toggle("hidden", !summary || !summary.worktree);
   showTab("chat");
@@ -497,6 +512,7 @@ function showTab(name) {
   activeTab = name;
   detailStack = [];
   pendingListRefresh = false;   // this switch's own unconditional fetch below covers it
+  pendingExpandedPathsRefresh = false;   // ditto
   $("diff-view").classList.add("hidden");
   $("file-view").classList.add("hidden");
   showTabListLevel();
@@ -523,16 +539,16 @@ function requestChanges() {
 /// refresh doesn't collapse the tree back to just the root — `applyNodes`
 /// overwrites a path's children in place, so this is safe to call whether
 /// or not anything actually changed on the host.
+// Set by `refreshFileTree()`; consumed by the `fileTree`/`fileTreeFailed`
+// handlers once the ROOT response for that refresh comes back. See the
+// `fileTree` case for why the expanded-descendant requests wait for it
+// instead of going out in the same burst as the root request.
+let pendingExpandedPathsRefresh = false;
+
 function refreshFileTree() {
   if (!currentSession) return;
   send({ type: "listFiles", sessionId: currentSession });
-  // `expandedPaths()`, not `visibleRows()`: a directory expanded behind a
-  // since-collapsed ancestor is invisible right now but still cached, and
-  // re-expanding the ancestor later would otherwise render it straight from
-  // that stale cache with no request in between.
-  for (const path of changesTree.expandedPaths()) {
-    send({ type: "listFiles", sessionId: currentSession, path });
-  }
+  pendingExpandedPathsRefresh = true;
 }
 
 $("tab-chat").addEventListener("click", () => showTab("chat"));
@@ -817,6 +833,7 @@ function showSessions() {
   if (changesRefreshDebounceTimer) { clearTimeout(changesRefreshDebounceTimer); changesRefreshDebounceTimer = null; }
   previousChangesStreamingState = "idle";
   pendingListRefresh = false;
+  pendingExpandedPathsRefresh = false;
   activeTab = "chat";
   $("detail-tabs").classList.add("hidden");
   $("changes").classList.add("hidden");

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -345,8 +345,29 @@ function handle(msg) {
       break;
     case "fileTree": {
       if (msg.sessionId !== currentSession) break;
-      $("file-error").classList.add("hidden");
       const treeKey = msg.path === undefined || msg.path === null ? "" : msg.path;
+      if (treeKey === "") {
+        // Starting a fresh refresh (or an ad-hoc root reload): whatever
+        // error a PRIOR cycle left behind no longer applies.
+        $("file-error").classList.add("hidden");
+      } else if (expandedPathsRefreshInFlight > 0) {
+        // Part of an in-flight refreshFileTree() batch — refreshing
+        // several expanded directories independently succeeds or fails
+        // per directory. Clearing the shared banner on every individual
+        // success would hide a still-outstanding (or already failed)
+        // sibling's error while that directory keeps showing its stale
+        // cached children with no indication anything went wrong. Only
+        // clear once every request in this batch has resolved AND none
+        // of them failed.
+        expandedPathsRefreshInFlight -= 1;
+        if (expandedPathsRefreshInFlight === 0 && !expandedPathsRefreshHadFailure) {
+          $("file-error").classList.add("hidden");
+        }
+      } else {
+        // An ad-hoc, user-initiated directory expansion outside any
+        // refresh batch — its own success clearing the banner is fine.
+        $("file-error").classList.add("hidden");
+      }
       if (msg.truncated) fileTreeTruncatedPaths.add(treeKey);
       else fileTreeTruncatedPaths.delete(treeKey);
       changesTree.applyNodes(msg.path === undefined ? null : msg.path, msg.nodes || []);
@@ -359,7 +380,10 @@ function handle(msg) {
       // fails, leaving a stale error banner over the freshly refreshed tree.
       if (treeKey === "" && pendingExpandedPathsRefresh) {
         pendingExpandedPathsRefresh = false;
-        for (const path of changesTree.expandedPaths()) {
+        const expandedPaths = changesTree.expandedPaths();
+        expandedPathsRefreshInFlight = expandedPaths.length;
+        expandedPathsRefreshHadFailure = false;
+        for (const path of expandedPaths) {
           send({ type: "listFiles", sessionId: currentSession, path });
         }
       }
@@ -368,7 +392,12 @@ function handle(msg) {
     }
     case "fileTreeFailed":
       if (msg.sessionId !== currentSession) break;
-      if (msg.path === undefined || msg.path === null) pendingExpandedPathsRefresh = false;
+      if (msg.path === undefined || msg.path === null) {
+        pendingExpandedPathsRefresh = false;
+      } else if (expandedPathsRefreshInFlight > 0) {
+        expandedPathsRefreshInFlight -= 1;
+        expandedPathsRefreshHadFailure = true;
+      }
       showFileError(fileAccessMessage(msg.reason, null));
       break;
     case "fileContents":
@@ -544,6 +573,15 @@ function requestChanges() {
 // `fileTree` case for why the expanded-descendant requests wait for it
 // instead of going out in the same burst as the root request.
 let pendingExpandedPathsRefresh = false;
+// Number of expanded-directory `listFiles` requests still outstanding for
+// the CURRENT refresh batch (0 when no batch is in flight), and whether any
+// of them has failed so far — together these let the `fileTree`/
+// `fileTreeFailed` handlers clear the shared error banner only once every
+// sibling directory in the batch has resolved AND none of them failed,
+// instead of one sibling's success wiping out another's still-visible
+// failure.
+let expandedPathsRefreshInFlight = 0;
+let expandedPathsRefreshHadFailure = false;
 
 function refreshFileTree() {
   if (!currentSession) return;

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -334,7 +334,7 @@ function handle(msg) {
       break;
     case "fileDiffResult":
       if (msg.sessionId !== currentSession) break;
-      renderDiff(msg.path, msg.hunks || [], !!msg.truncated);
+      renderDiff(msg.path, msg.hunks || [], !!msg.truncated, msg.metadataNote || null);
       break;
     case "fileDiffFailed":
       if (msg.sessionId !== currentSession) break;
@@ -639,19 +639,33 @@ function replayActiveDetailRequest() {
 // blank/loading indefinitely until the user switches tabs or manually
 // refreshes. Only fires at the list level (`detailStack` empty); once a
 // detail view is open, replaying its request above takes priority.
+//
+// The Files branch uses `refreshFileTree()` rather than a bare root
+// `listFiles` — a plain root request only repopulates top-level nodes and
+// leaves every already-expanded directory's cached children untouched, so
+// an edit made to a file beneath an expanded directory while disconnected
+// stayed stale until another manual refresh or tab switch. Also covers the
+// case where the socket dropped WHILE already showing the Files list (not
+// just before its first response ever arrived) — same code path, since
+// `detailStack` is empty in both.
 function replayActiveListRequest() {
   if (!currentSession || detailStack.length > 0) return;
   if (activeTab === "changes") {
     requestChanges();
   } else if (activeTab === "files") {
-    send({ type: "listFiles", sessionId: currentSession });
+    refreshFileTree();
   }
 }
 
-function renderDiff(path, hunks, truncated) {
+function renderDiff(path, hunks, truncated, metadataNote) {
   if ($("diff-path").textContent !== path) return;   // a newer file is open
   const container = $("diff-rows");
   container.innerHTML = "";
+  const metadataNotice = RemoteChangesView.metadataOnlyNotice(hunks, metadataNote);
+  if (metadataNotice) {
+    container.append(el("p", "placeholder-card", metadataNotice));
+    return;
+  }
   for (const row of RemoteChangesView.diffRows(hunks)) {
     if (row.type === "hunk") {
       container.append(el("div", "diff-hunk", row.text));

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -573,6 +573,9 @@ function renderDiff(path, hunks, truncated) {
       el("span", "diff-gutter", row.oldNumber === null ? "" : String(row.oldNumber)),
       el("span", "diff-gutter", row.newNumber === null ? "" : String(row.newNumber)),
       el("span", "", row.text));
+    if (row.noTrailingNewline) {
+      line.append(el("span", "diff-no-newline", " (no newline at end of file)"));
+    }
     container.appendChild(line);
   }
   const notice = RemoteChangesView.truncationNotice(truncated, "diff");

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -55,6 +55,12 @@ worktreeCreation.subscribe(() => renderCreateSheet());
 const changesTree = RemoteFileBrowser.createTree();
 let activeTab = "chat";
 let changesState = { comparisonRef: null, metricsAvailable: true, files: [], truncated: false, loaded: false };
+// Paths (root as "") of directory listings the server reported as truncated
+// (more immediate children than RemoteWorktreeFileAccess.maxFileTreeNodes).
+// `visibleRows()` shows the whole expanded tree at once, so a single notice
+// covering any truncated level (rather than per-directory placement) keeps
+// this simple.
+let fileTreeTruncatedPaths = new Set();
 let detailStack = [];   // [{ tab, path }] for the in-tab list → detail level
 const ATTACH_CAP = 10 * 1000 * 1000;   // 10 MB running total — matches the server's maxAttachmentsBytes
 
@@ -337,12 +343,16 @@ function handle(msg) {
         $("diff-rows").append(el("p", "placeholder-card", fileAccessMessage(msg.reason, null)));
       }
       break;
-    case "fileTree":
+    case "fileTree": {
       if (msg.sessionId !== currentSession) break;
       $("file-error").classList.add("hidden");
+      const treeKey = msg.path === undefined || msg.path === null ? "" : msg.path;
+      if (msg.truncated) fileTreeTruncatedPaths.add(treeKey);
+      else fileTreeTruncatedPaths.delete(treeKey);
       changesTree.applyNodes(msg.path === undefined ? null : msg.path, msg.nodes || []);
       renderFileTree();
       break;
+    }
     case "fileTreeFailed":
       if (msg.sessionId !== currentSession) break;
       showFileError(fileAccessMessage(msg.reason, null));
@@ -466,6 +476,7 @@ function openSession(id) {
   renderDriveBar("idle"); send({ type: "subscribe", sessionId: id });
   changesTree.reset();
   changesState = { comparisonRef: null, metricsAvailable: true, files: [], truncated: false, loaded: false };
+  fileTreeTruncatedPaths = new Set();
   detailStack = [];
   resetChangesAndFilesDOM();
   if (changesRefreshDebounceTimer) { clearTimeout(changesRefreshDebounceTimer); changesRefreshDebounceTimer = null; }
@@ -654,6 +665,9 @@ function renderFileTree() {
     };
     list.appendChild(button);
   }
+
+  const notice = RemoteChangesView.truncationNotice(fileTreeTruncatedPaths.size > 0, "directory");
+  if (notice) list.append(el("p", "placeholder-card", notice));
 }
 
 function openFileView(path) {
@@ -754,6 +768,7 @@ function showSessions() {
   $("transcript").classList.add("hidden"); $("sessions").classList.remove("hidden");
   changesTree.reset();
   changesState = { comparisonRef: null, metricsAvailable: true, files: [], truncated: false, loaded: false };
+  fileTreeTruncatedPaths = new Set();
   detailStack = [];
   resetChangesAndFilesDOM();
   if (changesRefreshDebounceTimer) { clearTimeout(changesRefreshDebounceTimer); changesRefreshDebounceTimer = null; }

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -208,6 +208,7 @@ async function connect() {
     send({ type: "listSessions" });
     if (currentSession) send({ type: "subscribe", sessionId: currentSession });   // re-sync after reconnect
     replayActiveDetailRequest();   // the file/diff request itself doesn't survive a dropped socket
+    replayActiveListRequest();     // ...and neither does a listChanges/root listFiles request
     if (createState.open) {
       createState.error = "";
       requestCreateLists();
@@ -576,6 +577,23 @@ function replayActiveDetailRequest() {
     send({ type: "readFile", sessionId: currentSession, path: top.path });
   } else if (top.tab === "changes") {
     send({ type: "fileDiff", sessionId: currentSession, path: top.path });
+  }
+}
+
+// Same reconnect problem as `replayActiveDetailRequest`, one level up: if
+// the socket drops right after the INITIAL `listChanges`/root `listFiles`
+// request but before its response, `detailStack` is still empty (the user
+// never got past the list level), so `replayActiveDetailRequest` has
+// nothing to replay — the Changes list or Files root would otherwise sit
+// blank/loading indefinitely until the user switches tabs or manually
+// refreshes. Only fires at the list level (`detailStack` empty); once a
+// detail view is open, replaying its request above takes priority.
+function replayActiveListRequest() {
+  if (!currentSession || detailStack.length > 0) return;
+  if (activeTab === "changes") {
+    requestChanges();
+  } else if (activeTab === "files") {
+    send({ type: "listFiles", sessionId: currentSession });
   }
 }
 

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -505,14 +505,30 @@ function showTab(name) {
   $("changes").classList.toggle("hidden", name !== "changes");
   $("files").classList.toggle("hidden", name !== "files");
   if (name === "changes") requestChanges();
-  if (name === "files" && changesTree.needsChildren(null)) {
-    send({ type: "listFiles", sessionId: currentSession });
-  }
+  // Always re-fetch on reopening (not just the first time,
+  // `needsChildren(null)`) — the agent may have created, deleted, or
+  // renamed files since the tree was last loaded, and there's no other
+  // signal that would invalidate the cached listing otherwise.
+  if (name === "files") refreshFileTree();
 }
 
 function requestChanges() {
   if (!currentSession) return;
   send({ type: "listChanges", sessionId: currentSession });
+}
+
+/// Re-requests the Files root PLUS every currently-expanded directory, so a
+/// refresh doesn't collapse the tree back to just the root — `applyNodes`
+/// overwrites a path's children in place, so this is safe to call whether
+/// or not anything actually changed on the host.
+function refreshFileTree() {
+  if (!currentSession) return;
+  send({ type: "listFiles", sessionId: currentSession });
+  for (const row of changesTree.visibleRows()) {
+    if (row.node.kind === "dir" && row.expanded) {
+      send({ type: "listFiles", sessionId: currentSession, path: row.node.path });
+    }
+  }
 }
 
 $("tab-chat").addEventListener("click", () => showTab("chat"));
@@ -729,21 +745,27 @@ let previousChangesStreamingState = "idle";   // so we can edge-trigger on the i
 let changesRefreshDebounceTimer = null;
 const CHANGES_REFRESH_DEBOUNCE_MS = 500;
 
-/// Re-fetch the change list when the agent stops, but only on the actual
-/// transition into idle (not on every idle delta, and not on an
-/// already-idle first delta) and only while the tab is open — the server
-/// keeps no per-tab state. Debounced as defense in depth: the gateway
-/// serializes non-control messages per-connection, so a burst of
-/// transitions must not queue up a pile of listChanges calls.
+/// Re-fetch the change list (or the Files tree, if that's the open tab)
+/// when the agent stops, but only on the actual transition into idle (not
+/// on every idle delta, and not on an already-idle first delta) and only
+/// while the relevant tab is open — the server keeps no per-tab state.
+/// Debounced as defense in depth: the gateway serializes non-control
+/// messages per-connection, so a burst of transitions must not queue up a
+/// pile of list requests. Files shares this edge-trigger rather than
+/// getting its own: an agent turn is the same underlying signal for both
+/// ("something on disk may have changed"), and only one of the two tabs is
+/// ever active at a time.
 function noteStreamingStateForChanges(state) {
   const wasIdle = previousChangesStreamingState === "idle";
   previousChangesStreamingState = state;
   if (state !== "idle" || wasIdle) return;
-  if (activeTab !== "changes" || detailStack.length !== 0) return;
+  if (detailStack.length !== 0) return;
+  if (activeTab !== "changes" && activeTab !== "files") return;
   if (changesRefreshDebounceTimer) clearTimeout(changesRefreshDebounceTimer);
   changesRefreshDebounceTimer = setTimeout(() => {
     changesRefreshDebounceTimer = null;
-    requestChanges();
+    if (activeTab === "changes") requestChanges();
+    else if (activeTab === "files") refreshFileTree();
   }, CHANGES_REFRESH_DEBOUNCE_MS);
 }
 

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -481,6 +481,7 @@ function openSession(id) {
   resetChangesAndFilesDOM();
   if (changesRefreshDebounceTimer) { clearTimeout(changesRefreshDebounceTimer); changesRefreshDebounceTimer = null; }
   previousChangesStreamingState = "idle";
+  pendingListRefresh = false;
   const summary = listedSessions.get(id);
   $("detail-tabs").classList.toggle("hidden", !summary || !summary.worktree);
   showTab("chat");
@@ -495,6 +496,7 @@ function showTabListLevel() {
 function showTab(name) {
   activeTab = name;
   detailStack = [];
+  pendingListRefresh = false;   // this switch's own unconditional fetch below covers it
   $("diff-view").classList.add("hidden");
   $("file-view").classList.add("hidden");
   showTabListLevel();
@@ -524,10 +526,12 @@ function requestChanges() {
 function refreshFileTree() {
   if (!currentSession) return;
   send({ type: "listFiles", sessionId: currentSession });
-  for (const row of changesTree.visibleRows()) {
-    if (row.node.kind === "dir" && row.expanded) {
-      send({ type: "listFiles", sessionId: currentSession, path: row.node.path });
-    }
+  // `expandedPaths()`, not `visibleRows()`: a directory expanded behind a
+  // since-collapsed ancestor is invisible right now but still cached, and
+  // re-expanding the ancestor later would otherwise render it straight from
+  // that stale cache with no request in between.
+  for (const path of changesTree.expandedPaths()) {
+    send({ type: "listFiles", sessionId: currentSession, path });
   }
 }
 
@@ -586,6 +590,10 @@ function closeDetailLevel() {
   $("diff-view").classList.add("hidden");
   $("file-view").classList.add("hidden");
   showTabListLevel();
+  if (pendingListRefresh && detailStack.length === 0) {
+    pendingListRefresh = false;
+    scheduleListRefresh();
+  }
 }
 
 // If the socket drops while a file or diff detail view is open, `onopen`'s
@@ -744,6 +752,21 @@ function showFileError(text) {
 let previousChangesStreamingState = "idle";   // so we can edge-trigger on the idle TRANSITION only
 let changesRefreshDebounceTimer = null;
 const CHANGES_REFRESH_DEBOUNCE_MS = 500;
+// Set when an idle transition wants to refresh the open tab's list but a
+// detail view (diff/file) is in the way — closing the detail only toggles
+// DOM visibility (`showTabListLevel()`), so without this the list would
+// otherwise show the pre-turn snapshot until a manual refresh or tab
+// switch. Consumed by `closeDetailLevel()`.
+let pendingListRefresh = false;
+
+function scheduleListRefresh() {
+  if (changesRefreshDebounceTimer) clearTimeout(changesRefreshDebounceTimer);
+  changesRefreshDebounceTimer = setTimeout(() => {
+    changesRefreshDebounceTimer = null;
+    if (activeTab === "changes") requestChanges();
+    else if (activeTab === "files") refreshFileTree();
+  }, CHANGES_REFRESH_DEBOUNCE_MS);
+}
 
 /// Re-fetch the change list (or the Files tree, if that's the open tab)
 /// when the agent stops, but only on the actual transition into idle (not
@@ -759,14 +782,12 @@ function noteStreamingStateForChanges(state) {
   const wasIdle = previousChangesStreamingState === "idle";
   previousChangesStreamingState = state;
   if (state !== "idle" || wasIdle) return;
-  if (detailStack.length !== 0) return;
   if (activeTab !== "changes" && activeTab !== "files") return;
-  if (changesRefreshDebounceTimer) clearTimeout(changesRefreshDebounceTimer);
-  changesRefreshDebounceTimer = setTimeout(() => {
-    changesRefreshDebounceTimer = null;
-    if (activeTab === "changes") requestChanges();
-    else if (activeTab === "files") refreshFileTree();
-  }, CHANGES_REFRESH_DEBOUNCE_MS);
+  if (detailStack.length !== 0) {
+    pendingListRefresh = true;
+    return;
+  }
+  scheduleListRefresh();
 }
 
 function clearSessionSheetsForOpen() {
@@ -795,6 +816,7 @@ function showSessions() {
   resetChangesAndFilesDOM();
   if (changesRefreshDebounceTimer) { clearTimeout(changesRefreshDebounceTimer); changesRefreshDebounceTimer = null; }
   previousChangesStreamingState = "idle";
+  pendingListRefresh = false;
   activeTab = "chat";
   $("detail-tabs").classList.add("hidden");
   $("changes").classList.add("hidden");

--- a/Alas/Resources/RemoteWeb/changes-view.js
+++ b/Alas/Resources/RemoteWeb/changes-view.js
@@ -1,0 +1,66 @@
+// Pure logic for the Changes tab: ordering, labels, and the diff row model.
+// DOM wiring lives in app.js; everything here is unit-tested under
+// scripts/tests/remote-web-changes.
+
+function sortFiles(files) {
+  return (files || []).slice().sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+}
+
+function splitPath(path) {
+  const value = path || "";
+  const index = value.lastIndexOf("/");
+  if (index < 0) return { dir: "", name: value };
+  return { dir: value.slice(0, index + 1), name: value.slice(index + 1) };
+}
+
+function formatFileCounts(file) {
+  const add = file && file.add ? file.add : 0;
+  const del = file && file.del ? file.del : 0;
+  return "+" + add + " −" + del;
+}
+
+function formatSummary(state) {
+  const files = (state && state.files) || [];
+  let add = 0;
+  let del = 0;
+  for (const file of files) {
+    add += file.add || 0;
+    del += file.del || 0;
+  }
+  const count = files.length + (files.length === 1 ? " file" : " files");
+  const totals = count + " · +" + add + " −" + del;
+  const ref = state && state.comparisonRef;
+  return ref ? "vs " + ref + " · " + totals : totals;
+}
+
+function diffRows(hunks) {
+  const rows = [];
+  for (const hunk of hunks || []) {
+    rows.push({ type: "hunk", text: hunk.header, kind: null, oldNumber: null, newNumber: null });
+    for (const line of hunk.lines || []) {
+      rows.push({
+        type: "line",
+        text: line.text,
+        kind: line.kind,
+        oldNumber: typeof line.oldNumber === "number" ? line.oldNumber : null,
+        newNumber: typeof line.newNumber === "number" ? line.newNumber : null
+      });
+    }
+  }
+  return rows;
+}
+
+function truncationNotice(truncated, kind) {
+  if (!truncated) return "";
+  if (kind === "files") return "File list truncated — too many changed files to show.";
+  return "Diff truncated — open this file on the desktop to see the rest.";
+}
+
+globalThis.RemoteChangesView = {
+  sortFiles,
+  splitPath,
+  formatSummary,
+  formatFileCounts,
+  diffRows,
+  truncationNotice
+};

--- a/Alas/Resources/RemoteWeb/changes-view.js
+++ b/Alas/Resources/RemoteWeb/changes-view.js
@@ -53,6 +53,7 @@ function diffRows(hunks) {
 function truncationNotice(truncated, kind) {
   if (!truncated) return "";
   if (kind === "files") return "File list truncated — too many changed files to show.";
+  if (kind === "lines") return "File truncated — too many lines to show.";
   return "Diff truncated — open this file on the desktop to see the rest.";
 }
 

--- a/Alas/Resources/RemoteWeb/changes-view.js
+++ b/Alas/Resources/RemoteWeb/changes-view.js
@@ -36,14 +36,15 @@ function formatSummary(state) {
 function diffRows(hunks) {
   const rows = [];
   for (const hunk of hunks || []) {
-    rows.push({ type: "hunk", text: hunk.header, kind: null, oldNumber: null, newNumber: null });
+    rows.push({ type: "hunk", text: hunk.header, kind: null, oldNumber: null, newNumber: null, noTrailingNewline: false });
     for (const line of hunk.lines || []) {
       rows.push({
         type: "line",
         text: line.text,
         kind: line.kind,
         oldNumber: typeof line.oldNumber === "number" ? line.oldNumber : null,
-        newNumber: typeof line.newNumber === "number" ? line.newNumber : null
+        newNumber: typeof line.newNumber === "number" ? line.newNumber : null,
+        noTrailingNewline: !!line.noTrailingNewline
       });
     }
   }

--- a/Alas/Resources/RemoteWeb/changes-view.js
+++ b/Alas/Resources/RemoteWeb/changes-view.js
@@ -59,11 +59,23 @@ function truncationNotice(truncated, kind) {
   return "Diff truncated — open this file on the desktop to see the rest.";
 }
 
+// A pure rename/copy or executable-bit-only change has no `@@` hunks to
+// render — an empty diff would look indistinguishable from "nothing
+// changed", so the server sends `metadataNote` describing what actually
+// happened (see `ParsedDiff.metadataSummary`). Only surfaced when there
+// really are no hunks: a rename/mode change alongside real content edits
+// already has hunks to show, and the note would just be noise there.
+function metadataOnlyNotice(hunks, metadataNote) {
+  if ((hunks || []).length > 0) return "";
+  return metadataNote || "";
+}
+
 globalThis.RemoteChangesView = {
   sortFiles,
   splitPath,
   formatSummary,
   formatFileCounts,
   diffRows,
-  truncationNotice
+  truncationNotice,
+  metadataOnlyNotice
 };

--- a/Alas/Resources/RemoteWeb/changes-view.js
+++ b/Alas/Resources/RemoteWeb/changes-view.js
@@ -55,6 +55,7 @@ function truncationNotice(truncated, kind) {
   if (!truncated) return "";
   if (kind === "files") return "File list truncated — too many changed files to show.";
   if (kind === "lines") return "File truncated — too many lines to show.";
+  if (kind === "directory") return "Directory truncated — too many entries to show.";
   return "Diff truncated — open this file on the desktop to see the rest.";
 }
 

--- a/Alas/Resources/RemoteWeb/file-browser.js
+++ b/Alas/Resources/RemoteWeb/file-browser.js
@@ -1,0 +1,63 @@
+// Pure state for the lazy file tree in the Files tab. The server sends one
+// directory's children at a time; this module remembers what has arrived, what
+// is expanded, and flattens it into display rows. DOM wiring lives in app.js.
+
+function nodeOrder(a, b) {
+  if (a.kind !== b.kind) return a.kind === "dir" ? -1 : 1;
+  return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+}
+
+function createTree() {
+  const childrenByPath = new Map();   // key: "" for root, else directory path
+  const expanded = new Set();
+
+  function key(path) {
+    return path === null || path === undefined ? "" : path;
+  }
+
+  function applyNodes(path, nodes) {
+    childrenByPath.set(key(path), (nodes || []).slice().sort(nodeOrder));
+  }
+
+  function isExpanded(path) {
+    return expanded.has(key(path));
+  }
+
+  function needsChildren(path) {
+    return !childrenByPath.has(key(path));
+  }
+
+  function toggle(path) {
+    const id = key(path);
+    if (expanded.has(id)) {
+      expanded.delete(id);
+      return false;
+    }
+    expanded.add(id);
+    return needsChildren(path);
+  }
+
+  function collect(path, depth, rows) {
+    const nodes = childrenByPath.get(key(path)) || [];
+    for (const node of nodes) {
+      const open = node.kind === "dir" && expanded.has(node.path);
+      rows.push({ node, depth, expanded: open });
+      if (open) collect(node.path, depth + 1, rows);
+    }
+  }
+
+  function visibleRows() {
+    const rows = [];
+    collect(null, 0, rows);
+    return rows;
+  }
+
+  function reset() {
+    childrenByPath.clear();
+    expanded.clear();
+  }
+
+  return { applyNodes, isExpanded, needsChildren, toggle, visibleRows, reset };
+}
+
+globalThis.RemoteFileBrowser = { createTree };

--- a/Alas/Resources/RemoteWeb/file-browser.js
+++ b/Alas/Resources/RemoteWeb/file-browser.js
@@ -27,6 +27,17 @@ function createTree() {
     return !childrenByPath.has(key(path));
   }
 
+  /// Every expanded directory's path, root excluded (the caller re-requests
+  /// root separately). Unlike `visibleRows()`, this includes a directory
+  /// expanded behind a since-collapsed ancestor — collapsing a parent
+  /// doesn't clear its descendants' own expanded state, so re-expanding the
+  /// parent later reveals them again straight from cache with no request in
+  /// between. A refresh that only walked `visibleRows()` would miss exactly
+  /// that hidden-but-still-expanded subtree.
+  function expandedPaths() {
+    return Array.from(expanded).filter(path => path !== "");
+  }
+
   function toggle(path) {
     const id = key(path);
     if (expanded.has(id)) {
@@ -57,7 +68,7 @@ function createTree() {
     expanded.clear();
   }
 
-  return { applyNodes, isExpanded, needsChildren, toggle, visibleRows, reset };
+  return { applyNodes, isExpanded, needsChildren, toggle, visibleRows, reset, expandedPaths };
 }
 
 globalThis.RemoteFileBrowser = { createTree };

--- a/Alas/Resources/RemoteWeb/file-browser.js
+++ b/Alas/Resources/RemoteWeb/file-browser.js
@@ -16,7 +16,35 @@ function createTree() {
   }
 
   function applyNodes(path, nodes) {
-    childrenByPath.set(key(path), (nodes || []).slice().sort(nodeOrder));
+    const id = key(path);
+    const sorted = (nodes || []).slice().sort(nodeOrder);
+    const previous = childrenByPath.get(id);
+    childrenByPath.set(id, sorted);
+    // A directory the agent deleted or renamed since the last listing no
+    // longer appears here — forget it (and anything cached under it)
+    // rather than leaving it in `expanded`/`childrenByPath` forever: a
+    // refresh (`expandedPaths()`) would otherwise keep re-requesting a
+    // path that no longer exists, failing every single time.
+    if (previous) {
+      const stillPresent = new Set(sorted.map(node => node.path));
+      for (const child of previous) {
+        if (child.kind === "dir" && !stillPresent.has(child.path)) {
+          forgetSubtree(child.path);
+        }
+      }
+    }
+  }
+
+  function forgetSubtree(path) {
+    const id = key(path);
+    expanded.delete(id);
+    const children = childrenByPath.get(id);
+    childrenByPath.delete(id);
+    if (children) {
+      for (const child of children) {
+        if (child.kind === "dir") forgetSubtree(child.path);
+      }
+    }
   }
 
   function isExpanded(path) {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -198,7 +198,7 @@
   <script src="/worktree-creation.js?v=1"></script>
   <script src="/changes-view.js?v=1"></script>
   <script src="/file-browser.js?v=1"></script>
-  <script src="/app.js?v=64"></script>
+  <script src="/app.js?v=65"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -11,13 +11,18 @@
   <link rel="icon" href="/icon.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/icon-180.png" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=41" />
+  <link rel="stylesheet" href="/style.css?v=42" />
 </head>
 <body>
   <header id="bar">
     <button id="back" class="hidden">‹ Sessions</button>
     <span id="detail-title" class="hidden"></span>
     <button id="detail-rename" class="rename-btn hidden" aria-label="Rename session">✎</button>
+    <div id="detail-tabs" class="tabs hidden" role="tablist">
+      <button id="tab-chat" class="tab is-active" role="tab" type="button">Chat</button>
+      <button id="tab-changes" class="tab" role="tab" type="button">Changes</button>
+      <button id="tab-files" class="tab" role="tab" type="button">Files</button>
+    </div>
     <span id="nav-title">Alas Remote</span>
     <button id="new-session" aria-label="New session">+ New</button>
     <span id="status" class="chip" data-state="connecting">connecting…</span>
@@ -59,6 +64,26 @@
           </div>
           <input id="file" type="file" accept="image/*" multiple hidden />
         </div>
+      </div>
+    </section>
+    <section id="changes" class="view hidden">
+      <div id="changes-header">
+        <span id="changes-summary"></span>
+        <button id="changes-refresh" type="button" aria-label="Refresh changes">↻</button>
+      </div>
+      <p id="changes-error" class="sheet-error hidden" role="alert"></p>
+      <div id="changes-list"></div>
+      <div id="diff-view" class="hidden">
+        <p id="diff-path" class="detail-path"></p>
+        <div id="diff-rows"></div>
+      </div>
+    </section>
+    <section id="files" class="view hidden">
+      <p id="file-error" class="sheet-error hidden" role="alert"></p>
+      <div id="file-list"></div>
+      <div id="file-view" class="hidden">
+        <p id="file-view-path" class="detail-path"></p>
+        <div id="file-view-body"></div>
       </div>
     </section>
   </main>
@@ -171,7 +196,9 @@
   <script src="/purify.min.js?v=28"></script>
   <script src="/session-ordering.js?v=1"></script>
   <script src="/worktree-creation.js?v=1"></script>
-  <script src="/app.js?v=63"></script>
+  <script src="/changes-view.js?v=1"></script>
+  <script src="/file-browser.js?v=1"></script>
+  <script src="/app.js?v=64"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -196,9 +196,9 @@
   <script src="/purify.min.js?v=28"></script>
   <script src="/session-ordering.js?v=1"></script>
   <script src="/worktree-creation.js?v=1"></script>
-  <script src="/changes-view.js?v=1"></script>
+  <script src="/changes-view.js?v=2"></script>
   <script src="/file-browser.js?v=1"></script>
-  <script src="/app.js?v=67"></script>
+  <script src="/app.js?v=68"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -196,9 +196,9 @@
   <script src="/purify.min.js?v=28"></script>
   <script src="/session-ordering.js?v=1"></script>
   <script src="/worktree-creation.js?v=1"></script>
-  <script src="/changes-view.js?v=2"></script>
+  <script src="/changes-view.js?v=3"></script>
   <script src="/file-browser.js?v=3"></script>
-  <script src="/app.js?v=71"></script>
+  <script src="/app.js?v=72"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -198,7 +198,7 @@
   <script src="/worktree-creation.js?v=1"></script>
   <script src="/changes-view.js?v=2"></script>
   <script src="/file-browser.js?v=3"></script>
-  <script src="/app.js?v=70"></script>
+  <script src="/app.js?v=71"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -198,7 +198,7 @@
   <script src="/worktree-creation.js?v=1"></script>
   <script src="/changes-view.js?v=1"></script>
   <script src="/file-browser.js?v=1"></script>
-  <script src="/app.js?v=65"></script>
+  <script src="/app.js?v=66"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -198,7 +198,7 @@
   <script src="/worktree-creation.js?v=1"></script>
   <script src="/changes-view.js?v=1"></script>
   <script src="/file-browser.js?v=1"></script>
-  <script src="/app.js?v=66"></script>
+  <script src="/app.js?v=67"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -198,7 +198,7 @@
   <script src="/worktree-creation.js?v=1"></script>
   <script src="/changes-view.js?v=2"></script>
   <script src="/file-browser.js?v=1"></script>
-  <script src="/app.js?v=68"></script>
+  <script src="/app.js?v=69"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -197,8 +197,8 @@
   <script src="/session-ordering.js?v=1"></script>
   <script src="/worktree-creation.js?v=1"></script>
   <script src="/changes-view.js?v=2"></script>
-  <script src="/file-browser.js?v=1"></script>
-  <script src="/app.js?v=69"></script>
+  <script src="/file-browser.js?v=2"></script>
+  <script src="/app.js?v=70"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -197,7 +197,7 @@
   <script src="/session-ordering.js?v=1"></script>
   <script src="/worktree-creation.js?v=1"></script>
   <script src="/changes-view.js?v=2"></script>
-  <script src="/file-browser.js?v=2"></script>
+  <script src="/file-browser.js?v=3"></script>
   <script src="/app.js?v=70"></script>
   <script>
     if ("serviceWorker" in navigator) {

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -317,6 +317,7 @@ button.create-row.is-selected { border-color: var(--accent); background: color-m
 .change-name { font-weight: 600; }
 .change-counts { margin-left: auto; font-variant-numeric: tabular-nums; color: var(--fg-muted); }
 .change-conflict { color: var(--del); }
+.change-status { color: var(--fg-faint); font-variant-numeric: tabular-nums; }
 
 #diff-rows, #file-view-body {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -295,3 +295,43 @@ button.create-row.is-selected { border-color: var(--accent); background: color-m
 
 .steer-undo { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 7px 12px; border: 0.5px solid var(--line); border-radius: 10px; background: color-mix(in oklab, var(--bg-2) 80%, transparent); color: var(--fg-muted); font-size: 12px; }
 .steer-undo-btn { border: none; background: none; color: var(--accent); font: inherit; font-size: 12px; font-weight: 650; cursor: pointer; -webkit-tap-highlight-color: transparent; }
+
+.tabs { display: flex; gap: 2px; }
+.tab {
+  background: none; border: none; padding: 6px 10px;
+  font: inherit; color: var(--fg-muted); border-radius: 6px;
+}
+.tab.is-active { color: var(--fg); background: color-mix(in oklab, var(--bg-3) 70%, transparent); }
+
+#changes-header {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 8px; padding: 10px 12px; color: var(--fg-muted);
+}
+#changes-refresh { background: none; border: none; color: var(--fg-muted); font-size: 16px; }
+.change-row, .file-row {
+  display: flex; align-items: baseline; gap: 8px; width: 100%;
+  padding: 10px 12px; background: none; border: none;
+  border-bottom: 0.5px solid var(--line-soft); text-align: left; font: inherit; color: var(--fg);
+}
+.change-dir { color: var(--fg-faint); }
+.change-name { font-weight: 600; }
+.change-counts { margin-left: auto; font-variant-numeric: tabular-nums; color: var(--fg-muted); }
+.change-conflict { color: var(--del); }
+
+#diff-rows, #file-view-body {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px; overflow-x: auto;
+}
+.diff-hunk {
+  padding: 6px 12px; color: var(--fg-muted);
+  background: color-mix(in oklab, var(--bg-3) 70%, transparent); position: sticky; top: 0;
+}
+.diff-line { display: flex; gap: 8px; padding: 0 12px; white-space: pre; }
+.diff-line.add { background: color-mix(in oklab, var(--add) 16%, transparent); }
+.diff-line.delete { background: color-mix(in oklab, var(--del) 16%, transparent); }
+.diff-gutter { min-width: 4ch; text-align: right; color: var(--fg-faint); }
+.detail-path { padding: 8px 12px; color: var(--fg-muted); word-break: break-all; }
+.placeholder-card {
+  margin: 16px 12px; padding: 12px; border: 0.5px solid var(--line);
+  border-radius: 10px; color: var(--fg-muted);
+}

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -331,6 +331,7 @@ button.create-row.is-selected { border-color: var(--accent); background: color-m
 .diff-line.add { background: color-mix(in oklab, var(--add) 16%, transparent); }
 .diff-line.delete { background: color-mix(in oklab, var(--del) 16%, transparent); }
 .diff-gutter { min-width: 4ch; text-align: right; color: var(--fg-faint); }
+.diff-no-newline { color: var(--fg-faint); font-style: italic; }
 .detail-path { padding: 8px 12px; color: var(--fg-muted); word-break: break-all; }
 .placeholder-card {
   margin: 16px 12px; padding: 12px; border: 0.5px solid var(--line);

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "alas-remote-shell-v42";
+const CACHE_NAME = "alas-remote-shell-v43";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
@@ -7,7 +7,7 @@ const SHELL_ASSETS = [
   "/worktree-creation.js?v=1",
   "/changes-view.js?v=1",
   "/file-browser.js?v=1",
-  "/app.js?v=64",
+  "/app.js?v=65",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,11 +1,13 @@
-const CACHE_NAME = "alas-remote-shell-v41";
+const CACHE_NAME = "alas-remote-shell-v42";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
-  "/style.css?v=41",
+  "/style.css?v=42",
   "/session-ordering.js?v=1",
   "/worktree-creation.js?v=1",
-  "/app.js?v=63",
+  "/changes-view.js?v=1",
+  "/file-browser.js?v=1",
+  "/app.js?v=64",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "alas-remote-shell-v48";
+const CACHE_NAME = "alas-remote-shell-v49";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
@@ -6,7 +6,7 @@ const SHELL_ASSETS = [
   "/session-ordering.js?v=1",
   "/worktree-creation.js?v=1",
   "/changes-view.js?v=2",
-  "/file-browser.js?v=2",
+  "/file-browser.js?v=3",
   "/app.js?v=70",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,13 +1,13 @@
-const CACHE_NAME = "alas-remote-shell-v50";
+const CACHE_NAME = "alas-remote-shell-v51";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=42",
   "/session-ordering.js?v=1",
   "/worktree-creation.js?v=1",
-  "/changes-view.js?v=2",
+  "/changes-view.js?v=3",
   "/file-browser.js?v=3",
-  "/app.js?v=71",
+  "/app.js?v=72",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,13 +1,13 @@
-const CACHE_NAME = "alas-remote-shell-v45";
+const CACHE_NAME = "alas-remote-shell-v46";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=42",
   "/session-ordering.js?v=1",
   "/worktree-creation.js?v=1",
-  "/changes-view.js?v=1",
+  "/changes-view.js?v=2",
   "/file-browser.js?v=1",
-  "/app.js?v=67",
+  "/app.js?v=68",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "alas-remote-shell-v43";
+const CACHE_NAME = "alas-remote-shell-v44";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
@@ -7,7 +7,7 @@ const SHELL_ASSETS = [
   "/worktree-creation.js?v=1",
   "/changes-view.js?v=1",
   "/file-browser.js?v=1",
-  "/app.js?v=65",
+  "/app.js?v=66",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "alas-remote-shell-v47";
+const CACHE_NAME = "alas-remote-shell-v48";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
@@ -6,8 +6,8 @@ const SHELL_ASSETS = [
   "/session-ordering.js?v=1",
   "/worktree-creation.js?v=1",
   "/changes-view.js?v=2",
-  "/file-browser.js?v=1",
-  "/app.js?v=69",
+  "/file-browser.js?v=2",
+  "/app.js?v=70",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "alas-remote-shell-v44";
+const CACHE_NAME = "alas-remote-shell-v45";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
@@ -7,7 +7,7 @@ const SHELL_ASSETS = [
   "/worktree-creation.js?v=1",
   "/changes-view.js?v=1",
   "/file-browser.js?v=1",
-  "/app.js?v=66",
+  "/app.js?v=67",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "alas-remote-shell-v49";
+const CACHE_NAME = "alas-remote-shell-v50";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
@@ -7,7 +7,7 @@ const SHELL_ASSETS = [
   "/worktree-creation.js?v=1",
   "/changes-view.js?v=2",
   "/file-browser.js?v=3",
-  "/app.js?v=70",
+  "/app.js?v=71",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "alas-remote-shell-v46";
+const CACHE_NAME = "alas-remote-shell-v47";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
@@ -7,7 +7,7 @@ const SHELL_ASSETS = [
   "/worktree-creation.js?v=1",
   "/changes-view.js?v=2",
   "/file-browser.js?v=1",
-  "/app.js?v=68",
+  "/app.js?v=69",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7907,14 +7907,112 @@ extension AppState: RemoteSessionsProvider {
 
     /// Resolves the worktree backing a session id by scanning the live
     /// per-worktree managers, mirroring how `session(for:)` looks sessions up.
+    ///
+    /// Checks both the live session and the persisted rows — matching every
+    /// other lookup in this file (`session(for:)`, `hydrateIfNeeded`,
+    /// `renameSession`) — because a just-created session is installed into
+    /// `liveSession(for:)` immediately, while `sessionRows` can briefly lag
+    /// behind an in-flight `refreshRecent()` snapshot.
     private func remoteWorktreeContext(sessionId: String) -> RemoteWorktreeContextResult {
-        for mgr in acpManagers.values where mgr.sessionRows.contains(where: { $0.id == sessionId }) {
+        for mgr in acpManagers.values
+        where mgr.liveSession(for: sessionId) != nil || mgr.sessionRows.contains(where: { $0.id == sessionId }) {
             guard let resolved = projectAndWorktree(withWorktreeId: mgr.worktreeId) else {
                 return .worktreeUnavailable
             }
             return .found(resolved.worktree)
         }
         return .sessionUnknown
+    }
+
+    /// Outcome of reading a worktree-relative file's raw bytes from a
+    /// registered SSH host, mirroring the containment + read pipeline
+    /// `ACPRemoteFileServer.read` uses for editor reads — but surfacing raw
+    /// `Data` instead of requiring UTF-8, since the remote Files/Changes
+    /// surface applies its own binary-sniff / size-cap logic on top.
+    ///
+    /// Internal (not `private`) so `AlasTests` can exercise
+    /// `readRemoteWorktreeFileRaw` directly: this environment has no
+    /// reachable SSH host to stand up a full remote-worktree integration
+    /// test against, so this is the seam that lets a test prove the remote
+    /// branch never silently falls back to local-disk I/O.
+    enum RemoteWorktreeRawReadOutcome {
+        case data(Data)
+        /// The remote path is missing, a directory, or a symlink — not a
+        /// readable plain file.
+        case notFound
+        /// Transport or remote-side error unrelated to the containment check.
+        case unreadable(String)
+        /// The resolved path escaped the worktree root.
+        case containmentRejected
+    }
+
+    /// Reads `relativePath` (already validated by
+    /// `RemoteWorktreeFileAccess.normalizedRelativePath`) from `host`,
+    /// applying the same lexical + physical containment checks
+    /// `ACPRemoteFileServer.read` uses before touching the remote
+    /// filesystem. Git-based operations (`GitService.status`/`.diff`/etc.)
+    /// already run correctly against a remote worktree because
+    /// `Process.git` is itself remote-host-aware — this helper exists only
+    /// for the raw, non-git file reads this surface also needs (plain file
+    /// contents, the pre-diff binary sniff).
+    func readRemoteWorktreeFileRaw(
+        host: String, worktreeRoot: String, relativePath: String
+    ) async -> RemoteWorktreeRawReadOutcome {
+        let target: String
+        do {
+            target = try RemotePathContainment.lexicallyResolveInsideWorktree(
+                path: relativePath, worktreeRoot: worktreeRoot)
+        } catch {
+            return .containmentRejected
+        }
+        do {
+            try await RemotePathContainment.verifyRemoteContainment(
+                host: host, path: target, worktreeRoot: worktreeRoot)
+        } catch RemotePathContainment.ContainmentError.outsideWorktree(_) {
+            return .containmentRejected
+        } catch {
+            return .unreadable(String(describing: error))
+        }
+        do {
+            switch try await RemoteFileAccess.read(host: host, path: target) {
+            case let .file(data, _): return .data(data)
+            case .missing, .directory, .symlink: return .notFound
+            case let .unreadable(detail): return .unreadable(detail)
+            }
+        } catch {
+            return .unreadable(String(describing: error))
+        }
+    }
+
+    /// Whether `normalizedPath` looks like a binary file for diff purposes.
+    /// Prefers an on-disk sniff against the current working tree (mirroring
+    /// git's own heuristic). When the file is missing from the working tree
+    /// — the case a binary file deleted since `comparisonRef` hits — falls
+    /// back to sniffing the blob at `comparisonRef` instead, so a deleted
+    /// binary file still reports `.binary` rather than slipping through as
+    /// an empty "successful" diff.
+    private func isDiffTargetBinary(
+        worktree: Worktree, normalizedPath: String, url: URL, comparisonRef: String?, git: GitService
+    ) async -> Bool {
+        let existsOnDisk: Bool
+        let onDiskLooksBinary: Bool
+        if worktree.path.isRemoteAlasPath, let host = RemoteHostRegistry.shared.host(forPath: worktree.path.path) {
+            switch await readRemoteWorktreeFileRaw(host: host, worktreeRoot: worktree.path.path, relativePath: normalizedPath) {
+            case .data(let data):
+                existsOnDisk = true
+                onDiskLooksBinary = GitService.looksBinary(data)
+            case .notFound, .unreadable, .containmentRejected:
+                existsOnDisk = false
+                onDiskLooksBinary = false
+            }
+        } else {
+            existsOnDisk = FileManager.default.fileExists(atPath: url.path)
+            onDiskLooksBinary = await RemoteWorktreeFileAccess.looksBinaryOnDisk(at: url)
+        }
+        if onDiskLooksBinary { return true }
+        if existsOnDisk { return false }
+        guard let comparisonRef, !comparisonRef.isEmpty else { return false }
+        return (try? await git.looksBinaryAtRef(worktreePath: worktree.path, ref: comparisonRef, file: normalizedPath)) ?? false
     }
 
     private static func remoteChangedFile(_ file: ChangedFile) -> RemoteChangedFile {
@@ -8014,15 +8112,18 @@ extension AppState: RemoteSessionsProvider {
         } catch {
             return .failure(reason: .gitFailed, message: error.localizedDescription)
         }
-        if await RemoteWorktreeFileAccess.looksBinaryOnDisk(at: url) {
-            return .failure(reason: .binary, message: nil)
-        }
         do {
             let commits = try await git.commitsAhead(
                 at: worktree.path,
                 baseBranch: config.worktrees.baseBranch,
                 resolution: GitService.BaseResolution.forCommits(
                     mode: config.changes.comparisonMode, userOverrodeBaseBranch: false))
+            if await isDiffTargetBinary(
+                worktree: worktree, normalizedPath: normalizedPath, url: url,
+                comparisonRef: commits.comparisonRef, git: git
+            ) {
+                return .failure(reason: .binary, message: nil)
+            }
             let parsed = try await git.diff(
                 worktreePath: worktree.path,
                 againstRef: commits.comparisonRef,
@@ -8088,6 +8189,34 @@ extension AppState: RemoteSessionsProvider {
         } catch {
             return .failure(reason: .gitFailed, byteSize: nil, message: error.localizedDescription)
         }
+
+        if worktree.path.isRemoteAlasPath {
+            guard let host = RemoteHostRegistry.shared.host(forPath: worktree.path.path) else {
+                return .failure(
+                    reason: .gitFailed, byteSize: nil,
+                    message: "Remote host is not registered for this worktree.")
+            }
+            switch await readRemoteWorktreeFileRaw(host: host, worktreeRoot: worktree.path.path, relativePath: normalizedPath) {
+            case .containmentRejected:
+                return .failure(reason: .pathRejected, byteSize: nil, message: nil)
+            case .notFound:
+                return .failure(reason: .notFound, byteSize: nil, message: nil)
+            case .unreadable(let detail):
+                return .failure(reason: .gitFailed, byteSize: nil, message: detail)
+            case .data(let data):
+                guard data.count <= RemoteWorktreeFileAccess.maxFileBytes else {
+                    return .failure(reason: .tooLarge, byteSize: data.count, message: nil)
+                }
+                guard !GitService.looksBinary(data) else {
+                    return .failure(reason: .binary, byteSize: data.count, message: nil)
+                }
+                guard let text = String(data: data, encoding: .utf8) else {
+                    return .failure(reason: .binary, byteSize: data.count, message: nil)
+                }
+                return .success(text: text, truncated: false)
+            }
+        }
+
         switch await RemoteWorktreeFileAccess.readFileContents(at: url) {
         case .notFound:
             return .failure(reason: .notFound, byteSize: nil, message: nil)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7896,13 +7896,25 @@ extension AppState: RemoteSessionsProvider {
         return nil
     }
 
+    /// Distinguishes between a session that was never found vs. one whose
+    /// worktree is no longer available (e.g. deleted while its manager still
+    /// lives), so callers can report different error messages.
+    private enum RemoteWorktreeContextResult {
+        case found(Worktree)
+        case sessionUnknown
+        case worktreeUnavailable
+    }
+
     /// Resolves the worktree backing a session id by scanning the live
     /// per-worktree managers, mirroring how `session(for:)` looks sessions up.
-    private func remoteWorktreeContext(sessionId: String) -> (project: ProjectConfig, worktree: Worktree)? {
+    private func remoteWorktreeContext(sessionId: String) -> RemoteWorktreeContextResult {
         for mgr in acpManagers.values where mgr.sessionRows.contains(where: { $0.id == sessionId }) {
-            return projectAndWorktree(withWorktreeId: mgr.worktreeId)
+            guard let resolved = projectAndWorktree(withWorktreeId: mgr.worktreeId) else {
+                return .worktreeUnavailable
+            }
+            return .found(resolved.worktree)
         }
-        return nil
+        return .sessionUnknown
     }
 
     private static func remoteChangedFile(_ file: ChangedFile) -> RemoteChangedFile {
@@ -7949,18 +7961,24 @@ extension AppState: RemoteSessionsProvider {
     }
 
     func remoteChangeList(sessionId: String) async -> RemoteChangeListResult {
-        guard let context = remoteWorktreeContext(sessionId: sessionId) else {
+        let worktree: Worktree
+        switch remoteWorktreeContext(sessionId: sessionId) {
+        case .sessionUnknown:
             return .failure(reason: .sessionUnknown, message: nil)
+        case .worktreeUnavailable:
+            return .failure(reason: .worktreeUnavailable, message: nil)
+        case .found(let w):
+            worktree = w
         }
         let git = GitService()
         do {
             let commits = try await git.commitsAhead(
-                at: context.worktree.path,
+                at: worktree.path,
                 baseBranch: config.worktrees.baseBranch,
                 resolution: GitService.BaseResolution.forCommits(
                     mode: config.changes.comparisonMode, userOverrodeBaseBranch: false))
             let changed = try await git.changedFilesAgainstRef(
-                worktreePath: context.worktree.path, ref: commits.comparisonRef)
+                worktreePath: worktree.path, ref: commits.comparisonRef)
             let capped = RemoteWorktreeFileAccess.truncateFiles(changed)
             return .success(
                 comparisonRef: commits.comparisonRef,
@@ -7973,10 +7991,16 @@ extension AppState: RemoteSessionsProvider {
     }
 
     func remoteFileDiff(sessionId: String, path: String) async -> RemoteFileDiffResult {
-        guard let context = remoteWorktreeContext(sessionId: sessionId) else {
+        let worktree: Worktree
+        switch remoteWorktreeContext(sessionId: sessionId) {
+        case .sessionUnknown:
             return .failure(reason: .sessionUnknown, message: nil)
+        case .worktreeUnavailable:
+            return .failure(reason: .worktreeUnavailable, message: nil)
+        case .found(let w):
+            worktree = w
         }
-        guard let url = RemoteWorktreeFileAccess.resolve(path: path, in: context.worktree.path) else {
+        guard let url = RemoteWorktreeFileAccess.resolve(path: path, in: worktree.path) else {
             return .failure(reason: .pathRejected, message: nil)
         }
         if let data = try? Data(contentsOf: url), GitService.looksBinary(data) {
@@ -7985,12 +8009,12 @@ extension AppState: RemoteSessionsProvider {
         let git = GitService()
         do {
             let commits = try await git.commitsAhead(
-                at: context.worktree.path,
+                at: worktree.path,
                 baseBranch: config.worktrees.baseBranch,
                 resolution: GitService.BaseResolution.forCommits(
                     mode: config.changes.comparisonMode, userOverrodeBaseBranch: false))
             let parsed = try await git.diff(
-                worktreePath: context.worktree.path,
+                worktreePath: worktree.path,
                 againstRef: commits.comparisonRef,
                 file: path)
             let capped = RemoteWorktreeFileAccess.truncateHunks(parsed.hunks)
@@ -8003,22 +8027,28 @@ extension AppState: RemoteSessionsProvider {
     }
 
     func remoteFileTree(sessionId: String, path: String?) async -> RemoteFileTreeResult {
-        guard let context = remoteWorktreeContext(sessionId: sessionId) else {
+        let worktree: Worktree
+        switch remoteWorktreeContext(sessionId: sessionId) {
+        case .sessionUnknown:
             return .failure(reason: .sessionUnknown, message: nil)
+        case .worktreeUnavailable:
+            return .failure(reason: .worktreeUnavailable, message: nil)
+        case .found(let w):
+            worktree = w
         }
         let git = GitService()
         do {
             guard let path, !path.isEmpty else {
-                let statusEntries = try await git.status(worktreePath: context.worktree.path)
+                let statusEntries = try await git.status(worktreePath: worktree.path)
                 let nodes = try await git.fileTree(
-                    worktreePath: context.worktree.path, statusEntries: statusEntries)
+                    worktreePath: worktree.path, statusEntries: statusEntries)
                 return .success(nodes: Self.remoteFileNodes(nodes))
             }
-            guard RemoteWorktreeFileAccess.resolve(path: path, in: context.worktree.path) != nil else {
+            guard RemoteWorktreeFileAccess.resolve(path: path, in: worktree.path) != nil else {
                 return .failure(reason: .pathRejected, message: nil)
             }
             let nodes = try await git.fileTreeChildren(
-                worktreePath: context.worktree.path, path: path)
+                worktreePath: worktree.path, path: path)
             return .success(nodes: Self.remoteFileNodes(nodes))
         } catch {
             return .failure(reason: .gitFailed, message: error.localizedDescription)
@@ -8026,10 +8056,16 @@ extension AppState: RemoteSessionsProvider {
     }
 
     func remoteFileContents(sessionId: String, path: String) async -> RemoteFileContentsResult {
-        guard let context = remoteWorktreeContext(sessionId: sessionId) else {
+        let worktree: Worktree
+        switch remoteWorktreeContext(sessionId: sessionId) {
+        case .sessionUnknown:
             return .failure(reason: .sessionUnknown, byteSize: nil, message: nil)
+        case .worktreeUnavailable:
+            return .failure(reason: .worktreeUnavailable, byteSize: nil, message: nil)
+        case .found(let w):
+            worktree = w
         }
-        guard let url = RemoteWorktreeFileAccess.resolve(path: path, in: context.worktree.path) else {
+        guard let url = RemoteWorktreeFileAccess.resolve(path: path, in: worktree.path) else {
             return .failure(reason: .pathRejected, byteSize: nil, message: nil)
         }
         guard let data = try? Data(contentsOf: url) else {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -8129,6 +8129,19 @@ extension AppState: RemoteSessionsProvider {
         else {
             return .failure(reason: .pathRejected, message: nil)
         }
+        // `resolve` returns the UNRESOLVED candidate URL, so this checks the
+        // alias itself (lstat), not whatever it points to. A tracked
+        // symlink whose own name isn't ignored but whose target is (e.g.
+        // `public-env -> .env`) would otherwise pass `isPathIgnored` below
+        // and then have its target's content served transparently, first
+        // by the on-disk binary sniff and then by the `git diff` subprocess
+        // itself resolving the link at the OS level. Reject ANY local
+        // symlink outright rather than trying to resolve-and-recheck the
+        // target — the same choice already made for `.git` symlink aliases
+        // and for the SSH read path's `.symlink` outcome.
+        if !worktree.path.isRemoteAlasPath, RemoteWorktreeFileAccess.isSymlink(at: url) {
+            return .failure(reason: .notFound, message: nil)
+        }
         let git = GitService()
         do {
             let ignored = try await git.isPathIgnored(worktreePath: worktree.path, path: normalizedPath)
@@ -8228,6 +8241,15 @@ extension AppState: RemoteSessionsProvider {
               let url = RemoteWorktreeFileAccess.resolve(path: path, in: worktree.path)
         else {
             return .failure(reason: .pathRejected, byteSize: nil, message: nil)
+        }
+        // See the matching comment in `remoteFileDiff`: a tracked symlink
+        // whose alias name isn't itself ignored can still point at an
+        // ignored (or otherwise off-limits) target, and `readFileContents`
+        // below would otherwise transparently follow it via
+        // `Data(contentsOf:)`. Reject the alias outright rather than
+        // resolving-and-rechecking the target.
+        if !worktree.path.isRemoteAlasPath, RemoteWorktreeFileAccess.isSymlink(at: url) {
+            return .failure(reason: .notFound, byteSize: nil, message: nil)
         }
         do {
             let ignored = try await GitService().isPathIgnored(worktreePath: worktree.path, path: normalizedPath)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -8000,12 +8000,14 @@ extension AppState: RemoteSessionsProvider {
         case .found(let w):
             worktree = w
         }
-        guard let url = RemoteWorktreeFileAccess.resolve(path: path, in: worktree.path) else {
+        guard let normalizedPath = RemoteWorktreeFileAccess.normalizedRelativePath(path),
+              let url = RemoteWorktreeFileAccess.resolve(path: path, in: worktree.path)
+        else {
             return .failure(reason: .pathRejected, message: nil)
         }
         let git = GitService()
         do {
-            let ignored = try await git.isPathIgnored(worktreePath: worktree.path, path: path)
+            let ignored = try await git.isPathIgnored(worktreePath: worktree.path, path: normalizedPath)
             if ignored {
                 return .failure(reason: .pathRejected, message: nil)
             }
@@ -8024,7 +8026,7 @@ extension AppState: RemoteSessionsProvider {
             let parsed = try await git.diff(
                 worktreePath: worktree.path,
                 againstRef: commits.comparisonRef,
-                file: path)
+                file: normalizedPath)
             let capped = RemoteWorktreeFileAccess.truncateHunks(parsed.hunks)
             return .success(
                 hunks: capped.hunks.map(Self.remoteDiffHunk),
@@ -8073,11 +8075,13 @@ extension AppState: RemoteSessionsProvider {
         case .found(let w):
             worktree = w
         }
-        guard let url = RemoteWorktreeFileAccess.resolve(path: path, in: worktree.path) else {
+        guard let normalizedPath = RemoteWorktreeFileAccess.normalizedRelativePath(path),
+              let url = RemoteWorktreeFileAccess.resolve(path: path, in: worktree.path)
+        else {
             return .failure(reason: .pathRejected, byteSize: nil, message: nil)
         }
         do {
-            let ignored = try await GitService().isPathIgnored(worktreePath: worktree.path, path: path)
+            let ignored = try await GitService().isPathIgnored(worktreePath: worktree.path, path: normalizedPath)
             if ignored {
                 return .failure(reason: .pathRejected, byteSize: nil, message: nil)
             }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -8003,10 +8003,18 @@ extension AppState: RemoteSessionsProvider {
         guard let url = RemoteWorktreeFileAccess.resolve(path: path, in: worktree.path) else {
             return .failure(reason: .pathRejected, message: nil)
         }
-        if let data = try? Data(contentsOf: url), GitService.looksBinary(data) {
+        let git = GitService()
+        do {
+            let ignored = try await git.isPathIgnored(worktreePath: worktree.path, path: path)
+            if ignored {
+                return .failure(reason: .pathRejected, message: nil)
+            }
+        } catch {
+            return .failure(reason: .gitFailed, message: error.localizedDescription)
+        }
+        if await RemoteWorktreeFileAccess.looksBinaryOnDisk(at: url) {
             return .failure(reason: .binary, message: nil)
         }
-        let git = GitService()
         do {
             let commits = try await git.commitsAhead(
                 at: worktree.path,
@@ -8068,18 +8076,23 @@ extension AppState: RemoteSessionsProvider {
         guard let url = RemoteWorktreeFileAccess.resolve(path: path, in: worktree.path) else {
             return .failure(reason: .pathRejected, byteSize: nil, message: nil)
         }
-        guard let data = try? Data(contentsOf: url) else {
+        do {
+            let ignored = try await GitService().isPathIgnored(worktreePath: worktree.path, path: path)
+            if ignored {
+                return .failure(reason: .pathRejected, byteSize: nil, message: nil)
+            }
+        } catch {
+            return .failure(reason: .gitFailed, byteSize: nil, message: error.localizedDescription)
+        }
+        switch await RemoteWorktreeFileAccess.readFileContents(at: url) {
+        case .notFound:
             return .failure(reason: .notFound, byteSize: nil, message: nil)
+        case .tooLarge(let byteSize):
+            return .failure(reason: .tooLarge, byteSize: byteSize, message: nil)
+        case .binary(let byteSize):
+            return .failure(reason: .binary, byteSize: byteSize, message: nil)
+        case .text(let text):
+            return .success(text: text, truncated: false)
         }
-        guard !GitService.looksBinary(data) else {
-            return .failure(reason: .binary, byteSize: data.count, message: nil)
-        }
-        guard data.count <= RemoteWorktreeFileAccess.maxFileBytes else {
-            return .failure(reason: .tooLarge, byteSize: data.count, message: nil)
-        }
-        guard let text = String(data: data, encoding: .utf8) else {
-            return .failure(reason: .binary, byteSize: data.count, message: nil)
-        }
-        return .success(text: text, truncated: false)
     }
 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -8074,6 +8074,15 @@ extension AppState: RemoteSessionsProvider {
                 existsOnDisk = false
                 onDiskLooksBinary = false
             }
+        } else if RemoteWorktreeFileAccess.isSymlink(at: url) {
+            // A symlink's git-tracked "content" is its destination path
+            // string, never the target's bytes — never binary in any
+            // meaningful sense. `looksBinaryOnDisk` opens through the link
+            // to sniff the TARGET's bytes, which could otherwise leak
+            // whether an ignored/secret target looks binary; short-circuit
+            // before ever following it.
+            existsOnDisk = true
+            onDiskLooksBinary = false
         } else {
             existsOnDisk = FileManager.default.fileExists(atPath: url.path)
             onDiskLooksBinary = await RemoteWorktreeFileAccess.looksBinaryOnDisk(at: url)
@@ -8191,19 +8200,17 @@ extension AppState: RemoteSessionsProvider {
         else {
             return .failure(reason: .pathRejected, message: nil)
         }
-        // `resolve` returns the UNRESOLVED candidate URL, so this checks the
-        // alias itself (lstat), not whatever it points to. A tracked
-        // symlink whose own name isn't ignored but whose target is (e.g.
-        // `public-env -> .env`) would otherwise pass `isPathIgnored` below
-        // and then have its target's content served transparently, first
-        // by the on-disk binary sniff and then by the `git diff` subprocess
-        // itself resolving the link at the OS level. Reject ANY local
-        // symlink outright rather than trying to resolve-and-recheck the
-        // target — the same choice already made for `.git` symlink aliases
-        // and for the SSH read path's `.symlink` outcome.
-        if !worktree.path.isRemoteAlasPath, RemoteWorktreeFileAccess.isSymlink(at: url) {
-            return .failure(reason: .notFound, message: nil)
-        }
+        // Unlike a direct content read, a symlink is safe to DIFF: git
+        // tracks a symlink's blob as its destination path STRING, never
+        // the target's content, and `git diff` reads that side via
+        // `lstat`/`readlink` — it never opens through the link at the OS
+        // level (verified empirically: a changed symlink's diff shows only
+        // the old/new destination strings). So a tracked symlink whose own
+        // name isn't ignored but whose target is (e.g. `public-env ->
+        // .env`) can't leak the target's content through `git diff` itself
+        // — the one place that WOULD leak it is the on-disk binary sniff
+        // below, which `isDiffTargetBinary` guards against by special-
+        // casing a symlink path before ever following it.
         let git = GitService()
         do {
             let commits = try await git.commitsAhead(
@@ -8228,26 +8235,6 @@ extension AppState: RemoteSessionsProvider {
                 comparisonRef: commits.comparisonRef, git: git
             ) {
                 return .failure(reason: .binary, message: nil)
-            }
-            // Re-check the symlink alias immediately before the actual
-            // read, rather than relying solely on the check made at the top
-            // of this function. `git.diff` below spawns an external `git`
-            // subprocess that opens `normalizedPath` itself, at the OS
-            // level, from a path STRING — there is no file descriptor to
-            // thread through a subprocess boundary the way
-            // `RemoteWorktreeFileAccess.readFileContents` now does for
-            // direct content reads, so this specific read can't be made
-            // fully atomic with its containment check without a much larger
-            // change (e.g. piping the file through our own already-open,
-            // already-validated descriptor instead of letting `git diff`
-            // touch the path itself). Moving the recheck to just before the
-            // subprocess spawn — after `isPathIgnored`, `commitsAhead`, and
-            // `isDiffTargetBinary` have all already run — substantially
-            // narrows the TOCTOU window (from "the whole async pipeline
-            // above" down to "the gap between this check and the subprocess
-            // spawn") without closing it completely.
-            if !worktree.path.isRemoteAlasPath, RemoteWorktreeFileAccess.isSymlink(at: url) {
-                return .failure(reason: .notFound, message: nil)
             }
             let parsed = try await git.diff(
                 worktreePath: worktree.path,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -8268,7 +8268,8 @@ extension AppState: RemoteSessionsProvider {
             let capped = RemoteWorktreeFileAccess.truncateHunks(parsed.hunks)
             return .success(
                 hunks: capped.hunks.map(Self.remoteDiffHunk),
-                truncated: capped.truncated)
+                truncated: capped.truncated,
+                metadataNote: parsed.metadataSummary)
         } catch {
             return .failure(reason: .gitFailed, message: error.localizedDescription)
         }
@@ -8293,13 +8294,19 @@ extension AppState: RemoteSessionsProvider {
             // case for reviewing an agent's finished work) still shows the
             // same badge here that Changes already reports for it, instead
             // of appearing unbadged just because `status()` alone has
-            // nothing to say about it.
+            // nothing to say about it. `changedFileBadges` (not
+            // `changedFilesAgainstRef`) — this endpoint only needs a badge
+            // letter per path, and computing full add/del metrics (a local
+            // untracked file read whole, or a remote line-count round trip)
+            // on every `listFiles` request, for the root AND every
+            // directory a client expands, did substantial repeated I/O for
+            // numbers nothing here displays.
             let commits = try await git.commitsAhead(
                 at: worktree.path,
                 baseBranch: config.worktrees.baseBranch,
                 resolution: GitService.BaseResolution.forCommits(
                     mode: config.changes.comparisonMode, userOverrodeBaseBranch: false))
-            let changedEntries = try await git.changedFilesAgainstRef(
+            let changedEntries = try await git.changedFileBadges(
                 worktreePath: worktree.path, ref: commits.comparisonRef)
 
             guard let path, !path.isEmpty else {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -8002,6 +8002,49 @@ extension AppState: RemoteSessionsProvider {
         }
     }
 
+    /// Number of bytes `isDiffTargetBinary` sniffs to decide whether a file
+    /// looks binary — matches `GitService.looksBinary` and
+    /// `RemoteWorktreeFileAccess.looksBinaryOnDisk`'s 8 KB prefix, so a
+    /// binary pre-check never needs more than that, on-disk or remote.
+    private static let binarySniffPrefixBytes = 8192
+
+    /// Bounded-prefix variant of `readRemoteWorktreeFileRaw`, used only for
+    /// the binary pre-check ahead of a diff (`isDiffTargetBinary`): reads
+    /// just the first `maxBytes` bytes of the remote file
+    /// (`RemoteFileAccess.readPrefix`, exec-only — there is no helper-RPC
+    /// byte cap), so a binary sniff never needs to consult the file's total
+    /// size or hit `RemoteWorktreeFileAccess.maxFileBytes` at all. Mirrors
+    /// the local path's `RemoteWorktreeFileAccess.looksBinaryOnDisk`, which
+    /// reads only an 8 KB prefix via `FileHandle.read(upToCount:)`
+    /// regardless of the file's size. Never returns `.tooLarge`.
+    func readRemoteWorktreeFilePrefix(
+        host: String, worktreeRoot: String, relativePath: String, maxBytes: Int
+    ) async -> RemoteWorktreeRawReadOutcome {
+        let target: String
+        do {
+            target = try RemotePathContainment.lexicallyResolveInsideWorktree(
+                path: relativePath, worktreeRoot: worktreeRoot)
+        } catch {
+            return .containmentRejected
+        }
+        do {
+            try await RemotePathContainment.verifyRemoteContainment(
+                host: host, path: target, worktreeRoot: worktreeRoot)
+        } catch RemotePathContainment.ContainmentError.outsideWorktree(_) {
+            return .containmentRejected
+        } catch {
+            return .unreadable(String(describing: error))
+        }
+        do {
+            guard let data = try await RemoteFileAccess.readPrefix(host: host, path: target, maxBytes: maxBytes) else {
+                return .notFound
+            }
+            return .data(data)
+        } catch {
+            return .unreadable(String(describing: error))
+        }
+    }
+
     /// Whether `normalizedPath` looks like a binary file for diff purposes.
     /// Prefers an on-disk sniff against the current working tree (mirroring
     /// git's own heuristic). When the file is missing from the working tree
@@ -8009,25 +8052,29 @@ extension AppState: RemoteSessionsProvider {
     /// back to sniffing the blob at `comparisonRef` instead, so a deleted
     /// binary file still reports `.binary` rather than slipping through as
     /// an empty "successful" diff.
+    ///
+    /// The SSH branch sniffs only a bounded PREFIX
+    /// (`readRemoteWorktreeFilePrefix`) rather than the full file: a binary
+    /// verdict never needs more than the first 8 KB, so it must never be
+    /// gated on `RemoteWorktreeFileAccess.maxFileBytes` — a new, oversized,
+    /// untracked binary file used to hit that cap's `.tooLarge` outcome
+    /// here, which (having nothing to sniff at any historical ref either,
+    /// since the file is new) collapsed to "not binary" and produced a
+    /// misleading empty "successful" diff.
     private func isDiffTargetBinary(
         worktree: Worktree, normalizedPath: String, url: URL, comparisonRef: String?, git: GitService
     ) async -> Bool {
         let existsOnDisk: Bool
         let onDiskLooksBinary: Bool
         if worktree.path.isRemoteAlasPath, let host = RemoteHostRegistry.shared.host(forPath: worktree.path.path) {
-            switch await readRemoteWorktreeFileRaw(host: host, worktreeRoot: worktree.path.path, relativePath: normalizedPath) {
+            switch await readRemoteWorktreeFilePrefix(
+                host: host, worktreeRoot: worktree.path.path, relativePath: normalizedPath,
+                maxBytes: Self.binarySniffPrefixBytes
+            ) {
             case .data(let data):
                 existsOnDisk = true
                 onDiskLooksBinary = GitService.looksBinary(data)
-            case .notFound, .unreadable, .containmentRejected:
-                existsOnDisk = false
-                onDiskLooksBinary = false
-            case .tooLarge:
-                // Too large to sniff without an unbounded download; treat as
-                // "cannot tell from disk" so the caller falls back to
-                // sniffing the blob at `comparisonRef` (or, failing that,
-                // proceeds as non-binary — the diff payload itself is still
-                // bounded by `maxDiffBytes`/`maxDiffLines`).
+            case .notFound, .unreadable, .containmentRejected, .tooLarge:
                 existsOnDisk = false
                 onDiskLooksBinary = false
             }
@@ -8071,10 +8118,28 @@ extension AppState: RemoteSessionsProvider {
 
     /// Drops ignored and excluded nodes at the wire boundary: the remote file
     /// browser is git-aware, so build output never reaches the phone.
+    ///
+    /// Runs the same recursive keep-if-has-visible-children pass
+    /// `FilesTabView.filteredNodes` uses for the native desktop Files tab
+    /// (`FileTreeNode.filteredKeepingVisibleDescendants`) BEFORE the flat
+    /// wire projection below: a directory can be individually marked
+    /// `.ignored`/`.excluded` while still holding a tracked (force-added)
+    /// descendant, and `RemoteFileNode` carries no `children` field, so once
+    /// such a directory is dropped from its parent's listing the client can
+    /// never issue the `listFiles` request that would reveal the descendant.
+    /// This only helps when `nodes` actually has real, eagerly-populated
+    /// `children` for the directory in question — true for
+    /// `GitService.fileTree`'s LOCAL-worktree root scan (which builds full
+    /// nested children for exactly this case), but NOT for
+    /// `GitService.fileTreeChildren`'s single-level, on-demand directory
+    /// expansion, which by design never populates nested `children` beyond
+    /// the one level requested. A nested ignored directory with a tracked
+    /// descendant one or more levels below an on-demand `fileTreeChildren`
+    /// expansion can therefore remain unreachable — a known, narrower gap
+    /// than the one this fixes.
     private static func remoteFileNodes(_ nodes: [FileTreeNode]) -> [RemoteFileNode] {
-        nodes.compactMap { node in
-            guard node.visibility != .ignored, node.visibility != .excluded else { return nil }
-            return RemoteFileNode(
+        FileTreeNode.filteredKeepingVisibleDescendants(nodes).map { node in
+            RemoteFileNode(
                 name: node.name,
                 path: node.path,
                 kind: node.kind.rawValue,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -8290,7 +8290,8 @@ extension AppState: RemoteSessionsProvider {
                 let statusEntries = try await git.status(worktreePath: worktree.path)
                 let nodes = try await git.fileTree(
                     worktreePath: worktree.path, statusEntries: statusEntries)
-                return .success(nodes: Self.remoteFileNodes(nodes))
+                let capped = RemoteWorktreeFileAccess.truncateFileNodes(Self.remoteFileNodes(nodes))
+                return .success(nodes: capped.nodes, truncated: capped.truncated)
             }
             guard let normalizedPath = RemoteWorktreeFileAccess.normalizedRelativePath(path),
                   RemoteWorktreeFileAccess.resolve(path: path, in: worktree.path) != nil
@@ -8329,7 +8330,8 @@ extension AppState: RemoteSessionsProvider {
                 statusEntries.map { ($0.path, $0.status) }, uniquingKeysWith: { first, _ in first })
             let nodes = try await git.fileTreeChildren(
                 worktreePath: worktree.path, path: path, badges: badges)
-            return .success(nodes: Self.remoteFileNodes(nodes))
+            let capped = RemoteWorktreeFileAccess.truncateFileNodes(Self.remoteFileNodes(nodes))
+            return .success(nodes: capped.nodes, truncated: capped.truncated)
         } catch {
             return .failure(reason: .gitFailed, message: error.localizedDescription)
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -8181,8 +8181,30 @@ extension AppState: RemoteSessionsProvider {
                     worktreePath: worktree.path, statusEntries: statusEntries)
                 return .success(nodes: Self.remoteFileNodes(nodes))
             }
-            guard RemoteWorktreeFileAccess.resolve(path: path, in: worktree.path) != nil else {
+            guard let normalizedPath = RemoteWorktreeFileAccess.normalizedRelativePath(path),
+                  RemoteWorktreeFileAccess.resolve(path: path, in: worktree.path) != nil
+            else {
                 return .failure(reason: .pathRejected, message: nil)
+            }
+            // `resolve` above only performs LOCAL symlink resolution and
+            // containment checking — a no-op for a remote worktree, since
+            // nothing exists at `worktree.path` on this Mac to escape from.
+            // A symlink inside the SSH worktree that points outside it (or
+            // at `.git`) would otherwise let a remote listing leak directory
+            // names from anywhere on the remote host. Mirrors
+            // `readRemoteWorktreeFileRaw`'s containment check for reads.
+            if worktree.path.isRemoteAlasPath {
+                guard let host = RemoteHostRegistry.shared.host(forPath: worktree.path.path) else {
+                    return .failure(reason: .gitFailed, message: "Remote host is not registered for this worktree.")
+                }
+                do {
+                    try await RemotePathContainment.verifyRemoteContainment(
+                        host: host, path: normalizedPath, worktreeRoot: worktree.path.path)
+                } catch RemotePathContainment.ContainmentError.outsideWorktree(_) {
+                    return .failure(reason: .pathRejected, message: nil)
+                } catch {
+                    return .failure(reason: .gitFailed, message: error.localizedDescription)
+                }
             }
             let nodes = try await git.fileTreeChildren(
                 worktreePath: worktree.path, path: path)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -8286,10 +8286,25 @@ extension AppState: RemoteSessionsProvider {
         }
         let git = GitService()
         do {
+            // Base-relative (against `comparisonRef`), matching the Changes
+            // tab — not working-tree/index `status()` — so a file with
+            // committed-but-not-working-tree-dirty changes (a clean
+            // checkout of a branch with real commits on it, the common
+            // case for reviewing an agent's finished work) still shows the
+            // same badge here that Changes already reports for it, instead
+            // of appearing unbadged just because `status()` alone has
+            // nothing to say about it.
+            let commits = try await git.commitsAhead(
+                at: worktree.path,
+                baseBranch: config.worktrees.baseBranch,
+                resolution: GitService.BaseResolution.forCommits(
+                    mode: config.changes.comparisonMode, userOverrodeBaseBranch: false))
+            let changedEntries = try await git.changedFilesAgainstRef(
+                worktreePath: worktree.path, ref: commits.comparisonRef)
+
             guard let path, !path.isEmpty else {
-                let statusEntries = try await git.status(worktreePath: worktree.path)
                 let nodes = try await git.fileTree(
-                    worktreePath: worktree.path, statusEntries: statusEntries)
+                    worktreePath: worktree.path, statusEntries: changedEntries)
                 let capped = RemoteWorktreeFileAccess.truncateFileNodes(Self.remoteFileNodes(nodes))
                 return .success(nodes: capped.nodes, truncated: capped.truncated)
             }
@@ -8318,16 +8333,15 @@ extension AppState: RemoteSessionsProvider {
                     return .failure(reason: .gitFailed, message: error.localizedDescription)
                 }
             }
-            // Same badge source the ROOT branch above uses
-            // (`status(worktreePath:)`), so a nested directory expansion
-            // shows the same status badges the root listing would if it
+            // Same badge source the ROOT branch above uses (`changedEntries`,
+            // base-relative against `comparisonRef`), so a nested directory
+            // expansion shows the same badges the root listing would if it
             // eagerly built this far — without this, `fileTreeChildren`
             // always built its nodes with `badges: [:]`, so any change in a
             // subdirectory lost its badge the moment a client expanded into
             // that directory.
-            let statusEntries = try await git.status(worktreePath: worktree.path)
             let badges = Dictionary(
-                statusEntries.map { ($0.path, $0.status) }, uniquingKeysWith: { first, _ in first })
+                changedEntries.map { ($0.path, $0.status) }, uniquingKeysWith: { first, _ in first })
             let nodes = try await git.fileTreeChildren(
                 worktreePath: worktree.path, path: path, badges: badges)
             let capped = RemoteWorktreeFileAccess.truncateFileNodes(Self.remoteFileNodes(nodes))

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7951,52 +7951,48 @@ extension AppState: RemoteSessionsProvider {
     }
 
     /// Reads `relativePath` (already validated by
-    /// `RemoteWorktreeFileAccess.normalizedRelativePath`) from `host`,
-    /// applying the same lexical + physical containment checks
-    /// `ACPRemoteFileServer.read` uses before touching the remote
-    /// filesystem. Git-based operations (`GitService.status`/`.diff`/etc.)
-    /// already run correctly against a remote worktree because
-    /// `Process.git` is itself remote-host-aware — this helper exists only
-    /// for the raw, non-git file reads this surface also needs (plain file
-    /// contents, the pre-diff binary sniff).
+    /// `RemoteWorktreeFileAccess.normalizedRelativePath`) from `host` via
+    /// `RemotePathContainment.containedRead`: a SINGLE remote script that
+    /// performs the physical containment/`.git`-exclusion check and the
+    /// bounded content read together, off the SAME resolved path, in one
+    /// `RemoteExec.runData` round trip.
     ///
-    /// Stats the remote file and rejects an oversized one BEFORE
-    /// transferring its bytes, mirroring the local path's stat-before-read
-    /// discipline (`RemoteWorktreeFileAccess.readFileContents`) — a client
-    /// naming a huge remote file must not force a full network transfer
-    /// just to be told `.tooLarge`.
+    /// This replaces what used to be three separate round trips —
+    /// `verifyRemoteContainment`, then `RemoteFileAccess.size`, then
+    /// `RemoteFileAccess.read` — each of which re-resolved `target` by
+    /// STRING independently. Between those round trips, a concurrently
+    /// running remote process could swap a path component for a symlink:
+    /// the containment check saw a safe path, but a later, separately
+    /// re-resolved read could still escape the worktree. See
+    /// `RemotePathContainment.containedReadScript`'s doc comment for exactly
+    /// what this closes and what residual (much narrower) race remains.
+    ///
+    /// Only ever transfers up to `RemoteWorktreeFileAccess.maxFileBytes`
+    /// bytes of the file's body regardless of its actual size — the
+    /// oversized case is reported from the script's own `stat`-derived size
+    /// header, never from having transferred the whole file.
     func readRemoteWorktreeFileRaw(
         host: String, worktreeRoot: String, relativePath: String
     ) async -> RemoteWorktreeRawReadOutcome {
-        let target: String
         do {
-            target = try RemotePathContainment.lexicallyResolveInsideWorktree(
-                path: relativePath, worktreeRoot: worktreeRoot)
-        } catch {
-            return .containmentRejected
-        }
-        do {
-            try await RemotePathContainment.verifyRemoteContainment(
-                host: host, path: target, worktreeRoot: worktreeRoot)
+            switch try await RemotePathContainment.containedRead(
+                host: host, path: relativePath, worktreeRoot: worktreeRoot,
+                maxBytes: RemoteWorktreeFileAccess.maxFileBytes
+            ) {
+            case .outsideWorktree:
+                return .containmentRejected
+            case .symlink, .directory, .missing:
+                return .notFound
+            case .unreadable:
+                return .unreadable("remote read failed")
+            case let .ok(byteSize, prefix):
+                guard byteSize <= RemoteWorktreeFileAccess.maxFileBytes else {
+                    return .tooLarge(byteSize: byteSize)
+                }
+                return .data(prefix)
+            }
         } catch RemotePathContainment.ContainmentError.outsideWorktree(_) {
             return .containmentRejected
-        } catch {
-            return .unreadable(String(describing: error))
-        }
-        do {
-            if let byteSize = try await RemoteFileAccess.size(host: host, path: target),
-               byteSize > UInt64(RemoteWorktreeFileAccess.maxFileBytes) {
-                return .tooLarge(byteSize: Int(clamping: byteSize))
-            }
-        } catch {
-            return .unreadable(String(describing: error))
-        }
-        do {
-            switch try await RemoteFileAccess.read(host: host, path: target) {
-            case let .file(data, _): return .data(data)
-            case .missing, .directory, .symlink: return .notFound
-            case let .unreadable(detail): return .unreadable(detail)
-            }
         } catch {
             return .unreadable(String(describing: error))
         }
@@ -8112,7 +8108,8 @@ extension AppState: RemoteSessionsProvider {
                 }
                 return RemoteDiffLine(
                     kind: kind, text: line.text,
-                    oldNumber: line.oldNumber, newNumber: line.newNumber)
+                    oldNumber: line.oldNumber, newNumber: line.newNumber,
+                    noTrailingNewline: line.noTrailingNewline)
             })
     }
 
@@ -8209,29 +8206,65 @@ extension AppState: RemoteSessionsProvider {
         }
         let git = GitService()
         do {
-            let ignored = try await git.isPathIgnored(worktreePath: worktree.path, path: normalizedPath)
-            if ignored {
-                return .failure(reason: .pathRejected, message: nil)
-            }
-        } catch {
-            return .failure(reason: .gitFailed, message: error.localizedDescription)
-        }
-        do {
             let commits = try await git.commitsAhead(
                 at: worktree.path,
                 baseBranch: config.worktrees.baseBranch,
                 resolution: GitService.BaseResolution.forCommits(
                     mode: config.changes.comparisonMode, userOverrodeBaseBranch: false))
+            // Threading `comparisonRef` through lets `isPathIgnored` exempt a
+            // path that existed there even though it's since been deleted —
+            // otherwise a deleted, gitignore-pattern-matching file's
+            // legitimate deletion diff (shown correctly with status `D` in
+            // the Changes list) gets wrongly rejected as `.pathRejected`,
+            // because a deleted path is no longer in the current index for
+            // `check-ignore` to exempt the way a force-added tracked file is.
+            let ignored = try await git.isPathIgnored(
+                worktreePath: worktree.path, path: normalizedPath, comparisonRef: commits.comparisonRef)
+            if ignored {
+                return .failure(reason: .pathRejected, message: nil)
+            }
             if await isDiffTargetBinary(
                 worktree: worktree, normalizedPath: normalizedPath, url: url,
                 comparisonRef: commits.comparisonRef, git: git
             ) {
                 return .failure(reason: .binary, message: nil)
             }
+            // Re-check the symlink alias immediately before the actual
+            // read, rather than relying solely on the check made at the top
+            // of this function. `git.diff` below spawns an external `git`
+            // subprocess that opens `normalizedPath` itself, at the OS
+            // level, from a path STRING — there is no file descriptor to
+            // thread through a subprocess boundary the way
+            // `RemoteWorktreeFileAccess.readFileContents` now does for
+            // direct content reads, so this specific read can't be made
+            // fully atomic with its containment check without a much larger
+            // change (e.g. piping the file through our own already-open,
+            // already-validated descriptor instead of letting `git diff`
+            // touch the path itself). Moving the recheck to just before the
+            // subprocess spawn — after `isPathIgnored`, `commitsAhead`, and
+            // `isDiffTargetBinary` have all already run — substantially
+            // narrows the TOCTOU window (from "the whole async pipeline
+            // above" down to "the gap between this check and the subprocess
+            // spawn") without closing it completely.
+            if !worktree.path.isRemoteAlasPath, RemoteWorktreeFileAccess.isSymlink(at: url) {
+                return .failure(reason: .notFound, message: nil)
+            }
             let parsed = try await git.diff(
                 worktreePath: worktree.path,
                 againstRef: commits.comparisonRef,
                 file: normalizedPath)
+            // `isDiffTargetBinary` above only sniffs byte content, which
+            // misses a file declared binary purely via `.gitattributes`
+            // (e.g. `*.dat binary`) whose bytes happen to still look like
+            // valid UTF-8. Catch that case here instead: git's OWN binary
+            // classification survives into `parsed.isBinary`, detected from
+            // the raw `Binary files ... differ` line before hunk parsing
+            // discarded it — so a hunk-less result from this specific
+            // reason reports `.binary` rather than a misleading empty
+            // "successful" diff.
+            guard !parsed.isBinary else {
+                return .failure(reason: .binary, message: nil)
+            }
             let capped = RemoteWorktreeFileAccess.truncateHunks(parsed.hunks)
             return .success(
                 hunks: capped.hunks.map(Self.remoteDiffHunk),
@@ -8284,8 +8317,18 @@ extension AppState: RemoteSessionsProvider {
                     return .failure(reason: .gitFailed, message: error.localizedDescription)
                 }
             }
+            // Same badge source the ROOT branch above uses
+            // (`status(worktreePath:)`), so a nested directory expansion
+            // shows the same status badges the root listing would if it
+            // eagerly built this far — without this, `fileTreeChildren`
+            // always built its nodes with `badges: [:]`, so any change in a
+            // subdirectory lost its badge the moment a client expanded into
+            // that directory.
+            let statusEntries = try await git.status(worktreePath: worktree.path)
+            let badges = Dictionary(
+                statusEntries.map { ($0.path, $0.status) }, uniquingKeysWith: { first, _ in first })
             let nodes = try await git.fileTreeChildren(
-                worktreePath: worktree.path, path: path)
+                worktreePath: worktree.path, path: path, badges: badges)
             return .success(nodes: Self.remoteFileNodes(nodes))
         } catch {
             return .failure(reason: .gitFailed, message: error.localizedDescription)
@@ -8309,10 +8352,11 @@ extension AppState: RemoteSessionsProvider {
         }
         // See the matching comment in `remoteFileDiff`: a tracked symlink
         // whose alias name isn't itself ignored can still point at an
-        // ignored (or otherwise off-limits) target, and `readFileContents`
-        // below would otherwise transparently follow it via
-        // `Data(contentsOf:)`. Reject the alias outright rather than
-        // resolving-and-rechecking the target.
+        // ignored (or otherwise off-limits) target. `readFileContents`
+        // below rejects a symlink itself (`O_NOFOLLOW` in its single
+        // open/fstat/read sequence), but this earlier, cheaper check lets
+        // the request fail fast with the right reason before doing the
+        // ignore-check git call at all.
         if !worktree.path.isRemoteAlasPath, RemoteWorktreeFileAccess.isSymlink(at: url) {
             return .failure(reason: .notFound, byteSize: nil, message: nil)
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7895,4 +7895,155 @@ extension AppState: RemoteSessionsProvider {
         }
         return nil
     }
+
+    /// Resolves the worktree backing a session id by scanning the live
+    /// per-worktree managers, mirroring how `session(for:)` looks sessions up.
+    private func remoteWorktreeContext(sessionId: String) -> (project: ProjectConfig, worktree: Worktree)? {
+        for mgr in acpManagers.values where mgr.sessionRows.contains(where: { $0.id == sessionId }) {
+            return projectAndWorktree(withWorktreeId: mgr.worktreeId)
+        }
+        return nil
+    }
+
+    private static func remoteChangedFile(_ file: ChangedFile) -> RemoteChangedFile {
+        RemoteChangedFile(
+            path: file.path,
+            status: file.status,
+            add: file.add,
+            del: file.del,
+            conflict: file.conflict?.rawValue,
+            renameFrom: file.renameFrom)
+    }
+
+    private static func remoteDiffHunk(_ hunk: ParsedDiff.Hunk) -> RemoteDiffHunk {
+        RemoteDiffHunk(
+            header: hunk.header,
+            oldStart: hunk.oldStart,
+            newStart: hunk.newStart,
+            lines: hunk.lines.map { line in
+                let kind: String
+                switch line.kind {
+                case .context: kind = "context"
+                case .add: kind = "add"
+                case .delete: kind = "delete"
+                }
+                return RemoteDiffLine(
+                    kind: kind, text: line.text,
+                    oldNumber: line.oldNumber, newNumber: line.newNumber)
+            })
+    }
+
+    /// Drops ignored and excluded nodes at the wire boundary: the remote file
+    /// browser is git-aware, so build output never reaches the phone.
+    private static func remoteFileNodes(_ nodes: [FileTreeNode]) -> [RemoteFileNode] {
+        nodes.compactMap { node in
+            guard node.visibility != .ignored, node.visibility != .excluded else { return nil }
+            return RemoteFileNode(
+                name: node.name,
+                path: node.path,
+                kind: node.kind.rawValue,
+                badge: node.badge,
+                childrenState: node.childrenState.rawValue,
+                isSubmodule: node.isSubmodule)
+        }
+    }
+
+    func remoteChangeList(sessionId: String) async -> RemoteChangeListResult {
+        guard let context = remoteWorktreeContext(sessionId: sessionId) else {
+            return .failure(reason: .sessionUnknown, message: nil)
+        }
+        let git = GitService()
+        do {
+            let commits = try await git.commitsAhead(
+                at: context.worktree.path,
+                baseBranch: config.worktrees.baseBranch,
+                resolution: GitService.BaseResolution.forCommits(
+                    mode: config.changes.comparisonMode, userOverrodeBaseBranch: false))
+            let changed = try await git.changedFilesAgainstRef(
+                worktreePath: context.worktree.path, ref: commits.comparisonRef)
+            let capped = RemoteWorktreeFileAccess.truncateFiles(changed)
+            return .success(
+                comparisonRef: commits.comparisonRef,
+                metricsAvailable: true,
+                files: capped.files.map(Self.remoteChangedFile),
+                truncated: capped.truncated)
+        } catch {
+            return .failure(reason: .gitFailed, message: error.localizedDescription)
+        }
+    }
+
+    func remoteFileDiff(sessionId: String, path: String) async -> RemoteFileDiffResult {
+        guard let context = remoteWorktreeContext(sessionId: sessionId) else {
+            return .failure(reason: .sessionUnknown, message: nil)
+        }
+        guard let url = RemoteWorktreeFileAccess.resolve(path: path, in: context.worktree.path) else {
+            return .failure(reason: .pathRejected, message: nil)
+        }
+        if let data = try? Data(contentsOf: url), GitService.looksBinary(data) {
+            return .failure(reason: .binary, message: nil)
+        }
+        let git = GitService()
+        do {
+            let commits = try await git.commitsAhead(
+                at: context.worktree.path,
+                baseBranch: config.worktrees.baseBranch,
+                resolution: GitService.BaseResolution.forCommits(
+                    mode: config.changes.comparisonMode, userOverrodeBaseBranch: false))
+            let parsed = try await git.diff(
+                worktreePath: context.worktree.path,
+                againstRef: commits.comparisonRef,
+                file: path)
+            let capped = RemoteWorktreeFileAccess.truncateHunks(parsed.hunks)
+            return .success(
+                hunks: capped.hunks.map(Self.remoteDiffHunk),
+                truncated: capped.truncated)
+        } catch {
+            return .failure(reason: .gitFailed, message: error.localizedDescription)
+        }
+    }
+
+    func remoteFileTree(sessionId: String, path: String?) async -> RemoteFileTreeResult {
+        guard let context = remoteWorktreeContext(sessionId: sessionId) else {
+            return .failure(reason: .sessionUnknown, message: nil)
+        }
+        let git = GitService()
+        do {
+            guard let path, !path.isEmpty else {
+                let statusEntries = try await git.status(worktreePath: context.worktree.path)
+                let nodes = try await git.fileTree(
+                    worktreePath: context.worktree.path, statusEntries: statusEntries)
+                return .success(nodes: Self.remoteFileNodes(nodes))
+            }
+            guard RemoteWorktreeFileAccess.resolve(path: path, in: context.worktree.path) != nil else {
+                return .failure(reason: .pathRejected, message: nil)
+            }
+            let nodes = try await git.fileTreeChildren(
+                worktreePath: context.worktree.path, path: path)
+            return .success(nodes: Self.remoteFileNodes(nodes))
+        } catch {
+            return .failure(reason: .gitFailed, message: error.localizedDescription)
+        }
+    }
+
+    func remoteFileContents(sessionId: String, path: String) async -> RemoteFileContentsResult {
+        guard let context = remoteWorktreeContext(sessionId: sessionId) else {
+            return .failure(reason: .sessionUnknown, byteSize: nil, message: nil)
+        }
+        guard let url = RemoteWorktreeFileAccess.resolve(path: path, in: context.worktree.path) else {
+            return .failure(reason: .pathRejected, byteSize: nil, message: nil)
+        }
+        guard let data = try? Data(contentsOf: url) else {
+            return .failure(reason: .notFound, byteSize: nil, message: nil)
+        }
+        guard !GitService.looksBinary(data) else {
+            return .failure(reason: .binary, byteSize: data.count, message: nil)
+        }
+        guard data.count <= RemoteWorktreeFileAccess.maxFileBytes else {
+            return .failure(reason: .tooLarge, byteSize: data.count, message: nil)
+        }
+        guard let text = String(data: data, encoding: .utf8) else {
+            return .failure(reason: .binary, byteSize: data.count, message: nil)
+        }
+        return .success(text: text, truncated: false)
+    }
 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7944,6 +7944,10 @@ extension AppState: RemoteSessionsProvider {
         case unreadable(String)
         /// The resolved path escaped the worktree root.
         case containmentRejected
+        /// The remote file's stat'd size exceeds
+        /// `RemoteWorktreeFileAccess.maxFileBytes` — its bytes were never
+        /// transferred.
+        case tooLarge(byteSize: Int)
     }
 
     /// Reads `relativePath` (already validated by
@@ -7955,6 +7959,12 @@ extension AppState: RemoteSessionsProvider {
     /// `Process.git` is itself remote-host-aware — this helper exists only
     /// for the raw, non-git file reads this surface also needs (plain file
     /// contents, the pre-diff binary sniff).
+    ///
+    /// Stats the remote file and rejects an oversized one BEFORE
+    /// transferring its bytes, mirroring the local path's stat-before-read
+    /// discipline (`RemoteWorktreeFileAccess.readFileContents`) — a client
+    /// naming a huge remote file must not force a full network transfer
+    /// just to be told `.tooLarge`.
     func readRemoteWorktreeFileRaw(
         host: String, worktreeRoot: String, relativePath: String
     ) async -> RemoteWorktreeRawReadOutcome {
@@ -7970,6 +7980,14 @@ extension AppState: RemoteSessionsProvider {
                 host: host, path: target, worktreeRoot: worktreeRoot)
         } catch RemotePathContainment.ContainmentError.outsideWorktree(_) {
             return .containmentRejected
+        } catch {
+            return .unreadable(String(describing: error))
+        }
+        do {
+            if let byteSize = try await RemoteFileAccess.size(host: host, path: target),
+               byteSize > UInt64(RemoteWorktreeFileAccess.maxFileBytes) {
+                return .tooLarge(byteSize: Int(clamping: byteSize))
+            }
         } catch {
             return .unreadable(String(describing: error))
         }
@@ -8002,6 +8020,14 @@ extension AppState: RemoteSessionsProvider {
                 existsOnDisk = true
                 onDiskLooksBinary = GitService.looksBinary(data)
             case .notFound, .unreadable, .containmentRejected:
+                existsOnDisk = false
+                onDiskLooksBinary = false
+            case .tooLarge:
+                // Too large to sniff without an unbounded download; treat as
+                // "cannot tell from disk" so the caller falls back to
+                // sniffing the blob at `comparisonRef` (or, failing that,
+                // proceeds as non-binary — the diff payload itself is still
+                // bounded by `maxDiffBytes`/`maxDiffLines`).
                 existsOnDisk = false
                 onDiskLooksBinary = false
             }
@@ -8203,6 +8229,8 @@ extension AppState: RemoteSessionsProvider {
                 return .failure(reason: .notFound, byteSize: nil, message: nil)
             case .unreadable(let detail):
                 return .failure(reason: .gitFailed, byteSize: nil, message: detail)
+            case .tooLarge(let byteSize):
+                return .failure(reason: .tooLarge, byteSize: byteSize, message: nil)
             case .data(let data):
                 guard data.count <= RemoteWorktreeFileAccess.maxFileBytes else {
                     return .failure(reason: .tooLarge, byteSize: data.count, message: nil)

--- a/Alas/Sources/Git/DiffParser.swift
+++ b/Alas/Sources/Git/DiffParser.swift
@@ -2,6 +2,15 @@ import Foundation
 
 struct ParsedDiff: Equatable {
     var hunks: [Hunk]
+    /// True when git's raw diff output reported `Binary files ... differ`
+    /// instead of any renderable hunks. A file can be declared binary via
+    /// `.gitattributes` (e.g. `*.dat binary`) even when its content happens
+    /// to look like valid UTF-8 at the byte level — an on-disk content
+    /// sniff alone would miss that case and treat a hunk-less result as a
+    /// legitimate empty diff. Detected directly from the raw diff text here
+    /// (before hunk parsing discards everything that isn't a `@@` line),
+    /// rather than a separate git call.
+    var isBinary: Bool = false
     struct Hunk: Equatable {
         let header: String          // raw "@@ ... @@" line
         let oldStart: Int
@@ -28,6 +37,7 @@ enum DiffParser {
         var current: (header: String, oldStart: Int, newStart: Int, lines: [ParsedDiff.Hunk.Line])? = nil
         var oldCounter = 0
         var newCounter = 0
+        var isBinary = false
 
         func flush() {
             if let c = current {
@@ -38,6 +48,10 @@ enum DiffParser {
         }
 
         for line in raw.split(separator: "\n", omittingEmptySubsequences: false).map(String.init) {
+            if line.hasPrefix("Binary files ") && line.hasSuffix(" differ") {
+                isBinary = true
+                continue
+            }
             if line.hasPrefix("@@") {
                 flush()
                 let (oldStart, newStart) = parseHunkHeader(line)
@@ -71,7 +85,7 @@ enum DiffParser {
             }
         }
         flush()
-        return ParsedDiff(hunks: hunks)
+        return ParsedDiff(hunks: hunks, isBinary: isBinary)
     }
 
     private static func parseHunkHeader(_ header: String) -> (Int, Int) {

--- a/Alas/Sources/Git/DiffParser.swift
+++ b/Alas/Sources/Git/DiffParser.swift
@@ -11,6 +11,14 @@ struct ParsedDiff: Equatable {
     /// (before hunk parsing discards everything that isn't a `@@` line),
     /// rather than a separate git call.
     var isBinary: Bool = false
+    /// Set when git reported a change with no renderable `@@` hunks AND no
+    /// `Binary files ... differ` line either — a pure rename/copy (100%
+    /// similarity, no content edits) or an executable-bit-only change.
+    /// Without this, such a diff parses to empty `hunks`, indistinguishable
+    /// from "nothing changed" even though the file IS listed as changed —
+    /// the caller would otherwise report a misleading successful empty
+    /// diff instead of surfacing what actually happened.
+    var metadataSummary: String? = nil
     struct Hunk: Equatable {
         let header: String          // raw "@@ ... @@" line
         let oldStart: Int
@@ -38,6 +46,12 @@ enum DiffParser {
         var oldCounter = 0
         var newCounter = 0
         var isBinary = false
+        var renameFrom: String?
+        var renameTo: String?
+        var copyFrom: String?
+        var copyTo: String?
+        var oldMode: String?
+        var newMode: String?
 
         func flush() {
             if let c = current {
@@ -51,6 +65,37 @@ enum DiffParser {
             if line.hasPrefix("Binary files ") && line.hasSuffix(" differ") {
                 isBinary = true
                 continue
+            }
+            // Metadata-only lines (rename/copy pairing, executable-bit
+            // change) only ever appear in the header section, before any
+            // `@@` hunk — a content line with this exact text would still
+            // carry a leading `+`/`-`/` ` prefix, so matching the bare
+            // prefix here can't misfire on hunk content.
+            if current == nil {
+                if line.hasPrefix("rename from ") {
+                    renameFrom = String(line.dropFirst("rename from ".count))
+                    continue
+                }
+                if line.hasPrefix("rename to ") {
+                    renameTo = String(line.dropFirst("rename to ".count))
+                    continue
+                }
+                if line.hasPrefix("copy from ") {
+                    copyFrom = String(line.dropFirst("copy from ".count))
+                    continue
+                }
+                if line.hasPrefix("copy to ") {
+                    copyTo = String(line.dropFirst("copy to ".count))
+                    continue
+                }
+                if line.hasPrefix("old mode ") {
+                    oldMode = String(line.dropFirst("old mode ".count))
+                    continue
+                }
+                if line.hasPrefix("new mode ") {
+                    newMode = String(line.dropFirst("new mode ".count))
+                    continue
+                }
             }
             if line.hasPrefix("@@") {
                 flush()
@@ -85,7 +130,20 @@ enum DiffParser {
             }
         }
         flush()
-        return ParsedDiff(hunks: hunks, isBinary: isBinary)
+        // Only worth surfacing when there's nothing else to show — a rename
+        // or mode change alongside real content edits already has hunks to
+        // render, so the note would just be noise there.
+        var metadataSummary: String?
+        if hunks.isEmpty, !isBinary {
+            if let renameFrom, let renameTo {
+                metadataSummary = "Renamed from \(renameFrom) to \(renameTo) — no content changes."
+            } else if let copyFrom, let copyTo {
+                metadataSummary = "Copied from \(copyFrom) to \(copyTo) — no content changes."
+            } else if let oldMode, let newMode {
+                metadataSummary = "File mode changed from \(oldMode) to \(newMode) — no content changes."
+            }
+        }
+        return ParsedDiff(hunks: hunks, isBinary: isBinary, metadataSummary: metadataSummary)
     }
 
     private static func parseHunkHeader(_ header: String) -> (Int, Int) {

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -73,9 +73,11 @@ extension GitService {
             return try await diff(worktreePath: worktreePath, file: file)
         }
 
-        let tracked = try await Process.git(
-            ["ls-files", "--error-unmatch", "--", file], cwd: worktreePath)
-        if tracked.exitCode != 0 {
+        // Check if file exists at ref (not just in current index) to handle deleted files correctly.
+        let existsAtRef = try await Process.git(
+            ["cat-file", "-e", "\(ref):\(file)"], cwd: worktreePath)
+        if existsAtRef.exitCode != 0 {
+            // File doesn't exist at ref (untracked/new file), so diff against /dev/null.
             let result = try await Process.git(
                 ["diff", "--no-color", "--no-index", "--", "/dev/null", file], cwd: worktreePath)
             // `--no-index` exits 1 when there ARE differences, which is the
@@ -84,6 +86,7 @@ extension GitService {
             return DiffParser.parse(result.stdout)
         }
 
+        // File exists at ref (tracked or previously committed), so diff ref to current state.
         let result = try await Process.git(
             ["diff", "--no-color", "-M", "-C", ref, "--", file], cwd: worktreePath)
         guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -112,8 +112,16 @@ extension GitService {
         }
 
         if let originalPath = try await renameSource(worktreePath: worktreePath, ref: ref, file: file) {
+            // `--literal-pathspecs` (a global flag, so it must precede the
+            // subcommand) stops `file`/`originalPath` from being interpreted
+            // as glob pathspecs — a tracked name containing `*`/`?`/`[...]`
+            // would otherwise also match unrelated files. `-c
+            // core.quotePath=false` keeps a non-ASCII destination name
+            // unquoted in the `diff --git a/<old> b/<new>` header, which
+            // `sliceDiffForFile` below matches on as a raw string.
             let result = try await Process.git(
-                ["diff", "--no-color", "-M", "-C", ref, "--", file, originalPath], cwd: worktreePath)
+                ["--literal-pathspecs", "-c", "core.quotePath=false",
+                 "diff", "--no-color", "-M", "-C", ref, "--", file, originalPath], cwd: worktreePath)
             guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
             return DiffParser.parse(Self.sliceDiffForFile(result.stdout, file: file))
         }
@@ -123,8 +131,12 @@ extension GitService {
             ["cat-file", "-e", "\(ref):\(file)"], cwd: worktreePath)
         if existsAtRef.exitCode != 0 {
             // File doesn't exist at ref (untracked/new file), so diff against /dev/null.
+            // `--no-index` compares the two given paths directly rather than
+            // through pathspec matching, so `--literal-pathspecs` is a no-op
+            // here — kept for consistency with the other client-path calls
+            // in this function.
             let result = try await Process.git(
-                ["diff", "--no-color", "--no-index", "--", "/dev/null", file], cwd: worktreePath)
+                ["--literal-pathspecs", "diff", "--no-color", "--no-index", "--", "/dev/null", file], cwd: worktreePath)
             // `--no-index` exits 1 when there ARE differences, which is the
             // normal case here; only >= 2 is a real failure.
             guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
@@ -132,8 +144,10 @@ extension GitService {
         }
 
         // File exists at ref (tracked or previously committed), so diff ref to current state.
+        // `--literal-pathspecs` stops `file` from being interpreted as a
+        // glob pathspec (see comment above).
         let result = try await Process.git(
-            ["diff", "--no-color", "-M", "-C", ref, "--", file], cwd: worktreePath)
+            ["--literal-pathspecs", "diff", "--no-color", "-M", "-C", ref, "--", file], cwd: worktreePath)
         guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
         return DiffParser.parse(result.stdout)
     }

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -12,15 +12,19 @@ extension GitService {
             return try await status(worktreePath: worktreePath)
         }
 
+        // `-c core.quotePath=false` plus `-z` keep non-ASCII (and
+        // tab/newline-containing) filenames intact instead of git's default
+        // octal-escaped, quoted rendering — mirrors `stagedChangedFiles`,
+        // whose NUL-token parsers this reuses.
         let numstat = try await Process.git(
-            ["diff", "--numstat", "-M", "-C", ref, "--"], cwd: worktreePath)
+            ["-c", "core.quotePath=false", "diff", "--numstat", "-z", "-M", "-C", ref, "--"], cwd: worktreePath)
         guard numstat.exitCode == 0 else {
             return try await status(worktreePath: worktreePath)
         }
-        let counts = NumstatParser.parse(numstat.stdout)
+        let counts = GitService.parseNumstatZOutput(numstat.stdout)
 
         let nameStatus = try await Process.git(
-            ["diff", "--name-status", "-M", "-C", ref, "--"], cwd: worktreePath)
+            ["-c", "core.quotePath=false", "diff", "--name-status", "-z", "-M", "-C", ref, "--"], cwd: worktreePath)
         let statusEntries = try await status(worktreePath: worktreePath)
         let conflicts = Dictionary(
             statusEntries.compactMap { entry in entry.conflict.map { (entry.path, $0) } },
@@ -28,29 +32,26 @@ extension GitService {
 
         var files: [ChangedFile] = []
         var seen = Set<String>()
-        for line in nameStatus.stdout.split(separator: "\n") {
-            let parts = line.split(separator: "\t").map(String.init)
-            guard let code = parts.first, parts.count >= 2 else { continue }
-            let letter = String(code.prefix(1))
-            // Rename/copy entries carry both the source and destination path.
-            let path = parts.count >= 3 ? parts[2] : parts[1]
-            let renameFrom = parts.count >= 3 ? parts[1] : nil
+        let parsedNameStatus = GitService.parseNameStatusZOutput(nameStatus.stdout)
+        for path in parsedNameStatus.ordered {
             guard seen.insert(path).inserted else { continue }
-            let count = counts[path] ?? (add: 0, del: 0)
+            let letter = parsedNameStatus.status[path] ?? "M"
+            let renameFrom = parsedNameStatus.original[path]
+            let add = counts.add[path] ?? 0
+            let del = counts.del[path] ?? 0
             files.append(ChangedFile(
                 path: path,
                 status: letter,
                 stage: .unstaged,   // not meaningful for a base-relative view
-                add: count.add,
-                del: count.del,
+                add: add,
+                del: del,
                 renameFrom: renameFrom,
                 conflict: conflicts[path]))
         }
 
         let untracked = try await Process.git(
-            ["ls-files", "--others", "--exclude-standard"], cwd: worktreePath)
-        let untrackedPaths = untracked.stdout.split(separator: "\n")
-            .map(String.init)
+            ["ls-files", "--others", "--exclude-standard", "-z"], cwd: worktreePath)
+        let untrackedPaths = untracked.stdout.components(separatedBy: "\0")
             .filter { !$0.isEmpty && seen.insert($0).inserted }
 
         // `addedLineCount` shells out to `Data(contentsOf:)` against a LOCAL
@@ -98,7 +99,16 @@ extension GitService {
     /// against.
     func diff(worktreePath: URL, againstRef ref: String?, file: String) async throws -> ParsedDiff {
         guard let ref, !ref.isEmpty else {
-            return try await diff(worktreePath: worktreePath, file: file)
+            // `diff(worktreePath:file:)`'s default (`staged: false`) is a
+            // working-tree-vs-INDEX diff, which omits changes that are
+            // staged but not yet committed — so a staged-only file would
+            // show up in `changedFilesAgainstRef`'s own nil-ref fallback
+            // (`status(worktreePath:)`, which includes staged entries) but
+            // open to an empty diff here. `diffAgainstHEAD` compares the
+            // working tree against HEAD (or /dev/null on an unborn branch),
+            // which captures staged AND unstaged changes together, matching
+            // what `status` already reflects in the change list.
+            return try await diffAgainstHEAD(worktreePath: worktreePath, file: file)
         }
 
         if let originalPath = try await renameSource(worktreePath: worktreePath, ref: ref, file: file) {
@@ -137,14 +147,11 @@ extension GitService {
     /// old path entirely.
     private func renameSource(worktreePath: URL, ref: String, file: String) async throws -> String? {
         let result = try await Process.git(
-            ["diff", "--name-status", "-M", "-C", ref], cwd: worktreePath)
+            ["-c", "core.quotePath=false", "diff", "--name-status", "-z", "-M", "-C", ref], cwd: worktreePath)
         guard result.exitCode == 0 else { return nil }
-        for line in result.stdout.split(separator: "\n") {
-            let parts = line.split(separator: "\t").map(String.init)
-            guard parts.count == 3, let status = parts.first, status.hasPrefix("R"), parts[2] == file else { continue }
-            return parts[1]
-        }
-        return nil
+        let parsed = GitService.parseNameStatusZOutput(result.stdout)
+        guard let status = parsed.status[file], status.hasPrefix("R") else { return nil }
+        return parsed.original[file]
     }
 
     /// Sniffs whether the blob at `ref:file` looks binary, for files that no

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -138,19 +138,27 @@ extension GitService {
         return DiffParser.parse(result.stdout)
     }
 
-    /// Looks up the source path of a rename that landed `file` at its
-    /// current path since `ref`, or nil when `file` was not renamed (it's
+    /// Looks up the source path of a rename OR copy that landed `file` at
+    /// its current path since `ref`, or nil when `file` is neither (it's
     /// untracked, unchanged, or was modified/deleted/added without a
-    /// rename). Scans the UNRESTRICTED rename-aware name-status diff (no
-    /// pathspec) rather than one scoped to `file`, since pathspec
-    /// restriction happens before rename pairing in git and would hide the
-    /// old path entirely.
+    /// rename/copy). Scans the UNRESTRICTED rename-aware name-status diff
+    /// (no pathspec) rather than one scoped to `file`, since pathspec
+    /// restriction happens before rename/copy pairing in git and would hide
+    /// the old path entirely.
+    ///
+    /// With `-C` enabled, git emits `"C<score>"` (not `"R<score>"`) when
+    /// `file` was copied from a source path that STILL EXISTS — distinct
+    /// from a pure rename, where the source is gone.
+    /// `parseNameStatusZOutput` already records the source path for `C`
+    /// entries too; without accepting `"C"` here, a copied file's diff fell
+    /// through to being treated as brand new (all-add against
+    /// `/dev/null`) instead of a proper diff against its copy source.
     private func renameSource(worktreePath: URL, ref: String, file: String) async throws -> String? {
         let result = try await Process.git(
             ["-c", "core.quotePath=false", "diff", "--name-status", "-z", "-M", "-C", ref], cwd: worktreePath)
         guard result.exitCode == 0 else { return nil }
         let parsed = GitService.parseNameStatusZOutput(result.stdout)
-        guard let status = parsed.status[file], status.hasPrefix("R") else { return nil }
+        guard let status = parsed.status[file], status.hasPrefix("R") || status.hasPrefix("C") else { return nil }
         return parsed.original[file]
     }
 
@@ -158,13 +166,18 @@ extension GitService {
     /// longer exist in the working tree (so an on-disk sniff can't tell).
     /// Returns nil when `file` doesn't exist at `ref` either — nothing to
     /// sniff, so the caller should fall back to its prior on-disk verdict.
+    ///
+    /// Reads only the first 8 KB of the blob via `Process.gitDataPrefix`
+    /// (the same prefix `looksBinary` inspects) rather than buffering the
+    /// entire historical blob — a large deleted file no longer forces a
+    /// full `git show` read (unnecessary network transfer too, over SSH).
     func looksBinaryAtRef(worktreePath: URL, ref: String, file: String) async throws -> Bool? {
         let existsAtRef = try await Process.git(
             ["cat-file", "-e", "\(ref):\(file)"], cwd: worktreePath)
         guard existsAtRef.exitCode == 0 else { return nil }
-        let blob = try await Process.gitData(["show", "\(ref):\(file)"], cwd: worktreePath)
-        guard blob.exitCode == 0 else { return nil }
-        return Self.looksBinary(blob.stdout)
+        let prefix = try await Process.gitDataPrefix(
+            ["show", "\(ref):\(file)"], cwd: worktreePath, maxBytes: 8192)
+        return Self.looksBinary(prefix)
     }
 
     /// Line count for an untracked file, or 0 when it is binary or unreadable.

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -49,14 +49,31 @@ extension GitService {
 
         let untracked = try await Process.git(
             ["ls-files", "--others", "--exclude-standard"], cwd: worktreePath)
-        for raw in untracked.stdout.split(separator: "\n") {
-            let path = String(raw)
-            guard !path.isEmpty, seen.insert(path).inserted else { continue }
+        let untrackedPaths = untracked.stdout.split(separator: "\n")
+            .map(String.init)
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+
+        // `addedLineCount` shells out to `Data(contentsOf:)` against a LOCAL
+        // URL, which silently reads nothing (0 lines) for a remote worktree
+        // path — batch a single remote round-trip instead, mirroring
+        // `status(worktreePath:)`'s identical remote/local split for
+        // untracked line counts.
+        let remoteCounts: [String: Int]
+        if worktreePath.isRemoteAlasPath, let host = RemoteHostRegistry.shared.host(forPath: worktreePath.path) {
+            remoteCounts = await RemoteFileStats.lineCounts(host: host, cwd: worktreePath.path, paths: untrackedPaths)
+        } else {
+            remoteCounts = [:]
+        }
+
+        for path in untrackedPaths {
+            let add = worktreePath.isRemoteAlasPath
+                ? (remoteCounts[path] ?? 0)
+                : Self.addedLineCount(worktreePath: worktreePath, path: path)
             files.append(ChangedFile(
                 path: path,
                 status: "A",
                 stage: .unstaged,
-                add: Self.addedLineCount(worktreePath: worktreePath, path: path),
+                add: add,
                 del: 0,
                 renameFrom: nil,
                 conflict: nil))
@@ -68,9 +85,27 @@ extension GitService {
     /// Diff of one file between `ref` and the working tree. Untracked files
     /// diff against /dev/null so they render as a single all-add hunk. A nil
     /// `ref` falls back to the working-tree diff.
+    ///
+    /// A file renamed since `ref` did not exist at `ref` under its CURRENT
+    /// path (it existed under its OLD path), so the plain `cat-file -e`
+    /// existence check below would otherwise treat it as untracked/new and
+    /// diff the whole current content against `/dev/null` instead of
+    /// showing the rename's actual edits. `renameSource` catches that case
+    /// first by consulting the unrestricted (no-pathspec) rename-aware
+    /// name-status diff — pathspec-restricting `git diff -M -C ref --
+    /// <file>` does NOT detect the rename, because git's pathspec filtering
+    /// happens before rename pairing, so it never sees the old path to pair
+    /// against.
     func diff(worktreePath: URL, againstRef ref: String?, file: String) async throws -> ParsedDiff {
         guard let ref, !ref.isEmpty else {
             return try await diff(worktreePath: worktreePath, file: file)
+        }
+
+        if let originalPath = try await renameSource(worktreePath: worktreePath, ref: ref, file: file) {
+            let result = try await Process.git(
+                ["diff", "--no-color", "-M", "-C", ref, "--", file, originalPath], cwd: worktreePath)
+            guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+            return DiffParser.parse(Self.sliceDiffForFile(result.stdout, file: file))
         }
 
         // Check if file exists at ref (not just in current index) to handle deleted files correctly.
@@ -91,6 +126,25 @@ extension GitService {
             ["diff", "--no-color", "-M", "-C", ref, "--", file], cwd: worktreePath)
         guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
         return DiffParser.parse(result.stdout)
+    }
+
+    /// Looks up the source path of a rename that landed `file` at its
+    /// current path since `ref`, or nil when `file` was not renamed (it's
+    /// untracked, unchanged, or was modified/deleted/added without a
+    /// rename). Scans the UNRESTRICTED rename-aware name-status diff (no
+    /// pathspec) rather than one scoped to `file`, since pathspec
+    /// restriction happens before rename pairing in git and would hide the
+    /// old path entirely.
+    private func renameSource(worktreePath: URL, ref: String, file: String) async throws -> String? {
+        let result = try await Process.git(
+            ["diff", "--name-status", "-M", "-C", ref], cwd: worktreePath)
+        guard result.exitCode == 0 else { return nil }
+        for line in result.stdout.split(separator: "\n") {
+            let parts = line.split(separator: "\t").map(String.init)
+            guard parts.count == 3, let status = parts.first, status.hasPrefix("R"), parts[2] == file else { continue }
+            return parts[1]
+        }
+        return nil
     }
 
     /// Sniffs whether the blob at `ref:file` looks binary, for files that no

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -93,6 +93,19 @@ extension GitService {
         return DiffParser.parse(result.stdout)
     }
 
+    /// Sniffs whether the blob at `ref:file` looks binary, for files that no
+    /// longer exist in the working tree (so an on-disk sniff can't tell).
+    /// Returns nil when `file` doesn't exist at `ref` either — nothing to
+    /// sniff, so the caller should fall back to its prior on-disk verdict.
+    func looksBinaryAtRef(worktreePath: URL, ref: String, file: String) async throws -> Bool? {
+        let existsAtRef = try await Process.git(
+            ["cat-file", "-e", "\(ref):\(file)"], cwd: worktreePath)
+        guard existsAtRef.exitCode == 0 else { return nil }
+        let blob = try await Process.gitData(["show", "\(ref):\(file)"], cwd: worktreePath)
+        guard blob.exitCode == 0 else { return nil }
+        return Self.looksBinary(blob.stdout)
+    }
+
     /// Line count for an untracked file, or 0 when it is binary or unreadable.
     private static func addedLineCount(worktreePath: URL, path: String) -> Int {
         let url = worktreePath.appendingPathComponent(path)

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Base-relative views used by the remote changes surface. Unlike the desktop
+/// Changes panel (working tree vs index/HEAD), these compare the whole
+/// worktree — commits plus uncommitted work — against the comparison ref, so
+/// the remote client shows everything an agent did on this branch.
+extension GitService {
+    /// Changed files between `ref` and the working tree, plus untracked files.
+    /// A nil `ref` (unborn branch, no resolvable base) falls back to `status`.
+    func changedFilesAgainstRef(worktreePath: URL, ref: String?) async throws -> [ChangedFile] {
+        guard let ref, !ref.isEmpty else {
+            return try await status(worktreePath: worktreePath)
+        }
+
+        let numstat = try await Process.git(
+            ["diff", "--numstat", "-M", "-C", ref, "--"], cwd: worktreePath)
+        guard numstat.exitCode == 0 else {
+            return try await status(worktreePath: worktreePath)
+        }
+        let counts = NumstatParser.parse(numstat.stdout)
+
+        let nameStatus = try await Process.git(
+            ["diff", "--name-status", "-M", "-C", ref, "--"], cwd: worktreePath)
+        let statusEntries = try await status(worktreePath: worktreePath)
+        let conflicts = Dictionary(
+            statusEntries.compactMap { entry in entry.conflict.map { (entry.path, $0) } },
+            uniquingKeysWith: { first, _ in first })
+
+        var files: [ChangedFile] = []
+        var seen = Set<String>()
+        for line in nameStatus.stdout.split(separator: "\n") {
+            let parts = line.split(separator: "\t").map(String.init)
+            guard let code = parts.first, parts.count >= 2 else { continue }
+            let letter = String(code.prefix(1))
+            // Rename/copy entries carry both the source and destination path.
+            let path = parts.count >= 3 ? parts[2] : parts[1]
+            let renameFrom = parts.count >= 3 ? parts[1] : nil
+            guard seen.insert(path).inserted else { continue }
+            let count = counts[path] ?? (add: 0, del: 0)
+            files.append(ChangedFile(
+                path: path,
+                status: letter,
+                stage: .unstaged,   // not meaningful for a base-relative view
+                add: count.add,
+                del: count.del,
+                renameFrom: renameFrom,
+                conflict: conflicts[path]))
+        }
+
+        let untracked = try await Process.git(
+            ["ls-files", "--others", "--exclude-standard"], cwd: worktreePath)
+        for raw in untracked.stdout.split(separator: "\n") {
+            let path = String(raw)
+            guard !path.isEmpty, seen.insert(path).inserted else { continue }
+            files.append(ChangedFile(
+                path: path,
+                status: "A",
+                stage: .unstaged,
+                add: Self.addedLineCount(worktreePath: worktreePath, path: path),
+                del: 0,
+                renameFrom: nil,
+                conflict: nil))
+        }
+
+        return files.sorted { $0.path < $1.path }
+    }
+
+    /// Diff of one file between `ref` and the working tree. Untracked files
+    /// diff against /dev/null so they render as a single all-add hunk. A nil
+    /// `ref` falls back to the working-tree diff.
+    func diff(worktreePath: URL, againstRef ref: String?, file: String) async throws -> ParsedDiff {
+        guard let ref, !ref.isEmpty else {
+            return try await diff(worktreePath: worktreePath, file: file)
+        }
+
+        let tracked = try await Process.git(
+            ["ls-files", "--error-unmatch", "--", file], cwd: worktreePath)
+        if tracked.exitCode != 0 {
+            let result = try await Process.git(
+                ["diff", "--no-color", "--no-index", "--", "/dev/null", file], cwd: worktreePath)
+            // `--no-index` exits 1 when there ARE differences, which is the
+            // normal case here; only >= 2 is a real failure.
+            guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+            return DiffParser.parse(result.stdout)
+        }
+
+        let result = try await Process.git(
+            ["diff", "--no-color", "-M", "-C", ref, "--", file], cwd: worktreePath)
+        guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+        return DiffParser.parse(result.stdout)
+    }
+
+    /// Line count for an untracked file, or 0 when it is binary or unreadable.
+    private static func addedLineCount(worktreePath: URL, path: String) -> Int {
+        let url = worktreePath.appendingPathComponent(path)
+        guard let data = try? Data(contentsOf: url), !looksBinary(data),
+              let text = String(data: data, encoding: .utf8) else { return 0 }
+        if text.isEmpty { return 0 }
+        return text.hasSuffix("\n")
+            ? text.split(separator: "\n", omittingEmptySubsequences: false).count - 1
+            : text.split(separator: "\n", omittingEmptySubsequences: false).count
+    }
+}

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -9,7 +9,7 @@ extension GitService {
     /// A nil `ref` (unborn branch, no resolvable base) falls back to `status`.
     func changedFilesAgainstRef(worktreePath: URL, ref: String?) async throws -> [ChangedFile] {
         guard let ref, !ref.isEmpty else {
-            return try await status(worktreePath: worktreePath)
+            return Self.collapsingStagedAndUnstagedEntries(try await status(worktreePath: worktreePath))
         }
 
         // `-c core.quotePath=false` plus `-z` keep non-ASCII (and
@@ -317,5 +317,38 @@ extension GitService {
         return text.hasSuffix("\n")
             ? text.split(separator: "\n", omittingEmptySubsequences: false).count - 1
             : text.split(separator: "\n", omittingEmptySubsequences: false).count
+    }
+
+    /// `status()` (used verbatim by the desktop Changes panel, which shows
+    /// separate Staged/Unstaged sections) returns TWO entries for a path
+    /// that's both staged and further modified in the working tree — one
+    /// per stage (e.g. an "AM" file). This function's ref-resolved path
+    /// above already hardcodes `stage: .unstaged` for every entry, since
+    /// stage isn't meaningful when comparing against a base commit instead
+    /// of the index; the nil-ref fallback (the only caller of this
+    /// function) needs the same collapsing, or the remote Changes list
+    /// renders a duplicate row for the path and double-counts its (now
+    /// whole-working-tree, per the numstat fix above) add/del total across
+    /// both entries when a caller sums them.
+    ///
+    /// On the unborn branch this fallback is reached for, the index side of
+    /// such a pair is always "added" (there is no HEAD for it to be
+    /// anything else relative to), so the staged entry — not the unstaged
+    /// one, which would misleadingly read "M" as if a base version existed
+    /// — is kept whenever a path has both.
+    static func collapsingStagedAndUnstagedEntries(_ files: [ChangedFile]) -> [ChangedFile] {
+        var byPath: [String: ChangedFile] = [:]
+        var order: [String] = []
+        for file in files {
+            if let existing = byPath[file.path] {
+                if existing.stage != .staged, file.stage == .staged {
+                    byPath[file.path] = file
+                }
+            } else {
+                byPath[file.path] = file
+                order.append(file.path)
+            }
+        }
+        return order.compactMap { byPath[$0] }
     }
 }

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -280,6 +280,17 @@ extension GitService {
     /// matter (a trailing-newline off-by-one).
     static func addedLineCount(worktreePath: URL, path: String) -> Int {
         let url = worktreePath.appendingPathComponent(path)
+        // `Data(contentsOf:)` below performs a plain blocking open+read: on
+        // a FIFO with no writer, that blocks indefinitely. Since this runs
+        // synchronously on whatever actor called it (ultimately
+        // `changedFilesAgainstRef`, reachable from the `@MainActor`
+        // `remoteChangeList`), a worktree containing an untracked FIFO
+        // would freeze the whole app, not just this one request. Reject
+        // anything that isn't a regular file (a symlink resolving to one is
+        // still fine) before ever opening it.
+        guard (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true else {
+            return 0
+        }
         guard let data = try? Data(contentsOf: url), !looksBinary(data),
               let text = String(data: data, encoding: .utf8) else { return 0 }
         if text.isEmpty { return 0 }

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -117,7 +117,21 @@ extension GitService {
     /// answer "does this path have a badge, and which one".
     func changedFileBadges(worktreePath: URL, ref: String?) async throws -> [ChangedFile] {
         guard let ref, !ref.isEmpty else {
-            return Self.collapsingStagedAndUnstagedEntries(try await status(worktreePath: worktreePath))
+            // NOT `status(worktreePath:)` — that runs the exact same
+            // numstat-plus-untracked-line-counting work this function
+            // exists to avoid, just working-tree/index-relative instead of
+            // ref-relative. An unborn branch (no resolvable comparison ref)
+            // would otherwise still pay that full cost on every
+            // `listFiles` request. `StatusParser.parse` alone gives
+            // path/status/stage/renameFrom/conflict with add/del left at
+            // their 0 default — exactly what a badge needs.
+            let s = try await Process.git(
+                ["status", "--porcelain=v2", "-z", "--untracked-files=all"], cwd: worktreePath)
+            guard s.exitCode == 0 else {
+                throw ProcessError.nonZeroExit(s.exitCode, s.stderr)
+            }
+            let entries = try StatusParser.parse(s.stdout)
+            return Self.collapsingStagedAndUnstagedEntries(entries)
         }
 
         let nameStatus = try await Process.git(
@@ -357,19 +371,36 @@ extension GitService {
     /// matter (a trailing-newline off-by-one).
     static func addedLineCount(worktreePath: URL, path: String) -> Int {
         let url = worktreePath.appendingPathComponent(path)
+        // Git's object model never follows a symlink to compute its blob:
+        // the blob IS the link's target path string. Handled BEFORE the
+        // regular-file check below (which DOES follow the link via
+        // `.isRegularFileKey`) — otherwise an untracked symlink either
+        // reports 0 (a broken link, or one whose target isn't itself a
+        // regular file) or the TARGET file's own line count (a symlink to a
+        // huge file wrongly inflating this to thousands), neither of which
+        // matches what `git diff`/`numstat` would show for the same path.
+        if (try? url.resourceValues(forKeys: [.isSymbolicLinkKey]))?.isSymbolicLink == true {
+            guard let target = try? FileManager.default.destinationOfSymbolicLink(atPath: url.path) else {
+                return 0
+            }
+            return Self.lineCount(of: target)
+        }
         // `Data(contentsOf:)` below performs a plain blocking open+read: on
         // a FIFO with no writer, that blocks indefinitely. Since this runs
         // synchronously on whatever actor called it (ultimately
         // `changedFilesAgainstRef`, reachable from the `@MainActor`
         // `remoteChangeList`), a worktree containing an untracked FIFO
         // would freeze the whole app, not just this one request. Reject
-        // anything that isn't a regular file (a symlink resolving to one is
-        // still fine) before ever opening it.
+        // anything that isn't a regular file before ever opening it.
         guard (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true else {
             return 0
         }
         guard let data = try? Data(contentsOf: url), !looksBinary(data),
               let text = String(data: data, encoding: .utf8) else { return 0 }
+        return Self.lineCount(of: text)
+    }
+
+    private static func lineCount(of text: String) -> Int {
         if text.isEmpty { return 0 }
         return text.hasSuffix("\n")
             ? text.split(separator: "\n", omittingEmptySubsequences: false).count - 1

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -115,7 +115,10 @@ extension GitService {
     /// <file>` does NOT detect the rename, because git's pathspec filtering
     /// happens before rename pairing, so it never sees the old path to pair
     /// against.
-    func diff(worktreePath: URL, againstRef ref: String?, file: String) async throws -> ParsedDiff {
+    func diff(
+        worktreePath: URL, againstRef ref: String?, file: String,
+        maxOutputBytes: Int = RemoteWorktreeFileAccess.maxDiffSubprocessBytes
+    ) async throws -> ParsedDiff {
         guard let ref, !ref.isEmpty else {
             // `diff(worktreePath:file:)`'s default (`staged: false`) is a
             // working-tree-vs-INDEX diff, which omits changes that are
@@ -128,7 +131,7 @@ extension GitService {
             // what `status` already reflects in the change list.
             return try await diffAgainstHEAD(
                 worktreePath: worktreePath, file: file,
-                maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes)
+                maxOutputBytes: maxOutputBytes)
         }
 
         if let originalPath = try await renameSource(worktreePath: worktreePath, ref: ref, file: file) {
@@ -142,7 +145,7 @@ extension GitService {
             let result = try await Process.gitCapped(
                 ["--literal-pathspecs", "-c", "core.quotePath=false",
                  "diff", "--no-color", "-M", "-C", ref, "--", file, originalPath], cwd: worktreePath,
-                maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes)
+                maxOutputBytes: maxOutputBytes)
             // A fatal exit (>= 2, e.g. a dropped SSH connection) must propagate
             // rather than fall through as a successful, blank diff — see the
             // matching comment on the tracked-file diff below. A size-capped
@@ -151,7 +154,24 @@ extension GitService {
             guard result.stdoutTruncated || result.exitCode <= 1 else {
                 throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
             }
-            return DiffParser.parse(Self.sliceDiffForFile(result.stdout, file: file))
+            let sliced = Self.sliceDiffForFile(result.stdout, file: file)
+            // This is a two-path diff (`file` plus `originalPath`), and git
+            // emits sections in the order the two paths sort — when
+            // `originalPath` sorts first and its OWN section alone exceeds
+            // `maxOutputBytes`, `gitCapped` can terminate before `file`'s
+            // section ever appears. `sliceDiffForFile` then finds no
+            // matching section and returns "", indistinguishable from a
+            // genuinely empty diff. There's no way to tell those apart from
+            // the captured bytes alone, so — only when the process was
+            // ACTUALLY size-capped — treat an empty slice as a failure
+            // rather than silently showing "no changes" for a file that
+            // definitely has some.
+            guard !(result.stdoutTruncated && sliced.isEmpty) else {
+                throw ProcessError.nonZeroExit(
+                    result.exitCode,
+                    "diff for \(file) exceeded the size cap before its section was captured")
+            }
+            return DiffParser.parse(sliced)
         }
 
         // Check if file exists at ref (not just in current index) to handle deleted files correctly.
@@ -180,7 +200,7 @@ extension GitService {
             // in this function.
             let result = try await Process.gitCapped(
                 ["--literal-pathspecs", "diff", "--no-color", "--no-index", "--", "/dev/null", file], cwd: worktreePath,
-                maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes)
+                maxOutputBytes: maxOutputBytes)
             // `--no-index` exits 1 when there ARE differences, which is the
             // normal case here; only >= 2 is a real failure that must
             // propagate — see the matching comment on the tracked-file diff
@@ -196,7 +216,7 @@ extension GitService {
         // glob pathspec (see comment above).
         let result = try await Process.gitCapped(
             ["--literal-pathspecs", "diff", "--no-color", "-M", "-C", ref, "--", file], cwd: worktreePath,
-            maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes)
+            maxOutputBytes: maxOutputBytes)
         // A fatal exit here (e.g. an SSH connection dropping after the
         // preceding probes succeeded) must propagate rather than turn into a
         // successful, blank diff: `remoteFileDiff` maps a thrown error to

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -101,6 +101,63 @@ extension GitService {
         return files.sorted { $0.path < $1.path }
     }
 
+    /// Badge-only variant of `changedFilesAgainstRef`: just `path` + status
+    /// letter (+ rename source), skipping the `numstat` call AND
+    /// per-untracked-file line counting entirely.
+    ///
+    /// `remoteFileTree` only needs a badge letter per path (the Files tab's
+    /// `RemoteFileNode` has no add/del or conflict fields at all) — unlike
+    /// `remoteChangeList`, which needs real metrics to display. Computing
+    /// full `changedFilesAgainstRef` metrics for every `listFiles` request
+    /// (the root listing AND every directory a client expands) redid that
+    /// work from scratch each time: a local untracked file gets read whole
+    /// via `addedLineCount`, and a remote one costs an SSH round trip
+    /// through `RemoteFileStats.lineCounts` — for a worktree with many or
+    /// large untracked files, that's substantial, repeated I/O just to
+    /// answer "does this path have a badge, and which one".
+    func changedFileBadges(worktreePath: URL, ref: String?) async throws -> [ChangedFile] {
+        guard let ref, !ref.isEmpty else {
+            return Self.collapsingStagedAndUnstagedEntries(try await status(worktreePath: worktreePath))
+        }
+
+        let nameStatus = try await Process.git(
+            ["-c", "core.quotePath=false", "diff", "--name-status", "-z", "-M", "-C", ref, "--"], cwd: worktreePath)
+        guard nameStatus.exitCode == 0 else {
+            throw ProcessError.nonZeroExit(nameStatus.exitCode, nameStatus.stderr)
+        }
+
+        var files: [ChangedFile] = []
+        var seen = Set<String>()
+        let parsedNameStatus = GitService.parseNameStatusZOutput(nameStatus.stdout)
+        for path in parsedNameStatus.ordered {
+            guard seen.insert(path).inserted else { continue }
+            let letter = parsedNameStatus.status[path] ?? "M"
+            files.append(ChangedFile(
+                path: path,
+                status: letter,
+                stage: .unstaged,
+                add: 0,
+                del: 0,
+                renameFrom: parsedNameStatus.original[path],
+                conflict: nil))
+        }
+
+        let untracked = try await Process.git(
+            ["ls-files", "--others", "--exclude-standard", "-z"], cwd: worktreePath)
+        guard untracked.exitCode == 0 else {
+            throw ProcessError.nonZeroExit(untracked.exitCode, untracked.stderr)
+        }
+        let untrackedPaths = untracked.stdout.components(separatedBy: "\0")
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+        for path in untrackedPaths {
+            files.append(ChangedFile(
+                path: path, status: "A", stage: .unstaged, add: 0, del: 0,
+                renameFrom: nil, conflict: nil))
+        }
+
+        return files.sorted { $0.path < $1.path }
+    }
+
     /// Diff of one file between `ref` and the working tree. Untracked files
     /// diff against /dev/null so they render as a single all-add hunk. A nil
     /// `ref` falls back to the working-tree diff.

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -25,6 +25,14 @@ extension GitService {
 
         let nameStatus = try await Process.git(
             ["-c", "core.quotePath=false", "diff", "--name-status", "-z", "-M", "-C", ref, "--"], cwd: worktreePath)
+        // A dropped SSH connection (or any other fatal exit) between the
+        // numstat call above and this one must propagate, not be parsed as
+        // an empty (and so misleadingly valid) name-status list: that would
+        // report only untracked files, or nothing at all, as the whole set
+        // of base-relative changes.
+        guard nameStatus.exitCode == 0 else {
+            throw ProcessError.nonZeroExit(nameStatus.exitCode, nameStatus.stderr)
+        }
         let statusEntries = try await status(worktreePath: worktreePath)
         let conflicts = Dictionary(
             statusEntries.compactMap { entry in entry.conflict.map { (entry.path, $0) } },
@@ -51,6 +59,9 @@ extension GitService {
 
         let untracked = try await Process.git(
             ["ls-files", "--others", "--exclude-standard", "-z"], cwd: worktreePath)
+        guard untracked.exitCode == 0 else {
+            throw ProcessError.nonZeroExit(untracked.exitCode, untracked.stderr)
+        }
         let untrackedPaths = untracked.stdout.components(separatedBy: "\0")
             .filter { !$0.isEmpty && seen.insert($0).inserted }
 

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -130,6 +130,21 @@ extension GitService {
         let existsAtRef = try await Process.git(
             ["cat-file", "-e", "\(ref):\(file)"], cwd: worktreePath)
         if existsAtRef.exitCode != 0 {
+            // `cat-file -e` exits with the SAME code (128, empirically, on
+            // git 2.50) both when the object genuinely doesn't exist at
+            // `ref` AND for unrelated fatal errors — an invalid ref name, a
+            // corrupt/inaccessible repository, a dropped SSH connection on a
+            // remote worktree. The exit code alone can't tell these apart;
+            // blindly treating every nonzero exit as "new/untracked file"
+            // means a real failure silently shows the wrong diff (or, if the
+            // fallback below also fails to find a difference, a misleadingly
+            // "successful" empty one). Git's own fatal message text is the
+            // only distinguishing signal available: a missing object says
+            // "does not exist in"; every other failure mode says something
+            // else entirely.
+            guard Self.isMissingObjectAtRef(existsAtRef) else {
+                throw ProcessError.nonZeroExit(existsAtRef.exitCode, existsAtRef.stderr)
+            }
             // File doesn't exist at ref (untracked/new file), so diff against /dev/null.
             // `--no-index` compares the two given paths directly rather than
             // through pathspec matching, so `--literal-pathspecs` is a no-op
@@ -194,8 +209,31 @@ extension GitService {
         return Self.looksBinary(prefix)
     }
 
+    /// `git cat-file -e <ref>:<file>` exits with the SAME code (128,
+    /// empirically, on git 2.50) both when the object genuinely doesn't
+    /// exist at `ref` AND for unrelated fatal errors (an invalid ref name,
+    /// a corrupt/inaccessible repository, a dropped SSH connection). The
+    /// exit code alone can't distinguish these; git's own fatal message
+    /// text is the only signal available. Empirically, a missing object
+    /// says one of two things depending on whether the path also exists on
+    /// disk right now:
+    ///   - "path 'X' does not exist in 'REF'" (path absent everywhere), or
+    ///   - "path 'X' exists on disk, but not in 'REF'" (the common
+    ///     untracked-file shape: never committed, so absent from every ref).
+    /// Every OTHER failure says something else entirely (invalid ref name:
+    /// "invalid object name"; run outside a repository: "not a git
+    /// repository").
+    private static func isMissingObjectAtRef(_ result: ProcessResult) -> Bool {
+        result.stderr.contains("does not exist in") || result.stderr.contains("exists on disk, but not in")
+    }
+
     /// Line count for an untracked file, or 0 when it is binary or unreadable.
-    private static func addedLineCount(worktreePath: URL, path: String) -> Int {
+    /// `internal` (not `private`) so `GitService.status(worktreePath:)`
+    /// (a different file/extension of the same type) can share this exact
+    /// counting logic instead of duplicating a slightly different one — see
+    /// the comment at its call site there for why that duplication used to
+    /// matter (a trailing-newline off-by-one).
+    static func addedLineCount(worktreePath: URL, path: String) -> Int {
         let url = worktreePath.appendingPathComponent(path)
         guard let data = try? Data(contentsOf: url), !looksBinary(data),
               let text = String(data: data, encoding: .utf8) else { return 0 }

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -410,33 +410,54 @@ extension GitService {
     /// `status()` (used verbatim by the desktop Changes panel, which shows
     /// separate Staged/Unstaged sections) returns TWO entries for a path
     /// that's both staged and further modified in the working tree — one
-    /// per stage (e.g. an "AM" file). This function's ref-resolved path
-    /// above already hardcodes `stage: .unstaged` for every entry, since
-    /// stage isn't meaningful when comparing against a base commit instead
-    /// of the index; the nil-ref fallback (the only caller of this
-    /// function) needs the same collapsing, or the remote Changes list
-    /// renders a duplicate row for the path and double-counts its (now
-    /// whole-working-tree, per the numstat fix above) add/del total across
-    /// both entries when a caller sums them.
+    /// per stage (e.g. an "AM" file), each with its OWN correct metric
+    /// (`status()` computes a separate index-only numstat for the staged
+    /// side and a whole-working-tree one for the unstaged side). This
+    /// function's ref-resolved path above already hardcodes `stage:
+    /// .unstaged` for every entry, since stage isn't meaningful when
+    /// comparing against a base commit instead of the index; the nil-ref
+    /// fallback (the only caller of this function) needs the same
+    /// collapsing, or the remote Changes list renders a duplicate row for
+    /// the path.
     ///
-    /// On the unborn branch this fallback is reached for, the index side of
-    /// such a pair is always "added" (there is no HEAD for it to be
-    /// anything else relative to), so the staged entry — not the unstaged
-    /// one, which would misleadingly read "M" as if a base version existed
-    /// — is kept whenever a path has both.
+    /// The merged row takes its IDENTITY (status/renameFrom/conflict) from
+    /// the staged side — on the unborn branch this fallback is reached
+    /// for, the index side of such a pair is always "added" (there is no
+    /// HEAD for it to be anything else relative to), so the unstaged
+    /// sibling would misleadingly read "M" as if a base version existed —
+    /// but its METRICS from the unstaged side, which reflect the WHOLE
+    /// working tree, matching what `remoteFileDiff` actually renders for
+    /// this single-row-per-path list. Using the staged side's own
+    /// (correctly index-only) metrics here instead would undercount
+    /// relative to that diff view for a file staged and then further
+    /// edited.
     static func collapsingStagedAndUnstagedEntries(_ files: [ChangedFile]) -> [ChangedFile] {
-        var byPath: [String: ChangedFile] = [:]
+        var staged: [String: ChangedFile] = [:]
+        var unstaged: [String: ChangedFile] = [:]
         var order: [String] = []
         for file in files {
-            if let existing = byPath[file.path] {
-                if existing.stage != .staged, file.stage == .staged {
-                    byPath[file.path] = file
-                }
-            } else {
-                byPath[file.path] = file
+            if staged[file.path] == nil, unstaged[file.path] == nil {
                 order.append(file.path)
             }
+            if file.stage == .staged {
+                staged[file.path] = file
+            } else {
+                unstaged[file.path] = file
+            }
         }
-        return order.compactMap { byPath[$0] }
+        return order.map { path in
+            switch (staged[path], unstaged[path]) {
+            case (let s?, let u?):
+                return ChangedFile(
+                    path: path, status: s.status, stage: s.stage,
+                    add: u.add, del: u.del, renameFrom: s.renameFrom, conflict: s.conflict)
+            case (let s?, nil):
+                return s
+            case (nil, let u?):
+                return u
+            case (nil, nil):
+                preconditionFailure("path \(path) tracked in `order` without a staged or unstaged entry")
+            }
+        }
     }
 }

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -122,7 +122,10 @@ extension GitService {
             let result = try await Process.git(
                 ["--literal-pathspecs", "-c", "core.quotePath=false",
                  "diff", "--no-color", "-M", "-C", ref, "--", file, originalPath], cwd: worktreePath)
-            guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+            // A fatal exit (>= 2, e.g. a dropped SSH connection) must propagate
+            // rather than fall through as a successful, blank diff — see the
+            // matching comment on the tracked-file diff below.
+            guard result.exitCode <= 1 else { throw ProcessError.nonZeroExit(result.exitCode, result.stderr) }
             return DiffParser.parse(Self.sliceDiffForFile(result.stdout, file: file))
         }
 
@@ -153,8 +156,10 @@ extension GitService {
             let result = try await Process.git(
                 ["--literal-pathspecs", "diff", "--no-color", "--no-index", "--", "/dev/null", file], cwd: worktreePath)
             // `--no-index` exits 1 when there ARE differences, which is the
-            // normal case here; only >= 2 is a real failure.
-            guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+            // normal case here; only >= 2 is a real failure that must
+            // propagate — see the matching comment on the tracked-file diff
+            // below.
+            guard result.exitCode <= 1 else { throw ProcessError.nonZeroExit(result.exitCode, result.stderr) }
             return DiffParser.parse(result.stdout)
         }
 
@@ -163,7 +168,12 @@ extension GitService {
         // glob pathspec (see comment above).
         let result = try await Process.git(
             ["--literal-pathspecs", "diff", "--no-color", "-M", "-C", ref, "--", file], cwd: worktreePath)
-        guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+        // A fatal exit here (e.g. an SSH connection dropping after the
+        // preceding probes succeeded) must propagate rather than turn into a
+        // successful, blank diff: `remoteFileDiff` maps a thrown error to
+        // `.gitFailed`, but silently returning empty hunks would instead
+        // report success with nothing to show.
+        guard result.exitCode <= 1 else { throw ProcessError.nonZeroExit(result.exitCode, result.stderr) }
         return DiffParser.parse(result.stdout)
     }
 

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -126,7 +126,9 @@ extension GitService {
             // working tree against HEAD (or /dev/null on an unborn branch),
             // which captures staged AND unstaged changes together, matching
             // what `status` already reflects in the change list.
-            return try await diffAgainstHEAD(worktreePath: worktreePath, file: file)
+            return try await diffAgainstHEAD(
+                worktreePath: worktreePath, file: file,
+                maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes)
         }
 
         if let originalPath = try await renameSource(worktreePath: worktreePath, ref: ref, file: file) {

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -79,7 +79,7 @@ extension GitService {
         // untracked line counts.
         let remoteCounts: [String: Int]
         if worktreePath.isRemoteAlasPath, let host = RemoteHostRegistry.shared.host(forPath: worktreePath.path) {
-            remoteCounts = await RemoteFileStats.lineCounts(host: host, cwd: worktreePath.path, paths: untrackedPaths)
+            remoteCounts = try await RemoteFileStats.lineCounts(host: host, cwd: worktreePath.path, paths: untrackedPaths)
         } else {
             remoteCounts = [:]
         }

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -18,8 +18,15 @@ extension GitService {
         // whose NUL-token parsers this reuses.
         let numstat = try await Process.git(
             ["-c", "core.quotePath=false", "diff", "--numstat", "-z", "-M", "-C", ref, "--"], cwd: worktreePath)
+        // Unlike the guard at the top of this function, `ref` here is
+        // already resolved and non-empty — this is NOT the "no base to
+        // compare against" case, so a failure (a dropped SSH connection, a
+        // corrupt repository) must propagate rather than fall back to
+        // `status()`: that fallback silently reports only current
+        // index/worktree changes, omitting every committed change relative
+        // to `ref`, as if the request had genuinely been base-less.
         guard numstat.exitCode == 0 else {
-            return try await status(worktreePath: worktreePath)
+            throw ProcessError.nonZeroExit(numstat.exitCode, numstat.stderr)
         }
         let counts = GitService.parseNumstatZOutput(numstat.stdout)
 
@@ -130,13 +137,18 @@ extension GitService {
             // core.quotePath=false` keeps a non-ASCII destination name
             // unquoted in the `diff --git a/<old> b/<new>` header, which
             // `sliceDiffForFile` below matches on as a raw string.
-            let result = try await Process.git(
+            let result = try await Process.gitCapped(
                 ["--literal-pathspecs", "-c", "core.quotePath=false",
-                 "diff", "--no-color", "-M", "-C", ref, "--", file, originalPath], cwd: worktreePath)
+                 "diff", "--no-color", "-M", "-C", ref, "--", file, originalPath], cwd: worktreePath,
+                maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes)
             // A fatal exit (>= 2, e.g. a dropped SSH connection) must propagate
             // rather than fall through as a successful, blank diff — see the
-            // matching comment on the tracked-file diff below.
-            guard result.exitCode <= 1 else { throw ProcessError.nonZeroExit(result.exitCode, result.stderr) }
+            // matching comment on the tracked-file diff below. A size-capped
+            // exit is NOT fatal — `exitCode` is meaningless there — so it
+            // takes the same path as an ordinary successful diff.
+            guard result.stdoutTruncated || result.exitCode <= 1 else {
+                throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
+            }
             return DiffParser.parse(Self.sliceDiffForFile(result.stdout, file: file))
         }
 
@@ -164,27 +176,37 @@ extension GitService {
             // through pathspec matching, so `--literal-pathspecs` is a no-op
             // here — kept for consistency with the other client-path calls
             // in this function.
-            let result = try await Process.git(
-                ["--literal-pathspecs", "diff", "--no-color", "--no-index", "--", "/dev/null", file], cwd: worktreePath)
+            let result = try await Process.gitCapped(
+                ["--literal-pathspecs", "diff", "--no-color", "--no-index", "--", "/dev/null", file], cwd: worktreePath,
+                maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes)
             // `--no-index` exits 1 when there ARE differences, which is the
             // normal case here; only >= 2 is a real failure that must
             // propagate — see the matching comment on the tracked-file diff
-            // below.
-            guard result.exitCode <= 1 else { throw ProcessError.nonZeroExit(result.exitCode, result.stderr) }
+            // below. A size-capped exit is NOT fatal.
+            guard result.stdoutTruncated || result.exitCode <= 1 else {
+                throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
+            }
             return DiffParser.parse(result.stdout)
         }
 
         // File exists at ref (tracked or previously committed), so diff ref to current state.
         // `--literal-pathspecs` stops `file` from being interpreted as a
         // glob pathspec (see comment above).
-        let result = try await Process.git(
-            ["--literal-pathspecs", "diff", "--no-color", "-M", "-C", ref, "--", file], cwd: worktreePath)
+        let result = try await Process.gitCapped(
+            ["--literal-pathspecs", "diff", "--no-color", "-M", "-C", ref, "--", file], cwd: worktreePath,
+            maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes)
         // A fatal exit here (e.g. an SSH connection dropping after the
         // preceding probes succeeded) must propagate rather than turn into a
         // successful, blank diff: `remoteFileDiff` maps a thrown error to
         // `.gitFailed`, but silently returning empty hunks would instead
-        // report success with nothing to show.
-        guard result.exitCode <= 1 else { throw ProcessError.nonZeroExit(result.exitCode, result.stderr) }
+        // report success with nothing to show. A size-capped exit is NOT
+        // fatal — `exitCode` is meaningless there — so it takes the same
+        // path as an ordinary successful diff, letting `DiffParser` and
+        // `truncateHunks` handle the (possibly incomplete at the very end)
+        // captured prefix exactly like any other oversized diff.
+        guard result.stdoutTruncated || result.exitCode <= 1 else {
+            throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
+        }
         return DiffParser.parse(result.stdout)
     }
 

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -679,6 +679,10 @@ extension GitService {
             let prefix = path.isEmpty ? "" : path + "/"
             var paths = try await gitVisibleFilePaths(worktreePath: worktreePath)
                 .filter { path.isEmpty || $0.hasPrefix(prefix) }
+            // Snapshot before the remote-listing loop below starts appending
+            // newly discovered (untracked/ignored) entries to `paths`, so
+            // descendant lookups only ever see paths git already knows about.
+            let gitVisiblePaths = Set(paths)
             var directories = Set<String>()
             for candidate in paths {
                 let components = candidate.split(separator: "/")
@@ -704,7 +708,13 @@ extension GitService {
                     if entry.isDirectory { directories.insert(fullPath) }
                     if !paths.contains(fullPath) {
                         paths.append(fullPath)
-                        ignoreCandidates.append(RootIgnoreCandidate(path: fullPath, isDirectory: entry.isDirectory))
+                        if shouldClassifyRemotelyDiscoveredEntry(
+                            fullPath: fullPath,
+                            isDirectory: entry.isDirectory,
+                            gitVisiblePaths: gitVisiblePaths
+                        ) {
+                            ignoreCandidates.append(RootIgnoreCandidate(path: fullPath, isDirectory: entry.isDirectory))
+                        }
                     }
                 }
             }
@@ -895,6 +905,32 @@ extension GitService {
     private func hasVisibleDescendant(of root: String, in paths: Set<String>) -> Bool {
         let prefix = "\(root)/"
         return paths.contains { $0.hasPrefix(prefix) }
+    }
+
+    /// Whether an entry discovered only by listing the remote filesystem
+    /// (i.e. not already known to git) should be run through
+    /// `ignoredOrExcludedVisibility`.
+    ///
+    /// A directory that matches a `.gitignore` pattern can still contain a
+    /// tracked, force-added (`git add -f`) descendant. Unlike the local/eager
+    /// file tree — where `FileTreeNode.children` is a real nested array the
+    /// native UI recurses into even when the parent is `.ignored` — the
+    /// remote wire protocol's `RemoteFileNode` has no `children` field:
+    /// directory contents are fetched lazily, one flat `listFiles` request
+    /// per directory the client expands. If this directory is classified
+    /// `.ignored`/`.excluded`, `AppState.remoteFileNodes` drops it from its
+    /// PARENT's listing entirely, and the client can never issue the
+    /// `listFiles` request that would reveal the tracked descendant — there
+    /// is no way to "promote" that descendant up to reappear elsewhere.
+    /// Skipping classification here instead lets the directory default to
+    /// `.tracked` visibility (`FileTreeBuilder`'s default for any path with
+    /// no explicit entry), keeping it expandable.
+    func shouldClassifyRemotelyDiscoveredEntry(
+        fullPath: String,
+        isDirectory: Bool,
+        gitVisiblePaths: Set<String>
+    ) -> Bool {
+        !(isDirectory && hasVisibleDescendant(of: fullPath, in: gitVisiblePaths))
     }
 
     private func excludedSourcePaths(worktreePath: URL) async throws -> Set<String> {

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -789,14 +789,21 @@ extension GitService {
     }
 
     /// Whether `path` (worktree-relative) is covered by gitignore rules,
-    /// including local excludes (`.git/info/exclude`, `core.excludesFile`) —
-    /// `--no-index` folds those in the same way `ignoredOrExcludedVisibility`
-    /// does for the file tree. Used to reject reading or diffing a single
-    /// path the client already knows about, mirroring the visibility filter
-    /// that already keeps such paths out of the file tree entirely.
+    /// including local excludes (`.git/info/exclude`, `core.excludesFile`).
+    /// Used to reject reading or diffing a single path the client already
+    /// knows about, mirroring the visibility filter that already keeps such
+    /// paths out of the file tree entirely.
+    ///
+    /// Deliberately does NOT pass `--no-index`: that flag makes git ignore
+    /// the index entirely, which would report a force-added tracked file
+    /// (`git add -f`) matching a `.gitignore` pattern as "ignored" even
+    /// though it's correctly shown as tracked in the Files/Changes tabs.
+    /// Without the flag, git consults the index first, so a tracked path
+    /// always reports as not ignored while a genuinely untracked, gitignored
+    /// path still reports as ignored.
     func isPathIgnored(worktreePath: URL, path: String) async throws -> Bool {
         let result = try await Process.git(
-            ["check-ignore", "-q", "--no-index", "--", path],
+            ["check-ignore", "-q", "--", path],
             cwd: worktreePath
         )
         switch result.exitCode {

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -221,7 +221,25 @@ extension GitService {
         let head = try await hasHead(worktreePath: worktreePath)
         if !head {
             let fileURL = worktreePath.appendingPathComponent(file)
-            guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            // `FileManager.fileExists` only ever sees this Mac's local
+            // filesystem. For an SSH-backed worktree there is nothing local
+            // at `fileURL.path` to find — the check always reports "missing"
+            // regardless of the file's real state on the remote host, so
+            // every staged/untracked file's diff on an unborn remote branch
+            // silently came back empty. Route the existence check through
+            // the remote host when one is registered for this worktree;
+            // `.missing` is the only outcome treated as absent (mirrors
+            // `WorktreeService`'s use of the same primitive) so a transient
+            // "unknown" result doesn't itself suppress a real diff — the
+            // `--no-index` invocation below is still the actual source of
+            // truth and fails harmlessly if the file truly isn't there.
+            let exists: Bool
+            if worktreePath.isRemoteAlasPath, let host = RemoteHostRegistry.shared.host(forPath: worktreePath.path) {
+                exists = await RemoteFileAccess.existence(host: host, path: fileURL.path) != .missing
+            } else {
+                exists = FileManager.default.fileExists(atPath: fileURL.path)
+            }
+            guard exists else {
                 return ParsedDiff(hunks: [])
             }
             let result = try await Process.git(

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1225,79 +1225,8 @@ extension GitService {
             )
         }
 
-        // Parse --numstat -z output.
-        // Format per entry (NUL-separated fields within each record):
-        //   "<add>\t<del>\t<path>\0"   (ordinary files)
-        //   "<add>\t<del>\t\0<oldPath>\0<newPath>\0"  (renames/copies)
-        // The -z flag separates records with NUL; we split on NUL and then
-        // handle the tab-delimited first element per record.
-        var addByPath: [String: Int] = [:]
-        var delByPath: [String: Int] = [:]
-
-        // With -z the stream is NUL-terminated. Split and process tokens.
-        let numstatTokens = numstat.stdout.components(separatedBy: "\0").filter { !$0.isEmpty }
-        var ni = 0
-        while ni < numstatTokens.count {
-            let token = numstatTokens[ni]
-            // Split on the first two tabs only so paths containing tab
-            // characters survive intact. Format is `<adds>\t<dels>\t<path>`;
-            // the trailing path field may itself contain tabs.
-            let parts = token.split(separator: "\t", maxSplits: 2, omittingEmptySubsequences: false).map(String.init)
-            guard parts.count >= 3 else { ni += 1
-            continue }
-            let addStr = parts[0]
-            let delStr = parts[1]
-            let pathField = parts[2]
-
-            let newPath: String
-            if pathField.isEmpty {
-                // Rename/copy: next two tokens are old and new path.
-                guard ni + 2 < numstatTokens.count else { ni += 1
-                continue }
-                // ni+1 = old path, ni+2 = new path
-                newPath = numstatTokens[ni + 2]
-                ni += 3
-            } else {
-                newPath = Self.numstatNewPath(pathField)
-                ni += 1
-            }
-            addByPath[newPath] = (addStr == "-") ? 0 : (Int(addStr) ?? 0)
-            delByPath[newPath] = (delStr == "-") ? 0 : (Int(delStr) ?? 0)
-        }
-
-        // Parse --name-status -z output.
-        // Format: "<status>\0<path>\0"  (ordinary)
-        //         "<status>\0<oldPath>\0<newPath>\0"  (R/C)
-        var statusByPath: [String: String] = [:]
-        var originalByPath: [String: String] = [:]
-        var ordered: [String] = []
-        var orderedSet: Set<String> = []
-
-        let nsTokens = nameStatus.stdout.components(separatedBy: "\0").filter { !$0.isEmpty }
-        var si = 0
-        while si < nsTokens.count {
-            let statusField = nsTokens[si]
-            guard !statusField.isEmpty else { si += 1
-            continue }
-            let statusLetter = String(statusField.prefix(1))
-            if statusLetter == "R" || statusLetter == "C" {
-                guard si + 2 < nsTokens.count else { si += 1
-                continue }
-                let oldPath = nsTokens[si + 1]
-                let newPath = nsTokens[si + 2]
-                statusByPath[newPath] = statusLetter
-                originalByPath[newPath] = oldPath
-                if orderedSet.insert(newPath).inserted { ordered.append(newPath) }
-                si += 3
-            } else {
-                guard si + 1 < nsTokens.count else { si += 1
-                continue }
-                let path = nsTokens[si + 1]
-                statusByPath[path] = statusLetter
-                if orderedSet.insert(path).inserted { ordered.append(path) }
-                si += 2
-            }
-        }
+        let (addByPath, delByPath) = Self.parseNumstatZOutput(numstat.stdout)
+        let (statusByPath, originalByPath, ordered) = Self.parseNameStatusZOutput(nameStatus.stdout)
 
         return ordered.map { path in
             CommitChangedFile(
@@ -1308,6 +1237,103 @@ extension GitService {
                 del: delByPath[path] ?? 0
             )
         }
+    }
+
+    /// Parses the NUL-separated token stream produced by `git diff ...
+    /// --numstat -z` (with `-c core.quotePath=false` so non-ASCII paths
+    /// aren't octal-escaped), returning per-path added/deleted line counts.
+    ///
+    /// Format per entry (NUL-separated fields within each record):
+    ///   "<add>\t<del>\t<path>\0"   (ordinary files)
+    ///   "<add>\t<del>\t\0<oldPath>\0<newPath>\0"  (renames/copies)
+    /// The -z flag separates records with NUL; this splits on NUL and then
+    /// handles the tab-delimited first element per record.
+    ///
+    /// Extracted from `stagedChangedFiles` so the remote-changes surface
+    /// (`GitService+RemoteChanges.swift`) can reuse the same
+    /// already-hardened parsing instead of duplicating it.
+    static func parseNumstatZOutput(_ stdout: String) -> (add: [String: Int], del: [String: Int]) {
+        var addByPath: [String: Int] = [:]
+        var delByPath: [String: Int] = [:]
+
+        // With -z the stream is NUL-terminated. Split and process tokens.
+        let tokens = stdout.components(separatedBy: "\0").filter { !$0.isEmpty }
+        var i = 0
+        while i < tokens.count {
+            let token = tokens[i]
+            // Split on the first two tabs only so paths containing tab
+            // characters survive intact. Format is `<adds>\t<dels>\t<path>`;
+            // the trailing path field may itself contain tabs.
+            let parts = token.split(separator: "\t", maxSplits: 2, omittingEmptySubsequences: false).map(String.init)
+            guard parts.count >= 3 else { i += 1
+            continue }
+            let addStr = parts[0]
+            let delStr = parts[1]
+            let pathField = parts[2]
+
+            let newPath: String
+            if pathField.isEmpty {
+                // Rename/copy: next two tokens are old and new path.
+                guard i + 2 < tokens.count else { i += 1
+                continue }
+                // i+1 = old path, i+2 = new path
+                newPath = tokens[i + 2]
+                i += 3
+            } else {
+                newPath = numstatNewPath(pathField)
+                i += 1
+            }
+            addByPath[newPath] = (addStr == "-") ? 0 : (Int(addStr) ?? 0)
+            delByPath[newPath] = (delStr == "-") ? 0 : (Int(delStr) ?? 0)
+        }
+        return (addByPath, delByPath)
+    }
+
+    /// Parses the NUL-separated token stream produced by `git diff ...
+    /// --name-status -z` (with `-c core.quotePath=false`), returning
+    /// per-path status letters, rename/copy source paths, and first-seen
+    /// path order.
+    ///
+    /// Format: "<status>\0<path>\0"  (ordinary)
+    ///         "<status>\0<oldPath>\0<newPath>\0"  (R/C)
+    ///
+    /// Extracted from `stagedChangedFiles` so the remote-changes surface
+    /// (`GitService+RemoteChanges.swift`) can reuse the same
+    /// already-hardened parsing instead of duplicating it.
+    static func parseNameStatusZOutput(
+        _ stdout: String
+    ) -> (status: [String: String], original: [String: String], ordered: [String]) {
+        var statusByPath: [String: String] = [:]
+        var originalByPath: [String: String] = [:]
+        var ordered: [String] = []
+        var orderedSet: Set<String> = []
+
+        let tokens = stdout.components(separatedBy: "\0").filter { !$0.isEmpty }
+        var i = 0
+        while i < tokens.count {
+            let statusField = tokens[i]
+            guard !statusField.isEmpty else { i += 1
+            continue }
+            let statusLetter = String(statusField.prefix(1))
+            if statusLetter == "R" || statusLetter == "C" {
+                guard i + 2 < tokens.count else { i += 1
+                continue }
+                let oldPath = tokens[i + 1]
+                let newPath = tokens[i + 2]
+                statusByPath[newPath] = statusLetter
+                originalByPath[newPath] = oldPath
+                if orderedSet.insert(newPath).inserted { ordered.append(newPath) }
+                i += 3
+            } else {
+                guard i + 1 < tokens.count else { i += 1
+                continue }
+                let path = tokens[i + 1]
+                statusByPath[path] = statusLetter
+                if orderedSet.insert(path).inserted { ordered.append(path) }
+                i += 2
+            }
+        }
+        return (statusByPath, originalByPath, ordered)
     }
 }
 

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -788,6 +788,24 @@ extension GitService {
             .filter { !$0.isEmpty }
     }
 
+    /// Whether `path` (worktree-relative) is covered by gitignore rules,
+    /// including local excludes (`.git/info/exclude`, `core.excludesFile`) —
+    /// `--no-index` folds those in the same way `ignoredOrExcludedVisibility`
+    /// does for the file tree. Used to reject reading or diffing a single
+    /// path the client already knows about, mirroring the visibility filter
+    /// that already keeps such paths out of the file tree entirely.
+    func isPathIgnored(worktreePath: URL, path: String) async throws -> Bool {
+        let result = try await Process.git(
+            ["check-ignore", "-q", "--no-index", "--", path],
+            cwd: worktreePath
+        )
+        switch result.exitCode {
+        case 0: return true
+        case 1: return false
+        default: throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
+        }
+    }
+
     private struct RootIgnoreCandidate {
         let path: String
         let isDirectory: Bool

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -827,13 +827,18 @@ extension GitService {
     }
 
     private func gitVisibleFilePaths(worktreePath: URL) async throws -> [String] {
+        // `-c core.quotePath=false` plus `-z` keep non-ASCII (and
+        // tab/newline-containing) filenames intact instead of git's default
+        // octal-escaped, quoted rendering — mirrors `changedFilesAgainstRef`,
+        // which needed the same fix for the Changes tab. This feeds the
+        // root Files tree, so a quoted name here would show the wrong
+        // (escaped) filename and fail to resolve when selected.
         let result = try await Process.git(
-            ["ls-files", "--cached", "--others", "--exclude-standard"],
+            ["-c", "core.quotePath=false", "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
             cwd: worktreePath
         )
         return result.stdout
-            .split(separator: "\n")
-            .map(String.init)
+            .components(separatedBy: "\0")
             .filter { !$0.isEmpty }
     }
 

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -687,20 +687,41 @@ extension GitService {
                     directories.insert(components.prefix(index).joined(separator: "/"))
                 }
             }
+            // Entries the remote directory listing surfaces that git itself
+            // doesn't already know about (untracked, and — unlike
+            // `gitVisibleFilePaths`, which excludes them — gitignored) need
+            // the same ignore/exclude classification the local branch below
+            // applies, so `.ignored`/`.excluded` names (e.g. `node_modules`,
+            // `.env`) get filtered out at the wire boundary
+            // (`AppState.remoteFileNodes`) instead of leaking their names to
+            // the client.
+            var ignoreCandidates: [RootIgnoreCandidate] = []
             if let host = RemoteHostRegistry.shared.host(forPath: worktreePath.path) {
                 let directory = path.isEmpty ? worktreePath.path : worktreePath.appendingPathComponent(path).path
                 for entry in await RemoteFileStats.directoryEntries(host: host, path: directory)
                     where entry.name != ".git" {
                     let fullPath = path.isEmpty ? entry.name : path + "/" + entry.name
                     if entry.isDirectory { directories.insert(fullPath) }
-                    if !paths.contains(fullPath) { paths.append(fullPath) }
+                    if !paths.contains(fullPath) {
+                        paths.append(fullPath)
+                        ignoreCandidates.append(RootIgnoreCandidate(path: fullPath, isDirectory: entry.isDirectory))
+                    }
                 }
+            }
+            var visibility: [String: FileVisibility] = [:]
+            if !ignoreCandidates.isEmpty {
+                let excludedSources = try await excludedSourcePaths(worktreePath: worktreePath)
+                visibility = try await ignoredOrExcludedVisibility(
+                    candidates: ignoreCandidates,
+                    worktreePath: worktreePath,
+                    excludedSourcePaths: excludedSources
+                )
             }
             let lazyDirectories = path.isEmpty ? directories : directories.subtracting([path])
             let built = FileTreeBuilder.build(
                 paths: paths,
                 badges: [:],
-                visibility: [:],
+                visibility: visibility,
                 directories: directories,
                 lazyDirectories: lazyDirectories,
                 submodules: (try? await submodulePaths(worktreePath: worktreePath)) ?? []

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -294,6 +294,17 @@ extension GitService {
         }
         if let maxOutputBytes {
             let result = try await Process.gitCapped(args, cwd: worktreePath, maxOutputBytes: maxOutputBytes)
+            // Unlike the two branches above, this one previously had NO
+            // exit-code check at all: a fatal exit (e.g. an SSH connection
+            // dropping) parsed whatever (usually empty) stdout came back as
+            // a successful, blank diff. `remoteFileDiff` — reachable here
+            // through the nil-comparison-ref fallback at the top of this
+            // function — maps a thrown error to `.gitFailed`; a size-capped
+            // exit is NOT fatal (`exitCode` is meaningless there), so it
+            // takes the same path as an ordinary successful diff.
+            guard result.stdoutTruncated || result.exitCode <= 1 else {
+                throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
+            }
             return await Self.parseOffMain(result.stdout)
         }
         let result = try await Process.git(args, cwd: worktreePath)

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -140,7 +140,7 @@ extension GitService {
         let untrackedPaths = entries.filter { $0.add == 0 && $0.del == 0 }.map(\.path)
         let remoteCounts: [String: Int]
         if worktreePath.isRemoteAlasPath, let host = RemoteHostRegistry.shared.host(forPath: worktreePath.path) {
-            remoteCounts = await RemoteFileStats.lineCounts(host: host, cwd: worktreePath.path, paths: untrackedPaths)
+            remoteCounts = try await RemoteFileStats.lineCounts(host: host, cwd: worktreePath.path, paths: untrackedPaths)
         } else {
             remoteCounts = [:]
         }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -731,7 +731,7 @@ extension GitService {
             var ignoreCandidates: [RootIgnoreCandidate] = []
             if let host = RemoteHostRegistry.shared.host(forPath: worktreePath.path) {
                 let directory = path.isEmpty ? worktreePath.path : worktreePath.appendingPathComponent(path).path
-                for entry in await RemoteFileStats.directoryEntries(host: host, path: directory)
+                for entry in await RemoteFileStats.directoryEntries(host: host, worktreeRoot: worktreePath.path, path: directory)
                     where entry.name != ".git" {
                     let fullPath = path.isEmpty ? entry.name : path + "/" + entry.name
                     if entry.isDirectory { directories.insert(fullPath) }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -755,7 +755,7 @@ extension GitService {
             var ignoreCandidates: [RootIgnoreCandidate] = []
             if let host = RemoteHostRegistry.shared.host(forPath: worktreePath.path) {
                 let directory = path.isEmpty ? worktreePath.path : worktreePath.appendingPathComponent(path).path
-                for entry in await RemoteFileStats.directoryEntries(host: host, worktreeRoot: worktreePath.path, path: directory)
+                for entry in try await RemoteFileStats.directoryEntries(host: host, worktreeRoot: worktreePath.path, path: directory)
                     where entry.name != ".git" {
                     let fullPath = path.isEmpty ? entry.name : path + "/" + entry.name
                     if entry.isDirectory { directories.insert(fullPath) }
@@ -958,7 +958,16 @@ extension GitService {
             cwd: worktreePath,
             stdin: inputPaths.joined(separator: "\0") + "\0"
         )
-        guard result.exitCode == 0 else { return [:] }
+        // `check-ignore` exits 1 when NONE of the input paths matched an
+        // ignore pattern — a legitimate, common result (an empty visibility
+        // map is exactly right here), not a failure. Only >= 2 is fatal (a
+        // dropped SSH connection, an invalid invocation): conflating that
+        // with "nothing is ignored" would let every candidate default to
+        // `.tracked` visibility and serialize names (e.g. `.env`) that
+        // should have been hidden, or fail the whole request outright.
+        guard result.exitCode <= 1 else {
+            throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
+        }
 
         var visibility: [String: FileVisibility] = [:]
         for entry in checkIgnoreMatches(result.stdout) {

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -243,11 +243,18 @@ extension GitService {
             guard exists else {
                 return ParsedDiff(hunks: [])
             }
-            let result = try await Process.git(
+            // Capped like the ref-comparison diffs in `GitService+RemoteChanges`:
+            // an ordinary diff is captured in full (the cap sits far above the
+            // wire truncation caps `parseOffMain`'s caller applies), but a
+            // pathologically large file no longer has its ENTIRE diff
+            // buffered and materialized into hunks before those caps get a
+            // chance to trim it down.
+            let result = try await Process.gitCapped(
                 ["diff", "--no-color", "--no-index", "--", "/dev/null", file],
-                cwd: worktreePath
+                cwd: worktreePath,
+                maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes
             )
-            guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+            guard result.stdoutTruncated || result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
             return await Self.parseOffMain(result.stdout)
         }
 
@@ -257,11 +264,12 @@ extension GitService {
             cwd: worktreePath
         )
         if headBlob.exitCode != 0 {
-            let result = try await Process.git(
+            let result = try await Process.gitCapped(
                 ["diff", "--no-color", "--no-index", "--", "/dev/null", file],
-                cwd: worktreePath
+                cwd: worktreePath,
+                maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes
             )
-            guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+            guard result.stdoutTruncated || result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
             return await Self.parseOffMain(result.stdout)
         }
 
@@ -272,7 +280,8 @@ extension GitService {
         if let originalPath, !originalPath.isEmpty {
             args.append(originalPath)
         }
-        let result = try await Process.git(args, cwd: worktreePath)
+        let result = try await Process.gitCapped(
+            args, cwd: worktreePath, maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes)
         return await Self.parseOffMain(result.stdout)
     }
 

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -123,12 +123,18 @@ extension GitService {
         var entries = try StatusParser.parse(s.stdout)
 
         // Numstat needs a base revision. Use HEAD if one exists; on unborn
-        // branches diff `--cached` (index vs empty tree) so initial-commit
-        // workflows still see real add/del counts in the Changes pane.
+        // branches diff against git's well-known empty-tree object hash
+        // instead of `--cached` — `--cached` compares only the INDEX
+        // against nothing, so a file staged and then edited AGAIN
+        // (unstaged changes on top of a stage) would report only the staged
+        // version's line count while `remoteFileDiff`'s own all-add diff
+        // (working tree vs /dev/null) shows the current, fuller content.
+        // Diffing the empty tree WITHOUT `--cached` compares the whole
+        // working tree instead, matching that.
         let head = try await hasHead(worktreePath: worktreePath)
         let numstatArgs: [String] = head
             ? ["diff", "--numstat", "HEAD"]
-            : ["diff", "--numstat", "--cached"]
+            : ["diff", "--numstat", "4b825dc642cb6eb9a060e54bf8d69288fbee4904"]   // canonical empty tree
         let numstat = try await Process.git(numstatArgs, cwd: worktreePath)
         let counts = NumstatParser.parse(numstat.stdout)
         let untrackedPaths = entries.filter { $0.add == 0 && $0.del == 0 }.map(\.path)

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -218,7 +218,21 @@ extension GitService {
         return await Self.parseOffMain(stdout)
     }
 
-    func diffAgainstHEAD(worktreePath: URL, file: String, originalPath: String? = nil) async throws -> ParsedDiff {
+    /// `maxOutputBytes`, when non-nil, bounds the underlying `git diff`
+    /// subprocess's captured stdout the same way
+    /// `GitService+RemoteChanges.diff` bounds its own diff calls — see
+    /// `Process.runCapped`'s doc comment. Left `nil` (the default) for the
+    /// native desktop `DiffTabView` caller: `ParsedDiff` carries no
+    /// truncation state and the desktop UI applies no truncation notice, so
+    /// silently capping there would present a partial diff as complete with
+    /// no indication anything was cut. Only the remote request path (this
+    /// method's OTHER caller, `GitService+RemoteChanges.diff`'s nil-ref
+    /// fallback) passes a byte cap, because ITS caller
+    /// (`RemoteWorktreeFileAccess.truncateHunks`) already knows how to cap
+    /// and report truncation on the wire.
+    func diffAgainstHEAD(
+        worktreePath: URL, file: String, originalPath: String? = nil, maxOutputBytes: Int? = nil
+    ) async throws -> ParsedDiff {
         let head = try await hasHead(worktreePath: worktreePath)
         if !head {
             let fileURL = worktreePath.appendingPathComponent(file)
@@ -243,18 +257,14 @@ extension GitService {
             guard exists else {
                 return ParsedDiff(hunks: [])
             }
-            // Capped like the ref-comparison diffs in `GitService+RemoteChanges`:
-            // an ordinary diff is captured in full (the cap sits far above the
-            // wire truncation caps `parseOffMain`'s caller applies), but a
-            // pathologically large file no longer has its ENTIRE diff
-            // buffered and materialized into hunks before those caps get a
-            // chance to trim it down.
-            let result = try await Process.gitCapped(
-                ["diff", "--no-color", "--no-index", "--", "/dev/null", file],
-                cwd: worktreePath,
-                maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes
-            )
-            guard result.stdoutTruncated || result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+            let noIndexArgs = ["diff", "--no-color", "--no-index", "--", "/dev/null", file]
+            if let maxOutputBytes {
+                let result = try await Process.gitCapped(noIndexArgs, cwd: worktreePath, maxOutputBytes: maxOutputBytes)
+                guard result.stdoutTruncated || result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+                return await Self.parseOffMain(result.stdout)
+            }
+            let result = try await Process.git(noIndexArgs, cwd: worktreePath)
+            guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
             return await Self.parseOffMain(result.stdout)
         }
 
@@ -264,12 +274,14 @@ extension GitService {
             cwd: worktreePath
         )
         if headBlob.exitCode != 0 {
-            let result = try await Process.gitCapped(
-                ["diff", "--no-color", "--no-index", "--", "/dev/null", file],
-                cwd: worktreePath,
-                maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes
-            )
-            guard result.stdoutTruncated || result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+            let noIndexArgs = ["diff", "--no-color", "--no-index", "--", "/dev/null", file]
+            if let maxOutputBytes {
+                let result = try await Process.gitCapped(noIndexArgs, cwd: worktreePath, maxOutputBytes: maxOutputBytes)
+                guard result.stdoutTruncated || result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+                return await Self.parseOffMain(result.stdout)
+            }
+            let result = try await Process.git(noIndexArgs, cwd: worktreePath)
+            guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
             return await Self.parseOffMain(result.stdout)
         }
 
@@ -280,8 +292,11 @@ extension GitService {
         if let originalPath, !originalPath.isEmpty {
             args.append(originalPath)
         }
-        let result = try await Process.gitCapped(
-            args, cwd: worktreePath, maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes)
+        if let maxOutputBytes {
+            let result = try await Process.gitCapped(args, cwd: worktreePath, maxOutputBytes: maxOutputBytes)
+            return await Self.parseOffMain(result.stdout)
+        }
+        let result = try await Process.git(args, cwd: worktreePath)
         return await Self.parseOffMain(result.stdout)
     }
 

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -146,14 +146,16 @@ extension GitService {
                 // on disk; deleted files (no longer present) stay at 0/0.
                 if worktreePath.isRemoteAlasPath, let lines = remoteCounts[entries[i].path] {
                     entries[i] = ChangedFile(path: entries[i].path, status: entries[i].status, stage: entries[i].stage, add: lines, del: 0, renameFrom: entries[i].renameFrom, conflict: entries[i].conflict)
-                } else {
-                    let url = worktreePath.appendingPathComponent(entries[i].path)
-                    if !worktreePath.isRemoteAlasPath,
-                   let data = try? Data(contentsOf: url),
-                   let text = String(data: data, encoding: .utf8) {
-                    let lines = text.isEmpty
-                        ? 0
-                        : text.split(separator: "\n", omittingEmptySubsequences: false).count
+                } else if !worktreePath.isRemoteAlasPath {
+                    // Shares `addedLineCount`'s exact counting logic (also
+                    // used by `changedFilesAgainstRef`'s ref-resolved
+                    // untracked-file branch) rather than a separately
+                    // maintained duplicate: the duplicate used to omit the
+                    // trailing-newline adjustment `addedLineCount` applies,
+                    // so the SAME untracked file could report a different
+                    // add-count here than in the ref-resolved Changes view
+                    // depending on which code path served the request.
+                    let lines = Self.addedLineCount(worktreePath: worktreePath, path: entries[i].path)
                     entries[i] = ChangedFile(path: entries[i].path,
                                              status: entries[i].status,
                                              stage: entries[i].stage,
@@ -161,7 +163,6 @@ extension GitService {
                                              del: 0,
                                              renameFrom: entries[i].renameFrom,
                                              conflict: entries[i].conflict)
-                    }
                 }
             }
         }
@@ -692,7 +693,17 @@ extension GitService {
         return paths
     }
 
-    func fileTreeChildren(worktreePath: URL, path: String) async throws -> [FileTreeNode] {
+    /// `badges` maps a worktree-relative path to its status letter (e.g.
+    /// `"M"`, `"A"`, `"D"`), mirroring what `fileTree`'s ROOT listing already
+    /// receives from `status(worktreePath:)`. Defaults to `[:]` — the native
+    /// desktop Files tab (`RightPaneState.loadFileTreeChildren`) calls this
+    /// without a badge map and specifically relies on the returned nodes
+    /// having no badge of their own (see `RightPaneState.replacingChildren`'s
+    /// doc comment): it treats an incoming nil badge as "keep whatever badge
+    /// the existing node already had" rather than "this node has no badge".
+    /// Passing a real map here is opt-in for callers (the remote Files tree)
+    /// that want a directory expansion's badges to match the root listing's.
+    func fileTreeChildren(worktreePath: URL, path: String, badges: [String: String] = [:]) async throws -> [FileTreeNode] {
         if worktreePath.isRemoteAlasPath {
             let prefix = path.isEmpty ? "" : path + "/"
             var paths = try await gitVisibleFilePaths(worktreePath: worktreePath)
@@ -748,7 +759,7 @@ extension GitService {
             let lazyDirectories = path.isEmpty ? directories : directories.subtracting([path])
             let built = FileTreeBuilder.build(
                 paths: paths,
-                badges: [:],
+                badges: badges,
                 visibility: visibility,
                 directories: directories,
                 lazyDirectories: lazyDirectories,
@@ -803,7 +814,7 @@ extension GitService {
 
         let built = FileTreeBuilder.build(
             paths: childPaths,
-            badges: [:],
+            badges: badges,
             visibility: visibility,
             directories: directories,
             lazyDirectories: lazyDirectories,
@@ -837,6 +848,13 @@ extension GitService {
             ["-c", "core.quotePath=false", "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
             cwd: worktreePath
         )
+        // A transport failure on an SSH worktree (disconnected helper, etc.)
+        // produces a nonzero exit with empty stdout — parsing that as "zero
+        // files" would make a real failure look like a successful, empty
+        // repository instead of propagating as `.gitFailed`.
+        guard result.exitCode == 0 else {
+            throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
+        }
         return result.stdout
             .components(separatedBy: "\0")
             .filter { !$0.isEmpty }
@@ -855,16 +873,36 @@ extension GitService {
     /// Without the flag, git consults the index first, so a tracked path
     /// always reports as not ignored while a genuinely untracked, gitignored
     /// path still reports as ignored.
-    func isPathIgnored(worktreePath: URL, path: String) async throws -> Bool {
+    ///
+    /// `comparisonRef`, when given, exempts a path that existed there even
+    /// if it's since been deleted (staged or committed): a deleted file is
+    /// no longer in the CURRENT index, so without this exemption
+    /// `check-ignore` falls back to matching purely by name and reports a
+    /// legitimately-tracked-at-`comparisonRef`, since-deleted file as
+    /// "ignored" whenever its name happens to match a `.gitignore` pattern
+    /// — blocking its otherwise-correct deletion diff. Mirrors the
+    /// force-added-tracked-file exemption above, extended to a ref instead
+    /// of just the current index.
+    func isPathIgnored(worktreePath: URL, path: String, comparisonRef: String? = nil) async throws -> Bool {
         let result = try await Process.git(
             ["check-ignore", "-q", "--", path],
             cwd: worktreePath
         )
+        let ignoredByPattern: Bool
         switch result.exitCode {
-        case 0: return true
+        case 0: ignoredByPattern = true
         case 1: return false
         default: throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
         }
+        guard ignoredByPattern else { return false }
+        if let comparisonRef, !comparisonRef.isEmpty {
+            let existedAtRef = try await Process.git(
+                ["cat-file", "-e", "\(comparisonRef):\(path)"], cwd: worktreePath)
+            if existedAtRef.exitCode == 0 {
+                return false
+            }
+        }
+        return true
     }
 
     private struct RootIgnoreCandidate {

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -110,7 +110,16 @@ extension GitService {
             cwd: worktreePath
         )
         let s = try await statusResult
-        guard s.exitCode == 0 else { return [] }
+        // Unlike `--no-index diff`/`check-ignore`, plain `git status` has no
+        // legitimate nonzero exit for a healthy repo — ANY failure here (a
+        // dropped SSH connection, an invalid/corrupt repository) is fatal
+        // and must propagate. This is a widely shared method (the desktop
+        // Changes panel, the remote nil-ref fallback, `alas` CLI actions);
+        // silently returning `[]` previously meant a genuine failure looked
+        // identical to "nothing has changed" everywhere it's called.
+        guard s.exitCode == 0 else {
+            throw ProcessError.nonZeroExit(s.exitCode, s.stderr)
+        }
         var entries = try StatusParser.parse(s.stdout)
 
         // Numstat needs a base revision. Use HEAD if one exists; on unborn

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -275,7 +275,13 @@ extension GitService {
             let noIndexArgs = ["diff", "--no-color", "--no-index", "--", "/dev/null", file]
             if let maxOutputBytes {
                 let result = try await Process.gitCapped(noIndexArgs, cwd: worktreePath, maxOutputBytes: maxOutputBytes)
-                guard result.stdoutTruncated || result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+                // Same reasoning as the tracked-file branch below: a fatal
+                // exit (e.g. an SSH connection dropping) must propagate
+                // rather than parse whatever (usually empty) stdout came
+                // back as a successful, blank diff.
+                guard result.stdoutTruncated || result.exitCode <= 1 else {
+                    throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
+                }
                 return await Self.parseOffMain(result.stdout)
             }
             let result = try await Process.git(noIndexArgs, cwd: worktreePath)
@@ -292,7 +298,13 @@ extension GitService {
             let noIndexArgs = ["diff", "--no-color", "--no-index", "--", "/dev/null", file]
             if let maxOutputBytes {
                 let result = try await Process.gitCapped(noIndexArgs, cwd: worktreePath, maxOutputBytes: maxOutputBytes)
-                guard result.stdoutTruncated || result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+                // Same reasoning as the tracked-file branch below: a fatal
+                // exit (e.g. an SSH connection dropping) must propagate
+                // rather than parse whatever (usually empty) stdout came
+                // back as a successful, blank diff.
+                guard result.stdoutTruncated || result.exitCode <= 1 else {
+                    throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
+                }
                 return await Self.parseOffMain(result.stdout)
             }
             let result = try await Process.git(noIndexArgs, cwd: worktreePath)
@@ -309,10 +321,10 @@ extension GitService {
         }
         if let maxOutputBytes {
             let result = try await Process.gitCapped(args, cwd: worktreePath, maxOutputBytes: maxOutputBytes)
-            // Unlike the two branches above, this one previously had NO
-            // exit-code check at all: a fatal exit (e.g. an SSH connection
-            // dropping) parsed whatever (usually empty) stdout came back as
-            // a successful, blank diff. `remoteFileDiff` — reachable here
+            // Same reasoning as the two capped branches above: a fatal exit
+            // (e.g. an SSH connection dropping) must propagate rather than
+            // parse whatever (usually empty) stdout came back as a
+            // successful, blank diff. `remoteFileDiff` — reachable here
             // through the nil-comparison-ref fallback at the top of this
             // function — maps a thrown error to `.gitFailed`; a size-capped
             // exit is NOT fatal (`exitCode` is meaningless there), so it

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -614,17 +614,23 @@ extension GitService {
     static func sliceDiffForFile(_ raw: String, file: String) -> String {
         let lines = raw.components(separatedBy: "\n")
         let bMarker = "b/\(file)"
+        // Git quotes AND escapes the whole `b/<path>` header token (wrapping
+        // it in `"..."`) when the path contains a byte that always needs
+        // escaping — a tab, newline, double quote, or backslash — REGARDLESS
+        // of `core.quotePath` (that setting only suppresses quoting for
+        // non-ASCII bytes; every caller of this function already passes
+        // `-c core.quotePath=false`, which covers that case, but not this
+        // one). Without also matching that quoted form, a renamed/copied
+        // destination containing one of those bytes would never match any
+        // section here, silently returning an empty diff despite real hunks.
+        let quotedBMarker = Self.gitEscapedPathIfNeeded(file).map { "\"b/\($0)\"" }
         var sections: [(matches: Bool, lines: [String])] = []
         var current: (matches: Bool, lines: [String])? = nil
         for line in lines {
             if line.hasPrefix("diff --git ") {
                 if let c = current { sections.append(c) }
-                // The header reads `diff --git a/<old> b/<new>`. Check the
-                // b/<...> token by suffix; we already know the new path
-                // doesn't contain whitespace because git emits the raw
-                // path here (no quoting unless the path contains special
-                // chars, which we don't generate in tests / typical use).
                 let matches = line.hasSuffix(" " + bMarker)
+                    || quotedBMarker.map { line.hasSuffix(" " + $0) } == true
                 current = (matches: matches, lines: [line])
             } else if current != nil {
                 current!.lines.append(line)
@@ -633,6 +639,57 @@ extension GitService {
         if let c = current { sections.append(c) }
         let kept = sections.first(where: { $0.matches })?.lines ?? []
         return kept.joined(separator: "\n")
+    }
+
+    /// Mirrors the ESCAPING half of git's `quote_c_style` (not the
+    /// surrounding `"..."` wrapping, which the caller adds) for the bytes
+    /// that always trigger quoting regardless of `core.quotePath`: double
+    /// quote, backslash, and control characters. `core.quotePath=false`
+    /// only suppresses quoting for non-ASCII bytes — irrelevant here, since
+    /// this only handles the bytes that setting does NOT affect. Returns
+    /// nil when `path` contains none of those bytes (git leaves such names
+    /// completely unquoted, matching `sliceDiffForFile`'s plain match).
+    static func gitEscapedPathIfNeeded(_ path: String) -> String? {
+        var needsQuoting = false
+        var bytes: [UInt8] = []
+        for byte in path.utf8 {
+            switch byte {
+            case 0x22:   // "
+                bytes += Array("\\\"".utf8)
+                needsQuoting = true
+            case 0x5C:   // \
+                bytes += Array("\\\\".utf8)
+                needsQuoting = true
+            case 0x07:
+                bytes += Array("\\a".utf8)
+                needsQuoting = true
+            case 0x08:
+                bytes += Array("\\b".utf8)
+                needsQuoting = true
+            case 0x0C:
+                bytes += Array("\\f".utf8)
+                needsQuoting = true
+            case 0x0A:
+                bytes += Array("\\n".utf8)
+                needsQuoting = true
+            case 0x0D:
+                bytes += Array("\\r".utf8)
+                needsQuoting = true
+            case 0x09:
+                bytes += Array("\\t".utf8)
+                needsQuoting = true
+            case 0x0B:
+                bytes += Array("\\v".utf8)
+                needsQuoting = true
+            case 0x00...0x06, 0x0E...0x1F, 0x7F:
+                bytes += Array(String(format: "\\%03o", byte).utf8)
+                needsQuoting = true
+            default:
+                bytes.append(byte)
+            }
+        }
+        guard needsQuoting else { return nil }
+        return String(decoding: bytes, as: UTF8.self)
     }
 
     func fileTree(worktreePath: URL, statusEntries: [ChangedFile]) async throws -> [FileTreeNode] {

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -132,11 +132,26 @@ extension GitService {
         // Diffing the empty tree WITHOUT `--cached` compares the whole
         // working tree instead, matching that.
         let head = try await hasHead(worktreePath: worktreePath)
-        let numstatArgs: [String] = head
+        // Whole-working-tree metric (staged + unstaged combined) — correct
+        // for `.unstaged` entries, which must reflect the CURRENT on-disk
+        // content of a path regardless of what's staged, matching
+        // `diffAgainstHEAD`'s own all-add diff (see the comment there).
+        let workingTreeNumstatArgs: [String] = head
             ? ["diff", "--numstat", "HEAD"]
             : ["diff", "--numstat", "4b825dc642cb6eb9a060e54bf8d69288fbee4904"]   // canonical empty tree
-        let numstat = try await Process.git(numstatArgs, cwd: worktreePath)
-        let counts = NumstatParser.parse(numstat.stdout)
+        let workingTreeNumstat = try await Process.git(workingTreeNumstatArgs, cwd: worktreePath)
+        let workingTreeCounts = NumstatParser.parse(workingTreeNumstat.stdout)
+        // Index-only metric — correct for `.staged` entries. Without this,
+        // an "AM" path (staged, then further modified in the working tree)
+        // got the SAME whole-working-tree count applied to BOTH its staged
+        // and unstaged rows below, so a staged-only consumer (e.g. a
+        // draft-commit summary) reported the unstaged edit's line count as
+        // if it were already staged.
+        let stagedNumstatArgs: [String] = head
+            ? ["diff", "--cached", "--numstat", "HEAD"]
+            : ["diff", "--cached", "--numstat", "4b825dc642cb6eb9a060e54bf8d69288fbee4904"]
+        let stagedNumstat = try await Process.git(stagedNumstatArgs, cwd: worktreePath)
+        let stagedCounts = NumstatParser.parse(stagedNumstat.stdout)
         let untrackedPaths = entries.filter { $0.add == 0 && $0.del == 0 }.map(\.path)
         let remoteCounts: [String: Int]
         if worktreePath.isRemoteAlasPath, let host = RemoteHostRegistry.shared.host(forPath: worktreePath.path) {
@@ -146,6 +161,7 @@ extension GitService {
         }
 
         for i in entries.indices {
+            let counts = entries[i].stage == .staged ? stagedCounts : workingTreeCounts
             if let c = counts[entries[i].path] {
                 entries[i] = ChangedFile(path: entries[i].path,
                                           status: entries[i].status,

--- a/Alas/Sources/Git/GitTypes.swift
+++ b/Alas/Sources/Git/GitTypes.swift
@@ -118,6 +118,37 @@ struct FileTreeNode: Identifiable, Equatable, Codable {
     var isSubmodule: Bool = false
 
     enum Kind: String, Codable { case dir, file }
+
+    /// Recursively drops `.ignored`/`.excluded` nodes, but keeps a directory
+    /// if any of its (recursively filtered) children remain visible —
+    /// gitignore rules don't un-track a path that's already in the index, so
+    /// an ignored directory can still contain tracked descendants reachable
+    /// only through it. Operates on the EAGER `children` arrays a tree build
+    /// populates for a directory with a visible descendant (see
+    /// `GitService.fileTree`'s `hasVisibleDescendant` check); a node whose
+    /// `children` is nil (lazy, not-yet-loaded) is treated as having none.
+    ///
+    /// Shared by `FilesTabView.filteredNodes` (native desktop Files tab) and
+    /// `AppState.remoteFileNodes` (remote wire boundary) so both surfaces
+    /// keep such a directory reachable, without the data-layer function
+    /// depending on a SwiftUI view type.
+    nonisolated static func filteredKeepingVisibleDescendants(
+        _ nodes: [FileTreeNode]
+    ) -> [FileTreeNode] {
+        nodes.compactMap { node in
+            let offGit = node.visibility == .ignored || node.visibility == .excluded
+            if node.kind == .file {
+                return offGit ? nil : node
+            }
+            var copy = node
+            let visibleChildren = filteredKeepingVisibleDescendants(node.children ?? [])
+            copy.children = visibleChildren
+            if offGit && visibleChildren.isEmpty {
+                return nil
+            }
+            return copy
+        }
+    }
 }
 
 /// Classification of a git unmerged (conflicted) file. Mirrors git's

--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -245,6 +245,105 @@ extension Process {
         )
     }
 
+    /// Bounded-prefix variant of `gitData`: returns only the first
+    /// `maxBytes` of stdout, terminating the child process as soon as that
+    /// much has been buffered instead of waiting for it to exit naturally.
+    /// Used for binary sniffing (`GitService.looksBinaryAtRef`), where a
+    /// huge historical blob (`git show <ref>:<file>`) only needs its first
+    /// 8 KB inspected — mirrors `RemoteWorktreeFileAccess.looksBinaryOnDisk`'s
+    /// bounded `FileHandle.read(upToCount:)` for the on-disk case, for a
+    /// git-subprocess-sourced blob instead. Local git invocations have no
+    /// shell to pipe stdout through `head -c`, so this hooks the early stop
+    /// into the existing readability-handler loop rather than adding a
+    /// shell-pipeline codepath.
+    ///
+    /// An early SIGTERM here is the expected happy path, not a failure — the
+    /// caller only wants a bounded PREFIX (e.g. a binary sniff), not a
+    /// verdict on whether the process exited cleanly, so this never surfaces
+    /// an exit code: it returns whatever bytes were captured, up to
+    /// `maxBytes`, including an empty `Data` if the command produced
+    /// nothing or failed outright.
+    static func gitDataPrefix(
+        _ args: [String],
+        cwd: URL? = nil,
+        maxBytes: Int,
+        timeout: TimeInterval = Process.defaultTimeout
+    ) async throws -> Data {
+        let host = RemoteHostRegistry.shared.host(forPath: cwd?.path)
+        if host == nil {
+            try validateWorkingDirectory(cwd)
+        }
+        let invocation = GitInvocation.build(
+            gitArgs: args,
+            cwd: cwd,
+            host: host
+        )
+        try validateLaunchConfiguration(
+            executable: invocation.executable, args: invocation.args, cwd: invocation.cwd)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: invocation.executable)
+        process.arguments = invocation.args
+        if let cwd = invocation.cwd { process.currentDirectoryURL = cwd }
+        if let env = invocation.env { process.environment = env }
+
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+
+        let exit = ExitGateData()
+        process.terminationHandler = { _ in exit.didExit() }
+
+        let outAccum = ByteAccumulatorData()
+        outPipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+                outAccum.markClosed()
+                return
+            }
+            outAccum.append(data)
+            if outAccum.snapshot().count >= maxBytes {
+                handle.readabilityHandler = nil
+                outAccum.markClosed()
+                terminateProcessWithEscalation(process)
+            }
+        }
+        errPipe.fileHandleForReading.readabilityHandler = { handle in
+            if handle.availableData.isEmpty { handle.readabilityHandler = nil }
+        }
+
+        do {
+            try process.run()
+        } catch {
+            throw ProcessError.launchFailed(error.localizedDescription)
+        }
+        try? outPipe.fileHandleForWriting.close()
+        try? errPipe.fileHandleForWriting.close()
+
+        let watchdog = Task {
+            try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            if Task.isCancelled { return }
+            if process.isRunning {
+                terminateProcessWithEscalation(process)
+            }
+        }
+
+        await withTaskCancellationHandler {
+            await exit.wait()
+        } onCancel: {
+            terminateProcessWithEscalation(process)
+        }
+        watchdog.cancel()
+
+        _ = await outAccum.waitForClose(timeoutNanoseconds: 2_000_000_000)
+        outPipe.fileHandleForReading.readabilityHandler = nil
+        errPipe.fileHandleForReading.readabilityHandler = nil
+
+        return outAccum.snapshot().prefix(maxBytes)
+    }
+
     /// Internal: same shape as `run(...)` but emits stdout as `Data`.
     static func runData(
         _ executable: String,

--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -639,6 +639,16 @@ private func validateWorkingDirectory(_ cwd: URL?) throws {
 /// 3 bytes short of complete — trying to drop 0, then 1, then 2, then 3
 /// trailing bytes always finds a valid prefix (in the worst case, dropping
 /// all the way back to the last previously-complete character).
+///
+/// If none of those four attempts decode cleanly, the invalid byte isn't a
+/// truncation artifact at all — e.g. a changed file containing genuinely
+/// non-UTF-8 text (Latin-1, Windows-1252, ...) that happens to contain no
+/// NUL byte, so it passed binary sniffing upstream but still isn't valid
+/// UTF-8; git emits its raw bytes straight into the diff. Falling back to
+/// `String(decoding:as:)` (which never fails, replacing each invalid byte
+/// with U+FFFD) means that diff renders with a handful of replacement
+/// characters instead of vanishing into an empty, misleadingly "successful"
+/// response.
 func decodeUTF8DroppingIncompleteTrailingScalar(_ data: Data) -> String {
     if let exact = String(data: data, encoding: .utf8) { return exact }
     for dropCount in 1...3 where dropCount <= data.count {
@@ -646,7 +656,7 @@ func decodeUTF8DroppingIncompleteTrailingScalar(_ data: Data) -> String {
             return decoded
         }
     }
-    return ""
+    return String(decoding: data, as: UTF8.self)
 }
 
 private func terminateProcessWithEscalation(_ process: Process) {

--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -472,7 +472,13 @@ extension Process {
 
         return ProcessCappedResult(
             exitCode: process.terminationStatus,
-            stdout: String(data: outAccum.snapshot(), encoding: .utf8) ?? "",
+            // `decodeUTF8DroppingIncompleteTrailingScalar`, not a strict
+            // `String(data:encoding:)`: cutting `outAccum`'s snapshot at
+            // `maxOutputBytes` can land mid-way through a multibyte UTF-8
+            // character, and a strict decode fails CLOSED on that — turning
+            // an otherwise perfectly valid captured prefix into an empty
+            // string and silently presenting a large diff as blank.
+            stdout: decodeUTF8DroppingIncompleteTrailingScalar(outAccum.snapshot()),
             stderr: String(data: errAccum.snapshot(), encoding: .utf8) ?? "",
             stdoutTruncated: truncatedFlag.value
         )
@@ -621,6 +627,26 @@ private func validateWorkingDirectory(_ cwd: URL?) throws {
     guard FileManager.default.fileExists(atPath: cwd.path, isDirectory: &isDirectory), isDirectory.boolValue else {
         throw ProcessError.launchFailed("Working directory does not exist: \(cwd.path)")
     }
+}
+
+/// Decodes `data` as UTF-8, tolerating an incomplete multibyte scalar at the
+/// very end by dropping just that trailing partial sequence rather than
+/// failing the whole decode.
+///
+/// `runCapped` cuts the byte stream at an arbitrary point (`maxOutputBytes`),
+/// which has no reason to land on a UTF-8 character boundary. A UTF-8
+/// sequence is at most 4 bytes, so an incomplete one at the tail is at most
+/// 3 bytes short of complete — trying to drop 0, then 1, then 2, then 3
+/// trailing bytes always finds a valid prefix (in the worst case, dropping
+/// all the way back to the last previously-complete character).
+func decodeUTF8DroppingIncompleteTrailingScalar(_ data: Data) -> String {
+    if let exact = String(data: data, encoding: .utf8) { return exact }
+    for dropCount in 1...3 where dropCount <= data.count {
+        if let decoded = String(data: data.dropLast(dropCount), encoding: .utf8) {
+            return decoded
+        }
+    }
+    return ""
 }
 
 private func terminateProcessWithEscalation(_ process: Process) {

--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -344,6 +344,167 @@ extension Process {
         return outAccum.snapshot().prefix(maxBytes)
     }
 
+    /// Same shape as `run(...)`, but caps accumulated stdout at
+    /// `maxOutputBytes`: once that many bytes have been buffered, the child
+    /// is terminated early (SIGTERM) instead of being left running to
+    /// completion and buffering an unbounded amount of output.
+    ///
+    /// Used for `git diff` invocations whose output feeds `DiffParser`: a
+    /// pathologically large changed file (a multi-gigabyte generated
+    /// artifact, say) would otherwise have its ENTIRE diff captured into one
+    /// `String` and fully materialized into hunks before the caller's own
+    /// line/byte caps (`RemoteWorktreeFileAccess.truncateHunks`) ever get a
+    /// chance to trim it down — exhausting memory (or stalling the app) for
+    /// a response that was always going to be capped anyway. Set
+    /// `maxOutputBytes` comfortably above those wire caps (see
+    /// `RemoteWorktreeFileAccess.maxDiffSubprocessBytes`) so ordinary large
+    /// diffs are captured in full and `truncateHunks` still makes the exact
+    /// truncation call; only a genuinely pathological diff is cut short
+    /// here, before parsing.
+    struct ProcessCappedResult: Sendable {
+        let exitCode: Int32
+        let stdout: String
+        let stderr: String
+        /// True when `stdout` was cut short at (approximately —
+        /// `outAccum`'s last chunk can carry it a bit past `maxOutputBytes`
+        /// before the check fires; this is a soft cap, not an exact one)
+        /// `maxOutputBytes`, and the process was terminated early to
+        /// enforce that cap. This is a deliberate stop, not a process
+        /// failure: `exitCode` reflects whatever the early SIGTERM produced
+        /// and callers must not treat it as a normal git exit status when
+        /// this is `true` — proceed to parse the captured (possibly
+        /// hunk-incomplete at the very end, which downstream truncation
+        /// discards anyway) prefix instead.
+        let stdoutTruncated: Bool
+    }
+
+    static func runCapped(
+        _ executable: String,
+        args: [String],
+        cwd: URL? = nil,
+        env: [String: String]? = nil,
+        maxOutputBytes: Int,
+        timeout: TimeInterval = Process.defaultTimeout
+    ) async throws -> ProcessCappedResult {
+        try validateLaunchConfiguration(executable: executable, args: args, cwd: cwd)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = args
+        if let cwd { process.currentDirectoryURL = cwd }
+        if let env { process.environment = env }
+
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+
+        let exit = ExitGateData()
+        process.terminationHandler = { _ in exit.didExit() }
+
+        let outAccum = ByteAccumulatorData()
+        let errAccum = ByteAccumulatorData()
+        let truncatedFlag = TimedOutFlag()
+        outPipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+                outAccum.markClosed()
+                return
+            }
+            outAccum.append(data)
+            if outAccum.snapshot().count >= maxOutputBytes {
+                handle.readabilityHandler = nil
+                outAccum.markClosed()
+                truncatedFlag.mark()
+                terminateProcessWithEscalation(process)
+            }
+        }
+        errPipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+                errAccum.markClosed()
+            } else {
+                errAccum.append(data)
+            }
+        }
+
+        do {
+            try process.run()
+        } catch {
+            throw ProcessError.launchFailed(error.localizedDescription)
+        }
+
+        try? outPipe.fileHandleForWriting.close()
+        try? errPipe.fileHandleForWriting.close()
+
+        let timedOutFlag = TimedOutFlag()
+        let watchdog = Task {
+            try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            if Task.isCancelled { return }
+            if process.isRunning {
+                timedOutFlag.mark()
+                fputs(
+                    "[Process watchdog] \(timeout)s timeout — terminating: \(executable) \(args.joined(separator: " "))\n",
+                    stderr
+                )
+                terminateProcessWithEscalation(process)
+            }
+        }
+
+        await withTaskCancellationHandler {
+            await exit.wait()
+        } onCancel: {
+            terminateProcessWithEscalation(process)
+        }
+        watchdog.cancel()
+
+        async let outClosed = outAccum.waitForClose(timeoutNanoseconds: 2_000_000_000)
+        async let errClosed = errAccum.waitForClose(timeoutNanoseconds: 2_000_000_000)
+        _ = await (outClosed, errClosed)
+        outPipe.fileHandleForReading.readabilityHandler = nil
+        errPipe.fileHandleForReading.readabilityHandler = nil
+
+        if timedOutFlag.value {
+            throw ProcessError.timedOut(executable: executable, args: args, seconds: timeout)
+        }
+
+        return ProcessCappedResult(
+            exitCode: process.terminationStatus,
+            stdout: String(data: outAccum.snapshot(), encoding: .utf8) ?? "",
+            stderr: String(data: errAccum.snapshot(), encoding: .utf8) ?? "",
+            stdoutTruncated: truncatedFlag.value
+        )
+    }
+
+    /// Bounded-output variant of `git(_:cwd:stdin:timeout:)` — see
+    /// `runCapped` for why this exists.
+    static func gitCapped(
+        _ args: [String],
+        cwd: URL? = nil,
+        maxOutputBytes: Int,
+        timeout: TimeInterval = Process.defaultTimeout
+    ) async throws -> ProcessCappedResult {
+        let host = RemoteHostRegistry.shared.host(forPath: cwd?.path)
+        if host == nil {
+            try validateWorkingDirectory(cwd)
+        }
+        let invocation = GitInvocation.build(
+            gitArgs: args,
+            cwd: cwd,
+            host: host
+        )
+        return try await runCapped(
+            invocation.executable,
+            args: invocation.args,
+            cwd: invocation.cwd,
+            env: invocation.env,
+            maxOutputBytes: maxOutputBytes,
+            timeout: timeout
+        )
+    }
+
     /// Internal: same shape as `run(...)` but emits stdout as `Data`.
     static func runData(
         _ executable: String,

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -280,6 +280,18 @@ final class RemoteSessionGateway {
         case .queueSteerUndo(let id):
             guard provider.isWriter(for: id) else { return }
             await provider.queueSteerUndo(for: id)
+        case .listChanges:
+            // Read-only verb; implementation deferred to later tasks
+            break
+        case .fileDiff:
+            // Read-only verb; implementation deferred to later tasks
+            break
+        case .listFiles:
+            // Read-only verb; implementation deferred to later tasks
+            break
+        case .readFile:
+            // Read-only verb; implementation deferred to later tasks
+            break
         }
     }
 

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -37,6 +37,10 @@ final class RemoteSessionGateway {
     private var lastPermissionReq: [String: Int] = [:]
     private var lastQuestionReq: [String: Int] = [:]
     private var lastElicitationReq: [String: String] = [:]
+    /// Requests currently being served, keyed by "<verb>\0<sessionId>\0<path>".
+    /// A repeat while one is in flight is dropped: the client re-renders from
+    /// the response either way, and each of these spawns a git process.
+    private var inFlightFileRequests: Set<String> = []
     private static let coalesceNanos: UInt64 = 80_000_000  // ~80ms
 
     init(provider: RemoteSessionsProvider, send: @escaping (RemoteServerMessage) -> Void) {
@@ -280,18 +284,50 @@ final class RemoteSessionGateway {
         case .queueSteerUndo(let id):
             guard provider.isWriter(for: id) else { return }
             await provider.queueSteerUndo(for: id)
-        case .listChanges:
-            // Read-only verb; implementation deferred to later tasks
-            break
-        case .fileDiff:
-            // Read-only verb; implementation deferred to later tasks
-            break
-        case .listFiles:
-            // Read-only verb; implementation deferred to later tasks
-            break
-        case .readFile:
-            // Read-only verb; implementation deferred to later tasks
-            break
+        case .listChanges(let id):
+            let key = "listChanges\u{0}\(id)"
+            guard inFlightFileRequests.insert(key).inserted else { return }
+            defer { inFlightFileRequests.remove(key) }
+            switch await provider.remoteChangeList(sessionId: id) {
+            case .success(let ref, let available, let files, let truncated):
+                send(.changeList(
+                    sessionId: id, comparisonRef: ref, metricsAvailable: available,
+                    files: files, truncated: truncated))
+            case .failure(let reason, let message):
+                send(.changeListFailed(sessionId: id, reason: reason, message: message))
+            }
+        case .fileDiff(let id, let path):
+            let key = "fileDiff\u{0}\(id)\u{0}\(path)"
+            guard inFlightFileRequests.insert(key).inserted else { return }
+            defer { inFlightFileRequests.remove(key) }
+            switch await provider.remoteFileDiff(sessionId: id, path: path) {
+            case .success(let hunks, let truncated):
+                send(.fileDiffResult(sessionId: id, path: path, hunks: hunks, truncated: truncated))
+            case .failure(let reason, let message):
+                send(.fileDiffFailed(sessionId: id, path: path, reason: reason, message: message))
+            }
+        case .listFiles(let id, let path):
+            let key = "listFiles\u{0}\(id)\u{0}\(path ?? "")"
+            guard inFlightFileRequests.insert(key).inserted else { return }
+            defer { inFlightFileRequests.remove(key) }
+            switch await provider.remoteFileTree(sessionId: id, path: path) {
+            case .success(let nodes):
+                send(.fileTree(sessionId: id, path: path, nodes: nodes))
+            case .failure(let reason, let message):
+                send(.fileTreeFailed(sessionId: id, path: path, reason: reason, message: message))
+            }
+        case .readFile(let id, let path):
+            let key = "readFile\u{0}\(id)\u{0}\(path)"
+            guard inFlightFileRequests.insert(key).inserted else { return }
+            defer { inFlightFileRequests.remove(key) }
+            switch await provider.remoteFileContents(sessionId: id, path: path) {
+            case .success(let text, let truncated):
+                send(.fileContents(sessionId: id, path: path, text: text, truncated: truncated))
+            case .failure(let reason, let byteSize, let message):
+                send(.fileUnavailable(
+                    sessionId: id, path: path, reason: reason,
+                    byteSize: byteSize, message: message))
+            }
         }
     }
 

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -301,8 +301,10 @@ final class RemoteSessionGateway {
             guard inFlightFileRequests.insert(key).inserted else { return }
             defer { inFlightFileRequests.remove(key) }
             switch await provider.remoteFileDiff(sessionId: id, path: path) {
-            case .success(let hunks, let truncated):
-                send(.fileDiffResult(sessionId: id, path: path, hunks: hunks, truncated: truncated))
+            case .success(let hunks, let truncated, let metadataNote):
+                send(.fileDiffResult(
+                    sessionId: id, path: path, hunks: hunks, truncated: truncated,
+                    metadataNote: metadataNote))
             case .failure(let reason, let message):
                 send(.fileDiffFailed(sessionId: id, path: path, reason: reason, message: message))
             }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -311,8 +311,8 @@ final class RemoteSessionGateway {
             guard inFlightFileRequests.insert(key).inserted else { return }
             defer { inFlightFileRequests.remove(key) }
             switch await provider.remoteFileTree(sessionId: id, path: path) {
-            case .success(let nodes):
-                send(.fileTree(sessionId: id, path: path, nodes: nodes))
+            case .success(let nodes, let truncated):
+                send(.fileTree(sessionId: id, path: path, nodes: nodes, truncated: truncated))
             case .failure(let reason, let message):
                 send(.fileTreeFailed(sessionId: id, path: path, reason: reason, message: message))
             }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
@@ -53,6 +53,13 @@ protocol RemoteSessionsProvider: AnyObject {
     /// Projection of the session's config for the `sessionConfig` wire message,
     /// or nil if the session isn't live.
     func sessionConfig(for id: String) -> RemoteSessionConfig?
+    /// Read-only worktree inspection for the remote changes/files tabs. All
+    /// four resolve the session's worktree first and are ungated by the writer
+    /// lease: seeing a session is enough to read its code.
+    func remoteChangeList(sessionId: String) async -> RemoteChangeListResult
+    func remoteFileDiff(sessionId: String, path: String) async -> RemoteFileDiffResult
+    func remoteFileTree(sessionId: String, path: String?) async -> RemoteFileTreeResult
+    func remoteFileContents(sessionId: String, path: String) async -> RemoteFileContentsResult
 }
 
 extension RemoteSessionsProvider {

--- a/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
@@ -11,16 +11,34 @@ enum RemoteWorktreeFileAccess {
     static let maxDiffLines = 2_000
     static let maxChangedFiles = 500
 
-    /// Returns the on-disk URL for a worktree-relative path, or nil when the
-    /// path is empty, absolute, traverses upward, names `.git`, or resolves
-    /// outside the worktree through a symlink.
-    static func resolve(path: String, in worktreeRoot: URL) -> URL? {
+    /// Normalizes a client-supplied worktree-relative path: trims surrounding
+    /// whitespace/newlines and rejects the same shapes `resolve` rejects
+    /// (empty, absolute, upward traversal, `.git`). Returns the normalized
+    /// relative path string (e.g. `"src/file.txt"`, no leading/trailing
+    /// slashes) or nil when the path is invalid.
+    ///
+    /// Callers that need to gate access on a path (ignore checks, diff
+    /// pathspecs) MUST use this same normalized string — not the raw
+    /// caller-supplied path — so the string that decided "is this allowed"
+    /// is identical to the string used to actually read/diff the file.
+    /// `resolve(path:in:)` calls this internally to build its URL.
+    static func normalizedRelativePath(_ path: String) -> String? {
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, !trimmed.hasPrefix("/") else { return nil }
 
         let components = trimmed.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
         guard !components.isEmpty else { return nil }
         guard !components.contains(".."), !components.contains(".git") else { return nil }
+
+        return components.joined(separator: "/")
+    }
+
+    /// Returns the on-disk URL for a worktree-relative path, or nil when the
+    /// path is empty, absolute, traverses upward, names `.git`, or resolves
+    /// outside the worktree through a symlink.
+    static func resolve(path: String, in worktreeRoot: URL) -> URL? {
+        guard let normalized = normalizedRelativePath(path) else { return nil }
+        let components = normalized.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
 
         let candidate = components.reduce(worktreeRoot) { $0.appendingPathComponent($1) }
         let resolvedRoot = worktreeRoot.resolvingSymlinksInPath().standardizedFileURL

--- a/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
@@ -24,11 +24,16 @@ enum RemoteWorktreeFileAccess {
     static let maxDiffLineBytes = 64 * 1024
     private static let lineTruncationMarker = "…(line truncated)"
 
-    /// Normalizes a client-supplied worktree-relative path: trims surrounding
-    /// whitespace/newlines and rejects the same shapes `resolve` rejects
-    /// (empty, absolute, upward traversal, `.git`). Returns the normalized
-    /// relative path string (e.g. `"src/file.txt"`, no leading/trailing
-    /// slashes) or nil when the path is invalid.
+    /// Normalizes a client-supplied worktree-relative path: rejects the same
+    /// shapes `resolve` rejects (empty/whitespace-only, absolute, upward
+    /// traversal, `.git`) and returns the ORIGINAL path's exact bytes (no
+    /// leading/trailing slashes stripped beyond splitting on `/`) — not a
+    /// trimmed copy. A real file can legitimately be named with leading or
+    /// trailing whitespace; git does not trim filenames, so trimming here
+    /// would silently resolve a client's exact selection to a DIFFERENT
+    /// path than the one it asked for. Trimming is used only to decide
+    /// whether the input is empty/meaningless, never to build the string
+    /// callers actually resolve/serve.
     ///
     /// Callers that need to gate access on a path (ignore checks, diff
     /// pathspecs) MUST use this same normalized string — not the raw
@@ -36,14 +41,27 @@ enum RemoteWorktreeFileAccess {
     /// is identical to the string used to actually read/diff the file.
     /// `resolve(path:in:)` calls this internally to build its URL.
     static func normalizedRelativePath(_ path: String) -> String? {
-        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, !trimmed.hasPrefix("/") else { return nil }
+        guard !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, !path.hasPrefix("/") else { return nil }
 
-        let components = trimmed.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+        let components = path.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
         guard !components.isEmpty else { return nil }
         guard !components.contains(".."), !components.contains(".git") else { return nil }
 
         return components.joined(separator: "/")
+    }
+
+    /// True when `url` itself — not whatever it may point to — is a
+    /// symbolic link. `.isSymbolicLinkKey` is computed on the link itself
+    /// (lstat semantics), not its resolved target, so this is accurate even
+    /// for a dangling link. Local file/diff reads reject ANY symlink
+    /// outright rather than resolving-and-rechecking the target: an ignore
+    /// check against the alias name says nothing about the content actually
+    /// served by transparently following the link at the OS level (e.g.
+    /// `Data(contentsOf:)`), which is exactly the bypass shape already
+    /// closed above for `.git` symlink aliases and for the SSH read path's
+    /// `.symlink` outcome (mapped to `.notFound` rather than followed).
+    static func isSymlink(at url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isSymbolicLinkKey]))?.isSymbolicLink ?? false
     }
 
     /// Returns the on-disk URL for a worktree-relative path, or nil when the
@@ -168,6 +186,7 @@ enum RemoteWorktreeFileAccess {
     /// blocks the UI thread.
     static func readFileContents(at url: URL) async -> FileReadOutcome {
         await Task.detached(priority: .userInitiated) {
+            guard !isSymlink(at: url) else { return .notFound }
             guard let size = fileByteSize(at: url) else { return .notFound }
             guard size <= maxFileBytes else { return .tooLarge(byteSize: size) }
             guard let data = try? Data(contentsOf: url) else { return .notFound }
@@ -185,6 +204,7 @@ enum RemoteWorktreeFileAccess {
     /// a large file.
     static func looksBinaryOnDisk(at url: URL) async -> Bool {
         await Task.detached(priority: .userInitiated) {
+            guard !isSymlink(at: url) else { return false }
             guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
             defer { try? handle.close() }
             let sample = (try? handle.read(upToCount: 8192)) ?? Data()

--- a/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Path validation and payload caps for the remote changes/files surface.
+///
+/// Every path here arrives from a paired device, so containment is enforced on
+/// the resolved (symlink-followed) path, not the string. `.git` is excluded
+/// entirely: a worktree's git config can hold remote URLs with embedded
+/// credentials.
+enum RemoteWorktreeFileAccess {
+    static let maxFileBytes = 512 * 1024
+    static let maxDiffLines = 2_000
+    static let maxChangedFiles = 500
+
+    /// Returns the on-disk URL for a worktree-relative path, or nil when the
+    /// path is empty, absolute, traverses upward, names `.git`, or resolves
+    /// outside the worktree through a symlink.
+    static func resolve(path: String, in worktreeRoot: URL) -> URL? {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("/") else { return nil }
+
+        let components = trimmed.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+        guard !components.isEmpty else { return nil }
+        guard !components.contains(".."), !components.contains(".git") else { return nil }
+
+        let candidate = components.reduce(worktreeRoot) { $0.appendingPathComponent($1) }
+        let resolvedRoot = worktreeRoot.resolvingSymlinksInPath().standardizedFileURL
+        let resolved = candidate.resolvingSymlinksInPath().standardizedFileURL
+
+        let rootPath = resolvedRoot.path.hasSuffix("/") ? resolvedRoot.path : resolvedRoot.path + "/"
+        guard resolved.path.hasPrefix(rootPath) else { return nil }
+        return candidate
+    }
+
+    /// Caps a diff at `maxDiffLines` total lines, dropping whole trailing
+    /// lines from the hunk that crosses the cap. Reports whether anything was
+    /// dropped so the client can render a truncation footer.
+    static func truncateHunks(_ hunks: [ParsedDiff.Hunk]) -> (hunks: [ParsedDiff.Hunk], truncated: Bool) {
+        var remaining = maxDiffLines
+        var kept: [ParsedDiff.Hunk] = []
+        for hunk in hunks {
+            if remaining <= 0 { return (kept, true) }
+            if hunk.lines.count <= remaining {
+                kept.append(hunk)
+                remaining -= hunk.lines.count
+                continue
+            }
+            kept.append(ParsedDiff.Hunk(
+                header: hunk.header,
+                oldStart: hunk.oldStart,
+                newStart: hunk.newStart,
+                lines: Array(hunk.lines.prefix(remaining))))
+            return (kept, true)
+        }
+        return (kept, false)
+    }
+
+    /// Caps a change list at `maxChangedFiles` entries.
+    static func truncateFiles(_ files: [ChangedFile]) -> (files: [ChangedFile], truncated: Bool) {
+        guard files.count > maxChangedFiles else { return (files, false) }
+        return (Array(files.prefix(maxChangedFiles)), true)
+    }
+}

--- a/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
@@ -10,6 +10,19 @@ enum RemoteWorktreeFileAccess {
     static let maxFileBytes = 512 * 1024
     static let maxDiffLines = 2_000
     static let maxChangedFiles = 500
+    /// Overall byte budget for a diff payload, on top of the line-count cap.
+    /// A single pathological line (e.g. minified/generated code) can stay
+    /// under `maxDiffLines` while still being megabytes long, so the line
+    /// count alone doesn't bound the wire payload — this does. Matches
+    /// `maxFileBytes`'s order of magnitude: a diff is not expected to need a
+    /// materially larger budget than a single whole file.
+    static let maxDiffBytes = 512 * 1024
+    /// Per-line cap: a single line longer than this is truncated with a
+    /// marker rather than shipped whole (or dropped silently), so one huge
+    /// line can't itself blow the byte budget before the accountant even
+    /// gets a chance to stop it.
+    static let maxDiffLineBytes = 64 * 1024
+    private static let lineTruncationMarker = "…(line truncated)"
 
     /// Normalizes a client-supplied worktree-relative path: trims surrounding
     /// whitespace/newlines and rejects the same shapes `resolve` rejects
@@ -58,27 +71,77 @@ enum RemoteWorktreeFileAccess {
         return candidate
     }
 
-    /// Caps a diff at `maxDiffLines` total lines, dropping whole trailing
-    /// lines from the hunk that crosses the cap. Reports whether anything was
-    /// dropped so the client can render a truncation footer.
-    static func truncateHunks(_ hunks: [ParsedDiff.Hunk]) -> (hunks: [ParsedDiff.Hunk], truncated: Bool) {
-        var remaining = maxDiffLines
-        var kept: [ParsedDiff.Hunk] = []
-        for hunk in hunks {
-            if remaining <= 0 { return (kept, true) }
-            if hunk.lines.count <= remaining {
-                kept.append(hunk)
-                remaining -= hunk.lines.count
-                continue
-            }
-            kept.append(ParsedDiff.Hunk(
-                header: hunk.header,
-                oldStart: hunk.oldStart,
-                newStart: hunk.newStart,
-                lines: Array(hunk.lines.prefix(remaining))))
-            return (kept, true)
+    /// Truncates a single line's `text` to `maxDiffLineBytes` UTF-8 bytes,
+    /// appending a marker, when it individually exceeds the cap. Keeps the
+    /// line (rather than dropping it) so the diff shape (add/delete/context)
+    /// stays intact — only the payload is bounded.
+    private static func clampedLine(_ line: ParsedDiff.Hunk.Line) -> ParsedDiff.Hunk.Line {
+        let bytes = line.text.utf8
+        guard bytes.count > maxDiffLineBytes else { return line }
+        let markerBytes = lineTruncationMarker.utf8.count
+        let keep = max(0, maxDiffLineBytes - markerBytes)
+        // Byte-prefix a String's UTF-8 view safely: decode only up to the
+        // last complete scalar within `keep` bytes rather than slicing
+        // mid-codepoint.
+        var prefixByteCount = 0
+        var truncatedScalars = String.UnicodeScalarView()
+        for scalar in line.text.unicodeScalars {
+            let scalarByteCount = String(scalar).utf8.count
+            guard prefixByteCount + scalarByteCount <= keep else { break }
+            truncatedScalars.append(scalar)
+            prefixByteCount += scalarByteCount
         }
-        return (kept, false)
+        var result = ParsedDiff.Hunk.Line(
+            kind: line.kind,
+            text: String(truncatedScalars) + lineTruncationMarker,
+            oldNumber: line.oldNumber,
+            newNumber: line.newNumber)
+        result.noTrailingNewline = line.noTrailingNewline
+        return result
+    }
+
+    /// Caps a diff at `maxDiffLines` total lines AND `maxDiffBytes` total
+    /// UTF-8 bytes of line text, whichever comes first — dropping whole
+    /// trailing lines from the hunk that crosses either cap, and truncating
+    /// (not shipping whole or dropping silently) any single line that alone
+    /// exceeds `maxDiffLineBytes`. Reports whether anything was dropped or
+    /// clamped so the client can render a truncation footer.
+    static func truncateHunks(_ hunks: [ParsedDiff.Hunk]) -> (hunks: [ParsedDiff.Hunk], truncated: Bool) {
+        var remainingLines = maxDiffLines
+        var remainingBytes = maxDiffBytes
+        var kept: [ParsedDiff.Hunk] = []
+        var truncated = false
+
+        hunkLoop: for hunk in hunks {
+            if remainingLines <= 0 || remainingBytes <= 0 {
+                truncated = true
+                break
+            }
+            var keptLines: [ParsedDiff.Hunk.Line] = []
+            for rawLine in hunk.lines {
+                if remainingLines <= 0 || remainingBytes <= 0 {
+                    truncated = true
+                    break
+                }
+                let line = clampedLine(rawLine)
+                if line.text != rawLine.text { truncated = true }
+                keptLines.append(line)
+                remainingLines -= 1
+                remainingBytes -= line.text.utf8.count
+            }
+            if !keptLines.isEmpty {
+                kept.append(ParsedDiff.Hunk(
+                    header: hunk.header,
+                    oldStart: hunk.oldStart,
+                    newStart: hunk.newStart,
+                    lines: keptLines))
+            }
+            if keptLines.count < hunk.lines.count {
+                truncated = true
+                break hunkLoop
+            }
+        }
+        return (kept, truncated)
     }
 
     /// Caps a change list at `maxChangedFiles` entries.

--- a/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
@@ -28,6 +28,15 @@ enum RemoteWorktreeFileAccess {
 
         let rootPath = resolvedRoot.path.hasSuffix("/") ? resolvedRoot.path : resolvedRoot.path + "/"
         guard resolved.path.hasPrefix(rootPath) else { return nil }
+
+        // Check that no component of the resolved path is .git (case-insensitive),
+        // including via symlink aliases or case variations. This is the actual
+        // security boundary: we check the canonical (symlink-resolved) path,
+        // not just the user's input string.
+        let resolvedRelativePath = String(resolved.path.dropFirst(rootPath.count))
+        let resolvedComponents = resolvedRelativePath.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+        guard !resolvedComponents.contains(where: { $0.lowercased() == ".git" }) else { return nil }
+
         return candidate
     }
 

--- a/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
@@ -68,4 +68,53 @@ enum RemoteWorktreeFileAccess {
         guard files.count > maxChangedFiles else { return (files, false) }
         return (Array(files.prefix(maxChangedFiles)), true)
     }
+
+    /// Result of an off-main-actor file read for the remote contents
+    /// surface. Deliberately independent of the wire protocol type so this
+    /// file has no dependency on `Remote/Protocol`.
+    enum FileReadOutcome: Equatable {
+        case notFound
+        case tooLarge(byteSize: Int)
+        case binary(byteSize: Int)
+        case text(String)
+    }
+
+    /// Stats, caps, reads, and UTF-8-decodes `url` entirely off the caller's
+    /// actor. The size cap is checked against a cheap `stat` result — BEFORE
+    /// any `Data(contentsOf:)` — so a client naming a huge file never forces
+    /// a full read. Callers on `@MainActor` (`AppState`) must `await` this
+    /// rather than reading the file directly, so an unbounded read never
+    /// blocks the UI thread.
+    static func readFileContents(at url: URL) async -> FileReadOutcome {
+        await Task.detached(priority: .userInitiated) {
+            guard let size = fileByteSize(at: url) else { return .notFound }
+            guard size <= maxFileBytes else { return .tooLarge(byteSize: size) }
+            guard let data = try? Data(contentsOf: url) else { return .notFound }
+            guard !GitService.looksBinary(data) else { return .binary(byteSize: data.count) }
+            guard let text = String(data: data, encoding: .utf8) else {
+                return .binary(byteSize: data.count)
+            }
+            return .text(text)
+        }.value
+    }
+
+    /// Sniffs whether `url` looks binary without reading the whole file, off
+    /// the caller's actor. `GitService.looksBinary` only ever inspects the
+    /// first 8 KB, so a full read buys nothing here but main-thread risk on
+    /// a large file.
+    static func looksBinaryOnDisk(at url: URL) async -> Bool {
+        await Task.detached(priority: .userInitiated) {
+            guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+            defer { try? handle.close() }
+            let sample = (try? handle.read(upToCount: 8192)) ?? Data()
+            return GitService.looksBinary(sample)
+        }.value
+    }
+
+    private static func fileByteSize(at url: URL) -> Int? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path) else {
+            return nil
+        }
+        return (attributes[.size] as? NSNumber)?.intValue
+    }
 }

--- a/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Darwin
 
 /// Path validation and payload caps for the remote changes/files surface.
 ///
@@ -142,10 +143,22 @@ enum RemoteWorktreeFileAccess {
                     break
                 }
                 let line = clampedLine(rawLine)
+                // `clampedLine` only bounds a single line to
+                // `maxDiffLineBytes` — that clamped size can still be
+                // larger than what's left of the OVERALL `maxDiffBytes`
+                // budget. Check the fit BEFORE appending (not just
+                // `remainingBytes <= 0` at the top of the loop, which only
+                // catches an ALREADY-exhausted budget) so the very last line
+                // kept can never itself push the total past the cap.
+                let lineByteCount = line.text.utf8.count
+                guard lineByteCount <= remainingBytes else {
+                    truncated = true
+                    break
+                }
                 if line.text != rawLine.text { truncated = true }
                 keptLines.append(line)
                 remainingLines -= 1
-                remainingBytes -= line.text.utf8.count
+                remainingBytes -= lineByteCount
             }
             if !keptLines.isEmpty {
                 kept.append(ParsedDiff.Hunk(
@@ -178,44 +191,154 @@ enum RemoteWorktreeFileAccess {
         case text(String)
     }
 
+    /// Number of bytes `looksBinaryOnDisk` sniffs — matches
+    /// `GitService.looksBinary`'s own 8 KB inspection window, so a binary
+    /// sniff never needs more than that.
+    private static let binarySniffPrefixBytes = 8192
+
+    /// Outcome of `openReadCapped`, the single-descriptor open+fstat+read
+    /// primitive both `readFileContents` and `looksBinaryOnDisk` funnel
+    /// through.
+    private enum RawReadOutcome {
+        case notFound
+        case tooLarge(byteSize: Int)
+        case data(Data)
+    }
+
+    /// Opens `url` and, on success, returns a descriptor already `fstat`-
+    /// verified as a *regular file* — never a symlink, directory, FIFO, or
+    /// other special file. Callers own the returned descriptor and must
+    /// `close` it.
+    ///
+    /// `O_NOFOLLOW` rejects a symlink at the FINAL path component atomically
+    /// with the open itself (no separate `lstat`-then-`open` gap to race).
+    /// `O_NONBLOCK` prevents `open` from blocking forever on a FIFO with no
+    /// writer — without it, opening a named pipe for reading blocks
+    /// indefinitely, which (since `RemoteSessionGateway` serializes ordinary
+    /// messages per connection) would hang every subsequent message on that
+    /// connection too. `O_NONBLOCK` is a no-op for regular files, so it
+    /// changes nothing about how the eventual read behaves once `fstat`
+    /// confirms `S_IFREG`.
+    ///
+    /// This closes the specific TOCTOU gap Codex flagged: `resolve()` already
+    /// canonicalizes and validates the full path (including intermediate
+    /// symlinks) once, up front. The remaining gap was that a LATER, separate
+    /// operation (`Data(contentsOf:)`, or a separate `stat` call) re-resolved
+    /// the same path string from scratch, giving a concurrently-running
+    /// process a window to swap a path component for a symlink between the
+    /// check and that later re-resolution. Threading a single already-opened
+    /// descriptor through open → fstat (regular-file check) → read means
+    /// there is no later re-resolution left to race: whatever the kernel
+    /// resolved when `open` succeeded is exactly what every subsequent
+    /// `fstat`/`read` call on that descriptor sees.
+    ///
+    /// Not perfect: `resolve()`'s own canonicalization (`resolvingSymlinksInPath`)
+    /// and this `open` call are still two separate filesystem operations, so
+    /// an intermediate directory component could theoretically be swapped
+    /// for a symlink in between them. That residual window is far narrower
+    /// than the one this closes (a single open syscall's worth of time, vs.
+    /// the entire duration of an unrelated later read), and closing it
+    /// completely would require a hand-rolled `openat`-per-component walk;
+    /// not implemented here as disproportionate to the residual risk.
+    private static func openRegularFileNoFollow(at url: URL) -> Int32? {
+        let fd = url.withUnsafeFileSystemRepresentation { representation -> Int32 in
+            guard let representation else { return -1 }
+            return open(representation, O_RDONLY | O_NOFOLLOW | O_NONBLOCK | O_CLOEXEC)
+        }
+        guard fd >= 0 else { return nil }
+        var status = stat()
+        guard fstat(fd, &status) == 0, (status.st_mode & S_IFMT) == S_IFREG else {
+            close(fd)
+            return nil
+        }
+        return fd
+    }
+
+    /// Reads the ENTIRE contents of `url` via a single open/fstat/read
+    /// sequence (see `openRegularFileNoFollow`), capped at `maxBytes`. The
+    /// size check and the read both happen against the SAME already-opened
+    /// descriptor — no re-`stat`, no re-`open` by path — so a concurrent
+    /// write growing the file past the cap after `fstat` is still caught by
+    /// the read loop's own running total rather than a stale earlier stat.
+    private static func openReadCapped(at url: URL, maxBytes: Int) -> RawReadOutcome {
+        guard let fd = openRegularFileNoFollow(at: url) else { return .notFound }
+        defer { close(fd) }
+
+        var status = stat()
+        guard fstat(fd, &status) == 0 else { return .notFound }
+        let statedSize = Int(clamping: status.st_size)
+        if statedSize > maxBytes {
+            return .tooLarge(byteSize: statedSize)
+        }
+
+        // Read via the SAME fd, capped at `maxBytes + 1` so a file that
+        // grows past the cap after `fstat` (e.g. a concurrent writer) is
+        // still caught here rather than silently served in full.
+        var data = Data()
+        data.reserveCapacity(min(statedSize, maxBytes) + 1)
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while data.count <= maxBytes {
+            let bytesRead = buffer.withUnsafeMutableBytes { pointer -> Int in
+                read(fd, pointer.baseAddress, pointer.count)
+            }
+            guard bytesRead > 0 else { break }
+            data.append(contentsOf: buffer[0..<bytesRead])
+        }
+        if data.count > maxBytes {
+            return .tooLarge(byteSize: data.count)
+        }
+        return .data(data)
+    }
+
+    /// Reads only the first `maxBytes` of `url` (or fewer if the file is
+    /// smaller), via the same `openRegularFileNoFollow` open+fstat sequence,
+    /// WITHOUT treating a larger total file size as an error — this is a
+    /// bounded-prefix sniff, not a capped whole-file read. Returns nil when
+    /// the path can't be opened as a validated regular file.
+    private static func openReadPrefix(at url: URL, maxBytes: Int) -> Data? {
+        guard let fd = openRegularFileNoFollow(at: url) else { return nil }
+        defer { close(fd) }
+        var buffer = [UInt8](repeating: 0, count: maxBytes)
+        let bytesRead = buffer.withUnsafeMutableBytes { pointer -> Int in
+            read(fd, pointer.baseAddress, pointer.count)
+        }
+        guard bytesRead >= 0 else { return nil }
+        return Data(buffer[0..<bytesRead])
+    }
+
     /// Stats, caps, reads, and UTF-8-decodes `url` entirely off the caller's
-    /// actor. The size cap is checked against a cheap `stat` result — BEFORE
-    /// any `Data(contentsOf:)` — so a client naming a huge file never forces
-    /// a full read. Callers on `@MainActor` (`AppState`) must `await` this
-    /// rather than reading the file directly, so an unbounded read never
-    /// blocks the UI thread.
+    /// actor, via a single open/fstat/read sequence (`openReadCapped`) so no
+    /// path is ever re-resolved between the size check and the actual read.
+    /// Callers on `@MainActor` (`AppState`) must `await` this rather than
+    /// reading the file directly, so an unbounded read never blocks the UI
+    /// thread.
     static func readFileContents(at url: URL) async -> FileReadOutcome {
         await Task.detached(priority: .userInitiated) {
-            guard !isSymlink(at: url) else { return .notFound }
-            guard let size = fileByteSize(at: url) else { return .notFound }
-            guard size <= maxFileBytes else { return .tooLarge(byteSize: size) }
-            guard let data = try? Data(contentsOf: url) else { return .notFound }
-            guard !GitService.looksBinary(data) else { return .binary(byteSize: data.count) }
-            guard let text = String(data: data, encoding: .utf8) else {
-                return .binary(byteSize: data.count)
+            switch openReadCapped(at: url, maxBytes: maxFileBytes) {
+            case .notFound: return .notFound
+            case .tooLarge(let byteSize): return .tooLarge(byteSize: byteSize)
+            case .data(let data):
+                guard !GitService.looksBinary(data) else { return .binary(byteSize: data.count) }
+                guard let text = String(data: data, encoding: .utf8) else {
+                    return .binary(byteSize: data.count)
+                }
+                return .text(text)
             }
-            return .text(text)
         }.value
     }
 
     /// Sniffs whether `url` looks binary without reading the whole file, off
-    /// the caller's actor. `GitService.looksBinary` only ever inspects the
-    /// first 8 KB, so a full read buys nothing here but main-thread risk on
-    /// a large file.
+    /// the caller's actor, via the same `openRegularFileNoFollow` open+fstat
+    /// sequence so a symlink or non-regular file (including a FIFO with no
+    /// writer — see `openRegularFileNoFollow`'s doc comment) can never block
+    /// or bypass validation here either. Reads only a bounded PREFIX
+    /// (`openReadPrefix`), regardless of the file's total size — a file
+    /// larger than the sniff window is not itself an error here, unlike the
+    /// whole-file cap `readFileContents` enforces.
     static func looksBinaryOnDisk(at url: URL) async -> Bool {
         await Task.detached(priority: .userInitiated) {
-            guard !isSymlink(at: url) else { return false }
-            guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
-            defer { try? handle.close() }
-            let sample = (try? handle.read(upToCount: 8192)) ?? Data()
+            guard let sample = openReadPrefix(at: url, maxBytes: binarySniffPrefixBytes) else { return false }
             return GitService.looksBinary(sample)
         }.value
-    }
-
-    private static func fileByteSize(at url: URL) -> Int? {
-        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path) else {
-            return nil
-        }
-        return (attributes[.size] as? NSNumber)?.intValue
     }
 }

--- a/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
@@ -23,6 +23,14 @@ enum RemoteWorktreeFileAccess {
     /// line can't itself blow the byte budget before the accountant even
     /// gets a chance to stop it.
     static let maxDiffLineBytes = 64 * 1024
+    /// Cap on the RAW `git diff` subprocess output `GitService`'s diff
+    /// methods capture, before `DiffParser` even runs — comfortably above
+    /// `maxDiffBytes` (8x) so an ordinary large diff is captured in full and
+    /// `truncateHunks` below still makes the exact truncation call; only a
+    /// genuinely pathological diff (a multi-gigabyte generated file) is cut
+    /// short here, before parsing ever materializes it into hunks. See
+    /// `Process.runCapped`.
+    static let maxDiffSubprocessBytes = maxDiffBytes * 8
     private static let lineTruncationMarker = "…(line truncated)"
 
     /// Normalizes a client-supplied worktree-relative path: rejects the same

--- a/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
@@ -220,17 +220,17 @@ enum RemoteWorktreeFileAccess {
     /// changes nothing about how the eventual read behaves once `fstat`
     /// confirms `S_IFREG`.
     ///
-    /// This closes the specific TOCTOU gap Codex flagged: `resolve()` already
-    /// canonicalizes and validates the full path (including intermediate
-    /// symlinks) once, up front. The remaining gap was that a LATER, separate
-    /// operation (`Data(contentsOf:)`, or a separate `stat` call) re-resolved
-    /// the same path string from scratch, giving a concurrently-running
-    /// process a window to swap a path component for a symlink between the
-    /// check and that later re-resolution. Threading a single already-opened
-    /// descriptor through open → fstat (regular-file check) → read means
-    /// there is no later re-resolution left to race: whatever the kernel
-    /// resolved when `open` succeeded is exactly what every subsequent
-    /// `fstat`/`read` call on that descriptor sees.
+    /// This closes a specific time-of-check/time-of-use gap: `resolve()`
+    /// already canonicalizes and validates the full path (including
+    /// intermediate symlinks) once, up front. The remaining gap was that a
+    /// LATER, separate operation (`Data(contentsOf:)`, or a separate `stat`
+    /// call) re-resolved the same path string from scratch, giving a
+    /// concurrently-running process a window to swap a path component for a
+    /// symlink between the check and that later re-resolution. Threading a
+    /// single already-opened descriptor through open → fstat (regular-file
+    /// check) → read means there is no later re-resolution left to race:
+    /// whatever the kernel resolved when `open` succeeded is exactly what
+    /// every subsequent `fstat`/`read` call on that descriptor sees.
     ///
     /// Not perfect: `resolve()`'s own canonicalization (`resolvingSymlinksInPath`)
     /// and this `open` call are still two separate filesystem operations, so

--- a/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift
@@ -11,6 +11,13 @@ enum RemoteWorktreeFileAccess {
     static let maxFileBytes = 512 * 1024
     static let maxDiffLines = 2_000
     static let maxChangedFiles = 500
+    /// Caps a single directory listing (the root, or one expanded
+    /// subdirectory — `fileTreeChildren` returns immediate children only,
+    /// never a deep tree) at this many entries. Without a cap, a tracked
+    /// directory with an enormous number of immediate children would ship
+    /// every one of them in a single `fileTree` response and have the
+    /// client build one DOM row per node.
+    static let maxFileTreeNodes = 1_000
     /// Overall byte budget for a diff payload, on top of the line-count cap.
     /// A single pathological line (e.g. minified/generated code) can stay
     /// under `maxDiffLines` while still being megabytes long, so the line
@@ -187,6 +194,20 @@ enum RemoteWorktreeFileAccess {
     static func truncateFiles(_ files: [ChangedFile]) -> (files: [ChangedFile], truncated: Bool) {
         guard files.count > maxChangedFiles else { return (files, false) }
         return (Array(files.prefix(maxChangedFiles)), true)
+    }
+
+    /// Caps a single directory listing at `maxFileTreeNodes` entries.
+    ///
+    /// Operates on the already wire-mapped `[RemoteFileNode]` — i.e. AFTER
+    /// `FileTreeNode.filteredKeepingVisibleDescendants` has dropped
+    /// ignored/excluded entries — rather than the raw `[FileTreeNode]` walk
+    /// result. Capping before that filter would waste the budget on entries
+    /// that were never going to be shown anyway, potentially truncating
+    /// away legitimate tracked files that simply sorted after a large run
+    /// of filtered-out ones.
+    static func truncateFileNodes(_ nodes: [RemoteFileNode]) -> (nodes: [RemoteFileNode], truncated: Bool) {
+        guard nodes.count > maxFileTreeNodes else { return (nodes, false) }
+        return (Array(nodes.prefix(maxFileTreeNodes)), true)
     }
 
     /// Result of an off-main-actor file read for the remote contents

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -231,3 +231,60 @@ struct RemoteElicitationPayload: Codable, Equatable, Sendable {
     let elicitationId: String?
     let url: String?
 }
+
+/// Why a changes/files request could not be served. Decoded leniently so an
+/// older client keeps working against a newer host that adds reasons.
+enum RemoteFileAccessReason: String, Codable, Equatable, Sendable {
+    case sessionUnknown
+    case worktreeUnavailable
+    case pathRejected
+    case notFound
+    case binary
+    case tooLarge
+    case gitFailed
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = RemoteFileAccessReason(rawValue: raw) ?? .unknown
+    }
+}
+
+/// Wire projection of `ChangedFile`. `conflict` carries `ConflictKind`'s raw
+/// value so the client can mark conflicted files without knowing the enum.
+struct RemoteChangedFile: Codable, Equatable, Sendable {
+    let path: String
+    let status: String
+    let add: Int
+    let del: Int
+    let conflict: String?
+    let renameFrom: String?
+}
+
+/// Wire projection of `ParsedDiff.Hunk.Line`. `kind` is "context", "add", or
+/// "delete"; `text` has no leading +/-/space.
+struct RemoteDiffLine: Codable, Equatable, Sendable {
+    let kind: String
+    let text: String
+    let oldNumber: Int?
+    let newNumber: Int?
+}
+
+/// Wire projection of `ParsedDiff.Hunk`.
+struct RemoteDiffHunk: Codable, Equatable, Sendable {
+    let header: String
+    let oldStart: Int
+    let newStart: Int
+    let lines: [RemoteDiffLine]
+}
+
+/// Wire projection of `FileTreeNode`. `kind` is "dir" or "file";
+/// `childrenState` carries `DirectoryChildrenState`'s raw value.
+struct RemoteFileNode: Codable, Equatable, Sendable {
+    let name: String
+    let path: String
+    let kind: String
+    let badge: String?
+    let childrenState: String
+    let isSubmodule: Bool
+}

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -288,3 +288,25 @@ struct RemoteFileNode: Codable, Equatable, Sendable {
     let childrenState: String
     let isSubmodule: Bool
 }
+
+enum RemoteChangeListResult: Equatable, Sendable {
+    case success(
+        comparisonRef: String?, metricsAvailable: Bool,
+        files: [RemoteChangedFile], truncated: Bool)
+    case failure(reason: RemoteFileAccessReason, message: String?)
+}
+
+enum RemoteFileDiffResult: Equatable, Sendable {
+    case success(hunks: [RemoteDiffHunk], truncated: Bool)
+    case failure(reason: RemoteFileAccessReason, message: String?)
+}
+
+enum RemoteFileTreeResult: Equatable, Sendable {
+    case success(nodes: [RemoteFileNode])
+    case failure(reason: RemoteFileAccessReason, message: String?)
+}
+
+enum RemoteFileContentsResult: Equatable, Sendable {
+    case success(text: String, truncated: Bool)
+    case failure(reason: RemoteFileAccessReason, byteSize: Int?, message: String?)
+}

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -262,12 +262,52 @@ struct RemoteChangedFile: Codable, Equatable, Sendable {
 }
 
 /// Wire projection of `ParsedDiff.Hunk.Line`. `kind` is "context", "add", or
-/// "delete"; `text` has no leading +/-/space.
-struct RemoteDiffLine: Codable, Equatable, Sendable {
+/// "delete"; `text` has no leading +/-/space. `noTrailingNewline` mirrors
+/// the source line's `\ No newline at end of file` sentinel, so a diff that
+/// only adds/removes a trailing newline doesn't render as two
+/// identical-looking lines with no visual distinction.
+struct RemoteDiffLine: Equatable, Sendable {
     let kind: String
     let text: String
     let oldNumber: Int?
     let newNumber: Int?
+    let noTrailingNewline: Bool
+
+    init(kind: String, text: String, oldNumber: Int?, newNumber: Int?, noTrailingNewline: Bool = false) {
+        self.kind = kind
+        self.text = text
+        self.oldNumber = oldNumber
+        self.newNumber = newNumber
+        self.noTrailingNewline = noTrailingNewline
+    }
+}
+
+extension RemoteDiffLine: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case kind, text, oldNumber, newNumber, noTrailingNewline
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            kind: try c.decode(String.self, forKey: .kind),
+            text: try c.decode(String.self, forKey: .text),
+            oldNumber: try c.decodeIfPresent(Int.self, forKey: .oldNumber),
+            newNumber: try c.decodeIfPresent(Int.self, forKey: .newNumber),
+            // Decoded leniently so an older host that hasn't sent this field
+            // yet still decodes (a client ahead of a not-yet-updated host).
+            noTrailingNewline: try c.decodeIfPresent(Bool.self, forKey: .noTrailingNewline) ?? false
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(kind, forKey: .kind)
+        try c.encode(text, forKey: .text)
+        try c.encodeIfPresent(oldNumber, forKey: .oldNumber)
+        try c.encodeIfPresent(newNumber, forKey: .newNumber)
+        try c.encode(noTrailingNewline, forKey: .noTrailingNewline)
+    }
 }
 
 /// Wire projection of `ParsedDiff.Hunk`.

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -342,7 +342,7 @@ enum RemoteFileDiffResult: Equatable, Sendable {
 }
 
 enum RemoteFileTreeResult: Equatable, Sendable {
-    case success(nodes: [RemoteFileNode])
+    case success(nodes: [RemoteFileNode], truncated: Bool)
     case failure(reason: RemoteFileAccessReason, message: String?)
 }
 

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -337,7 +337,12 @@ enum RemoteChangeListResult: Equatable, Sendable {
 }
 
 enum RemoteFileDiffResult: Equatable, Sendable {
-    case success(hunks: [RemoteDiffHunk], truncated: Bool)
+    /// `metadataNote` is set when `hunks` is empty because the change was
+    /// metadata-only (a pure rename/copy or executable-bit change with no
+    /// content edits) — see `ParsedDiff.metadataSummary`. The client shows
+    /// it in place of the hunk viewer instead of rendering a blank diff
+    /// that looks indistinguishable from "nothing changed".
+    case success(hunks: [RemoteDiffHunk], truncated: Bool, metadataNote: String? = nil)
     case failure(reason: RemoteFileAccessReason, message: String?)
 }
 

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -54,10 +54,14 @@ enum RemoteClientMessage: Equatable, Sendable {
     case queueEdit(sessionId: String, itemId: String)
     case queueClear(sessionId: String)
     case queueSteerUndo(sessionId: String)
+    case listChanges(sessionId: String)
+    case fileDiff(sessionId: String, path: String)
+    case listFiles(sessionId: String, path: String?)
+    case readFile(sessionId: String, path: String)
 }
 
 extension RemoteClientMessage: Codable {
-    private enum CodingKeys: String, CodingKey { case type, sessionId, requestId, optionId, persistScope, answers, action, content, text, attachments, modelId, modeId, enabled, title, worktreeId, agentId, beforeIndex, limit, itemId, intent, projectId, base, branch }
+    private enum CodingKeys: String, CodingKey { case type, sessionId, requestId, optionId, persistScope, answers, action, content, text, attachments, modelId, modeId, enabled, title, worktreeId, agentId, beforeIndex, limit, itemId, intent, projectId, base, branch, path }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -148,6 +152,17 @@ extension RemoteClientMessage: Codable {
             self = .queueClear(sessionId: try c.decode(String.self, forKey: .sessionId))
         case "queueSteerUndo":
             self = .queueSteerUndo(sessionId: try c.decode(String.self, forKey: .sessionId))
+        case "listChanges":
+            self = .listChanges(sessionId: try c.decode(String.self, forKey: .sessionId))
+        case "fileDiff":
+            self = .fileDiff(sessionId: try c.decode(String.self, forKey: .sessionId),
+                             path: try c.decode(String.self, forKey: .path))
+        case "listFiles":
+            self = .listFiles(sessionId: try c.decode(String.self, forKey: .sessionId),
+                              path: try c.decodeIfPresent(String.self, forKey: .path))
+        case "readFile":
+            self = .readFile(sessionId: try c.decode(String.self, forKey: .sessionId),
+                             path: try c.decode(String.self, forKey: .path))
         case let other:
             throw DecodingError.dataCorruptedError(forKey: .type, in: c, debugDescription: "unknown type \(other)")
         }
@@ -252,6 +267,21 @@ extension RemoteClientMessage: Codable {
         case .queueSteerUndo(let s):
             try c.encode("queueSteerUndo", forKey: .type)
             try c.encode(s, forKey: .sessionId)
+        case .listChanges(let s):
+            try c.encode("listChanges", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+        case .fileDiff(let s, let path):
+            try c.encode("fileDiff", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(path, forKey: .path)
+        case .listFiles(let s, let path):
+            try c.encode("listFiles", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encodeIfPresent(path, forKey: .path)
+        case .readFile(let s, let path):
+            try c.encode("readFile", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(path, forKey: .path)
         }
     }
 }
@@ -320,6 +350,18 @@ enum RemoteServerMessage: Equatable, Sendable {
     case queueState(sessionId: String, items: [RemoteQueuedPrompt], steerUndoAvailable: Bool)
     case queueEditRestored(sessionId: String, itemId: String, text: String)
     case error(message: String)
+    case changeList(
+        sessionId: String, comparisonRef: String?, metricsAvailable: Bool,
+        files: [RemoteChangedFile], truncated: Bool)
+    case changeListFailed(sessionId: String, reason: RemoteFileAccessReason, message: String?)
+    case fileDiffResult(sessionId: String, path: String, hunks: [RemoteDiffHunk], truncated: Bool)
+    case fileDiffFailed(sessionId: String, path: String, reason: RemoteFileAccessReason, message: String?)
+    case fileTree(sessionId: String, path: String?, nodes: [RemoteFileNode])
+    case fileTreeFailed(sessionId: String, path: String?, reason: RemoteFileAccessReason, message: String?)
+    case fileContents(sessionId: String, path: String, text: String, truncated: Bool)
+    case fileUnavailable(
+        sessionId: String, path: String, reason: RemoteFileAccessReason,
+        byteSize: Int?, message: String?)
 }
 
 extension RemoteServerMessage: Codable {
@@ -329,6 +371,7 @@ extension RemoteServerMessage: Codable {
         case models, modes, currentModel, currentMode, autoRunEnabled, acceptsImages, title
         case firstIndex, totalCount, epoch, revision
         case items, steerUndoAvailable, itemId, text
+        case path, files, comparisonRef, metricsAvailable, truncated, hunks, nodes, reason, byteSize
     }
 
     init(from decoder: Decoder) throws {
@@ -439,6 +482,54 @@ extension RemoteServerMessage: Codable {
                 itemId: try c.decode(String.self, forKey: .itemId),
                 text: try c.decode(String.self, forKey: .text))
         case "error": self = .error(message: try c.decode(String.self, forKey: .message))
+        case "changeList":
+            self = .changeList(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                comparisonRef: try c.decodeIfPresent(String.self, forKey: .comparisonRef),
+                metricsAvailable: try c.decode(Bool.self, forKey: .metricsAvailable),
+                files: try c.decode([RemoteChangedFile].self, forKey: .files),
+                truncated: try c.decodeIfPresent(Bool.self, forKey: .truncated) ?? false)
+        case "changeListFailed":
+            self = .changeListFailed(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                reason: try c.decode(RemoteFileAccessReason.self, forKey: .reason),
+                message: try c.decodeIfPresent(String.self, forKey: .message))
+        case "fileDiffResult":
+            self = .fileDiffResult(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                path: try c.decode(String.self, forKey: .path),
+                hunks: try c.decode([RemoteDiffHunk].self, forKey: .hunks),
+                truncated: try c.decodeIfPresent(Bool.self, forKey: .truncated) ?? false)
+        case "fileDiffFailed":
+            self = .fileDiffFailed(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                path: try c.decode(String.self, forKey: .path),
+                reason: try c.decode(RemoteFileAccessReason.self, forKey: .reason),
+                message: try c.decodeIfPresent(String.self, forKey: .message))
+        case "fileTree":
+            self = .fileTree(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                path: try c.decodeIfPresent(String.self, forKey: .path),
+                nodes: try c.decode([RemoteFileNode].self, forKey: .nodes))
+        case "fileTreeFailed":
+            self = .fileTreeFailed(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                path: try c.decodeIfPresent(String.self, forKey: .path),
+                reason: try c.decode(RemoteFileAccessReason.self, forKey: .reason),
+                message: try c.decodeIfPresent(String.self, forKey: .message))
+        case "fileContents":
+            self = .fileContents(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                path: try c.decode(String.self, forKey: .path),
+                text: try c.decode(String.self, forKey: .text),
+                truncated: try c.decodeIfPresent(Bool.self, forKey: .truncated) ?? false)
+        case "fileUnavailable":
+            self = .fileUnavailable(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                path: try c.decode(String.self, forKey: .path),
+                reason: try c.decode(RemoteFileAccessReason.self, forKey: .reason),
+                byteSize: try c.decodeIfPresent(Int.self, forKey: .byteSize),
+                message: try c.decodeIfPresent(String.self, forKey: .message))
         case let other:
             throw DecodingError.dataCorruptedError(forKey: .type, in: c, debugDescription: "unknown type \(other)")
         }
@@ -561,6 +652,54 @@ extension RemoteServerMessage: Codable {
             try c.encode(text, forKey: .text)
         case .error(let m): try c.encode("error", forKey: .type)
         try c.encode(m, forKey: .message)
+        case .changeList(let s, let ref, let available, let files, let truncated):
+            try c.encode("changeList", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encodeIfPresent(ref, forKey: .comparisonRef)
+            try c.encode(available, forKey: .metricsAvailable)
+            try c.encode(files, forKey: .files)
+            try c.encode(truncated, forKey: .truncated)
+        case .changeListFailed(let s, let reason, let message):
+            try c.encode("changeListFailed", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(reason.rawValue, forKey: .reason)
+            try c.encodeIfPresent(message, forKey: .message)
+        case .fileDiffResult(let s, let path, let hunks, let truncated):
+            try c.encode("fileDiffResult", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(path, forKey: .path)
+            try c.encode(hunks, forKey: .hunks)
+            try c.encode(truncated, forKey: .truncated)
+        case .fileDiffFailed(let s, let path, let reason, let message):
+            try c.encode("fileDiffFailed", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(path, forKey: .path)
+            try c.encode(reason.rawValue, forKey: .reason)
+            try c.encodeIfPresent(message, forKey: .message)
+        case .fileTree(let s, let path, let nodes):
+            try c.encode("fileTree", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encodeIfPresent(path, forKey: .path)
+            try c.encode(nodes, forKey: .nodes)
+        case .fileTreeFailed(let s, let path, let reason, let message):
+            try c.encode("fileTreeFailed", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encodeIfPresent(path, forKey: .path)
+            try c.encode(reason.rawValue, forKey: .reason)
+            try c.encodeIfPresent(message, forKey: .message)
+        case .fileContents(let s, let path, let text, let truncated):
+            try c.encode("fileContents", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(path, forKey: .path)
+            try c.encode(text, forKey: .text)
+            try c.encode(truncated, forKey: .truncated)
+        case .fileUnavailable(let s, let path, let reason, let byteSize, let message):
+            try c.encode("fileUnavailable", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(path, forKey: .path)
+            try c.encode(reason.rawValue, forKey: .reason)
+            try c.encodeIfPresent(byteSize, forKey: .byteSize)
+            try c.encodeIfPresent(message, forKey: .message)
         }
     }
 }

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -385,7 +385,9 @@ enum RemoteServerMessage: Equatable, Sendable {
         sessionId: String, comparisonRef: String?, metricsAvailable: Bool,
         files: [RemoteChangedFile], truncated: Bool)
     case changeListFailed(sessionId: String, reason: RemoteFileAccessReason, message: String?)
-    case fileDiffResult(sessionId: String, path: String, hunks: [RemoteDiffHunk], truncated: Bool)
+    case fileDiffResult(
+        sessionId: String, path: String, hunks: [RemoteDiffHunk], truncated: Bool,
+        metadataNote: String? = nil)
     case fileDiffFailed(sessionId: String, path: String, reason: RemoteFileAccessReason, message: String?)
     case fileTree(sessionId: String, path: String?, nodes: [RemoteFileNode], truncated: Bool)
     case fileTreeFailed(sessionId: String, path: String?, reason: RemoteFileAccessReason, message: String?)
@@ -403,6 +405,7 @@ extension RemoteServerMessage: Codable {
         case firstIndex, totalCount, epoch, revision
         case items, steerUndoAvailable, itemId, text
         case path, files, comparisonRef, metricsAvailable, truncated, hunks, nodes, reason, byteSize
+        case metadataNote
     }
 
     init(from decoder: Decoder) throws {
@@ -530,7 +533,8 @@ extension RemoteServerMessage: Codable {
                 sessionId: try c.decode(String.self, forKey: .sessionId),
                 path: try c.decode(String.self, forKey: .path),
                 hunks: try c.decode([RemoteDiffHunk].self, forKey: .hunks),
-                truncated: try c.decodeIfPresent(Bool.self, forKey: .truncated) ?? false)
+                truncated: try c.decodeIfPresent(Bool.self, forKey: .truncated) ?? false,
+                metadataNote: try c.decodeIfPresent(String.self, forKey: .metadataNote))
         case "fileDiffFailed":
             self = .fileDiffFailed(
                 sessionId: try c.decode(String.self, forKey: .sessionId),
@@ -696,12 +700,13 @@ extension RemoteServerMessage: Codable {
             try c.encode(s, forKey: .sessionId)
             try c.encode(reason.rawValue, forKey: .reason)
             try c.encodeIfPresent(message, forKey: .message)
-        case .fileDiffResult(let s, let path, let hunks, let truncated):
+        case .fileDiffResult(let s, let path, let hunks, let truncated, let metadataNote):
             try c.encode("fileDiffResult", forKey: .type)
             try c.encode(s, forKey: .sessionId)
             try c.encode(path, forKey: .path)
             try c.encode(hunks, forKey: .hunks)
             try c.encode(truncated, forKey: .truncated)
+            try c.encodeIfPresent(metadataNote, forKey: .metadataNote)
         case .fileDiffFailed(let s, let path, let reason, let message):
             try c.encode("fileDiffFailed", forKey: .type)
             try c.encode(s, forKey: .sessionId)

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -296,6 +296,37 @@ extension RemoteClientMessage {
         return false
     }
 
+    /// Dedup key for the read-only file-request verbs, matching
+    /// `RemoteSessionGateway`'s own per-verb key shape (kept identical so
+    /// the two dedup layers agree on identity). `nil` for every other
+    /// message.
+    ///
+    /// `RemoteConnection.dispatchMessage` checks this BEFORE enqueueing into
+    /// the per-connection processing chain: these verbs are not `isControl`,
+    /// so they're always serialized behind `processingTail` like any other
+    /// ordered message — by the time a duplicate's `handle` call would run,
+    /// the original's has already completed and released its key, so a
+    /// dedup guard that only lives inside `handle` never actually rejects
+    /// anything for a real client. Checking here, at enqueue time, catches a
+    /// duplicate that arrives while the original is still queued or
+    /// in-flight, before it wastes a spot in the ordered chain (and,
+    /// downstream, a git process) on a request that will show identical
+    /// results to the one already running.
+    var fileRequestDedupKey: String? {
+        switch self {
+        case .listChanges(let sessionId):
+            return "listChanges\u{0}\(sessionId)"
+        case .fileDiff(let sessionId, let path):
+            return "fileDiff\u{0}\(sessionId)\u{0}\(path)"
+        case .listFiles(let sessionId, let path):
+            return "listFiles\u{0}\(sessionId)\u{0}\(path ?? "")"
+        case .readFile(let sessionId, let path):
+            return "readFile\u{0}\(sessionId)\u{0}\(path)"
+        default:
+            return nil
+        }
+    }
+
     /// Messages that establish or change which turn is active, and so a
     /// following `stop` must wait for them specifically (not the whole
     /// ordered queue) before running — otherwise stop could land before a

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -387,7 +387,7 @@ enum RemoteServerMessage: Equatable, Sendable {
     case changeListFailed(sessionId: String, reason: RemoteFileAccessReason, message: String?)
     case fileDiffResult(sessionId: String, path: String, hunks: [RemoteDiffHunk], truncated: Bool)
     case fileDiffFailed(sessionId: String, path: String, reason: RemoteFileAccessReason, message: String?)
-    case fileTree(sessionId: String, path: String?, nodes: [RemoteFileNode])
+    case fileTree(sessionId: String, path: String?, nodes: [RemoteFileNode], truncated: Bool)
     case fileTreeFailed(sessionId: String, path: String?, reason: RemoteFileAccessReason, message: String?)
     case fileContents(sessionId: String, path: String, text: String, truncated: Bool)
     case fileUnavailable(
@@ -541,7 +541,8 @@ extension RemoteServerMessage: Codable {
             self = .fileTree(
                 sessionId: try c.decode(String.self, forKey: .sessionId),
                 path: try c.decodeIfPresent(String.self, forKey: .path),
-                nodes: try c.decode([RemoteFileNode].self, forKey: .nodes))
+                nodes: try c.decode([RemoteFileNode].self, forKey: .nodes),
+                truncated: try c.decodeIfPresent(Bool.self, forKey: .truncated) ?? false)
         case "fileTreeFailed":
             self = .fileTreeFailed(
                 sessionId: try c.decode(String.self, forKey: .sessionId),
@@ -707,11 +708,12 @@ extension RemoteServerMessage: Codable {
             try c.encode(path, forKey: .path)
             try c.encode(reason.rawValue, forKey: .reason)
             try c.encodeIfPresent(message, forKey: .message)
-        case .fileTree(let s, let path, let nodes):
+        case .fileTree(let s, let path, let nodes, let truncated):
             try c.encode("fileTree", forKey: .type)
             try c.encode(s, forKey: .sessionId)
             try c.encodeIfPresent(path, forKey: .path)
             try c.encode(nodes, forKey: .nodes)
+            try c.encode(truncated, forKey: .truncated)
         case .fileTreeFailed(let s, let path, let reason, let message):
             try c.encode("fileTreeFailed", forKey: .type)
             try c.encode(s, forKey: .sessionId)

--- a/Alas/Sources/Remote/Server/RemoteConnection.swift
+++ b/Alas/Sources/Remote/Server/RemoteConnection.swift
@@ -7,7 +7,8 @@ import CryptoKit
 /// bridges decoded client messages to a `RemoteSessionGateway`.
 ///
 /// Concurrency model: all mutable state (`inbound`, `isWebSocket`, `gateway`,
-/// `closed`, `isClosing`) is confined to the single serial `queue` the connection runs on.
+/// `closed`, `isClosing`, `inFlightFileRequests`) is confined to the single
+/// serial `queue` the connection runs on.
 /// `NWConnection` delivers every `receive`/`send` completion on that queue, so
 /// those callbacks touch state directly. Work that must reach ACP/pairing state
 /// (the responder/authorize/makeGateway closures) hops to `@MainActor`, and any
@@ -45,6 +46,13 @@ final class RemoteConnection: @unchecked Sendable {
     /// work (subscribe/fetchOlder/list*/etc). Mutated only on `queue`.
     private var lastDriveActionTail: Task<Void, Never>?
     private var lastDriveActionID: UUID?
+    /// Keys (`RemoteClientMessage.fileRequestDedupKey`) of file-request
+    /// verbs currently somewhere in `processingTail` — queued or running.
+    /// Checked and inserted in `dispatchMessage`, BEFORE a message enters
+    /// the ordered chain, so an exact duplicate is dropped immediately
+    /// rather than occupying its own serialized slot. Removed once that
+    /// message's `MessageProcessingTask` finishes. Mutated only on `queue`.
+    private var inFlightFileRequests: Set<String> = []
     /// Reassembles fragmented WebSocket messages before they're decoded.
     private var reassembler = WebSocketReassembler()
     /// The device this connection authenticated as, set on `queue` once the WS
@@ -352,11 +360,26 @@ final class RemoteConnection: @unchecked Sendable {
             }
             return
         }
+        let dedupKey = msg.fileRequestDedupKey
+        if let dedupKey, !inFlightFileRequests.insert(dedupKey).inserted {
+            // An identical file-request verb is already queued or running
+            // for this connection; dropping here (before the message ever
+            // reaches `processingTail`) is what actually prevents a burst of
+            // duplicates from each running their own git process in
+            // sequence — checking inside `gateway.handle` is too late, since
+            // this connection already serializes every message before it.
+            return
+        }
         let task = MessageProcessingTask(previous: processingTail)
         task.start(
             operation: { await gateway.handle(msg) },
             onFinish: { [weak self] id in
-                self?.onQueue { [weak self] in self?.finishProcessingTask(id: id) }
+                self?.onQueue { [weak self] in
+                    self?.finishProcessingTask(id: id)
+                    if let dedupKey {
+                        self?.inFlightFileRequests.remove(dedupKey)
+                    }
+                }
             }
         )
         processingTail = task

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -300,24 +300,14 @@ struct FilesTabView: View {
         showIgnored: Bool
     ) -> [FileTreeNode] {
         guard !showIgnored else { return nodes }
-        return nodes.compactMap { node in
-            let offGit = node.visibility == .ignored || node.visibility == .excluded
-            // Files: drop if ignored/excluded.
-            if node.kind == .file {
-                return offGit ? nil : node
-            }
-            // Directories: filter children first. An ignored directory may
-            // still contain tracked descendants (gitignore rules don't
-            // un-track a path that's already in the index), so we only drop
-            // the directory if it has no visible children left.
-            var copy = node
-            let visibleChildren = filteredNodes(node.children ?? [], showIgnored: showIgnored)
-            copy.children = visibleChildren
-            if offGit && visibleChildren.isEmpty {
-                return nil
-            }
-            return copy
-        }
+        // Directories: filter children first. An ignored directory may
+        // still contain tracked descendants (gitignore rules don't
+        // un-track a path that's already in the index), so we only drop
+        // the directory if it has no visible children left. Shared with
+        // `AppState.remoteFileNodes`, which needs the exact same
+        // recursive keep-if-has-visible-children behavior at the remote
+        // wire boundary.
+        return FileTreeNode.filteredKeepingVisibleDescendants(nodes)
     }
 
     nonisolated static func revealDisplayName(for path: String) -> String {

--- a/Alas/Sources/SSH/ACPRemoteFileServer.swift
+++ b/Alas/Sources/SSH/ACPRemoteFileServer.swift
@@ -31,9 +31,60 @@ enum RemotePathContainment {
         """
     }
 
+    /// Like `containmentProbeCommand`, but fully resolves the ENTIRE target
+    /// path (not just its parent) to its physical/canonical form and rejects
+    /// when any resulting path component, relative to the worktree's own
+    /// canonical root, case-insensitively equals `.git`.
+    ///
+    /// This closes a gap `containmentProbeCommand` alone does not: a
+    /// directory symlink alias to `.git` (e.g. `alias -> .git` inside the
+    /// worktree) physically resolves to a location that IS still under the
+    /// worktree root, so a request for `alias/config` passes plain
+    /// containment while actually serving `.git/config` — which can contain
+    /// remote URLs with embedded credentials.
+    ///
+    /// Exit codes: 0 = contained and outside `.git`; 3 = no existing
+    /// ancestor found; 4/5 = `cd`/`pwd -P` failed; 6 = resolves outside the
+    /// worktree root; 7 = resolves inside `.git`.
+    static func containmentExcludingGitProbeCommand(path: String, worktreeRoot: String) -> String {
+        let root = SSHCommand.shellQuote(worktreeRoot)
+        let target = SSHCommand.shellQuote(path)
+        return """
+        root=\(root); target=\(target); root_phys=$(cd "$root" && pwd -P) || exit 4; \
+        existing="$target"; tail=""; \
+        while [ ! -e "$existing" ]; do \
+        comp=$(basename "$existing"); \
+        if [ -z "$tail" ]; then tail="$comp"; else tail="$comp/$tail"; fi; \
+        next=$(dirname "$existing"); [ "$next" = "$existing" ] && exit 3; existing="$next"; \
+        done; \
+        if [ -d "$existing" ]; then existing_phys=$(cd "$existing" && pwd -P) || exit 5; else \
+        comp=$(basename "$existing"); existing=$(dirname "$existing"); \
+        if [ -z "$tail" ]; then tail="$comp"; else tail="$comp/$tail"; fi; \
+        existing_phys=$(cd "$existing" && pwd -P) || exit 5; \
+        fi; \
+        full_phys="$existing_phys"; [ -n "$tail" ] && full_phys="$existing_phys/$tail"; \
+        case "$full_phys" in \
+        "$root_phys") rel="" ;; \
+        "$root_phys"/*) rel=${full_phys#"$root_phys"/} ;; \
+        *) exit 6 ;; \
+        esac; \
+        rest="$rel"; \
+        while [ -n "$rest" ]; do \
+        case "$rest" in \
+        */*) comp=${rest%%/*}; rest=${rest#*/} ;; \
+        *) comp="$rest"; rest="" ;; \
+        esac; \
+        case "$comp" in .[Gg][Ii][Tt]) exit 7 ;; esac; \
+        done; \
+        exit 0
+        """
+    }
+
     static func verifyRemoteContainment(host: String, path: String, worktreeRoot: String) async throws {
         let target = try lexicallyResolveInsideWorktree(path: path, worktreeRoot: worktreeRoot)
-        let result = try await RemoteExec.run(host: host, cwd: nil, command: containmentProbeCommand(path: target, worktreeRoot: worktreeRoot))
+        let result = try await RemoteExec.run(
+            host: host, cwd: nil,
+            command: containmentExcludingGitProbeCommand(path: target, worktreeRoot: worktreeRoot))
         if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
             throw RemoteFileAccessError.connectionFailed(result.stderr)
         }

--- a/Alas/Sources/SSH/ACPRemoteFileServer.swift
+++ b/Alas/Sources/SSH/ACPRemoteFileServer.swift
@@ -253,11 +253,11 @@ enum RemotePathContainment {
     /// against the raw path a moment later, wide open to an intermediate
     /// directory being swapped for a symlink in between).
     ///
-    /// GNU-then-BSD fallback mirrors `RemoteFileStats.lsCommand`: GNU
-    /// coreutils' `--zero` emits NUL-separated entries so an embedded
-    /// newline in a filename can't fragment it; BSD `ls` (a remote macOS
-    /// host) has no such mode and falls back to plain newline-delimited
-    /// output.
+    /// Lists via `find -print0`, split into a directories batch and a files
+    /// batch by `RemoteFileStats.lsSplitMarker` — mirrors
+    /// `RemoteFileStats.lsCommand` (see its doc comment for why: `find
+    /// -print0` is NUL-safe on BOTH GNU findutils and BSD `find`, unlike
+    /// `ls`'s `--zero` mode, which BSD `ls` has no equivalent for at all).
     static func containedListScript(path: String, worktreeRoot: String) -> String {
         let probe = containmentExcludingGitProbeCommand(path: path, worktreeRoot: worktreeRoot)
         let probeWithoutFinalExit = probe.hasSuffix("exit 0")
@@ -265,7 +265,9 @@ enum RemotePathContainment {
             : probe
         return probeWithoutFinalExit + """
         [ -d "$full_phys" ] || exit 9; \
-        ls -1Ap --zero -- "$full_phys" 2>/dev/null || ls -1Ap -- "$full_phys"
+        find "$full_phys" -mindepth 1 -maxdepth 1 -type d -print0; \
+        printf '\\0\(RemoteFileStats.lsSplitMarker)\\0'; \
+        find "$full_phys" -mindepth 1 -maxdepth 1 ! -type d -print0
         """
     }
 

--- a/Alas/Sources/SSH/ACPRemoteFileServer.swift
+++ b/Alas/Sources/SSH/ACPRemoteFileServer.swift
@@ -196,6 +196,62 @@ enum RemotePathContainment {
             return .unreadable
         }
     }
+
+    /// Exit codes for `containedListScript`, layered on top of
+    /// `containmentExcludingGitProbeCommand`'s own 3/4/5/6/7: 9 = resolves
+    /// to something other than a directory.
+    enum ContainedListOutcome {
+        case ok(entries: [(name: String, isDirectory: Bool)])
+        case outsideWorktree
+        case notADirectory
+        case unreadable
+    }
+
+    /// Same one-script pattern as `containedReadScript`, for listing a
+    /// directory instead of reading a file: containment verification and the
+    /// listing itself reuse the SAME `full_phys` value, so there is no later,
+    /// separate `ls` invocation that re-resolves the path string from
+    /// scratch — which is exactly the gap a helperless SSH worktree's
+    /// directory expansion had (containment checked once, then a plain `ls`
+    /// against the raw path a moment later, wide open to an intermediate
+    /// directory being swapped for a symlink in between).
+    ///
+    /// GNU-then-BSD fallback mirrors `RemoteFileStats.lsCommand`: GNU
+    /// coreutils' `--zero` emits NUL-separated entries so an embedded
+    /// newline in a filename can't fragment it; BSD `ls` (a remote macOS
+    /// host) has no such mode and falls back to plain newline-delimited
+    /// output.
+    static func containedListScript(path: String, worktreeRoot: String) -> String {
+        let probe = containmentExcludingGitProbeCommand(path: path, worktreeRoot: worktreeRoot)
+        let probeWithoutFinalExit = probe.hasSuffix("exit 0")
+            ? String(probe.dropLast("exit 0".count))
+            : probe
+        return probeWithoutFinalExit + """
+        [ -d "$full_phys" ] || exit 9; \
+        ls -1Ap --zero -- "$full_phys" 2>/dev/null || ls -1Ap -- "$full_phys"
+        """
+    }
+
+    /// Runs `containedListScript` over one `RemoteExec.run` round trip.
+    static func containedList(host: String, path: String, worktreeRoot: String) async throws -> ContainedListOutcome {
+        let target = try lexicallyResolveInsideWorktree(path: path, worktreeRoot: worktreeRoot)
+        let result = try await RemoteExec.run(
+            host: host, cwd: nil,
+            command: containedListScript(path: target, worktreeRoot: worktreeRoot))
+        if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
+            throw RemoteFileAccessError.connectionFailed(result.stderr)
+        }
+        switch result.exitCode {
+        case 0:
+            return .ok(entries: RemoteFileStats.parseLsEntries(result.stdout))
+        case 6, 7:
+            return .outsideWorktree
+        case 9:
+            return .notADirectory
+        default:
+            return .unreadable
+        }
+    }
 }
 
 /// Remote ACP file serving uses lexical containment first, then a remote

--- a/Alas/Sources/SSH/ACPRemoteFileServer.swift
+++ b/Alas/Sources/SSH/ACPRemoteFileServer.swift
@@ -97,7 +97,9 @@ enum RemotePathContainment {
     /// `containmentExcludingGitProbeCommand`'s own 3/4/5/6/7 (see that
     /// function's doc comment): 8 = resolves to a symlink; 9 = resolves to a
     /// directory; 10 = resolves to something that no longer exists by the
-    /// time the read runs; 11 = `stat` on the resolved path failed.
+    /// time the read runs; 11 = `stat` on the resolved path failed; 12 =
+    /// resolves to something other than a regular file (a FIFO, socket, or
+    /// device — reading one of these would otherwise block indefinitely).
     enum ContainedReadOutcome: Equatable {
         case ok(byteSize: Int, prefix: Data)
         case outsideWorktree
@@ -160,10 +162,18 @@ enum RemotePathContainment {
         // against `maxBytes` — ground truth from this read, not a
         // point-in-time stat — to decide whether to report the file as too
         // large regardless of what the header claims.
+        //
+        // `[ -f ]` rejects anything that isn't a regular file — in
+        // particular a FIFO, which passes every check above it (not a
+        // symlink, not a directory, exists) and then blocks `head`
+        // indefinitely waiting for a writer that will never come, stalling
+        // this request (and, since the connection serializes messages, every
+        // later one) until the process watchdog eventually kills it.
         return probeWithoutFinalExit + """
         [ -L "$full_phys" ] && exit 8; \
         [ -d "$full_phys" ] && exit 9; \
         [ -e "$full_phys" ] || exit 10; \
+        [ -f "$full_phys" ] || exit 12; \
         size=$(stat -c %s -- "$full_phys" 2>/dev/null || stat -f %z "$full_phys") || exit 11; \
         echo "$size"; \
         head -c \(maxBytes + 1) "$full_phys"

--- a/Alas/Sources/SSH/ACPRemoteFileServer.swift
+++ b/Alas/Sources/SSH/ACPRemoteFileServer.swift
@@ -151,13 +151,22 @@ enum RemotePathContainment {
         let probeWithoutFinalExit = probe.hasSuffix("exit 0")
             ? String(probe.dropLast("exit 0".count))
             : probe
+        // Reads ONE byte past `maxBytes`: `stat`'s size header can go stale
+        // if the file grows between it and this `head` call (a concurrently
+        // running remote process, e.g. the very agent whose worktree this
+        // is), and trusting that header alone would let a genuinely
+        // oversized-by-then file slip through as a "complete" `maxBytes`
+        // read. `containedRead` compares the ACTUAL byte count transferred
+        // against `maxBytes` — ground truth from this read, not a
+        // point-in-time stat — to decide whether to report the file as too
+        // large regardless of what the header claims.
         return probeWithoutFinalExit + """
         [ -L "$full_phys" ] && exit 8; \
         [ -d "$full_phys" ] && exit 9; \
         [ -e "$full_phys" ] || exit 10; \
         size=$(stat -c %s -- "$full_phys" 2>/dev/null || stat -f %z "$full_phys") || exit 11; \
         echo "$size"; \
-        head -c \(maxBytes) "$full_phys"
+        head -c \(maxBytes + 1) "$full_phys"
         """
     }
 
@@ -174,15 +183,33 @@ enum RemotePathContainment {
         if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
             throw RemoteFileAccessError.connectionFailed(result.stderr)
         }
-        switch result.exitCode {
+        return parseContainedReadResult(exitCode: result.exitCode, stdout: result.stdout, maxBytes: maxBytes)
+    }
+
+    /// Pure parsing half of `containedRead`, split out so the
+    /// stat-vs-actual-size reconciliation (the fix for the file-grew-during-
+    /// read race described on `containedReadScript`) is directly testable
+    /// against a synthetic transcript, without a real SSH round trip.
+    static func parseContainedReadResult(exitCode: Int32, stdout: Data, maxBytes: Int) -> ContainedReadOutcome {
+        switch exitCode {
         case 0:
-            guard let newline = result.stdout.firstIndex(of: UInt8(ascii: "\n")),
-                  let header = String(data: result.stdout[result.stdout.startIndex..<newline], encoding: .utf8),
+            guard let newline = stdout.firstIndex(of: UInt8(ascii: "\n")),
+                  let header = String(data: stdout[stdout.startIndex..<newline], encoding: .utf8),
                   let byteSize = Int(header.trimmingCharacters(in: .whitespaces))
             else {
                 return .unreadable
             }
-            let body = Data(result.stdout[result.stdout.index(after: newline)...])
+            let body = Data(stdout[stdout.index(after: newline)...])
+            // More than `maxBytes` actually came back — `containedReadScript`
+            // reads one extra byte specifically to catch this: the file grew
+            // past `maxBytes` between `stat` and `head` inside the script, so
+            // the earlier `byteSize` header is stale. Report the size as
+            // definitely over the cap (regardless of what the header said) so
+            // the caller's own size gate rejects it, rather than serving a
+            // truncated prefix as if it were the file's complete contents.
+            guard body.count <= maxBytes else {
+                return .ok(byteSize: max(byteSize, maxBytes + 1), prefix: body.prefix(maxBytes))
+            }
             return .ok(byteSize: byteSize, prefix: body)
         case 6, 7:
             return .outsideWorktree

--- a/Alas/Sources/SSH/ACPRemoteFileServer.swift
+++ b/Alas/Sources/SSH/ACPRemoteFileServer.swift
@@ -92,6 +92,110 @@ enum RemotePathContainment {
             throw ContainmentError.outsideWorktree(path)
         }
     }
+
+    /// Exit codes for `containedReadScript`, layered on top of
+    /// `containmentExcludingGitProbeCommand`'s own 3/4/5/6/7 (see that
+    /// function's doc comment): 8 = resolves to a symlink; 9 = resolves to a
+    /// directory; 10 = resolves to something that no longer exists by the
+    /// time the read runs; 11 = `stat` on the resolved path failed.
+    enum ContainedReadOutcome: Equatable {
+        case ok(byteSize: Int, prefix: Data)
+        case outsideWorktree
+        case symlink
+        case directory
+        case missing
+        case unreadable
+    }
+
+    /// Combines containment verification and a bounded content read into a
+    /// SINGLE remote script, so there is only one round trip — and, more
+    /// importantly, only one PATH RESOLUTION — between "is this path
+    /// contained" and "read its bytes".
+    ///
+    /// `containmentExcludingGitProbeCommand` alone resolves `path` to its
+    /// canonical, physical form (`full_phys`) purely to answer a yes/no
+    /// containment question; a caller that then wants the file's contents
+    /// has historically made a SEPARATE round trip (`RemoteFileAccess.size`
+    /// then `.read`), each of which re-resolves the same path STRING from
+    /// scratch via its own `[ -L "$f" ]` / `cat`/`head` invocation. Between
+    /// those round trips, a concurrently-running remote process can swap a
+    /// path component for a symlink: the containment check saw a safe path,
+    /// but the later read re-resolves the (now poisoned) string independently
+    /// and can escape the worktree.
+    ///
+    /// This script closes that gap by reusing the SAME `full_phys` value —
+    /// computed once, physically resolved via `cd ... && pwd -P` — for both
+    /// the containment/`.git`-exclusion check AND the subsequent symlink/
+    /// directory/existence checks and the bounded `head -c` read. Nothing
+    /// after the initial resolution re-resolves `path` by string.
+    ///
+    /// Residual risk: this is one shell script, but still several distinct
+    /// system calls (`stat`, `head`) against `$full_phys` in sequence, not a
+    /// single atomic kernel operation — a component of `$full_phys` could in
+    /// principle still be swapped between, say, the `[ -L ]` check and the
+    /// `head -c` call. That window is now a handful of shell builtins deep
+    /// inside one non-interactive ssh invocation (sub-millisecond on a
+    /// healthy connection) rather than the full duration of a separate
+    /// round trip (network latency plus whatever else runs between the two
+    /// calls on the Swift side) — a substantial, but not perfect,
+    /// narrowing. A fully atomic remote primitive would require a small
+    /// remote-side helper program doing `openat`-per-component plus
+    /// `O_NOFOLLOW`, which is out of scope here.
+    static func containedReadScript(path: String, worktreeRoot: String, maxBytes: Int) -> String {
+        let probe = containmentExcludingGitProbeCommand(path: path, worktreeRoot: worktreeRoot)
+        // `containmentExcludingGitProbeCommand` ends in `exit 0` on success
+        // with `$full_phys` holding the resolved, contained, non-`.git`
+        // path. Splice the read logic in place of that final `exit 0` so it
+        // runs in the SAME shell, against the SAME `full_phys` variable,
+        // rather than a separate script/round trip.
+        let probeWithoutFinalExit = probe.hasSuffix("exit 0")
+            ? String(probe.dropLast("exit 0".count))
+            : probe
+        return probeWithoutFinalExit + """
+        [ -L "$full_phys" ] && exit 8; \
+        [ -d "$full_phys" ] && exit 9; \
+        [ -e "$full_phys" ] || exit 10; \
+        size=$(stat -c %s -- "$full_phys" 2>/dev/null || stat -f %z "$full_phys") || exit 11; \
+        echo "$size"; \
+        head -c \(maxBytes) "$full_phys"
+        """
+    }
+
+    /// Runs `containedReadScript` over one `RemoteExec.runData` round trip.
+    /// Only ever transfers up to `maxBytes` of the file's body regardless of
+    /// its actual size — `head -c` stops the remote `head` process itself,
+    /// so an oversized file never gets fully read remotely just to be told
+    /// "too large".
+    static func containedRead(host: String, path: String, worktreeRoot: String, maxBytes: Int) async throws -> ContainedReadOutcome {
+        let target = try lexicallyResolveInsideWorktree(path: path, worktreeRoot: worktreeRoot)
+        let result = try await RemoteExec.runData(
+            host: host, cwd: nil,
+            command: containedReadScript(path: target, worktreeRoot: worktreeRoot, maxBytes: maxBytes))
+        if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
+            throw RemoteFileAccessError.connectionFailed(result.stderr)
+        }
+        switch result.exitCode {
+        case 0:
+            guard let newline = result.stdout.firstIndex(of: UInt8(ascii: "\n")),
+                  let header = String(data: result.stdout[result.stdout.startIndex..<newline], encoding: .utf8),
+                  let byteSize = Int(header.trimmingCharacters(in: .whitespaces))
+            else {
+                return .unreadable
+            }
+            let body = Data(result.stdout[result.stdout.index(after: newline)...])
+            return .ok(byteSize: byteSize, prefix: body)
+        case 6, 7:
+            return .outsideWorktree
+        case 8:
+            return .symlink
+        case 9:
+            return .directory
+        case 10:
+            return .missing
+        default:
+            return .unreadable
+        }
+    }
 }
 
 /// Remote ACP file serving uses lexical containment first, then a remote

--- a/Alas/Sources/SSH/RemoteFileAccess.swift
+++ b/Alas/Sources/SSH/RemoteFileAccess.swift
@@ -312,6 +312,52 @@ enum RemoteFileAccess {
         }
     }
 
+    /// Returns nil when the target does not exist (or size could not be
+    /// determined). Throws only for an ssh connection failure. Mirrors
+    /// `mtime`'s helper-first, exec-fallback structure so a caller can
+    /// reject an oversized remote file BEFORE transferring its bytes —
+    /// see `AppState.readRemoteWorktreeFileRaw`.
+    static func size(host: String, path: String) async throws -> UInt64? {
+        if await helperIsInstalled(host: host) {
+            let startedAt = CFAbsoluteTimeGetCurrent()
+            do {
+                let client = await RemoteHelperClientPool.shared.client(for: host)
+                let result = try await client.stat(paths: [path])
+                RemoteOperationTiming.log("fs/stat", host: host, transport: "helper", startedAt: startedAt)
+                guard let entry = result.entries.first, entry.exists else { return nil }
+                return entry.size
+            } catch let error as RemoteHelperClientError where !error.shouldFallbackToRemoteExec {
+                RemoteOperationTiming.log("fs/stat", host: host, transport: "helper", startedAt: startedAt)
+                return nil
+            } catch {
+                RemoteOperationTiming.log("fs/stat", host: host, transport: "helper-fallback", startedAt: startedAt)
+            }
+        }
+        return try await sizeViaExec(host: host, path: path)
+    }
+
+    /// Chained GNU-then-BSD byte-size probe, mirroring `statMtime`'s
+    /// GNU/BSD-`stat` fallback pattern. Exposed (not `private`) so tests can
+    /// exercise the exact script text locally via `sh -c`, the same seam
+    /// `readScript`/`writeScript` already provide.
+    static func sizeScript(path: String) -> String {
+        let f = SSHCommand.shellQuote(path)
+        return "f=\(f); stat -c %s -- \"$f\" 2>/dev/null || stat -f %z \"$f\""
+    }
+
+    private static func sizeViaExec(host: String, path: String) async throws -> UInt64? {
+        let startedAt = CFAbsoluteTimeGetCurrent()
+        defer { RemoteOperationTiming.log("fs/stat", host: host, transport: "exec", startedAt: startedAt) }
+        let result = try await RemoteExec.run(host: host, cwd: nil, command: sizeScript(path: path))
+        if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
+            throw RemoteFileAccessError.connectionFailed(result.stderr)
+        }
+        guard result.exitCode == 0,
+              let bytes = UInt64(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines))
+        else { return nil }
+        return bytes
+    }
+
     private static func mtimeViaExec(host: String, path: String) async throws -> Date? {
         let startedAt = CFAbsoluteTimeGetCurrent()
         defer { RemoteOperationTiming.log("fs/stat", host: host, transport: "exec", startedAt: startedAt) }

--- a/Alas/Sources/SSH/RemoteFileAccess.swift
+++ b/Alas/Sources/SSH/RemoteFileAccess.swift
@@ -127,6 +127,45 @@ enum RemoteFileAccess {
         }
     }
 
+    /// Bounded-prefix variant of `readScript`: reads only the first
+    /// `maxBytes` bytes via `head -c` instead of the whole file (`cat`).
+    /// Mirrors `readScript`'s exact quoting and exit-code conventions
+    /// (0 = readable, 3 = directory, 4 = missing, 5 = symlink) so it can
+    /// share `readViaExec`'s result mapping — this is the exec-only
+    /// counterpart to a helper-RPC bounded read, which doesn't exist: the
+    /// filesystem/v0.4 `fs/read` contract (`RemoteHelperProtocol.swift`)
+    /// only accepts an `offset`, not a byte cap.
+    ///
+    /// Used only for binary sniffing ahead of a diff
+    /// (`AppState.isDiffTargetBinary`), never to serve real file contents —
+    /// callers that need the whole file still go through `read(host:path:)`.
+    static func readPrefixScript(path: String, maxBytes: Int) -> String {
+        "f=\(SSHCommand.shellQuote(path)); "
+            + "[ -L \"$f\" ] && exit 5; "
+            + "[ -d \"$f\" ] && exit 3; "
+            + "[ -e \"$f\" ] || exit 4; "
+            + "head -c \(maxBytes) \"$f\""
+    }
+
+    /// Returns the first `maxBytes` bytes of the remote file at `path` over
+    /// exec, or nil when it's missing, a directory, a symlink, or otherwise
+    /// unreadable. There is no on-disk size check here (unlike `read`) —
+    /// the whole point is a bounded read that never needs to know the
+    /// file's total size.
+    static func readPrefix(host: String, path: String, maxBytes: Int) async throws -> Data? {
+        let startedAt = CFAbsoluteTimeGetCurrent()
+        defer { RemoteOperationTiming.log("fs/readPrefix", host: host, transport: "exec", startedAt: startedAt) }
+        let result = try await RemoteExec.runData(
+            host: host,
+            cwd: nil,
+            command: readPrefixScript(path: path, maxBytes: maxBytes)
+        )
+        if RemoteExec.isConnectionFailure(exitCode: result.exitCode) {
+            throw RemoteFileAccessError.connectionFailed(result.stderr)
+        }
+        return result.exitCode == 0 ? result.stdout : nil
+    }
+
     private static func readViaExec(host: String, path: String) async throws -> RemoteReadResult {
         let startedAt = CFAbsoluteTimeGetCurrent()
         defer { RemoteOperationTiming.log("fs/read", host: host, transport: "exec", startedAt: startedAt) }

--- a/Alas/Sources/SSH/RemoteFileStats.swift
+++ b/Alas/Sources/SSH/RemoteFileStats.swift
@@ -7,11 +7,31 @@ enum RemoteFileStats {
 
     static func wcCommand(paths: [String]) -> String? {
         guard !paths.isEmpty else { return nil }
-        // `--` stops a filename starting with `-` (e.g. `-c`, `-L`) from
-        // being parsed as a `wc` OPTION instead of a filename argument,
-        // which would silently drop that file from the output (and so
-        // silently report 0 for its line count).
-        return "wc -l -- " + paths.map(SSHCommand.shellQuote).joined(separator: " ")
+        // Plain `wc -l` counts newline BYTES, which undercounts a nonempty
+        // file whose final line has no trailing newline by one — git's
+        // numstat and the local `addedLineCount` diff-parsing logic both
+        // count that trailing partial line, so a one-line file with no
+        // trailing newline has a line count of 1, not 0. Loop per file
+        // (still a single remote exec round trip) so each raw `wc -l`
+        // count is corrected: a nonempty file whose last byte isn't `\n`
+        // gets +1.
+        //
+        // The trailing-newline check pipes `tail -c1` into `wc -l` rather
+        // than comparing a captured shell string, so an embedded NUL as
+        // the file's final byte — which a shell variable can't hold intact
+        // — is still classified correctly: `wc -l` just counts newline
+        // bytes piped to it, unaffected by NUL truncation.
+        //
+        // `--` (on both `wc` and `tail`) stops a filename starting with
+        // `-` (e.g. `-c`, `-L`) from being parsed as an OPTION instead of
+        // a filename argument, which would silently drop that file from
+        // the output (and so silently report 0 for its line count).
+        return paths.map { path in
+            let quoted = SSHCommand.shellQuote(path)
+            return "n=$(wc -l < \(quoted)); " +
+                "if [ -s \(quoted) ] && [ \"$(tail -c1 -- \(quoted) | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; " +
+                "printf '%s %s\\n' \"$n\" \(quoted)"
+        }.joined(separator: "; ")
     }
 
     static func parseWcOutput(_ output: String, requested: [String]) -> [String: Int] {

--- a/Alas/Sources/SSH/RemoteFileStats.swift
+++ b/Alas/Sources/SSH/RemoteFileStats.swift
@@ -3,10 +3,12 @@ import OSLog
 
 enum RemoteFileStatsError: Error, LocalizedError {
     case directoryListingFailed(path: String)
+    case lineCountBatchFailed
 
     var errorDescription: String? {
         switch self {
         case let .directoryListingFailed(path): "Could not list remote directory: \(path)"
+        case .lineCountBatchFailed: "Could not count lines for one or more remote files"
         }
     }
 }
@@ -71,7 +73,14 @@ enum RemoteFileStats {
         }
     }
 
-    static func lineCounts(host: String, cwd: String, paths: [String]) async -> [String: Int] {
+    /// Throws rather than silently returning a partial (or empty)
+    /// dictionary on failure: a caller (`GitService.status`,
+    /// `changedFilesAgainstRef`) that can't tell "no lines" from "the count
+    /// is simply unknown" defaults every missing path to `0` and reports a
+    /// successful change list with wrong addition totals for whichever
+    /// files happened to fall in a failed batch, instead of propagating the
+    /// failure as `changeListFailed`.
+    static func lineCounts(host: String, cwd: String, paths: [String]) async throws -> [String: Int] {
         guard !paths.isEmpty else { return [:] }
         if await RemoteHostCapabilityStore.shared.capabilities(for: host)?.helperHandshake != nil {
             let startedAt = CFAbsoluteTimeGetCurrent()
@@ -83,7 +92,7 @@ enum RemoteFileStats {
             } catch let error as RemoteHelperClientError where !error.shouldFallbackToRemoteExec {
                 RemoteOperationTiming.log("fs/line-counts", host: host, transport: "helper", startedAt: startedAt)
                 logger.debug("helper line counts failed: \(String(describing: error), privacy: .public)")
-                return [:]
+                throw error
             } catch {
                 RemoteOperationTiming.log("fs/line-counts", host: host, transport: "helper-fallback", startedAt: startedAt)
             }
@@ -96,15 +105,19 @@ enum RemoteFileStats {
         // for every untracked file beyond it, even though the caller's own
         // response cap (`RemoteWorktreeFileAccess.maxChangedFiles`, well
         // above `maxBatchedPaths`) still includes and displays them. Chunk
-        // into batches instead, one remote round trip per batch, and merge.
+        // into batches instead, one remote round trip per batch, and merge
+        // — throwing (rather than skipping) the first batch that fails, so
+        // a transient failure on, say, the third of five batches doesn't
+        // silently zero out just those paths.
         let startedAt = CFAbsoluteTimeGetCurrent()
         defer { RemoteOperationTiming.log("fs/line-counts", host: host, transport: "exec", startedAt: startedAt) }
         var counts: [String: Int] = [:]
         for chunk in Self.batches(paths) {
-            guard let command = wcCommand(paths: chunk),
-                  let result = try? await RemoteExec.run(host: host, cwd: cwd, command: command),
-                  !RemoteExec.isConnectionFailure(exitCode: result.exitCode)
-            else { continue }
+            guard let command = wcCommand(paths: chunk) else { continue }
+            let result = try await RemoteExec.run(host: host, cwd: cwd, command: command)
+            guard !RemoteExec.isConnectionFailure(exitCode: result.exitCode) else {
+                throw RemoteFileStatsError.lineCountBatchFailed
+            }
             counts.merge(parseWcOutput(result.stdout, requested: chunk)) { _, new in new }
         }
         return counts

--- a/Alas/Sources/SSH/RemoteFileStats.swift
+++ b/Alas/Sources/SSH/RemoteFileStats.swift
@@ -78,7 +78,13 @@ enum RemoteFileStats {
         return parseWcOutput(result.stdout, requested: fallbackPaths)
     }
 
-    static func directoryEntries(host: String, path: String) async -> [(name: String, isDirectory: Bool)] {
+    /// `worktreeRoot` is only used by the helperless exec fallback, to make
+    /// containment verification and the listing itself a single remote
+    /// script (`RemotePathContainment.containedList`) rather than two
+    /// separate round trips racing an intermediate symlink swap between
+    /// them. The helper path doesn't need it: the persistent helper already
+    /// enforces containment server-side against its own subscribed root.
+    static func directoryEntries(host: String, worktreeRoot: String, path: String) async -> [(name: String, isDirectory: Bool)] {
         if await RemoteHostCapabilityStore.shared.capabilities(for: host)?.helperHandshake != nil {
             let startedAt = CFAbsoluteTimeGetCurrent()
             do {
@@ -97,12 +103,10 @@ enum RemoteFileStats {
 
         let startedAt = CFAbsoluteTimeGetCurrent()
         defer { RemoteOperationTiming.log("fs/list", host: host, transport: "exec", startedAt: startedAt) }
-        guard let result = try? await RemoteExec.run(
-            host: host,
-            cwd: nil,
-            command: lsCommand(path: path)
-        ), result.exitCode == 0 else { return [] }
-        return parseLsEntries(result.stdout)
+        guard let outcome = try? await RemotePathContainment.containedList(host: host, path: path, worktreeRoot: worktreeRoot),
+              case let .ok(entries) = outcome
+        else { return [] }
+        return entries
     }
 
     /// GNU-then-BSD `ls` invocation, chained the same way `statMtime` chains

--- a/Alas/Sources/SSH/RemoteFileStats.swift
+++ b/Alas/Sources/SSH/RemoteFileStats.swift
@@ -15,6 +15,17 @@ enum RemoteFileStats {
     private static let logger = Logger(subsystem: "app.alas", category: "RemoteFileStats")
     static let maxBatchedPaths = 200
 
+    /// Splits `paths` into `maxBatchedPaths`-sized chunks, in order —
+    /// extracted so the chunk boundaries themselves (e.g. that 450 paths
+    /// become 200/200/50, not silently truncated to the first 200) are
+    /// directly unit-testable without a real remote exec call.
+    static func batches(_ paths: [String]) -> [[String]] {
+        guard !paths.isEmpty else { return [] }
+        return stride(from: 0, to: paths.count, by: maxBatchedPaths).map {
+            Array(paths[$0 ..< min($0 + maxBatchedPaths, paths.count)])
+        }
+    }
+
     static func wcCommand(paths: [String]) -> String? {
         guard !paths.isEmpty else { return nil }
         // Plain `wc -l` counts newline BYTES, which undercounts a nonempty
@@ -78,14 +89,25 @@ enum RemoteFileStats {
             }
         }
 
-        let fallbackPaths = Array(paths.prefix(maxBatchedPaths))
+        // `maxBatchedPaths` bounds a single remote command line's length,
+        // not how many paths this function can ever count — silently
+        // dropping everything past the first batch (as a single
+        // `paths.prefix(maxBatchedPaths)` call used to) would report `0`
+        // for every untracked file beyond it, even though the caller's own
+        // response cap (`RemoteWorktreeFileAccess.maxChangedFiles`, well
+        // above `maxBatchedPaths`) still includes and displays them. Chunk
+        // into batches instead, one remote round trip per batch, and merge.
         let startedAt = CFAbsoluteTimeGetCurrent()
         defer { RemoteOperationTiming.log("fs/line-counts", host: host, transport: "exec", startedAt: startedAt) }
-        guard let command = wcCommand(paths: fallbackPaths),
-              let result = try? await RemoteExec.run(host: host, cwd: cwd, command: command),
-              !RemoteExec.isConnectionFailure(exitCode: result.exitCode)
-        else { return [:] }
-        return parseWcOutput(result.stdout, requested: fallbackPaths)
+        var counts: [String: Int] = [:]
+        for chunk in Self.batches(paths) {
+            guard let command = wcCommand(paths: chunk),
+                  let result = try? await RemoteExec.run(host: host, cwd: cwd, command: command),
+                  !RemoteExec.isConnectionFailure(exitCode: result.exitCode)
+            else { continue }
+            counts.merge(parseWcOutput(result.stdout, requested: chunk)) { _, new in new }
+        }
+        return counts
     }
 
     /// `worktreeRoot` is only used by the helperless exec fallback, to make

--- a/Alas/Sources/SSH/RemoteFileStats.swift
+++ b/Alas/Sources/SSH/RemoteFileStats.swift
@@ -1,6 +1,16 @@
 import Foundation
 import OSLog
 
+enum RemoteFileStatsError: Error, LocalizedError {
+    case directoryListingFailed(path: String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .directoryListingFailed(path): "Could not list remote directory: \(path)"
+        }
+    }
+}
+
 enum RemoteFileStats {
     private static let logger = Logger(subsystem: "app.alas", category: "RemoteFileStats")
     static let maxBatchedPaths = 200
@@ -84,7 +94,14 @@ enum RemoteFileStats {
     /// separate round trips racing an intermediate symlink swap between
     /// them. The helper path doesn't need it: the persistent helper already
     /// enforces containment server-side against its own subscribed root.
-    static func directoryEntries(host: String, worktreeRoot: String, path: String) async -> [(name: String, isDirectory: Bool)] {
+    /// Throws rather than returning `[]` on failure: a directory that
+    /// genuinely has no entries and a directory whose listing FAILED (a
+    /// dropped connection, a helper error, containment rejection) look
+    /// identical to a caller that only sees an empty array — which
+    /// `fileTreeChildren` (and, through it, `remoteFileTree`) previously
+    /// turned into a misleadingly "successful" empty directory instead of
+    /// `fileTreeFailed`.
+    static func directoryEntries(host: String, worktreeRoot: String, path: String) async throws -> [(name: String, isDirectory: Bool)] {
         if await RemoteHostCapabilityStore.shared.capabilities(for: host)?.helperHandshake != nil {
             let startedAt = CFAbsoluteTimeGetCurrent()
             do {
@@ -95,7 +112,7 @@ enum RemoteFileStats {
             } catch let error as RemoteHelperClientError where !error.shouldFallbackToRemoteExec {
                 RemoteOperationTiming.log("fs/list", host: host, transport: "helper", startedAt: startedAt)
                 logger.debug("helper directory listing failed: \(String(describing: error), privacy: .public)")
-                return []
+                throw error
             } catch {
                 RemoteOperationTiming.log("fs/list", host: host, transport: "helper-fallback", startedAt: startedAt)
             }
@@ -103,10 +120,14 @@ enum RemoteFileStats {
 
         let startedAt = CFAbsoluteTimeGetCurrent()
         defer { RemoteOperationTiming.log("fs/list", host: host, transport: "exec", startedAt: startedAt) }
-        guard let outcome = try? await RemotePathContainment.containedList(host: host, path: path, worktreeRoot: worktreeRoot),
-              case let .ok(entries) = outcome
-        else { return [] }
-        return entries
+        switch try await RemotePathContainment.containedList(host: host, path: path, worktreeRoot: worktreeRoot) {
+        case .ok(let entries):
+            return entries
+        case .outsideWorktree:
+            throw RemotePathContainment.ContainmentError.outsideWorktree(path)
+        case .notADirectory, .unreadable:
+            throw RemoteFileStatsError.directoryListingFailed(path: path)
+        }
     }
 
     /// GNU-then-BSD `ls` invocation, chained the same way `statMtime` chains

--- a/Alas/Sources/SSH/RemoteFileStats.swift
+++ b/Alas/Sources/SSH/RemoteFileStats.swift
@@ -49,20 +49,37 @@ enum RemoteFileStats {
         // `-` (e.g. `-c`, `-L`) from being parsed as an OPTION instead of
         // a filename argument, which would silently drop that file from
         // the output (and so silently report 0 for its line count).
+        //
+        // Records are NUL-terminated, not newline-terminated: an untracked
+        // filename containing an embedded newline byte is emitted VERBATIM
+        // here (this is the raw path, not a git-escaped rendering of it),
+        // and a newline-delimited record would fragment that one file's
+        // "<count> <path>" line into two, losing the path→count
+        // association entirely (silently reporting `0` for that file
+        // instead). NUL can't appear in a POSIX path, so it's a safe
+        // separator regardless of what bytes the path itself contains.
         return paths.map { path in
             let quoted = SSHCommand.shellQuote(path)
             return "n=$(wc -l < \(quoted)); " +
                 "if [ -s \(quoted) ] && [ \"$(tail -c1 -- \(quoted) | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; " +
-                "printf '%s %s\\n' \"$n\" \(quoted)"
+                "printf '%s %s\\0' \"$n\" \(quoted)"
         }.joined(separator: "; ")
     }
 
     static func parseWcOutput(_ output: String, requested: [String]) -> [String: Int] {
         let requested = Set(requested)
-        return output.split(separator: "\n").reduce(into: [:]) { counts, line in
-            let line = line.trimmingCharacters(in: .whitespaces)
-            guard let separator = line.firstIndex(of: " "), let count = Int(line[..<separator]) else { return }
-            let path = String(line[line.index(after: separator)...])
+        return output.split(separator: "\u{0}", omittingEmptySubsequences: true).reduce(into: [:]) { counts, rawRecord in
+            // Drop LEADING whitespace only — `wc -l`'s own count is
+            // right-justified with padding spaces (`n=$(wc -l < file)`
+            // captures those verbatim; command substitution only strips
+            // TRAILING newlines). The path segment must stay untouched:
+            // trimming it too would corrupt a legitimate filename that
+            // itself starts or ends with whitespace.
+            let record = rawRecord.drop { $0 == " " }
+            guard let separator = record.firstIndex(of: " "),
+                  let count = Int(record[record.startIndex..<separator])
+            else { return }
+            let path = String(record[record.index(after: separator)...])
             if requested.contains(path) { counts[path] = count }
         }
     }

--- a/Alas/Sources/SSH/RemoteFileStats.swift
+++ b/Alas/Sources/SSH/RemoteFileStats.swift
@@ -7,7 +7,11 @@ enum RemoteFileStats {
 
     static func wcCommand(paths: [String]) -> String? {
         guard !paths.isEmpty else { return nil }
-        return "wc -l " + paths.map(SSHCommand.shellQuote).joined(separator: " ")
+        // `--` stops a filename starting with `-` (e.g. `-c`, `-L`) from
+        // being parsed as a `wc` OPTION instead of a filename argument,
+        // which would silently drop that file from the output (and so
+        // silently report 0 for its line count).
+        return "wc -l -- " + paths.map(SSHCommand.shellQuote).joined(separator: " ")
     }
 
     static func parseWcOutput(_ output: String, requested: [String]) -> [String: Int] {
@@ -76,13 +80,43 @@ enum RemoteFileStats {
         guard let result = try? await RemoteExec.run(
             host: host,
             cwd: nil,
-            command: "ls -1Ap " + SSHCommand.shellQuote(path)
+            command: lsCommand(path: path)
         ), result.exitCode == 0 else { return [] }
         return parseLsEntries(result.stdout)
     }
 
+    /// GNU-then-BSD `ls` invocation, chained the same way `statMtime` chains
+    /// GNU-then-BSD `stat` above: GNU coreutils' `ls --zero` emits
+    /// NUL-separated entries so a filename containing an embedded newline
+    /// byte doesn't fragment into bogus extra entries when parsed — this
+    /// mirrors the NUL-delimited fix already applied to the root Files-tree
+    /// listing source (`GitService.gitVisibleFilePaths`'s `git ls-files -z`),
+    /// which this exec-fallback directory listing (used for expanding a
+    /// directory on a helperless SSH host) hadn't been touched by.
+    ///
+    /// BSD `ls` (a remote macOS host) has no NUL-delimited output mode at
+    /// all, so this falls back to ordinary newline-delimited output there —
+    /// a residual, narrower gap: a directory name containing an embedded
+    /// newline byte can still fragment when listed via exec on a BSD/macOS
+    /// remote host specifically. A host with the persistent helper
+    /// installed never hits this at all (it lists via a JSON-safe RPC
+    /// instead, where an embedded newline in a name is just another JSON
+    /// string byte); this only matters for a helperless remote macOS host,
+    /// which is expected to be rare.
+    static func lsCommand(path: String) -> String {
+        let quoted = SSHCommand.shellQuote(path)
+        return "ls -1Ap --zero -- \(quoted) 2>/dev/null || ls -1Ap -- \(quoted)"
+    }
+
+    /// Parses `lsCommand`'s output. Detects which branch of the GNU/BSD
+    /// fallback actually ran by checking for an embedded NUL byte — a
+    /// legitimate filename can never itself contain one on a POSIX
+    /// filesystem, so its presence unambiguously means the NUL-delimited
+    /// (GNU) branch produced this output rather than the newline-delimited
+    /// (BSD) fallback.
     static func parseLsEntries(_ output: String) -> [(name: String, isDirectory: Bool)] {
-        output.split(separator: "\n").map {
+        let separator: Character = output.contains("\0") ? "\0" : "\n"
+        return output.split(separator: separator).map {
             let name = String($0)
             return name.hasSuffix("/") ? (String(name.dropLast()), true) : (name, false)
         }

--- a/Alas/Sources/SSH/RemoteFileStats.swift
+++ b/Alas/Sources/SSH/RemoteFileStats.swift
@@ -58,10 +58,28 @@ enum RemoteFileStats {
         // association entirely (silently reporting `0` for that file
         // instead). NUL can't appear in a POSIX path, so it's a safe
         // separator regardless of what bytes the path itself contains.
+        //
+        // A file over `RemoteWorktreeFileAccess.maxFileBytes` is counted via
+        // a capped `head -c` prefix instead of `wc -l < file` reading it in
+        // full: this exec fallback shares the same serialized remote
+        // connection every other message on it uses, so a multi-gigabyte
+        // untracked file would otherwise occupy that connection (and delay
+        // every later message) until the process timeout, mirroring the
+        // same cap the persistent-helper path (`AlasHelper`'s
+        // `fs_line_counts`) already applies. The capped count is an
+        // approximation (a lower bound) — the no-trailing-newline +1
+        // adjustment is skipped in that case, since the file's true last
+        // byte is outside what was actually read.
+        let cap = RemoteWorktreeFileAccess.maxFileBytes
         return paths.map { path in
             let quoted = SSHCommand.shellQuote(path)
-            return "n=$(wc -l < \(quoted)); " +
+            return "size=$(wc -c < \(quoted)); " +
+                "if [ \"$size\" -gt \(cap) ]; then " +
+                "n=$(head -c \(cap) -- \(quoted) | wc -l); " +
+                "else " +
+                "n=$(wc -l < \(quoted)); " +
                 "if [ -s \(quoted) ] && [ \"$(tail -c1 -- \(quoted) | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; " +
+                "fi; " +
                 "printf '%s %s\\0' \"$n\" \(quoted)"
         }.joined(separator: "; ")
     }
@@ -182,40 +200,56 @@ enum RemoteFileStats {
         }
     }
 
-    /// GNU-then-BSD `ls` invocation, chained the same way `statMtime` chains
-    /// GNU-then-BSD `stat` above: GNU coreutils' `ls --zero` emits
-    /// NUL-separated entries so a filename containing an embedded newline
-    /// byte doesn't fragment into bogus extra entries when parsed — this
-    /// mirrors the NUL-delimited fix already applied to the root Files-tree
-    /// listing source (`GitService.gitVisibleFilePaths`'s `git ls-files -z`),
-    /// which this exec-fallback directory listing (used for expanding a
-    /// directory on a helperless SSH host) hadn't been touched by.
+    /// Sentinel marking the boundary between the directory- and file-type
+    /// records `lsCommand` prints, as a NUL-delimited "entry" of its own.
+    /// Only misclassifies a real filesystem entry if it happens to be named
+    /// EXACTLY this string — an astronomically unlikely collision, and a
+    /// far narrower failure mode than the one this replaces (see
+    /// `lsCommand`'s doc comment).
+    static let lsSplitMarker = "__alas_ls_split__"
+
+    /// Two `find` invocations, immediate children only, NUL-delimited,
+    /// split into a directories batch and a files batch by a sentinel
+    /// record in between — used instead of `ls -1Ap`/GNU `ls --zero` (which
+    /// this used to be) because `find -print0` is NUL-safe on BOTH GNU
+    /// findutils AND BSD `find` (unlike `ls`, whose `--zero` NUL-delimited
+    /// mode has no BSD equivalent at all). A filename containing an
+    /// embedded newline byte previously fragmented into bogus extra entries
+    /// whenever a helperless SSH host's `ls` fell back to its
+    /// newline-delimited form (any remote macOS host, since BSD `ls` never
+    /// supports `--zero`) — including possible ignore-rule misclassification
+    /// from those bogus fragments. `find`'s NUL-safety applies uniformly
+    /// everywhere, so there's no GNU/BSD branch left to fall back from.
     ///
-    /// BSD `ls` (a remote macOS host) has no NUL-delimited output mode at
-    /// all, so this falls back to ordinary newline-delimited output there —
-    /// a residual, narrower gap: a directory name containing an embedded
-    /// newline byte can still fragment when listed via exec on a BSD/macOS
-    /// remote host specifically. A host with the persistent helper
-    /// installed never hits this at all (it lists via a JSON-safe RPC
-    /// instead, where an embedded newline in a name is just another JSON
-    /// string byte); this only matters for a helperless remote macOS host,
-    /// which is expected to be rare.
+    /// `-mindepth 1` excludes the directory itself (matching `ls -A`'s
+    /// omission of `.`/`..`); dotfiles are included by default (`find` has
+    /// no separate "hidden" concept requiring an extra flag, unlike `ls`'s
+    /// `-A`).
     static func lsCommand(path: String) -> String {
         let quoted = SSHCommand.shellQuote(path)
-        return "ls -1Ap --zero -- \(quoted) 2>/dev/null || ls -1Ap -- \(quoted)"
+        return "find \(quoted) -mindepth 1 -maxdepth 1 -type d -print0; " +
+            "printf '\\0\(lsSplitMarker)\\0'; " +
+            "find \(quoted) -mindepth 1 -maxdepth 1 ! -type d -print0"
     }
 
-    /// Parses `lsCommand`'s output. Detects which branch of the GNU/BSD
-    /// fallback actually ran by checking for an embedded NUL byte — a
-    /// legitimate filename can never itself contain one on a POSIX
-    /// filesystem, so its presence unambiguously means the NUL-delimited
-    /// (GNU) branch produced this output rather than the newline-delimited
-    /// (BSD) fallback.
+    /// Parses `lsCommand`'s output: NUL-delimited full paths, split into
+    /// directories (before the sentinel) and files (after it). The
+    /// basename is taken as everything after the LAST `/` — safe
+    /// regardless of what other bytes (including an embedded newline) the
+    /// name itself contains, since `/` can never be part of a POSIX
+    /// filename component.
     static func parseLsEntries(_ output: String) -> [(name: String, isDirectory: Bool)] {
-        let separator: Character = output.contains("\0") ? "\0" : "\n"
-        return output.split(separator: separator).map {
-            let name = String($0)
-            return name.hasSuffix("/") ? (String(name.dropLast()), true) : (name, false)
+        let records = output.split(separator: "\u{0}", omittingEmptySubsequences: true).map(String.init)
+        guard let splitIndex = records.firstIndex(of: lsSplitMarker) else {
+            return records.map { (basename(of: $0), false) }
         }
+        let directories = records[..<splitIndex].map { (basename(of: $0), true) }
+        let files = records[(splitIndex + 1)...].map { (basename(of: $0), false) }
+        return directories + files
+    }
+
+    private static func basename(of fullPath: String) -> String {
+        guard let lastSlash = fullPath.lastIndex(of: "/") else { return fullPath }
+        return String(fullPath[fullPath.index(after: lastSlash)...])
     }
 }

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -876,12 +876,40 @@ fn fs_line_counts(state: &HelperState, params: Option<Value>) -> Result<Value, H
     let mut entries = Vec::with_capacity(params.paths.len());
     for relative in params.paths {
         let requested = root.join(&relative);
-        let requested = requested.to_string_lossy().into_owned();
-        let path = match contained_existing_path(state, &requested) {
+        let requested_str = requested.to_string_lossy().into_owned();
+        // Git's blob for a symlink IS the link's target path string, never
+        // the target's own file content — `git add`/`diff --numstat` never
+        // follow the link. Checked on the ORIGINAL (pre-containment) path:
+        // `contained_existing_path` below resolves through symlinks via
+        // `std::fs::canonicalize`, so by the time `path` comes back there
+        // is no way to tell the request was ever a symlink at all.
+        let is_symlink = std::fs::symlink_metadata(&requested)
+            .map(|meta| meta.file_type().is_symlink())
+            .unwrap_or(false);
+        let path = match contained_existing_path(state, &requested_str) {
             Ok(path) => path,
             Err(error) if error.code == -32021 => continue,
             Err(error) => return Err(error),
         };
+        if is_symlink {
+            // Containment for the ultimate TARGET was already verified
+            // above (`contained_existing_path`'s canonical resolution must
+            // land inside a registered root); what's counted here is the
+            // LINK'S OWN target string, never the target's contents.
+            let target = std::fs::read_link(&requested)
+                .map_err(|error| jsonrpc_error(-32020, format!("read_link failed: {error}")))?;
+            let target = target.to_string_lossy();
+            let newlines = target.matches('\n').count() as u64;
+            let count = if target.is_empty() {
+                0
+            } else if target.ends_with('\n') {
+                newlines
+            } else {
+                newlines + 1
+            };
+            entries.push(json!({ "path": relative, "lineCount": count }));
+            continue;
+        }
         let metadata = std::fs::metadata(&path)
             .map_err(|error| jsonrpc_error(-32020, format!("metadata failed: {error}")))?;
         if !metadata.is_file() {
@@ -2619,6 +2647,44 @@ mod tests {
         assert_eq!(listing["entries"][0]["name"], "a file.txt");
         assert_eq!(listing["entries"][1]["name"], "folder");
         assert_eq!(listing["entries"][1]["isDirectory"], true);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// Git's blob for a symlink IS the link's target path string, never the
+    /// target's own file content. Without special-casing, `metadata` (which
+    /// follows the link) would find the target IS a big multi-line regular
+    /// file and read its whole content instead — wildly overcounting for a
+    /// path git itself always represents as a single-line blob (assuming a
+    /// realistic target path with no embedded newline).
+    #[test]
+    fn line_counts_count_a_symlink_as_its_target_path_string_not_the_targets_content() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-stats-symlink-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        std::fs::write(root.join("target.txt"), "one\ntwo\nthree\n").expect("target file");
+        std::os::unix::fs::symlink(root.join("target.txt"), root.join("link.txt"))
+            .expect("symlink");
+
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+        let counts = fs_line_counts(
+            &state,
+            Some(json!({
+                "root": root.display().to_string(),
+                "paths": ["link.txt"]
+            })),
+        )
+        .expect("line counts");
+        assert_eq!(
+            counts["entries"],
+            json!([{"path": "link.txt", "lineCount": 1}])
+        );
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -876,40 +876,44 @@ fn fs_line_counts(state: &HelperState, params: Option<Value>) -> Result<Value, H
     let mut entries = Vec::with_capacity(params.paths.len());
     for relative in params.paths {
         let requested = root.join(&relative);
-        let requested_str = requested.to_string_lossy().into_owned();
         // Git's blob for a symlink IS the link's target path string, never
         // the target's own file content — `git add`/`diff --numstat` never
-        // follow the link. Checked on the ORIGINAL (pre-containment) path:
-        // `contained_existing_path` below resolves through symlinks via
-        // `std::fs::canonicalize`, so by the time `path` comes back there
-        // is no way to tell the request was ever a symlink at all.
-        let is_symlink = std::fs::symlink_metadata(&requested)
-            .map(|meta| meta.file_type().is_symlink())
-            .unwrap_or(false);
+        // follow the link. Checked, and containment-validated, BEFORE ever
+        // calling `contained_existing_path` below: that call canonicalizes
+        // through the link to its TARGET, which is wrong on two counts for
+        // a symlink — a dangling target fails canonicalize entirely
+        // (silently dropping the entry, which the Changes list then shows
+        // as `+0`), and a target outside every registered root fails
+        // containment and aborts this whole request, even though reading
+        // the link's own destination string never touches that target at
+        // all. Containment here is validated against the LINK'S OWN
+        // location instead (`contained_symlink_path`, whose canonical
+        // parent is what has to land inside a root — the final,
+        // potentially-symlink component is deliberately left unresolved).
+        if let Ok(symlink_meta) = std::fs::symlink_metadata(&requested) {
+            if symlink_meta.file_type().is_symlink() {
+                let linked = contained_symlink_path(state, &requested)?;
+                let target = std::fs::read_link(&linked)
+                    .map_err(|error| jsonrpc_error(-32020, format!("read_link failed: {error}")))?;
+                let target = target.to_string_lossy();
+                let newlines = target.matches('\n').count() as u64;
+                let count = if target.is_empty() {
+                    0
+                } else if target.ends_with('\n') {
+                    newlines
+                } else {
+                    newlines + 1
+                };
+                entries.push(json!({ "path": relative, "lineCount": count }));
+                continue;
+            }
+        }
+        let requested_str = requested.to_string_lossy().into_owned();
         let path = match contained_existing_path(state, &requested_str) {
             Ok(path) => path,
             Err(error) if error.code == -32021 => continue,
             Err(error) => return Err(error),
         };
-        if is_symlink {
-            // Containment for the ultimate TARGET was already verified
-            // above (`contained_existing_path`'s canonical resolution must
-            // land inside a registered root); what's counted here is the
-            // LINK'S OWN target string, never the target's contents.
-            let target = std::fs::read_link(&requested)
-                .map_err(|error| jsonrpc_error(-32020, format!("read_link failed: {error}")))?;
-            let target = target.to_string_lossy();
-            let newlines = target.matches('\n').count() as u64;
-            let count = if target.is_empty() {
-                0
-            } else if target.ends_with('\n') {
-                newlines
-            } else {
-                newlines + 1
-            };
-            entries.push(json!({ "path": relative, "lineCount": count }));
-            continue;
-        }
         let metadata = std::fs::metadata(&path)
             .map_err(|error| jsonrpc_error(-32020, format!("metadata failed: {error}")))?;
         if !metadata.is_file() {
@@ -2075,6 +2079,38 @@ fn contained_existing_path(state: &HelperState, path: &str) -> Result<PathBuf, H
     }
 }
 
+/// Containment for a symlink's OWN location, not wherever it points.
+/// `contained_existing_path` canonicalizes all the way through to the
+/// TARGET, which is wrong for an operation (like reading `read_link`'s
+/// destination string) that never actually touches the target: a dangling
+/// target fails that canonicalize outright, and a target outside every
+/// registered root fails containment even though nothing there is ever
+/// read. Canonicalizing just the PARENT directory resolves any symlinks in
+/// the ancestry (as intended) while deliberately leaving the final
+/// component — the symlink itself — untouched, then re-joins its file name
+/// onto that canonical parent.
+fn contained_symlink_path(state: &HelperState, path: &Path) -> Result<PathBuf, HelperError> {
+    if state.subscriptions.is_empty() {
+        return Err(jsonrpc_error(-32022, "no registered roots"));
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| jsonrpc_error(-32020, "path has no parent"))?;
+    let canonical_parent = std::fs::canonicalize(parent)
+        .map_err(|error| jsonrpc_error(-32020, format!("parent failed: {error}")))?;
+    if !state
+        .subscriptions
+        .values()
+        .any(|root| canonical_parent.starts_with(root))
+    {
+        return Err(jsonrpc_error(-32023, "path outside registered roots"));
+    }
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| jsonrpc_error(-32020, "path has no file name"))?;
+    Ok(canonical_parent.join(file_name))
+}
+
 fn contained_write_path(state: &HelperState, path: &str) -> Result<PathBuf, HelperError> {
     if state.subscriptions.is_empty() {
         return Err(jsonrpc_error(-32022, "no registered roots"));
@@ -2686,6 +2722,88 @@ mod tests {
             json!([{"path": "link.txt", "lineCount": 1}])
         );
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// A dangling symlink (target doesn't exist) still has a real blob in
+    /// git's object model — the link's own destination string — counted
+    /// the same way as one whose target exists. `contained_existing_path`
+    /// would canonicalize straight through to the (missing) target and
+    /// fail outright; symlink handling must run BEFORE that call, using
+    /// containment on the link's own location instead.
+    #[test]
+    fn line_counts_count_a_dangling_symlink_as_its_target_path_string() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-stats-dangling-symlink-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        std::os::unix::fs::symlink(
+            root.join("does-not-exist.txt"),
+            root.join("broken-link.txt"),
+        )
+        .expect("symlink");
+
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+        let counts = fs_line_counts(
+            &state,
+            Some(json!({
+                "root": root.display().to_string(),
+                "paths": ["broken-link.txt"]
+            })),
+        )
+        .expect("line counts");
+        assert_eq!(
+            counts["entries"],
+            json!([{"path": "broken-link.txt", "lineCount": 1}])
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// A symlink pointing OUTSIDE every registered root is still safe to
+    /// count — reading `read_link`'s destination string never touches the
+    /// target at all — so this must succeed rather than aborting the whole
+    /// request the way `contained_existing_path`'s target-following
+    /// containment check would.
+    #[test]
+    fn line_counts_count_a_symlink_pointing_outside_every_registered_root() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-stats-outside-symlink-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        let outside = std::env::temp_dir().join(format!(
+            "alas-helper-stats-outside-target-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        std::fs::write(&outside, "secret\ncontent\n").expect("outside target");
+        std::os::unix::fs::symlink(&outside, root.join("outside-link.txt")).expect("symlink");
+
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+        let counts = fs_line_counts(
+            &state,
+            Some(json!({
+                "root": root.display().to_string(),
+                "paths": ["outside-link.txt"]
+            })),
+        )
+        .expect("line counts");
+        assert_eq!(
+            counts["entries"],
+            json!([{"path": "outside-link.txt", "lineCount": 1}])
+        );
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_file(outside);
     }
 
     /// Counting newline bytes alone undercounts a nonempty file whose final

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -18,6 +18,14 @@ use watch::{SubscriptionWatcher, WatchKind, WatchNotification};
 
 const PROTOCOL_VERSION: u32 = 1;
 
+/// Per-file byte budget for `fs_line_counts`. This request loop is shared by
+/// every filesystem/process request on this host, so counting a
+/// multi-gigabyte file's lines in full would monopolize it and delay
+/// unrelated requests. Matches the Swift-side `RemoteWorktreeFileAccess
+/// .maxFileBytes` order of magnitude: a file this large was never going to
+/// have its exact line count displayed precisely anyway.
+const FS_LINE_COUNT_MAX_BYTES: u64 = 512 * 1024;
+
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct Handshake<'a> {
@@ -885,23 +893,38 @@ fn fs_line_counts(state: &HelperState, params: Option<Value>) -> Result<Value, H
         let mut count = 0_u64;
         let mut saw_any_bytes = false;
         let mut last_byte = 0_u8;
-        loop {
+        let mut total_read: u64 = 0;
+        let mut reached_eof = false;
+        // Caps the work per file, not just the response: this request loop
+        // is shared by every filesystem/process request on this host, so an
+        // untracked multi-gigabyte generated file read in full here would
+        // monopolize it and delay unrelated requests, even though the
+        // eventual Changes response is capped downstream regardless. Once
+        // the cap is hit, the count is a lower bound on the real line count
+        // (an approximation) rather than an exact figure — good enough for
+        // a Changes-list badge, which was never going to display the exact
+        // total for a file this large anyway.
+        while total_read < FS_LINE_COUNT_MAX_BYTES {
             let read = file
                 .read(&mut buffer)
                 .map_err(|error| jsonrpc_error(-32020, format!("read failed: {error}")))?;
             if read == 0 {
+                reached_eof = true;
                 break;
             }
             saw_any_bytes = true;
             count += buffer[..read].iter().filter(|byte| **byte == b'\n').count() as u64;
             last_byte = buffer[read - 1];
+            total_read += read as u64;
         }
         // Counting newline bytes alone undercounts a nonempty file whose
         // final line has no trailing newline: git's numstat (and the local
         // diff-parsing `addedLineCount` logic) both count that trailing
         // partial line, so a one-line file with no trailing newline has a
-        // line count of 1, not 0.
-        if saw_any_bytes && last_byte != b'\n' {
+        // line count of 1, not 0. Only applies when the read actually
+        // reached EOF — `last_byte` after a cap-triggered stop is just
+        // wherever reading happened to end, not the file's true last byte.
+        if saw_any_bytes && reached_eof && last_byte != b'\n' {
             count += 1;
         }
         entries.push(json!({ "path": relative, "lineCount": count }));
@@ -2643,6 +2666,52 @@ mod tests {
                 {"path": "one-with-newline.txt", "lineCount": 1},
                 {"path": "two-no-trailing-newline.txt", "lineCount": 2},
             ])
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// A file larger than `FS_LINE_COUNT_MAX_BYTES` must not be read in
+    /// full: this request loop is shared by every filesystem/process
+    /// request on the host, so counting a multi-gigabyte generated file's
+    /// lines line-by-line would monopolize it and delay unrelated
+    /// requests. The count for an oversized file is an approximation (a
+    /// lower bound), not exact — asserted here as "less than the true
+    /// count" specifically, so a regression that silently reads the whole
+    /// file (making this assertion trivially true by coincidence) doesn't
+    /// slip through unnoticed.
+    #[test]
+    fn line_counts_cap_the_read_for_an_oversized_file() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-stats-oversized-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        // One line well past the cap, so a full read would report exactly
+        // 1 (no trailing newline) — capped counting must report something
+        // ELSE (0, since a `\n`-free prefix has no newlines) instead.
+        let huge_line = "x".repeat(FS_LINE_COUNT_MAX_BYTES as usize + 1024);
+        std::fs::write(root.join("huge.txt"), &huge_line).expect("file");
+
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+        let counts = fs_line_counts(
+            &state,
+            Some(json!({
+                "root": root.display().to_string(),
+                "paths": ["huge.txt"]
+            })),
+        )
+        .expect("line counts");
+        let reported = counts["entries"][0]["lineCount"]
+            .as_u64()
+            .expect("lineCount");
+        assert_eq!(
+            reported, 0,
+            "capped read must not reach EOF and apply the no-trailing-newline +1"
         );
         let _ = std::fs::remove_dir_all(root);
     }

--- a/AlasHelper/src/main.rs
+++ b/AlasHelper/src/main.rs
@@ -883,6 +883,8 @@ fn fs_line_counts(state: &HelperState, params: Option<Value>) -> Result<Value, H
             .map_err(|error| jsonrpc_error(-32020, format!("open failed: {error}")))?;
         let mut buffer = [0_u8; 64 * 1024];
         let mut count = 0_u64;
+        let mut saw_any_bytes = false;
+        let mut last_byte = 0_u8;
         loop {
             let read = file
                 .read(&mut buffer)
@@ -890,7 +892,17 @@ fn fs_line_counts(state: &HelperState, params: Option<Value>) -> Result<Value, H
             if read == 0 {
                 break;
             }
+            saw_any_bytes = true;
             count += buffer[..read].iter().filter(|byte| **byte == b'\n').count() as u64;
+            last_byte = buffer[read - 1];
+        }
+        // Counting newline bytes alone undercounts a nonempty file whose
+        // final line has no trailing newline: git's numstat (and the local
+        // diff-parsing `addedLineCount` logic) both count that trailing
+        // partial line, so a one-line file with no trailing newline has a
+        // line count of 1, not 0.
+        if saw_any_bytes && last_byte != b'\n' {
+            count += 1;
         }
         entries.push(json!({ "path": relative, "lineCount": count }));
     }
@@ -2584,6 +2596,54 @@ mod tests {
         assert_eq!(listing["entries"][0]["name"], "a file.txt");
         assert_eq!(listing["entries"][1]["name"], "folder");
         assert_eq!(listing["entries"][1]["isDirectory"], true);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// Counting newline bytes alone undercounts a nonempty file whose final
+    /// line has no trailing newline: git's numstat (and the local Swift
+    /// `addedLineCount` diff-parsing logic) both count that trailing
+    /// partial line, so a one-line file with no trailing newline has a
+    /// line count of 1, not 0.
+    #[test]
+    fn line_counts_account_for_a_missing_trailing_newline() {
+        let root = std::env::temp_dir().join(format!(
+            "alas-helper-stats-notrailingnl-{}-{}",
+            std::process::id(),
+            system_time_seconds(SystemTime::now()).unwrap()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        std::fs::write(root.join("empty.txt"), "").expect("file");
+        std::fs::write(root.join("one-no-newline.txt"), "hello").expect("file");
+        std::fs::write(root.join("one-with-newline.txt"), "hello\n").expect("file");
+        std::fs::write(root.join("two-no-trailing-newline.txt"), "a\nb").expect("file");
+
+        let mut state = HelperState::default();
+        state.subscriptions.insert(
+            "1".to_string(),
+            std::fs::canonicalize(&root).expect("canonical root"),
+        );
+        let counts = fs_line_counts(
+            &state,
+            Some(json!({
+                "root": root.display().to_string(),
+                "paths": [
+                    "empty.txt",
+                    "one-no-newline.txt",
+                    "one-with-newline.txt",
+                    "two-no-trailing-newline.txt",
+                ]
+            })),
+        )
+        .expect("line counts");
+        assert_eq!(
+            counts["entries"],
+            json!([
+                {"path": "empty.txt", "lineCount": 0},
+                {"path": "one-no-newline.txt", "lineCount": 1},
+                {"path": "one-with-newline.txt", "lineCount": 1},
+                {"path": "two-no-trailing-newline.txt", "lineCount": 2},
+            ])
+        );
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/AlasTests/CommitDetailsTests.swift
+++ b/AlasTests/CommitDetailsTests.swift
@@ -267,6 +267,42 @@ struct CommitDetailsTests {
         #expect(!kept.contains("@@ -1,3 +1,3 @@"))
     }
 
+    /// Real captured output of `git -c core.quotePath=false diff -M -C --
+    /// "na\tme.txt" old.txt` on a rename where the destination contains a
+    /// tab: git quotes+escapes the WHOLE `b/<path>` header token
+    /// (`"b/na\tme.txt"`) regardless of `core.quotePath`, since that
+    /// setting only suppresses quoting for non-ASCII bytes.
+    @Test func sliceDiffForFileMatchesAQuotedHeaderForAPathContainingATab() {
+        let raw = """
+        diff --git a/old.txt "b/na\\tme.txt"
+        similarity index 50%
+        rename from old.txt
+        rename to "na\\tme.txt"
+        index a29bdeb..c0d0fb4 100644
+        --- a/old.txt
+        +++ "b/na\\tme.txt"
+        @@ -1 +1,2 @@
+         line1
+        +line2
+        """
+        let kept = GitService.sliceDiffForFile(raw, file: "na\tme.txt")
+        #expect(kept.contains("@@ -1 +1,2 @@"))
+        #expect(kept.contains("+line2"))
+    }
+
+    @Test func gitEscapedPathIfNeededReturnsNilWhenNoSpecialBytesArePresent() {
+        #expect(GitService.gitEscapedPathIfNeeded("plain.txt") == nil)
+        #expect(GitService.gitEscapedPathIfNeeded("café.txt") == nil)   // non-ASCII: quotePath=false already handles this
+    }
+
+    @Test func gitEscapedPathIfNeededEscapesControlCharsQuoteAndBackslash() {
+        #expect(GitService.gitEscapedPathIfNeeded("na\tme.txt") == "na\\tme.txt")
+        #expect(GitService.gitEscapedPathIfNeeded("na\nme.txt") == "na\\nme.txt")
+        #expect(GitService.gitEscapedPathIfNeeded("na\"me.txt") == "na\\\"me.txt")
+        #expect(GitService.gitEscapedPathIfNeeded("na\\me.txt") == "na\\\\me.txt")
+        #expect(GitService.gitEscapedPathIfNeeded("na\u{01}me.txt") == "na\\001me.txt")
+    }
+
     @Test func diffOfMergeCommitFollowsFirstParent() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/DiffParserTests.swift
+++ b/AlasTests/DiffParserTests.swift
@@ -26,6 +26,23 @@ struct DiffParserTests {
     @Test func emptyDiff() {
         let diff = DiffParser.parse("")
         #expect(diff.hunks.isEmpty)
+        #expect(!diff.isBinary)
+    }
+
+    /// A file git classifies as binary (whether by content sniffing or a
+    /// `.gitattributes` `binary` declaration) produces no `@@` hunks at
+    /// all — just a `Binary files ... differ` line. Without detecting this
+    /// explicitly, a hunk-less result is indistinguishable from a
+    /// legitimately empty diff.
+    @Test func detectsGitsOwnBinaryClassificationLine() {
+        let raw = """
+        diff --git a/image.dat b/image.dat
+        index abc..def 100644
+        Binary files a/image.dat and b/image.dat differ
+        """
+        let diff = DiffParser.parse(raw)
+        #expect(diff.hunks.isEmpty)
+        #expect(diff.isBinary)
     }
 
     @Test func capturesNoTrailingNewlineOnDeleteAndAddSides() {

--- a/AlasTests/DiffParserTests.swift
+++ b/AlasTests/DiffParserTests.swift
@@ -66,4 +66,70 @@ struct DiffParserTests {
         #expect(lines[0].kind == .delete && lines[0].noTrailingNewline)
         #expect(lines[1].kind == .add && lines[1].noTrailingNewline)
     }
+
+    /// A pure rename (100% similarity, no content edits) produces no `@@`
+    /// hunks — without `metadataSummary`, the caller would report a
+    /// misleadingly "successful" empty diff, indistinguishable from a file
+    /// with genuinely no changes at all.
+    @Test func pureRenameProducesAMetadataSummary() {
+        let raw = """
+        diff --git a/old.txt b/new.txt
+        similarity index 100%
+        rename from old.txt
+        rename to new.txt
+        """
+        let diff = DiffParser.parse(raw)
+        #expect(diff.hunks.isEmpty)
+        #expect(!diff.isBinary)
+        #expect(diff.metadataSummary == "Renamed from old.txt to new.txt — no content changes.")
+    }
+
+    /// Same as a pure rename, but for `-C` copy detection (source path
+    /// still exists after the copy).
+    @Test func pureCopyProducesAMetadataSummary() {
+        let raw = """
+        diff --git a/old.txt b/new.txt
+        similarity index 100%
+        copy from old.txt
+        copy to new.txt
+        """
+        let diff = DiffParser.parse(raw)
+        #expect(diff.hunks.isEmpty)
+        #expect(diff.metadataSummary == "Copied from old.txt to new.txt — no content changes.")
+    }
+
+    /// An executable-bit-only change (no rename, no content edits).
+    @Test func pureModeChangeProducesAMetadataSummary() {
+        let raw = """
+        diff --git a/script.sh b/script.sh
+        old mode 100644
+        new mode 100755
+        """
+        let diff = DiffParser.parse(raw)
+        #expect(diff.hunks.isEmpty)
+        #expect(diff.metadataSummary == "File mode changed from 100644 to 100755 — no content changes.")
+    }
+
+    /// A rename that ALSO has content edits has real hunks to show — the
+    /// summary would just be noise layered over an actual diff, so it must
+    /// stay nil here.
+    @Test func renameWithContentChangesDoesNotProduceAMetadataSummary() {
+        let raw = """
+        diff --git a/old.txt b/new.txt
+        similarity index 66%
+        rename from old.txt
+        rename to new.txt
+        index abc..def 100644
+        --- a/old.txt
+        +++ b/new.txt
+        @@ -1,3 +1,3 @@
+         unchanged
+        -removed
+        +added
+         unchanged
+        """
+        let diff = DiffParser.parse(raw)
+        #expect(!diff.hunks.isEmpty)
+        #expect(diff.metadataSummary == nil)
+    }
 }

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -109,6 +109,33 @@ struct GitServiceRemoteChangesTests {
         #expect(deletedLines == ["line3"])
     }
 
+    /// Under git's default `core.quotePath=true`, a non-ASCII filename is
+    /// emitted quoted and octal-escaped (e.g. `café.txt` →
+    /// `"caf\303\251.txt"`). Without `-c core.quotePath=false` (and `-z` to
+    /// make the escaping avoidable in the first place), the client would be
+    /// handed that literal escaped string as the path, which doesn't name
+    /// any real file.
+    @Test func changedFilesAgainstRef_reportsTheExactNonASCIIFilename() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let filename = "café.txt"
+        try "one\n".write(to: repo.appendingPathComponent(filename), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", filename], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "add"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        try "one\ntwo\n".write(to: repo.appendingPathComponent(filename), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", filename], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "edit"], cwd: repo)
+
+        let files = try await GitService().changedFilesAgainstRef(worktreePath: repo, ref: "start")
+        #expect(files.map(\.path) == [filename])
+
+        let diff = try await GitService().diff(worktreePath: repo, againstRef: "start", file: filename)
+        let added = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }
+        #expect(added.map(\.text) == ["two"])
+    }
+
     @Test func changedFilesAgainstRef_handlesRename() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }
@@ -135,6 +162,29 @@ struct GitServiceRemoteChangesTests {
         _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
 
         try "one\ntwo\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+
+        let diff = try await GitService().diff(worktreePath: repo, againstRef: nil, file: "a.txt")
+        let added = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }
+        #expect(added.map(\.text) == ["two"])
+    }
+
+    /// `diff(worktreePath:againstRef: nil, file:)` used to fall back to
+    /// `diff(worktreePath:file:)`'s default (unstaged, working-tree-vs-INDEX)
+    /// view, which by definition shows nothing for a change that IS staged
+    /// (the index already matches the working tree). Meanwhile
+    /// `changedFilesAgainstRef`'s own nil-ref fallback (`status`) DOES
+    /// surface staged files, so the file appeared in the change list but
+    /// opened to an empty diff. `diffAgainstHEAD` compares the working tree
+    /// against HEAD, which reflects the staged content as changed.
+    @Test func diffAgainstRef_showsAStagedOnlyChangeWhenRefIsNil() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "one\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+
+        try "one\ntwo\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
 
         let diff = try await GitService().diff(worktreePath: repo, againstRef: nil, file: "a.txt")
         let added = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }
@@ -300,5 +350,38 @@ struct GitServiceRemoteChangesTests {
         )
 
         #expect(result)
+    }
+
+    // MARK: - parseNumstatZOutput / parseNameStatusZOutput
+
+    @Test func parseNumstatZOutput_parsesOrdinaryRecords() {
+        let stream = "3\t1\tfile1.txt\00\t5\tcafé.txt\0"
+        let (add, del) = GitService.parseNumstatZOutput(stream)
+        #expect(add == ["file1.txt": 3, "café.txt": 0])
+        #expect(del == ["file1.txt": 1, "café.txt": 5])
+    }
+
+    @Test func parseNumstatZOutput_parsesRenameRecords() {
+        // "<add>\t<del>\t\0<oldPath>\0<newPath>\0"
+        let stream = "2\t0\t\0old.txt\0new.txt\0"
+        let (add, del) = GitService.parseNumstatZOutput(stream)
+        #expect(add == ["new.txt": 2])
+        #expect(del == ["new.txt": 0])
+    }
+
+    @Test func parseNameStatusZOutput_parsesOrdinaryRecords() {
+        let stream = "M\0file1.txt\0A\0café.txt\0"
+        let parsed = GitService.parseNameStatusZOutput(stream)
+        #expect(parsed.ordered == ["file1.txt", "café.txt"])
+        #expect(parsed.status == ["file1.txt": "M", "café.txt": "A"])
+        #expect(parsed.original.isEmpty)
+    }
+
+    @Test func parseNameStatusZOutput_parsesRenameAndCopyRecords() {
+        let stream = "R100\0old.txt\0new.txt\0C75\0base.txt\0copy.txt\0"
+        let parsed = GitService.parseNameStatusZOutput(stream)
+        #expect(parsed.ordered == ["new.txt", "copy.txt"])
+        #expect(parsed.status == ["new.txt": "R", "copy.txt": "C"])
+        #expect(parsed.original == ["new.txt": "old.txt", "copy.txt": "base.txt"])
     }
 }

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -118,6 +118,36 @@ struct GitServiceRemoteChangesTests {
     /// diff — verified empirically before writing this test — so the
     /// original file is edited alongside the copy to reliably reproduce a
     /// `"C"` status rather than `"R"`.
+    /// The rename-diff branch of `diff(worktreePath:againstRef:file:)` used
+    /// to omit `-c core.quotePath=false` from the actual diff-producing
+    /// `Process.git` call (unlike `renameSource`'s own internal
+    /// `--name-status` lookup, which already had it). Under the default
+    /// quoting, a non-ASCII rename DESTINATION name comes back escaped in
+    /// the `diff --git a/<old> b/<new>` header (e.g. `b/cr\303\250me.txt`),
+    /// so `sliceDiffForFile`'s raw, unquoted `b/<file>` suffix match fails
+    /// to find the section and the file opens with an empty diff.
+    @Test func diffAgainstRef_showsChangesForARenamedFileWithANonASCIIDestinationName() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "line1\nline2\nline3\nline4\nline5\n".write(
+            to: repo.appendingPathComponent("café.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "café.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        _ = try await Process.git(["mv", "café.txt", "crème.txt"], cwd: repo)
+        try "line1\nline2\nline3-changed\nline4\nline5\n".write(
+            to: repo.appendingPathComponent("crème.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "-A"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "rename and edit"], cwd: repo)
+
+        let diff = try await GitService().diff(worktreePath: repo, againstRef: "start", file: "crème.txt")
+        let addedLines = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }.map(\.text)
+        let deletedLines = diff.hunks.flatMap(\.lines).filter { $0.kind == .delete }.map(\.text)
+        #expect(addedLines == ["line3-changed"])
+        #expect(deletedLines == ["line3"])
+    }
+
     @Test func diffAgainstRef_showsOnlyTheChangedLineForACopiedAndEditedFile() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }
@@ -179,6 +209,33 @@ struct GitServiceRemoteChangesTests {
         let diff = try await GitService().diff(worktreePath: repo, againstRef: "start", file: filename)
         let added = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }
         #expect(added.map(\.text) == ["two"])
+    }
+
+    /// A bare `--` pathspec argument is interpreted as a glob pattern by
+    /// default, and `[...]` is pathspec-magic for a character class — so
+    /// `report[1].txt` as a pathspec actually matches the UNRELATED tracked
+    /// file `report1.txt` (verified empirically: `git diff -- 'report[1].txt'`
+    /// without `--literal-pathspecs` returns both files' diffs). Without
+    /// `--literal-pathspecs`, requesting the diff for `report[1].txt` would
+    /// leak `report1.txt`'s changes into the result.
+    @Test func diffAgainstRef_treatsAFileNameContainingPathspecMagicAsLiteral() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "one\n".write(to: repo.appendingPathComponent("report1.txt"), atomically: true, encoding: .utf8)
+        try "one\n".write(to: repo.appendingPathComponent("report[1].txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "-A"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        try "one\ntwo\n".write(to: repo.appendingPathComponent("report1.txt"), atomically: true, encoding: .utf8)
+        try "one\nthree\n".write(to: repo.appendingPathComponent("report[1].txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "-A"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "edit both"], cwd: repo)
+
+        let diff = try await GitService().diff(worktreePath: repo, againstRef: "start", file: "report[1].txt")
+        let added = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }.map(\.text)
+        #expect(added == ["three"])
+        #expect(!added.contains("two"))
     }
 
     @Test func changedFilesAgainstRef_handlesRename() async throws {

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -352,6 +352,72 @@ struct GitServiceRemoteChangesTests {
         #expect(result)
     }
 
+    // MARK: - diffAgainstHEAD on an unborn branch
+
+    private func makeUnbornRepo() async throws -> URL {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-unborn-diff-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["config", "user.email", "test@example.com"], cwd: repo)
+        _ = try await Process.git(["config", "user.name", "Test User"], cwd: repo)
+        return repo
+    }
+
+    /// Baseline/regression coverage for the LOCAL branch of `diffAgainstHEAD`'s
+    /// unborn-HEAD existence check — must be unaffected by making the check
+    /// remote-aware.
+    @Test func diffAgainstHEADOnAnUnbornLocalBranchShowsAnExistingFileAsAllAdd() async throws {
+        let repo = try await makeUnbornRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "fresh\n".write(to: repo.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+
+        let diff = try await GitService().diffAgainstHEAD(worktreePath: repo, file: "new.txt")
+        let added = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }
+        #expect(added.map(\.text) == ["fresh"])
+    }
+
+    @Test func diffAgainstHEADOnAnUnbornLocalBranchReturnsEmptyHunksForAMissingFile() async throws {
+        let repo = try await makeUnbornRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let diff = try await GitService().diffAgainstHEAD(worktreePath: repo, file: "missing.txt")
+        #expect(diff.hunks.isEmpty)
+    }
+
+    /// `diffAgainstHEAD`'s unborn-HEAD existence check used to be
+    /// `FileManager.default.fileExists`, a purely LOCAL filesystem check
+    /// that is meaningless for an SSH-backed worktree — nothing exists
+    /// locally at that path, so it always reported the file as missing and
+    /// silently returned an empty diff for every staged/untracked file on a
+    /// remote unborn branch. There is no reachable SSH host in this
+    /// environment, so this can't drive a real end-to-end remote diff:
+    /// `Process.git` itself also routes every git invocation for a
+    /// `RemoteHostRegistry`-registered worktree over the same (unreachable)
+    /// host, so the final diff still comes back empty here regardless —
+    /// but for a different reason (a failed SSH connection), not because
+    /// the existence check took a local-disk shortcut. What this test
+    /// proves empirically is the structural negative that matters: handing
+    /// `diffAgainstHEAD` a worktree registered as remote does not crash or
+    /// hang (the `nonexistent-host.invalid` TLD fails DNS resolution fast
+    /// rather than hanging on a connection timeout). That the existence
+    /// check itself now calls `RemoteFileAccess.existence(host:path:)`
+    /// instead of `FileManager.default.fileExists` when
+    /// `worktreePath.isRemoteAlasPath` is true is verified by reading
+    /// `diffAgainstHEAD`'s source, not by this test.
+    @Test func diffAgainstHEADOnAnUnbornRemoteBranchDoesNotCrashOrHangOnAnUnreachableHost() async throws {
+        let repo = try await makeUnbornRepo()
+        defer {
+            RemoteHostRegistry.shared.unregister(root: repo.path)
+            try? FileManager.default.removeItem(at: repo)
+        }
+        try "fresh\n".write(to: repo.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+        RemoteHostRegistry.shared.register(root: repo.path, host: "nonexistent-host.invalid")
+
+        let diff = try await GitService().diffAgainstHEAD(worktreePath: repo, file: "new.txt")
+        #expect(diff.hunks.isEmpty)
+    }
+
     // MARK: - parseNumstatZOutput / parseNameStatusZOutput
 
     @Test func parseNumstatZOutput_parsesOrdinaryRecords() {

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -152,4 +152,16 @@ struct GitServiceRemoteChangesTests {
         let ignored = try await GitService().isPathIgnored(worktreePath: repo, path: "a.txt")
         #expect(!ignored)
     }
+
+    @Test func isPathIgnored_reportsFalseForAForceAddedTrackedFileMatchingAGitignorePattern() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "forced.log\n".write(to: repo.appendingPathComponent(".gitignore"), atomically: true, encoding: .utf8)
+        try "keep me\n".write(to: repo.appendingPathComponent("forced.log"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "-f", "forced.log"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "force add ignored file"], cwd: repo)
+
+        let ignored = try await GitService().isPathIgnored(worktreePath: repo, path: "forced.log")
+        #expect(!ignored)
+    }
 }

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -81,4 +81,54 @@ struct GitServiceRemoteChangesTests {
         let added = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }
         #expect(added.map(\.text) == ["fresh"])
     }
+
+    @Test func changedFilesAgainstRef_handlesRename() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "content\n".write(to: repo.appendingPathComponent("old.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "old.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "add file"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        _ = try await Process.git(["mv", "old.txt", "new.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "rename"], cwd: repo)
+
+        let files = try await GitService().changedFilesAgainstRef(worktreePath: repo, ref: "start")
+        #expect(files.map(\.path) == ["new.txt"])
+        let renamed = try #require(files.first { $0.path == "new.txt" })
+        #expect(renamed.status == "R")
+        #expect(renamed.renameFrom == "old.txt")
+    }
+
+    @Test func diffAgainstRef_fallsBackToWorkingTreeWhenRefIsNil() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "one\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+
+        try "one\ntwo\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+
+        let diff = try await GitService().diff(worktreePath: repo, againstRef: nil, file: "a.txt")
+        let added = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }
+        #expect(added.map(\.text) == ["two"])
+    }
+
+    @Test func diffAgainstRef_handlesDeletedFile() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "content\nline two\n".write(to: repo.appendingPathComponent("deleted.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "deleted.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "add file"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        _ = try await Process.git(["rm", "deleted.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "delete"], cwd: repo)
+
+        let diff = try await GitService().diff(worktreePath: repo, againstRef: "start", file: "deleted.txt")
+        let deleted = diff.hunks.flatMap(\.lines).filter { $0.kind == .delete }
+        #expect(!deleted.isEmpty)
+        #expect(deleted.map(\.text).contains("content"))
+        #expect(deleted.map(\.text).contains("line two"))
+    }
 }

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -231,4 +231,74 @@ struct GitServiceRemoteChangesTests {
         let ignored = try await GitService().isPathIgnored(worktreePath: repo, path: "forced.log")
         #expect(!ignored)
     }
+
+    // MARK: - fileTreeChildren (remote branch) ignored-directory-with-tracked-descendant
+
+    /// `fileTreeChildren`'s remote branch discovers directory entries by
+    /// listing the actual remote filesystem (not just `git ls-files`), so it
+    /// can encounter a directory like `.vscode` that matches `.gitignore`
+    /// but contains a force-added, tracked file such as
+    /// `.vscode/settings.json`. Classifying `.vscode` itself as `.ignored`
+    /// would make `AppState.remoteFileNodes` drop it from its parent's flat
+    /// listing entirely — since the wire protocol's `RemoteFileNode` has no
+    /// `children` and fetches each directory lazily, the client would never
+    /// be able to expand into `.vscode` to reach `settings.json`, even
+    /// though that file is genuinely tracked and reachable via
+    /// `remoteFileContents`/`remoteFileDiff` if the client already knew its
+    /// path. This exercises the extracted decision helper directly, since
+    /// driving the remote branch of `fileTreeChildren` end-to-end requires a
+    /// real SSH-reachable host (`RemoteFileStats.directoryEntries`), which
+    /// isn't available in this test environment — see
+    /// `RemoteAppStateAccessTests.readRemoteWorktreeFileRawDoesNotFallBackToLocalDiskWhenTheHostIsUnreachable`
+    /// for the same constraint acknowledged elsewhere.
+    @Test func shouldClassifyRemotelyDiscoveredEntry_skipsADirectoryWithATrackedDescendant() {
+        let gitVisiblePaths: Set<String> = [".vscode/settings.json"]
+
+        let result = GitService().shouldClassifyRemotelyDiscoveredEntry(
+            fullPath: ".vscode",
+            isDirectory: true,
+            gitVisiblePaths: gitVisiblePaths
+        )
+
+        #expect(!result)
+    }
+
+    @Test func shouldClassifyRemotelyDiscoveredEntry_classifiesADirectoryWithNoTrackedDescendant() {
+        let gitVisiblePaths: Set<String> = ["src/main.swift"]
+
+        let result = GitService().shouldClassifyRemotelyDiscoveredEntry(
+            fullPath: "node_modules",
+            isDirectory: true,
+            gitVisiblePaths: gitVisiblePaths
+        )
+
+        #expect(result)
+    }
+
+    @Test func shouldClassifyRemotelyDiscoveredEntry_alwaysClassifiesFiles() {
+        let gitVisiblePaths: Set<String> = []
+
+        let result = GitService().shouldClassifyRemotelyDiscoveredEntry(
+            fullPath: ".env",
+            isDirectory: false,
+            gitVisiblePaths: gitVisiblePaths
+        )
+
+        #expect(result)
+    }
+
+    @Test func shouldClassifyRemotelyDiscoveredEntry_skipsOnlyForADirectDescendantNotAPrefixCollision() {
+        // ".vscode-extra/tracked.txt" is NOT a descendant of ".vscode" (no
+        // "/" boundary), so this must not false-positive via a naive
+        // `hasPrefix(root)` check on the un-slashed root.
+        let gitVisiblePaths: Set<String> = [".vscode-extra/tracked.txt"]
+
+        let result = GitService().shouldClassifyRemotelyDiscoveredEntry(
+            fullPath: ".vscode",
+            isDirectory: true,
+            gitVisiblePaths: gitVisiblePaths
+        )
+
+        #expect(result)
+    }
 }

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -153,6 +153,46 @@ struct GitServiceRemoteChangesTests {
         #expect(!ignored)
     }
 
+    @Test func looksBinaryAtRef_sniffsTheBlobWhenTheWorkingTreeFileIsGone() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try Data([0x42, 0x00, 0x43]).write(to: repo.appendingPathComponent("image.bin"))
+        _ = try await Process.git(["add", "image.bin"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "add binary"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        _ = try await Process.git(["rm", "image.bin"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "remove binary"], cwd: repo)
+
+        let result = try await GitService().looksBinaryAtRef(worktreePath: repo, ref: "start", file: "image.bin")
+        #expect(result == true)
+    }
+
+    @Test func looksBinaryAtRef_returnsFalseForATextBlob() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "plain text\n".write(to: repo.appendingPathComponent("notes.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "notes.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "add notes"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        _ = try await Process.git(["rm", "notes.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "remove notes"], cwd: repo)
+
+        let result = try await GitService().looksBinaryAtRef(worktreePath: repo, ref: "start", file: "notes.txt")
+        #expect(result == false)
+    }
+
+    @Test func looksBinaryAtRef_returnsNilWhenTheFileDoesNotExistAtTheRef() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["commit", "--allow-empty", "-m", "init"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        let result = try await GitService().looksBinaryAtRef(worktreePath: repo, ref: "start", file: "missing.bin")
+        #expect(result == nil)
+    }
+
     @Test func isPathIgnored_reportsFalseForAForceAddedTrackedFileMatchingAGitignorePattern() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -82,6 +82,33 @@ struct GitServiceRemoteChangesTests {
         #expect(added.map(\.text) == ["fresh"])
     }
 
+    /// `diff(worktreePath:againstRef:file:)` used to check `git cat-file -e
+    /// <ref>:<file>` using the file's CURRENT (post-rename) path, which does
+    /// not exist at `ref` (it existed under its OLD name) — so a renamed
+    /// file rendered as an entirely new file (every line an addition)
+    /// instead of a rename-aware diff of just the actual edit.
+    @Test func diffAgainstRef_showsOnlyTheChangedLineForARenamedAndEditedFile() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "line1\nline2\nline3\nline4\nline5\n".write(
+            to: repo.appendingPathComponent("old.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "old.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        _ = try await Process.git(["mv", "old.txt", "new.txt"], cwd: repo)
+        try "line1\nline2\nline3-changed\nline4\nline5\n".write(
+            to: repo.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "-A"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "rename and edit"], cwd: repo)
+
+        let diff = try await GitService().diff(worktreePath: repo, againstRef: "start", file: "new.txt")
+        let addedLines = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }.map(\.text)
+        let deletedLines = diff.hunks.flatMap(\.lines).filter { $0.kind == .delete }.map(\.text)
+        #expect(addedLines == ["line3-changed"])
+        #expect(deletedLines == ["line3"])
+    }
+
     @Test func changedFilesAgainstRef_handlesRename() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -1,0 +1,84 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct GitServiceRemoteChangesTests {
+    private func makeRepo() async throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-remote-changes-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: tmp)
+        _ = try await Process.git(["config", "user.email", "test@example.com"], cwd: tmp)
+        _ = try await Process.git(["config", "user.name", "test user"], cwd: tmp)
+        return tmp
+    }
+
+    @Test func changedFilesAgainstRef_includesCommittedAndUncommittedAndUntracked() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "one\n".write(to: repo.appendingPathComponent("base.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "base.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        try "one\ntwo\n".write(to: repo.appendingPathComponent("base.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "base.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "committed change"], cwd: repo)
+
+        try "dirty\n".write(to: repo.appendingPathComponent("dirty.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "dirty.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "add dirty"], cwd: repo)
+        try "dirty\nedited\n".write(to: repo.appendingPathComponent("dirty.txt"), atomically: true, encoding: .utf8)
+
+        try "new\n".write(to: repo.appendingPathComponent("untracked.txt"), atomically: true, encoding: .utf8)
+
+        let files = try await GitService().changedFilesAgainstRef(worktreePath: repo, ref: "start")
+        #expect(files.map(\.path).sorted() == ["base.txt", "dirty.txt", "untracked.txt"])
+        let base = try #require(files.first { $0.path == "base.txt" })
+        #expect(base.status == "M")
+        #expect(base.add == 1)
+        let untracked = try #require(files.first { $0.path == "untracked.txt" })
+        #expect(untracked.status == "A")
+        #expect(untracked.add == 1)
+    }
+
+    @Test func changedFilesAgainstRef_fallsBackToStatusWhenRefIsNil() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["commit", "--allow-empty", "-m", "init"], cwd: repo)
+        try "hello\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+
+        let files = try await GitService().changedFilesAgainstRef(worktreePath: repo, ref: nil)
+        #expect(files.map(\.path) == ["a.txt"])
+    }
+
+    @Test func diffAgainstRef_returnsHunksForACommittedChange() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "one\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+        try "one\ntwo\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "second line"], cwd: repo)
+
+        let diff = try await GitService().diff(worktreePath: repo, againstRef: "start", file: "a.txt")
+        let added = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }
+        #expect(added.map(\.text) == ["two"])
+    }
+
+    @Test func diffAgainstRef_showsUntrackedFileAsAllAdd() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["commit", "--allow-empty", "-m", "init"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+        try "fresh\n".write(to: repo.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+
+        let diff = try await GitService().diff(worktreePath: repo, againstRef: "start", file: "new.txt")
+        let added = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }
+        #expect(added.map(\.text) == ["fresh"])
+    }
+}

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -131,4 +131,25 @@ struct GitServiceRemoteChangesTests {
         #expect(deleted.map(\.text).contains("content"))
         #expect(deleted.map(\.text).contains("line two"))
     }
+
+    @Test func isPathIgnored_reportsTrueForAGitignoredPath() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "secret.env\n".write(to: repo.appendingPathComponent(".gitignore"), atomically: true, encoding: .utf8)
+        try "TOKEN=abc\n".write(to: repo.appendingPathComponent("secret.env"), atomically: true, encoding: .utf8)
+
+        let ignored = try await GitService().isPathIgnored(worktreePath: repo, path: "secret.env")
+        #expect(ignored)
+    }
+
+    @Test func isPathIgnored_reportsFalseForATrackedPath() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "one\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+
+        let ignored = try await GitService().isPathIgnored(worktreePath: repo, path: "a.txt")
+        #expect(!ignored)
+    }
 }

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -109,6 +109,51 @@ struct GitServiceRemoteChangesTests {
         #expect(deletedLines == ["line3"])
     }
 
+    /// `renameSource` used to only recognize an `"R"` name-status prefix, so
+    /// a file git classifies as a COPY (`"C<score>"`, distinct from a rename
+    /// because the source path still exists) fell through to being diffed
+    /// as brand new — every line shown as an addition instead of a diff
+    /// against the copy source. With `-C` (not `-C -C`), git only considers
+    /// a path a copy SOURCE when that source is itself modified in the same
+    /// diff — verified empirically before writing this test — so the
+    /// original file is edited alongside the copy to reliably reproduce a
+    /// `"C"` status rather than `"R"`.
+    @Test func diffAgainstRef_showsOnlyTheChangedLineForACopiedAndEditedFile() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "line1\nline2\nline3\nline4\nline5\n".write(
+            to: repo.appendingPathComponent("old.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "old.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        try FileManager.default.copyItem(
+            at: repo.appendingPathComponent("old.txt"), to: repo.appendingPathComponent("new.txt"))
+        try "line1\nline2\nline3-changed\nline4\nline5\n".write(
+            to: repo.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+        // The original must also change in the SAME diff, or git's `-C`
+        // (without a second `-C`) won't consider it eligible as a copy
+        // source at all and `new.txt` would show up as a plain add instead.
+        try "line1\nline2\nline3\nline4\nline5\nline6\n".write(
+            to: repo.appendingPathComponent("old.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "old.txt", "new.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "copy and edit"], cwd: repo)
+
+        // Confirm the premise: git reports this as a copy (`C`), not a
+        // rename (`R`), before asserting on the diff that depends on it.
+        let nameStatus = try await Process.git(
+            ["-c", "core.quotePath=false", "diff", "--name-status", "-z", "-M", "-C", "start"], cwd: repo)
+        let parsed = GitService.parseNameStatusZOutput(nameStatus.stdout)
+        #expect(parsed.status["new.txt"] == "C")
+        #expect(parsed.original["new.txt"] == "old.txt")
+
+        let diff = try await GitService().diff(worktreePath: repo, againstRef: "start", file: "new.txt")
+        let addedLines = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }.map(\.text)
+        let deletedLines = diff.hunks.flatMap(\.lines).filter { $0.kind == .delete }.map(\.text)
+        #expect(addedLines == ["line3-changed"])
+        #expect(deletedLines == ["line3"])
+    }
+
     /// Under git's default `core.quotePath=true`, a non-ASCII filename is
     /// emitted quoted and octal-escaped (e.g. `café.txt` →
     /// `"caf\303\251.txt"`). Without `-c core.quotePath=false` (and `-z` to
@@ -268,6 +313,30 @@ struct GitServiceRemoteChangesTests {
 
         let result = try await GitService().looksBinaryAtRef(worktreePath: repo, ref: "start", file: "missing.bin")
         #expect(result == nil)
+    }
+
+    /// Regression coverage for bounding `looksBinaryAtRef`'s blob read: a
+    /// several-hundred-KB deleted binary file must still be correctly
+    /// detected as binary from just its first 8 KB, not by buffering the
+    /// entire historical blob.
+    @Test func looksBinaryAtRef_sniffsALargeBlobWithoutReadingItWhole() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        // A NUL byte up front plus a few hundred KB of filler — large enough
+        // that reading the whole blob (rather than an 8 KB prefix) would be
+        // wasteful, per the finding this test guards against.
+        var bytes = Data([0x00])
+        bytes.append(Data(repeating: 0x41, count: 400 * 1024))
+        try bytes.write(to: repo.appendingPathComponent("large.bin"))
+        _ = try await Process.git(["add", "large.bin"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "add large binary"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        _ = try await Process.git(["rm", "large.bin"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "remove large binary"], cwd: repo)
+
+        let result = try await GitService().looksBinaryAtRef(worktreePath: repo, ref: "start", file: "large.bin")
+        #expect(result == true)
     }
 
     @Test func isPathIgnored_reportsFalseForAForceAddedTrackedFileMatchingAGitignorePattern() async throws {

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -726,6 +726,24 @@ struct GitServiceRemoteChangesTests {
         #expect(diff.hunks.isEmpty)
     }
 
+    /// `status`'s no-HEAD numstat used to diff `--cached` (index vs empty
+    /// tree), which only sees the STAGED snapshot. Staging a one-line file
+    /// and then appending a second, unstaged line must still report both
+    /// lines as added — matching `diffAgainstHEAD`'s own all-add diff
+    /// (working tree vs `/dev/null`) above, which always shows the current
+    /// on-disk content regardless of what's staged.
+    @Test func changedFilesAgainstRef_countsPostStageEditsOnAnUnbornBranch() async throws {
+        let repo = try await makeUnbornRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "line1\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        try "line1\nline2\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+
+        let files = try await GitService().changedFilesAgainstRef(worktreePath: repo, ref: nil)
+        let entry = try #require(files.first { $0.path == "a.txt" })
+        #expect(entry.add == 2)
+    }
+
     /// `diffAgainstHEAD`'s unborn-HEAD existence check used to be
     /// `FileManager.default.fileExists`, a purely LOCAL filesystem check
     /// that is meaningless for an SSH-backed worktree — nothing exists

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -408,6 +408,141 @@ struct GitServiceRemoteChangesTests {
         #expect(!ignored)
     }
 
+    /// A file tracked at `comparisonRef` but since deleted is no longer in
+    /// the current index, so plain `check-ignore` (no `--no-index`) falls
+    /// back to matching purely by name — reporting it "ignored" whenever a
+    /// LATER-added `.gitignore` pattern happens to match its name, even
+    /// though its legitimate deletion diff should still be servable.
+    /// `comparisonRef` must exempt it the same way the force-added-tracked
+    /// exemption above exempts a currently-indexed path.
+    @Test func isPathIgnored_reportsFalseForAFileTrackedAtTheComparisonRefButSinceDeleted() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "keep me\n".write(to: repo.appendingPathComponent("was-tracked.log"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "was-tracked.log"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "add tracked file"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        // Gitignore does not untrack an already-tracked file, so adding this
+        // pattern now still leaves `was-tracked.log` tracked at HEAD.
+        try "*.log\n".write(to: repo.appendingPathComponent(".gitignore"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", ".gitignore"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "add gitignore pattern"], cwd: repo)
+
+        _ = try await Process.git(["rm", "was-tracked.log"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "delete tracked file"], cwd: repo)
+
+        // Without the ref exemption, this reports true (ignored-by-name):
+        let ignoredWithoutRef = try await GitService().isPathIgnored(worktreePath: repo, path: "was-tracked.log")
+        #expect(ignoredWithoutRef)
+
+        let ignoredWithRef = try await GitService().isPathIgnored(
+            worktreePath: repo, path: "was-tracked.log", comparisonRef: "start")
+        #expect(!ignoredWithRef)
+    }
+
+    /// End-to-end confirmation via the actual diff entry point: requesting
+    /// the diff for a deleted, ignore-pattern-matching file must show the
+    /// deletion rather than throwing/being blocked.
+    @Test func diffAgainstRef_showsADeletedFileEvenWhenItsNameMatchesALaterAddedGitignorePattern() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "keep me\n".write(to: repo.appendingPathComponent("was-tracked.log"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "was-tracked.log"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "add tracked file"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        try "*.log\n".write(to: repo.appendingPathComponent(".gitignore"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", ".gitignore"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "add gitignore pattern"], cwd: repo)
+        _ = try await Process.git(["rm", "was-tracked.log"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "delete tracked file"], cwd: repo)
+
+        let diff = try await GitService().diff(worktreePath: repo, againstRef: "start", file: "was-tracked.log")
+        let deleted = diff.hunks.flatMap(\.lines).filter { $0.kind == .delete }
+        #expect(deleted.map(\.text).contains("keep me"))
+    }
+
+    /// `cat-file -e` exits with the SAME code for a genuinely missing object
+    /// AND for an invalid ref name — the exit code alone can't distinguish
+    /// them (verified empirically: both are 128 on git 2.50). `diff` must
+    /// not silently treat the invalid-ref case as "new/untracked file"; it
+    /// must propagate the failure.
+    @Test func diffAgainstRef_throwsRatherThanTreatingAnInvalidRefAsANewFile() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "one\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+
+        await #expect(throws: (any Error).self) {
+            _ = try await GitService().diff(worktreePath: repo, againstRef: "not-a-real-ref", file: "a.txt")
+        }
+    }
+
+    /// The genuinely-missing-object case (a real ref, a path that doesn't
+    /// exist there) must still take the untracked/new-file branch rather
+    /// than throwing — this is the behavior `diffAgainstRef_showsUntrackedFileAsAllAdd`
+    /// already covers for a NEVER-committed file; this covers the "valid
+    /// ref, path absent at that ref" shape explicitly to guard the
+    /// cat-file-exit-code fix above from over-rejecting the legitimate case.
+    @Test func diffAgainstRef_stillShowsANewFileAsAllAddWhenItGenuinelyDidNotExistAtAValidRef() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["commit", "--allow-empty", "-m", "init"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+        try "fresh\n".write(to: repo.appendingPathComponent("brand-new.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "brand-new.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "add new file"], cwd: repo)
+
+        let diff = try await GitService().diff(worktreePath: repo, againstRef: "start", file: "brand-new.txt")
+        let added = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }
+        #expect(added.map(\.text) == ["fresh"])
+    }
+
+    /// A file declared binary purely via `.gitattributes` (content that
+    /// still looks like valid UTF-8 at the byte level) produces a
+    /// hunk-less diff with `Binary files ... differ` instead of `@@` hunks
+    /// — `ParsedDiff.isBinary` must pick that up so callers don't mistake
+    /// it for a legitimately empty diff.
+    @Test func diffAgainstRef_flagsAGitattributesDeclaredBinaryFileWithUTF8Content() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "*.dat binary\n".write(to: repo.appendingPathComponent(".gitattributes"), atomically: true, encoding: .utf8)
+        try "hello world this is text\n".write(to: repo.appendingPathComponent("f.dat"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", ".gitattributes", "f.dat"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+        try "hello world this is text CHANGED\n".write(to: repo.appendingPathComponent("f.dat"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "f.dat"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "change binary-declared file"], cwd: repo)
+
+        let diff = try await GitService().diff(worktreePath: repo, againstRef: "start", file: "f.dat")
+        #expect(diff.hunks.isEmpty)
+        #expect(diff.isBinary)
+    }
+
+    /// An untracked file ending in exactly one trailing newline must report
+    /// the same add-count whether or not a comparison ref happens to
+    /// resolve — `status(worktreePath:)`'s own line counting used to
+    /// disagree with `addedLineCount`'s (used by the ref-resolved path) by
+    /// exactly one for this shape.
+    @Test func changedFilesAgainstRef_reportsTheSameAddCountForAnUntrackedFileRegardlessOfRefResolution() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["commit", "--allow-empty", "-m", "init"], cwd: repo)
+        try "one\n".write(to: repo.appendingPathComponent("untracked.txt"), atomically: true, encoding: .utf8)
+
+        let withNilRef = try await GitService().changedFilesAgainstRef(worktreePath: repo, ref: nil)
+        let untrackedNilRef = try #require(withNilRef.first { $0.path == "untracked.txt" })
+        #expect(untrackedNilRef.add == 1)
+
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+        let withResolvedRef = try await GitService().changedFilesAgainstRef(worktreePath: repo, ref: "start")
+        let untrackedResolvedRef = try #require(withResolvedRef.first { $0.path == "untracked.txt" })
+        #expect(untrackedResolvedRef.add == 1)
+    }
+
     // MARK: - fileTreeChildren (remote branch) ignored-directory-with-tracked-descendant
 
     /// `fileTreeChildren`'s remote branch discovers directory entries by
@@ -542,6 +677,30 @@ struct GitServiceRemoteChangesTests {
 
         let diff = try await GitService().diffAgainstHEAD(worktreePath: repo, file: "new.txt")
         #expect(diff.hunks.isEmpty)
+    }
+
+    /// A transport failure (disconnected helper, unreachable host) on the
+    /// root Files-tree request used to parse as "zero files" — an empty,
+    /// misleadingly "successful" repository — because `gitVisibleFilePaths`
+    /// didn't check `ls-files`'s exit code. Registering a real, but
+    /// unreachable, remote host forces exactly that shape of failure (`ssh`
+    /// itself fails fast on the invalid TLD, no real network wait) and
+    /// `fileTree` must now propagate it as a thrown error instead of
+    /// returning an empty node list.
+    @Test func fileTreePropagatesAGitVisibleFilePathsFailureInsteadOfReportingAnEmptyTree() async throws {
+        let repo = try await makeRepo()
+        defer {
+            RemoteHostRegistry.shared.unregister(root: repo.path)
+            try? FileManager.default.removeItem(at: repo)
+        }
+        try "one\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+        RemoteHostRegistry.shared.register(root: repo.path, host: "nonexistent-host.invalid")
+
+        await #expect(throws: (any Error).self) {
+            _ = try await GitService().fileTree(worktreePath: repo, statusEntries: [])
+        }
     }
 
     // MARK: - parseNumstatZOutput / parseNameStatusZOutput

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -1,6 +1,23 @@
 import Testing
 import Foundation
+import Darwin
 @testable import Alas
+
+/// Races `operation` against a timeout so a regression that reintroduces a
+/// blocking read (e.g. `Data(contentsOf:)` against a writerless FIFO) fails
+/// the test loudly and promptly instead of hanging the whole suite.
+private func withTimeout<T: Sendable>(seconds: Double, _ operation: @escaping @Sendable () async -> T) async -> T? {
+    await withTaskGroup(of: T?.self) { group in
+        group.addTask { await operation() }
+        group.addTask {
+            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            return nil
+        }
+        let result = await group.next() ?? nil
+        group.cancelAll()
+        return result
+    }
+}
 
 @Suite(.serialized)
 @MainActor
@@ -752,5 +769,31 @@ struct GitServiceRemoteChangesTests {
         #expect(parsed.ordered == ["new.txt", "copy.txt"])
         #expect(parsed.status == ["new.txt": "R", "copy.txt": "C"])
         #expect(parsed.original == ["new.txt": "old.txt", "copy.txt": "base.txt"])
+    }
+
+    // MARK: - addedLineCount
+
+    /// `addedLineCount` runs synchronously on whatever actor called it —
+    /// ultimately `changedFilesAgainstRef`, reachable from the `@MainActor`
+    /// `remoteChangeList` (this test struct is itself `@MainActor`, matching
+    /// that). A FIFO passes every check `Data(contentsOf:)` doesn't itself
+    /// perform, so without an explicit regular-file guard, opening Changes
+    /// on a worktree containing an untracked FIFO would block the READ
+    /// indefinitely waiting for a writer that never arrives — freezing the
+    /// whole app, not just this one request. `mkfifo` creates a real named
+    /// pipe; nothing ever opens it for writing, so a regression would hang
+    /// this test until the timeout — asserted against explicitly so it
+    /// fails loudly rather than hanging the whole suite.
+    @Test func addedLineCount_returnsPromptlyForAFIFOWithNoWriter() async throws {
+        let root = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fifo = root.appendingPathComponent("pipe")
+        #expect(fifo.path.withCString { mkfifo($0, 0o600) } == 0)
+
+        let outcome = await withTimeout(seconds: 5) {
+            GitService.addedLineCount(worktreePath: root, path: "pipe")
+        }
+        let result = try #require(outcome, "addedLineCount hung on a writerless FIFO instead of returning promptly")
+        #expect(result == 0)
     }
 }

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -89,6 +89,76 @@ struct GitServiceRemoteChangesTests {
         }
     }
 
+    /// `changedFileBadges` reports the same paths/statuses as
+    /// `changedFilesAgainstRef` — just without ever populating add/del
+    /// (proving the numstat call and per-untracked-file line counting were
+    /// actually skipped, not merely unused by this particular fixture).
+    @Test func changedFileBadges_includesCommittedAndUncommittedAndUntrackedWithoutMetrics() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "one\n".write(to: repo.appendingPathComponent("base.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "base.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        try "one\ntwo\n".write(to: repo.appendingPathComponent("base.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "base.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "committed change"], cwd: repo)
+
+        try "new\n".write(to: repo.appendingPathComponent("untracked.txt"), atomically: true, encoding: .utf8)
+
+        let files = try await GitService().changedFileBadges(worktreePath: repo, ref: "start")
+        #expect(files.map(\.path).sorted() == ["base.txt", "untracked.txt"])
+        let base = try #require(files.first { $0.path == "base.txt" })
+        #expect(base.status == "M")
+        #expect(base.add == 0 && base.del == 0)
+        let untracked = try #require(files.first { $0.path == "untracked.txt" })
+        #expect(untracked.status == "A")
+        #expect(untracked.add == 0 && untracked.del == 0)
+    }
+
+    @Test func changedFileBadges_fallsBackToStatusWhenRefIsNil() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["commit", "--allow-empty", "-m", "init"], cwd: repo)
+        try "hello\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+
+        let files = try await GitService().changedFileBadges(worktreePath: repo, ref: nil)
+        #expect(files.map(\.path) == ["a.txt"])
+    }
+
+    /// Same "must propagate, not silently fall back" contract as
+    /// `changedFilesAgainstRef_throwsRatherThanFallingBackToStatusForAResolvedButInvalidRef`.
+    @Test func changedFileBadges_throwsRatherThanFallingBackToStatusForAResolvedButInvalidRef() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "one\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+
+        await #expect(throws: (any Error).self) {
+            _ = try await GitService().changedFileBadges(worktreePath: repo, ref: "not-a-real-ref")
+        }
+    }
+
+    @Test func changedFileBadges_handlesRename() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "content\n".write(to: repo.appendingPathComponent("old.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "old.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "add file"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        _ = try await Process.git(["mv", "old.txt", "new.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "rename"], cwd: repo)
+
+        let files = try await GitService().changedFileBadges(worktreePath: repo, ref: "start")
+        #expect(files.map(\.path) == ["new.txt"])
+        let renamed = try #require(files.first { $0.path == "new.txt" })
+        #expect(renamed.status == "R")
+        #expect(renamed.renameFrom == "old.txt")
+    }
+
     @Test func diffAgainstRef_returnsHunksForACommittedChange() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -973,4 +973,38 @@ struct GitServiceRemoteChangesTests {
         let result = try #require(outcome, "addedLineCount hung on a writerless FIFO instead of returning promptly")
         #expect(result == 0)
     }
+
+    /// Git's blob for a symlink IS the target path string, never the
+    /// target's own file content. An untracked symlink to a real,
+    /// multi-line file must therefore report a line count that matches the
+    /// TARGET PATH STRING (always 1 for a normal path with no embedded
+    /// newline) — not 0 (the old behavior once the target stopped looking
+    /// like a "regular file" through the follow) and not the target
+    /// file's own line count (a symlink to a huge file wrongly inflating
+    /// this).
+    @Test func addedLineCount_countsAnUntrackedSymlinkAsItsTargetPathStringNotTheTargetsContent() async throws {
+        let root = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "one\ntwo\nthree\n".write(to: root.appendingPathComponent("target.txt"), atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("link.txt"),
+            withDestinationURL: root.appendingPathComponent("target.txt"))
+
+        let result = GitService.addedLineCount(worktreePath: root, path: "link.txt")
+        #expect(result == 1)
+    }
+
+    /// A broken symlink (target doesn't exist) still has a real blob in
+    /// git's object model — the link's target path string — so it must
+    /// still report 1, not 0.
+    @Test func addedLineCount_countsABrokenUntrackedSymlinkAsItsTargetPathString() async throws {
+        let root = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("broken-link.txt"),
+            withDestinationURL: root.appendingPathComponent("does-not-exist.txt"))
+
+        let result = GitService.addedLineCount(worktreePath: root, path: "broken-link.txt")
+        #expect(result == 1)
+    }
 }

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -740,8 +740,13 @@ struct GitServiceRemoteChangesTests {
         try "line1\nline2\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
 
         let files = try await GitService().changedFilesAgainstRef(worktreePath: repo, ref: nil)
+        // Exactly one row for "a.txt" — an "AM" file (staged, then further
+        // edited) must not appear twice just because `status()` itself
+        // tracks stage separately.
+        #expect(files.filter { $0.path == "a.txt" }.count == 1)
         let entry = try #require(files.first { $0.path == "a.txt" })
         #expect(entry.add == 2)
+        #expect(entry.status == "A")
     }
 
     /// `diffAgainstHEAD`'s unborn-HEAD existence check used to be
@@ -855,6 +860,22 @@ struct GitServiceRemoteChangesTests {
         #expect(parsed.ordered == ["new.txt", "copy.txt"])
         #expect(parsed.status == ["new.txt": "R", "copy.txt": "C"])
         #expect(parsed.original == ["new.txt": "old.txt", "copy.txt": "base.txt"])
+    }
+
+    // MARK: - collapsingStagedAndUnstagedEntries
+
+    @Test func collapsingStagedAndUnstagedEntries_mergesAStagedAndUnstagedPairKeepingTheStagedOne() {
+        let staged = ChangedFile(path: "a.txt", status: "A", stage: .staged, add: 2, del: 0, renameFrom: nil)
+        let unstaged = ChangedFile(path: "a.txt", status: "M", stage: .unstaged, add: 2, del: 0, renameFrom: nil)
+        #expect(GitService.collapsingStagedAndUnstagedEntries([staged, unstaged]) == [staged])
+        // Order of the pair shouldn't matter — the staged entry always wins.
+        #expect(GitService.collapsingStagedAndUnstagedEntries([unstaged, staged]) == [staged])
+    }
+
+    @Test func collapsingStagedAndUnstagedEntries_leavesUnrelatedPathsAndSingleEntriesAlone() {
+        let a = ChangedFile(path: "a.txt", status: "A", stage: .staged, add: 1, del: 0, renameFrom: nil)
+        let b = ChangedFile(path: "b.txt", status: "M", stage: .unstaged, add: 1, del: 0, renameFrom: nil)
+        #expect(GitService.collapsingStagedAndUnstagedEntries([a, b]) == [a, b])
     }
 
     // MARK: - addedLineCount

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -291,6 +291,51 @@ struct GitServiceRemoteChangesTests {
         #expect(renamed.renameFrom == "old.txt")
     }
 
+    /// The exact shape the finding described: `file` ("zzz.txt") is a copy
+    /// of "aaa.txt", which sorts BEFORE it — so git emits aaa.txt's own
+    /// section of the two-path diff FIRST. When that section alone exceeds
+    /// the byte cap, the capped subprocess terminates before zzz.txt's
+    /// section ever appears, and `sliceDiffForFile` finds nothing to return
+    /// for it — indistinguishable from a genuinely empty diff unless this is
+    /// treated as a failure instead.
+    @Test func diffAgainstRef_throwsWhenACopySourceSectionAloneExceedsTheOutputCap() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let original = (1 ... 100).map { "line\($0)\n" }.joined()
+        try original.write(to: repo.appendingPathComponent("aaa.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "aaa.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        // Append enough new content to aaa.txt that its OWN diff section
+        // (measured at ~611 bytes for this exact fixture) exceeds the
+        // test's small cap below, while staying similar enough to its prior
+        // version for git's default (no --find-copies-harder) copy
+        // detection to still recognize zzz.txt as a copy of it — appending
+        // materially more than 10 lines here drops the similarity score
+        // below git's 50% threshold and the fixture stops producing a copy
+        // at all, defeating the point of the test.
+        let appended = original + (1 ... 10).map { "appended-line-\($0)-with-enough-padding-to-add-up\n" }.joined()
+        try appended.write(to: repo.appendingPathComponent("aaa.txt"), atomically: true, encoding: .utf8)
+        // zzz.txt: a copy of the now-appended aaa.txt, sorting AFTER it, with
+        // one more line so it's a distinct file highly similar to its source.
+        try (appended + "zzz-marker\n").write(to: repo.appendingPathComponent("zzz.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "-A"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "copy with modification"], cwd: repo)
+
+        // Confirm the fixture actually produces the copy relationship this
+        // test depends on before asserting anything about the cap.
+        let files = try await GitService().changedFilesAgainstRef(worktreePath: repo, ref: "start")
+        let copy = try #require(files.first { $0.path == "zzz.txt" })
+        #expect(copy.status == "C")
+        #expect(copy.renameFrom == "aaa.txt")
+
+        await #expect(throws: (any Error).self) {
+            _ = try await GitService().diff(
+                worktreePath: repo, againstRef: "start", file: "zzz.txt", maxOutputBytes: 300)
+        }
+    }
+
     @Test func diffAgainstRef_fallsBackToWorkingTreeWhenRefIsNil() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -759,6 +759,29 @@ struct GitServiceRemoteChangesTests {
         #expect(diff.hunks.isEmpty)
     }
 
+    /// `changedFilesAgainstRef`'s nil-ref case (no resolvable base, e.g. an
+    /// unborn branch) falls back to `status(worktreePath:)`. `status` used
+    /// to swallow ANY nonzero `git status` exit into `[]` — a dropped SSH
+    /// connection would then look identical to "nothing has changed"
+    /// instead of surfacing as a failure. Registering a real, but
+    /// unreachable, remote host forces every `git` subprocess for this
+    /// worktree through a failing SSH invocation (`ssh` itself fails fast on
+    /// the invalid TLD, no real network wait), which is exactly the shape of
+    /// failure `status` must now propagate.
+    @Test func changedFilesAgainstRef_propagatesAStatusFailureOnTheNilRefFallback() async throws {
+        let repo = try await makeUnbornRepo()
+        defer {
+            RemoteHostRegistry.shared.unregister(root: repo.path)
+            try? FileManager.default.removeItem(at: repo)
+        }
+        try "fresh\n".write(to: repo.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+        RemoteHostRegistry.shared.register(root: repo.path, host: "nonexistent-host.invalid")
+
+        await #expect(throws: (any Error).self) {
+            _ = try await GitService().changedFilesAgainstRef(worktreePath: repo, ref: nil)
+        }
+    }
+
     /// A transport failure (disconnected helper, unreachable host) on the
     /// root Files-tree request used to parse as "zero files" — an empty,
     /// misleadingly "successful" repository — because `gitVisibleFilePaths`

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -934,12 +934,21 @@ struct GitServiceRemoteChangesTests {
 
     // MARK: - collapsingStagedAndUnstagedEntries
 
-    @Test func collapsingStagedAndUnstagedEntries_mergesAStagedAndUnstagedPairKeepingTheStagedOne() {
-        let staged = ChangedFile(path: "a.txt", status: "A", stage: .staged, add: 2, del: 0, renameFrom: nil)
+    /// The merged row takes its IDENTITY (status/renameFrom/conflict) from
+    /// the staged side — the unstaged sibling would misleadingly read "M"
+    /// as if a base version existed (there is no HEAD on the unborn branch
+    /// this collapsing exists for) — but its METRICS from the unstaged
+    /// side, which `status()` now computes against the WHOLE working tree,
+    /// matching what `remoteFileDiff` actually renders for the path. The
+    /// staged side's own metrics are index-only (`status()`'s per-stage
+    /// fix) and would undercount here if used for the merged row instead.
+    @Test func collapsingStagedAndUnstagedEntries_mergesAStagedAndUnstagedPairKeepingStagedIdentityAndUnstagedMetrics() {
+        let staged = ChangedFile(path: "a.txt", status: "A", stage: .staged, add: 1, del: 0, renameFrom: nil)
         let unstaged = ChangedFile(path: "a.txt", status: "M", stage: .unstaged, add: 2, del: 0, renameFrom: nil)
-        #expect(GitService.collapsingStagedAndUnstagedEntries([staged, unstaged]) == [staged])
-        // Order of the pair shouldn't matter — the staged entry always wins.
-        #expect(GitService.collapsingStagedAndUnstagedEntries([unstaged, staged]) == [staged])
+        let expected = ChangedFile(path: "a.txt", status: "A", stage: .staged, add: 2, del: 0, renameFrom: nil)
+        #expect(GitService.collapsingStagedAndUnstagedEntries([staged, unstaged]) == [expected])
+        // Order of the pair shouldn't matter.
+        #expect(GitService.collapsingStagedAndUnstagedEntries([unstaged, staged]) == [expected])
     }
 
     @Test func collapsingStagedAndUnstagedEntries_leavesUnrelatedPathsAndSingleEntriesAlone() {

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -54,6 +54,24 @@ struct GitServiceRemoteChangesTests {
         #expect(files.map(\.path) == ["a.txt"])
     }
 
+    /// Unlike the nil-ref case above, a NON-nil ref that fails its numstat
+    /// diff (an invalid ref, here) is not "no base to compare against" —
+    /// falling back to `status()` would silently report only current
+    /// index/worktree changes as the complete change list, hiding every
+    /// committed change relative to the (bad) ref instead of surfacing the
+    /// failure.
+    @Test func changedFilesAgainstRef_throwsRatherThanFallingBackToStatusForAResolvedButInvalidRef() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "one\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+
+        await #expect(throws: (any Error).self) {
+            _ = try await GitService().changedFilesAgainstRef(worktreePath: repo, ref: "not-a-real-ref")
+        }
+    }
+
     @Test func diffAgainstRef_returnsHunksForACommittedChange() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceStagingTests.swift
+++ b/AlasTests/GitServiceStagingTests.swift
@@ -100,6 +100,28 @@ struct GitServiceStagingTests {
         #expect(status.allSatisfy { $0.status == "A" && $0.stage == .unstaged })
     }
 
+    /// An "AM" path (staged, then further modified in the working tree) has
+    /// TWO status() entries — one per stage — and each must report its OWN
+    /// correct metric: the staged entry reflects ONLY what's in the index
+    /// (1 line here), the unstaged entry reflects the WHOLE current working
+    /// tree (2 lines). Before this fix, a single numstat call (against the
+    /// whole working tree, with no `--cached` counterpart) fed BOTH
+    /// entries the same whole-tree count, so a staged-only consumer (e.g.
+    /// a draft-commit summary) over-reported what was actually staged.
+    @Test func statusReportsIndexOnlyMetricsForTheStagedSideOfAnAMFile() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try writeFile(repo, "a.txt", "line1\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        try writeFile(repo, "a.txt", "line1\nline2\n")
+
+        let status = try await GitService().status(worktreePath: repo)
+        let staged = try #require(status.first { $0.path == "a.txt" && $0.stage == .staged })
+        let unstaged = try #require(status.first { $0.path == "a.txt" && $0.stage == .unstaged })
+        #expect(staged.add == 1)
+        #expect(unstaged.add == 2)
+    }
+
     @Test func unstageAllClearsIndex() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -503,6 +503,28 @@ struct GitServiceTests {
         #expect(tracked.visibility == .tracked)
     }
 
+    /// Under git's default `core.quotePath=true`, a non-ASCII filename comes
+    /// back from `ls-files` quoted and octal-escaped (e.g. `café.txt` →
+    /// `"caf\303\251.txt"`). `gitVisibleFilePaths` (which feeds this root
+    /// Files tree) used to run plain `ls-files` with no `-c
+    /// core.quotePath=false`/`-z`, so the tree reported that escaped string
+    /// as the path instead of the real filename.
+    @Test func fileTreeReportsTheExactNonASCIIFilename() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let filename = "café.txt"
+        try "hola\n".write(to: repo.appendingPathComponent(filename), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", filename], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "add café"], cwd: repo)
+
+        let tree = try await GitService().fileTree(worktreePath: repo, statusEntries: [])
+
+        let file = try #require(tree.first { $0.path == filename })
+        #expect(file.visibility == .tracked)
+        #expect(!tree.contains { $0.path.contains("\\303") })
+    }
+
     @Test func fileTreeClassifiesGlobalExcludesAsExcludedRootEntries() async throws {
         let repo = try await makeRepo()
         let globalExcludes = FileManager.default.temporaryDirectory

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -740,6 +740,30 @@ struct GitServiceTests {
         #expect(children.contains { $0.path == "Sources/cache.log" && $0.visibility == .ignored })
     }
 
+    /// `fileTreeChildren` used to always build its nodes with `badges: [:]`,
+    /// so a change in a nested directory lost its status badge the moment a
+    /// client expanded into that directory — inconsistent with the root
+    /// Files tree, which DOES show badges. The native desktop caller
+    /// (`RightPaneState.loadFileTreeChildren`) omits the new `badges`
+    /// parameter and must be unaffected (still gets `[:]` by default).
+    @Test func fileTreeChildrenAppliesTheProvidedBadgeMapToNestedEntries() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try FileManager.default.createDirectory(
+            at: repo.appendingPathComponent("Sources"), withIntermediateDirectories: true)
+        try "one\n".write(to: repo.appendingPathComponent("Sources/App.swift"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "Sources/App.swift"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "seed"], cwd: repo)
+        try "one\ntwo\n".write(to: repo.appendingPathComponent("Sources/App.swift"), atomically: true, encoding: .utf8)
+
+        let withoutBadges = try await GitService().fileTreeChildren(worktreePath: repo, path: "Sources")
+        #expect(withoutBadges.first { $0.path == "Sources/App.swift" }?.badge == nil)
+
+        let withBadges = try await GitService().fileTreeChildren(
+            worktreePath: repo, path: "Sources", badges: ["Sources/App.swift": "M"])
+        #expect(withBadges.first { $0.path == "Sources/App.swift" }?.badge == "M")
+    }
+
     @Test func submodulePathsDetectsRegisteredSubmodules() async throws {
         let repo = try await makeRepo()
         let submoduleRepo = FileManager.default.temporaryDirectory

--- a/AlasTests/ProcessGitTests.swift
+++ b/AlasTests/ProcessGitTests.swift
@@ -190,6 +190,34 @@ struct ProcessGitTests {
         #expect(result.stdout.contains("git version"))
     }
 
+    @Test func runCappedTerminatesEarlyAndReportsTruncationForOversizedOutput() async throws {
+        let result = try await Process.runCapped(
+            "/usr/bin/awk",
+            args: ["BEGIN { for (i = 0; i < 2000000; i++) printf \"x\" }"],
+            maxOutputBytes: 1_000
+        )
+        #expect(result.stdoutTruncated)
+        // Soft cap: allowed to overshoot by up to one pipe chunk, but must
+        // never approach anywhere near the full 2,000,000 bytes the awk
+        // script would otherwise have produced.
+        #expect(result.stdout.count >= 1_000)
+        #expect(result.stdout.count < 500_000)
+    }
+
+    @Test func runCappedDoesNotTruncateOutputUnderTheCap() async throws {
+        let result = try await Process.runCapped("/bin/echo", args: ["hi"], maxOutputBytes: 1_000_000)
+        #expect(!result.stdoutTruncated)
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "hi")
+    }
+
+    @Test func gitCappedConvenienceCallStillWorks() async throws {
+        let result = try await Process.gitCapped(["--version"], maxOutputBytes: 1_000_000)
+        #expect(!result.stdoutTruncated)
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("git version"))
+    }
+
     @Test func gitInvocationSurvivesWorkingDirectoryDeletionBeforeLaunch() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-deleted-git-cwd-\(UUID().uuidString)")

--- a/AlasTests/ProcessGitTests.swift
+++ b/AlasTests/ProcessGitTests.swift
@@ -241,6 +241,25 @@ struct ProcessGitTests {
         #expect(decodeUTF8DroppingIncompleteTrailingScalar(complete) == "x😀")
     }
 
+    /// An invalid byte NOT at the tail — e.g. a Latin-1-encoded file with no
+    /// NUL byte (so it passes binary sniffing) whose raw bytes git emits
+    /// straight into the diff — isn't fixed by trimming the last 1-3 bytes.
+    /// Falling back to a lossy decode must still preserve the surrounding
+    /// valid text rather than discarding the whole captured diff.
+    @Test func decodeUTF8DroppingIncompleteTrailingScalarFallsBackToLossyDecodingForAnInteriorInvalidByte() {
+        // "café" in Latin-1: 'é' is the single byte 0xE9, which is not valid
+        // UTF-8 in this position (not a valid continuation or lead byte).
+        // Followed by more than 3 valid bytes, so the trailing-scalar-drop
+        // loop (which only ever removes the LAST 1-3 bytes) cannot mask this
+        // by coincidentally trimming the invalid byte away — the lossy
+        // fallback is the only path that can recover this input.
+        let data = Data("caf".utf8) + Data([0xE9]) + Data(" text after\n".utf8)
+        let decoded = decodeUTF8DroppingIncompleteTrailingScalar(data)
+        #expect(decoded.hasPrefix("caf"))
+        #expect(decoded.contains("\u{FFFD}"))
+        #expect(decoded.hasSuffix(" text after\n"))
+    }
+
     @Test func gitCappedConvenienceCallStillWorks() async throws {
         let result = try await Process.gitCapped(["--version"], maxOutputBytes: 1_000_000)
         #expect(!result.stdoutTruncated)

--- a/AlasTests/ProcessGitTests.swift
+++ b/AlasTests/ProcessGitTests.swift
@@ -211,6 +211,36 @@ struct ProcessGitTests {
         #expect(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "hi")
     }
 
+    /// `maxOutputBytes` cuts the byte stream wherever it happens to land —
+    /// including mid-way through a multibyte UTF-8 character. A strict
+    /// `String(data:encoding:.utf8)` decode fails closed on that, silently
+    /// turning an otherwise valid captured prefix into an empty string.
+    @Test func runCappedDecodesCleanlyWhenTheCapSplitsAMultibyteUTF8Character() async throws {
+        // "😀" (U+1F600) is 4 bytes in UTF-8 (F0 9F 98 80). Ask for exactly
+        // one leading ASCII byte plus the first 2 of those 4 bytes, so the
+        // cap lands inside the character.
+        let result = try await Process.runCapped(
+            "/bin/sh",
+            args: ["-c", "printf 'x\\360\\237\\230'"],   // "x" + 0xF0 0x9F 0x98 (missing the final 0x80)
+            maxOutputBytes: 3
+        )
+        #expect(result.stdout == "x")
+    }
+
+    @Test func decodeUTF8DroppingIncompleteTrailingScalarReturnsCompleteInputUnchanged() {
+        #expect(decodeUTF8DroppingIncompleteTrailingScalar(Data("hello".utf8)) == "hello")
+        #expect(decodeUTF8DroppingIncompleteTrailingScalar(Data()) == "")
+    }
+
+    @Test func decodeUTF8DroppingIncompleteTrailingScalarTrimsATruncatedTrailingCharacter() {
+        let complete = Data("x".utf8) + Data([0xF0, 0x9F, 0x98, 0x80])   // "x😀"
+        // Missing 1, 2, and 3 of the emoji's 4 bytes, respectively.
+        #expect(decodeUTF8DroppingIncompleteTrailingScalar(complete.dropLast(1)) == "x")
+        #expect(decodeUTF8DroppingIncompleteTrailingScalar(complete.dropLast(2)) == "x")
+        #expect(decodeUTF8DroppingIncompleteTrailingScalar(complete.dropLast(3)) == "x")
+        #expect(decodeUTF8DroppingIncompleteTrailingScalar(complete) == "x😀")
+    }
+
     @Test func gitCappedConvenienceCallStillWorks() async throws {
         let result = try await Process.gitCapped(["--version"], maxOutputBytes: 1_000_000)
         #expect(!result.stdoutTruncated)

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1225,6 +1225,62 @@ struct RemoteAppStateAccessTests {
         #expect(outcome == .text(marker))
     }
 
+    /// `AppState.remoteFileTree` must verify remote containment for a
+    /// worktree registered in `RemoteHostRegistry` before listing a
+    /// non-root directory — never trust `RemoteWorktreeFileAccess.resolve`
+    /// alone, since that check only performs LOCAL symlink resolution and
+    /// is a no-op when nothing exists locally at the worktree's path to
+    /// escape from (the real vulnerability: a symlink inside the SSH
+    /// worktree pointing outside it).
+    ///
+    /// As with `readRemoteWorktreeFileRawDoesNotFallBackToLocalDiskWhenTheHostIsUnreachable`,
+    /// there is no reachable SSH server in this environment, so this can't
+    /// drive a real end-to-end escape. Instead it proves the fix's
+    /// fail-closed behavior directly: `repository` is a REAL local git repo
+    /// with a real "alias" subdirectory tracked in git, so — absent the
+    /// fix — `GitService.fileTreeChildren` would happily list its (real,
+    /// local) contents once `resolve` vacuously passes. Registering
+    /// `repository.path` with `RemoteHostRegistry` (as a real remote
+    /// worktree root would be) makes `worktree.path.isRemoteAlasPath` true,
+    /// so the new containment check runs and must fail closed against the
+    /// unreachable host rather than falling through to the real local
+    /// listing. `nonexistent-host.invalid` is used for the same reason as
+    /// the sibling test: an IANA-reserved TLD guaranteed never to resolve.
+    @Test func remoteFileTreeVerifiesRemoteContainmentBeforeListingANonRootDirectory() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        defer {
+            RemoteHostRegistry.shared.unregister(root: repository.path)
+            try? FileManager.default.removeItem(at: repository)
+        }
+        let aliasDir = repository.appendingPathComponent("alias")
+        try FileManager.default.createDirectory(at: aliasDir, withIntermediateDirectories: true)
+        try "secret\n".write(to: aliasDir.appendingPathComponent("secret.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "alias"], cwd: repository)
+        _ = try await Process.git(["commit", "-q", "-m", "add alias dir"], cwd: repository)
+
+        RemoteHostRegistry.shared.register(root: repository.path, host: "nonexistent-host.invalid")
+
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+        let state = makeRemoteGitBackedState(repositoryPath: repository)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+
+        let result = await state.remoteFileTree(sessionId: tab.sessionId, path: "alias")
+
+        guard case let .failure(reason, _) = result else {
+            Issue.record("expected remote containment verification to fail closed, got \(result)")
+            return
+        }
+        #expect(reason == .gitFailed)
+    }
+
     /// End-to-end reproduction of the bug: a binary file that existed at the
     /// comparison ref but was deleted from the working tree since must still
     /// surface `.binary`, not an empty "successful" diff (the working-tree

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1001,6 +1001,30 @@ struct RemoteAppStateAccessTests {
         #expect(FileManager.default.fileExists(atPath: createdWorktree.path.path))
     }
 
+    @Test func remoteChangeListReportsSessionUnknownForAnUnknownSession() async throws {
+        let state = AppState(store: MemoryStore())
+        let result = await state.remoteChangeList(sessionId: "no-such-session")
+        #expect(result == .failure(reason: .sessionUnknown, message: nil))
+    }
+
+    @Test func remoteFileDiffReportsSessionUnknownForAnUnknownSession() async throws {
+        let state = AppState(store: MemoryStore())
+        let result = await state.remoteFileDiff(sessionId: "no-such-session", path: "a.txt")
+        #expect(result == .failure(reason: .sessionUnknown, message: nil))
+    }
+
+    @Test func remoteFileTreeReportsSessionUnknownForAnUnknownSession() async throws {
+        let state = AppState(store: MemoryStore())
+        let result = await state.remoteFileTree(sessionId: "no-such-session", path: nil)
+        #expect(result == .failure(reason: .sessionUnknown, message: nil))
+    }
+
+    @Test func remoteFileContentsReportsSessionUnknownForAnUnknownSession() async throws {
+        let state = AppState(store: MemoryStore())
+        let result = await state.remoteFileContents(sessionId: "no-such-session", path: "a.txt")
+        #expect(result == .failure(reason: .sessionUnknown, byteSize: nil, message: nil))
+    }
+
     private func statusCode(port: UInt16, host: String, path: String) async throws -> Int? {
         var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)\(path)")!)
         req.setValue(host, forHTTPHeaderField: "Host")

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1084,6 +1084,35 @@ struct RemoteAppStateAccessTests {
         #expect(diffResult == .failure(reason: .pathRejected, message: nil))
     }
 
+    @Test func remoteFileContentsAndDiffRejectAGitignoredFileWithAWhitespacePaddedPath() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        try "secret.env\n".write(
+            to: repository.appendingPathComponent(".gitignore"), atomically: true, encoding: .utf8)
+        try "TOKEN=abc\n".write(
+            to: repository.appendingPathComponent("secret.env"), atomically: true, encoding: .utf8)
+
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+        let state = makeRemoteGitBackedState(repositoryPath: repository)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        await settleSessionRowsRace(manager)
+
+        let contentsResult = await state.remoteFileContents(sessionId: tab.sessionId, path: " secret.env")
+        #expect(contentsResult == .failure(reason: .pathRejected, byteSize: nil, message: nil))
+
+        let diffResult = await state.remoteFileDiff(sessionId: tab.sessionId, path: " secret.env")
+        #expect(diffResult == .failure(reason: .pathRejected, message: nil))
+    }
+
     @Test func remoteFileContentsAndDiffServeATrackedFileNormally() async throws {
         let repository = try await makeRemoteBranchesRepository()
         defer { try? FileManager.default.removeItem(at: repository) }

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1171,14 +1171,23 @@ struct RemoteAppStateAccessTests {
     /// `AppState.readRemoteWorktreeFileRaw` must go over the (attempted) SSH
     /// transport for a worktree whose root is registered in
     /// `RemoteHostRegistry` — never silently fall back to reading local
-    /// disk. There is no reachable SSH server in this environment (confirmed
-    /// manually: `ssh 127.0.0.1` returns "Connection refused" immediately),
-    /// so this test can't drive a real end-to-end remote read; instead it
-    /// proves the negative that matters: given a local directory that
-    /// genuinely contains the requested file with known content, reading it
-    /// through the "remote" branch does NOT return that local content. A
-    /// regression that reintroduced a local-disk fallback would make this
-    /// test fail by returning `.data(...)` with the real bytes.
+    /// disk. There is no reachable SSH server in this environment, so this
+    /// test can't drive a real end-to-end remote read; instead it proves the
+    /// negative that matters: given a local directory that genuinely
+    /// contains the requested file with known content, reading it through
+    /// the "remote" branch does NOT return that local content. A regression
+    /// that reintroduced a local-disk fallback would make this test fail by
+    /// returning `.data(...)` with the real bytes.
+    ///
+    /// Uses `nonexistent-host.invalid` rather than `127.0.0.1`: `127.0.0.1`
+    /// is a real, routable address that would silently exercise an actual
+    /// local SSH server on any machine with Remote Login enabled, making
+    /// this test pass for the wrong reason (or fail outright) instead of
+    /// proving the no-fallback invariant it's named for. `.invalid` is an
+    /// IANA-reserved TLD (RFC 2606) guaranteed never to resolve, and DNS
+    /// resolution failure is fast — unlike a non-routable IP (e.g.
+    /// TEST-NET-1), which would instead hang for the configured SSH
+    /// `ConnectTimeout` (10-30s) waiting for packets nothing ever answers.
     @Test func readRemoteWorktreeFileRawDoesNotFallBackToLocalDiskWhenTheHostIsUnreachable() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-remote-raw-read-\(UUID().uuidString)")
@@ -1189,7 +1198,7 @@ struct RemoteAppStateAccessTests {
 
         let state = AppState(store: MemoryStore())
         let outcome = await state.readRemoteWorktreeFileRaw(
-            host: "127.0.0.1", worktreeRoot: root.path, relativePath: "a.txt")
+            host: "nonexistent-host.invalid", worktreeRoot: root.path, relativePath: "a.txt")
 
         switch outcome {
         case .data(let data):

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1074,9 +1074,6 @@ struct RemoteAppStateAccessTests {
         cleanupWorktreeId = worktreeId
         state.openNewACPSession(agentID: "test-agent")
         let tab = try #require(acpTabs(in: state).first)
-        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
-        await settleSessionRowsRace(manager)
-
         let contentsResult = await state.remoteFileContents(sessionId: tab.sessionId, path: "secret.env")
         #expect(contentsResult == .failure(reason: .pathRejected, byteSize: nil, message: nil))
 
@@ -1103,9 +1100,6 @@ struct RemoteAppStateAccessTests {
         cleanupWorktreeId = worktreeId
         state.openNewACPSession(agentID: "test-agent")
         let tab = try #require(acpTabs(in: state).first)
-        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
-        await settleSessionRowsRace(manager)
-
         let contentsResult = await state.remoteFileContents(sessionId: tab.sessionId, path: " secret.env")
         #expect(contentsResult == .failure(reason: .pathRejected, byteSize: nil, message: nil))
 
@@ -1131,11 +1125,135 @@ struct RemoteAppStateAccessTests {
         cleanupWorktreeId = worktreeId
         state.openNewACPSession(agentID: "test-agent")
         let tab = try #require(acpTabs(in: state).first)
-        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
-        await settleSessionRowsRace(manager)
 
         let contentsResult = await state.remoteFileContents(sessionId: tab.sessionId, path: "visible.txt")
         #expect(contentsResult == .success(text: "hello\n", truncated: false))
+    }
+
+    /// Reproduces the race `remoteWorktreeContext` used to lose: a manager's
+    /// own background `refreshRecentNow()` (fired from `init` before any
+    /// session exists) can land its `recentSessions()` read after
+    /// `createSession()` has already installed the session live but before
+    /// that session's own `upsertSession` write is visible to a fresh read —
+    /// overwriting `sessionRows` with a snapshot that omits the new session.
+    /// Forcing an extra `refreshRecentNow()` here — without first flushing
+    /// the just-created session's write — reproduces exactly that ordering.
+    /// Whether or not `sessionRows` actually loses the row on a given run,
+    /// the session is live either way, so the assertion must hold
+    /// regardless — this is what distinguishes the fix (checking
+    /// `liveSession` too) from the old `sessionRows`-only lookup.
+    @Test func remoteFileContentsSucceedsWhenLiveSessionRacesAheadOfPersistedSessionRows() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        try "hello\n".write(to: repository.appendingPathComponent("visible.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "visible.txt"], cwd: repository)
+        _ = try await Process.git(["commit", "-m", "add visible file"], cwd: repository)
+
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+        let state = makeRemoteGitBackedState(repositoryPath: repository)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+
+        await manager.refreshRecentNow()
+
+        let contentsResult = await state.remoteFileContents(sessionId: tab.sessionId, path: "visible.txt")
+        #expect(contentsResult == .success(text: "hello\n", truncated: false))
+    }
+
+    /// `AppState.readRemoteWorktreeFileRaw` must go over the (attempted) SSH
+    /// transport for a worktree whose root is registered in
+    /// `RemoteHostRegistry` — never silently fall back to reading local
+    /// disk. There is no reachable SSH server in this environment (confirmed
+    /// manually: `ssh 127.0.0.1` returns "Connection refused" immediately),
+    /// so this test can't drive a real end-to-end remote read; instead it
+    /// proves the negative that matters: given a local directory that
+    /// genuinely contains the requested file with known content, reading it
+    /// through the "remote" branch does NOT return that local content. A
+    /// regression that reintroduced a local-disk fallback would make this
+    /// test fail by returning `.data(...)` with the real bytes.
+    @Test func readRemoteWorktreeFileRawDoesNotFallBackToLocalDiskWhenTheHostIsUnreachable() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-remote-raw-read-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let marker = "local content that a remote read must never return\n"
+        try marker.write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+
+        let state = AppState(store: MemoryStore())
+        let outcome = await state.readRemoteWorktreeFileRaw(
+            host: "127.0.0.1", worktreeRoot: root.path, relativePath: "a.txt")
+
+        switch outcome {
+        case .data(let data):
+            Issue.record("remote read must not fall back to local disk, got local bytes: \(data)")
+        case .notFound, .unreadable, .containmentRejected:
+            break // any failure kind is fine — the point is it did not read local disk
+        }
+    }
+
+    /// Companion to the above: confirms the fixture actually would have
+    /// produced a misleadingly "successful" local read had the code taken
+    /// the local-disk branch instead — otherwise the test above would pass
+    /// vacuously (any host, reachable or not, "not returning local content"
+    /// is meaningless if there's no local content to begin with).
+    @Test func readRemoteWorktreeFileRawFixtureWouldSucceedIfReadLocally() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-remote-raw-read-control-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let marker = "local content that a remote read must never return\n"
+        try marker.write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+
+        let outcome = await RemoteWorktreeFileAccess.readFileContents(at: root.appendingPathComponent("a.txt"))
+        #expect(outcome == .text(marker))
+    }
+
+    /// End-to-end reproduction of the bug: a binary file that existed at the
+    /// comparison ref but was deleted from the working tree since must still
+    /// surface `.binary`, not an empty "successful" diff (the working-tree
+    /// sniff alone can't tell — the file isn't there to sniff).
+    @Test func remoteFileDiffReportsBinaryForABinaryFileDeletedSinceTheComparisonRef() async throws {
+        let repository = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-remote-binary-delete-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repository, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: repository) }
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repository)
+        _ = try await Process.git(["config", "user.email", "test@example.com"], cwd: repository)
+        _ = try await Process.git(["config", "user.name", "Test User"], cwd: repository)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "initial"], cwd: repository)
+
+        try Data([0x89, 0x50, 0x4E, 0x47, 0x00, 0x01, 0x02]).write(
+            to: repository.appendingPathComponent("image.bin"))
+        _ = try await Process.git(["add", "image.bin"], cwd: repository)
+        _ = try await Process.git(["commit", "-q", "-m", "add binary"], cwd: repository)
+        _ = try await Process.git(["branch", "start"], cwd: repository)
+
+        _ = try await Process.git(["rm", "-q", "image.bin"], cwd: repository)
+        _ = try await Process.git(["commit", "-q", "-m", "remove binary"], cwd: repository)
+
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+        let state = makeRemoteGitBackedState(repositoryPath: repository)
+        state.config.worktrees.baseBranch = "start"
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+
+        let diffResult = await state.remoteFileDiff(sessionId: tab.sessionId, path: "image.bin")
+        #expect(diffResult == .failure(reason: .binary, message: nil))
     }
 
     private func statusCode(port: UInt16, host: String, path: String) async throws -> Int? {
@@ -1224,22 +1342,6 @@ struct RemoteAppStateAccessTests {
             installedIds: ["test-agent"]
         )
         return state
-    }
-
-    /// `ACPSessionManager.init` fires an untracked background `refreshRecent()`
-    /// when constructed via `persistence:` (as `AppState.acpManager(for:)`
-    /// does) — see its `if store == nil { refreshRecent() }`. That task's own
-    /// DB read can be submitted to the persistence backend before a
-    /// same-tick `createSession()`'s `upsertSession` write, so it can
-    /// overwrite `sessionRows` with a snapshot that doesn't yet include the
-    /// just-created session as soon as this test's first `await` yields the
-    /// MainActor. Flushing the create's own write, then re-reading
-    /// ourselves, settles both writes before `sessionRows` is relied upon —
-    /// otherwise `remoteWorktreeContext` intermittently reports
-    /// `.sessionUnknown` for a session that very much exists.
-    private func settleSessionRowsRace(_ manager: ACPSessionManager) async {
-        await manager.flushPersistence()
-        await manager.refreshRecentNow()
     }
 
     /// Like `makeRemoteRenameState()` but points the worktree at a real git

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1055,6 +1055,60 @@ struct RemoteAppStateAccessTests {
         #expect(result == .failure(reason: .worktreeUnavailable, message: nil))
     }
 
+    @Test func remoteFileContentsAndDiffRejectAGitignoredFile() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        try "secret.env\n".write(
+            to: repository.appendingPathComponent(".gitignore"), atomically: true, encoding: .utf8)
+        try "TOKEN=abc\n".write(
+            to: repository.appendingPathComponent("secret.env"), atomically: true, encoding: .utf8)
+
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+        let state = makeRemoteGitBackedState(repositoryPath: repository)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        await settleSessionRowsRace(manager)
+
+        let contentsResult = await state.remoteFileContents(sessionId: tab.sessionId, path: "secret.env")
+        #expect(contentsResult == .failure(reason: .pathRejected, byteSize: nil, message: nil))
+
+        let diffResult = await state.remoteFileDiff(sessionId: tab.sessionId, path: "secret.env")
+        #expect(diffResult == .failure(reason: .pathRejected, message: nil))
+    }
+
+    @Test func remoteFileContentsAndDiffServeATrackedFileNormally() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        try "hello\n".write(to: repository.appendingPathComponent("visible.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "visible.txt"], cwd: repository)
+        _ = try await Process.git(["commit", "-m", "add visible file"], cwd: repository)
+
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+        let state = makeRemoteGitBackedState(repositoryPath: repository)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        await settleSessionRowsRace(manager)
+
+        let contentsResult = await state.remoteFileContents(sessionId: tab.sessionId, path: "visible.txt")
+        #expect(contentsResult == .success(text: "hello\n", truncated: false))
+    }
+
     private func statusCode(port: UInt16, host: String, path: String) async throws -> Int? {
         var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)\(path)")!)
         req.setValue(host, forHTTPHeaderField: "Host")
@@ -1116,6 +1170,68 @@ struct RemoteAppStateAccessTests {
             name: "main",
             branch: "main",
             path: URL(fileURLWithPath: project.path),
+            status: .clean,
+            lastActivity: Date()
+        )
+        state.projectsManager.insertOptimisticWorktree(worktree)
+        state.selectedWorktreeId = worktree.id
+        state.config.changes.aiToolId = "test-agent"
+        state.agentRegistry = AgentRegistry(
+            builtinState: [:],
+            customs: [
+                AgentDefinition(
+                    id: "test-agent",
+                    displayName: "Test Agent",
+                    binary: "test-agent",
+                    binaryOverride: nil,
+                    promptModeArgs: [],
+                    bypassPermissionsFlag: nil,
+                    extraTerminalArgs: nil,
+                    isBuiltin: false,
+                    isEnabled: true,
+                    builtinLogoAssetName: nil
+                ),
+            ],
+            installedIds: ["test-agent"]
+        )
+        return state
+    }
+
+    /// `ACPSessionManager.init` fires an untracked background `refreshRecent()`
+    /// when constructed via `persistence:` (as `AppState.acpManager(for:)`
+    /// does) — see its `if store == nil { refreshRecent() }`. That task's own
+    /// DB read can be submitted to the persistence backend before a
+    /// same-tick `createSession()`'s `upsertSession` write, so it can
+    /// overwrite `sessionRows` with a snapshot that doesn't yet include the
+    /// just-created session as soon as this test's first `await` yields the
+    /// MainActor. Flushing the create's own write, then re-reading
+    /// ourselves, settles both writes before `sessionRows` is relied upon —
+    /// otherwise `remoteWorktreeContext` intermittently reports
+    /// `.sessionUnknown` for a session that very much exists.
+    private func settleSessionRowsRace(_ manager: ACPSessionManager) async {
+        await manager.flushPersistence()
+        await manager.refreshRecentNow()
+    }
+
+    /// Like `makeRemoteRenameState()` but points the worktree at a real git
+    /// repository (rather than a bare `/tmp` directory) so `remoteFileDiff`
+    /// / `remoteFileContents`' git-backed checks (ignore status, diffing)
+    /// have a real repo to work against.
+    private func makeRemoteGitBackedState(repositoryPath: URL) -> AppState {
+        let project = ProjectConfig(
+            id: UUID().uuidString,
+            name: "test",
+            path: repositoryPath.path,
+            color: "blue",
+            addedAt: Date()
+        )
+        let state = AppState(store: ProjectMemoryStore(projectsFile: ProjectsFile(projects: [project])))
+        let worktree = Worktree(
+            id: UUID().uuidString,
+            projectId: project.id,
+            name: "main",
+            branch: "main",
+            path: repositoryPath,
             status: .clean,
             lastActivity: Date()
         )

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1203,7 +1203,7 @@ struct RemoteAppStateAccessTests {
         switch outcome {
         case .data(let data):
             Issue.record("remote read must not fall back to local disk, got local bytes: \(data)")
-        case .notFound, .unreadable, .containmentRejected:
+        case .notFound, .unreadable, .containmentRejected, .tooLarge:
             break // any failure kind is fine — the point is it did not read local disk
         }
     }

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1025,6 +1025,36 @@ struct RemoteAppStateAccessTests {
         #expect(result == .failure(reason: .sessionUnknown, byteSize: nil, message: nil))
     }
 
+    @Test func remoteChangeListReportsWorktreeUnavailableWhenProjectAndWorktreeReturnsNil() async throws {
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+
+        let state = makeRemoteRenameState()
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+
+        // Simulate worktree deletion while manager still holds session reference.
+        // First ensure the session is in the manager's rows.
+        let manager = try #require(state.acpManager(forWorktreeId: worktreeId))
+        #expect(manager.sessionRows.contains(where: { $0.id == tab.sessionId }))
+
+        // Now delete the worktree from projectsManager, making projectAndWorktree return nil
+        let project = try #require(state.projects.first)
+        let visibleWorktrees = state.projectsManager.visibleWorktrees(projectId: project.id)
+        for wt in visibleWorktrees {
+            state.projectsManager.removeOptimisticWorktree(id: wt.id, projectId: project.id)
+        }
+
+        let result = await state.remoteChangeList(sessionId: tab.sessionId)
+        #expect(result == .failure(reason: .worktreeUnavailable, message: nil))
+    }
+
     private func statusCode(port: UInt16, host: String, path: String) async throws -> Int? {
         var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)\(path)")!)
         req.setValue(host, forHTTPHeaderField: "Host")

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1081,6 +1081,16 @@ struct RemoteAppStateAccessTests {
         #expect(diffResult == .failure(reason: .pathRejected, message: nil))
     }
 
+    /// `normalizedRelativePath` used to trim the path before resolving it,
+    /// which happened to close this bypass for the wrong reason (a real
+    /// file legitimately named with leading/trailing whitespace would have
+    /// been silently misrouted to a different, trimmed path). Now that
+    /// resolution preserves the client's exact bytes, the padded path
+    /// simply doesn't name the real `secret.env` file — it fails to resolve
+    /// to anything, rather than being caught by the ignore check — so the
+    /// outcome shape changes (not-found / empty diff instead of path
+    /// rejected), but the actual security guarantee (the real, ignored
+    /// content is never served) must still hold.
     @Test func remoteFileContentsAndDiffRejectAGitignoredFileWithAWhitespacePaddedPath() async throws {
         let repository = try await makeRemoteBranchesRepository()
         defer { try? FileManager.default.removeItem(at: repository) }
@@ -1101,10 +1111,66 @@ struct RemoteAppStateAccessTests {
         state.openNewACPSession(agentID: "test-agent")
         let tab = try #require(acpTabs(in: state).first)
         let contentsResult = await state.remoteFileContents(sessionId: tab.sessionId, path: " secret.env")
-        #expect(contentsResult == .failure(reason: .pathRejected, byteSize: nil, message: nil))
+        if case .success(let text, _) = contentsResult {
+            Issue.record("secret content must never be served for a whitespace-padded path, got: \(text)")
+        }
+        #expect(contentsResult == .failure(reason: .notFound, byteSize: nil, message: nil))
 
         let diffResult = await state.remoteFileDiff(sessionId: tab.sessionId, path: " secret.env")
-        #expect(diffResult == .failure(reason: .pathRejected, message: nil))
+        if case .success(let hunks, _) = diffResult {
+            let text = hunks.flatMap(\.lines).map(\.text).joined()
+            #expect(!text.contains("abc"), "secret content must never be served for a whitespace-padded path")
+        }
+    }
+
+    /// A TRACKED symlink whose own name doesn't match any ignore pattern
+    /// (`public-env`) but whose target does (`.env`) must not have the
+    /// target's content served. `isPathIgnored("public-env")` correctly
+    /// reports "not ignored" — the check runs against the alias's own name,
+    /// which is the whole point of a symlink alias — so the read/diff path
+    /// itself must independently reject any symlink rather than trusting
+    /// the ignore check alone.
+    @Test func remoteFileContentsAndDiffRejectATrackedSymlinkAliasingAGitignoredTarget() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        try ".env\n".write(
+            to: repository.appendingPathComponent(".gitignore"), atomically: true, encoding: .utf8)
+        try "TOKEN=super-secret\n".write(
+            to: repository.appendingPathComponent(".env"), atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(
+            at: repository.appendingPathComponent("public-env"),
+            withDestinationURL: repository.appendingPathComponent(".env"))
+        _ = try await Process.git(["add", "public-env"], cwd: repository)
+        _ = try await Process.git(["commit", "-q", "-m", "add public-env symlink"], cwd: repository)
+
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+        let state = makeRemoteGitBackedState(repositoryPath: repository)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+
+        // Confirm the premise: the alias's own name is genuinely not ignored.
+        let ignored = try await GitService().isPathIgnored(worktreePath: repository, path: "public-env")
+        #expect(!ignored)
+
+        let contentsResult = await state.remoteFileContents(sessionId: tab.sessionId, path: "public-env")
+        #expect(contentsResult == .failure(reason: .notFound, byteSize: nil, message: nil))
+        if case .success(let text, _) = contentsResult {
+            Issue.record("secret content must never be served through a symlink alias, got: \(text)")
+        }
+
+        let diffResult = await state.remoteFileDiff(sessionId: tab.sessionId, path: "public-env")
+        #expect(diffResult == .failure(reason: .notFound, message: nil))
+        if case .success(let hunks, _) = diffResult {
+            let text = hunks.flatMap(\.lines).map(\.text).joined()
+            #expect(!text.contains("super-secret"), "secret content must never be served through a symlink alias diff")
+        }
     }
 
     @Test func remoteFileContentsAndDiffServeATrackedFileNormally() async throws {

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1347,6 +1347,57 @@ struct RemoteAppStateAccessTests {
         #expect(reason == .gitFailed)
     }
 
+    /// LOCAL-worktree counterpart of the SSH-specific
+    /// `shouldClassifyRemotelyDiscoveredEntry` fix: `GitService.fileTree`'s
+    /// LOCAL root scan can mark a directory `.ignored` even though it holds
+    /// a tracked, force-added descendant (gitignore rules don't un-track a
+    /// path already in the index) — intentional, since the native desktop
+    /// Files tab keeps such a directory visible via
+    /// `FilesTabView.filteredNodes`'s recursive keep-if-has-visible-children
+    /// check. `AppState.remoteFileNodes` used to do a flat, non-recursive
+    /// `compactMap` that dropped the directory outright — since
+    /// `RemoteFileNode` carries no `children`, once dropped from the ROOT
+    /// listing the client could never issue the `listFiles` request that
+    /// would reveal `generated/keep.txt`. This exercises the fix via the
+    /// same seam other tests in this file use for the root-level remote file
+    /// tree (`state.remoteFileTree(sessionId:path: nil)`), against a real
+    /// LOCAL git repo (not registered with `RemoteHostRegistry`), so it
+    /// actually drives `GitService.fileTree`'s local branch end-to-end.
+    @Test func remoteFileTreeSurfacesAnIgnoredRootDirectoryWithATrackedDescendant() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        try "generated/\n".write(
+            to: repository.appendingPathComponent(".gitignore"), atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(
+            at: repository.appendingPathComponent("generated"), withIntermediateDirectories: true)
+        try "tracked\n".write(
+            to: repository.appendingPathComponent("generated/keep.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", ".gitignore"], cwd: repository)
+        _ = try await Process.git(["add", "-f", "generated/keep.txt"], cwd: repository)
+        _ = try await Process.git(["commit", "-q", "-m", "seed"], cwd: repository)
+
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+        let state = makeRemoteGitBackedState(repositoryPath: repository)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+
+        let result = await state.remoteFileTree(sessionId: tab.sessionId, path: nil)
+
+        guard case let .success(nodes) = result else {
+            Issue.record("expected a successful root file tree listing, got \(result)")
+            return
+        }
+        let generated = try #require(nodes.first { $0.path == "generated" })
+        #expect(generated.kind == "dir")
+    }
+
     /// End-to-end reproduction of the bug: a binary file that existed at the
     /// comparison ref but was deleted from the working tree since must still
     /// surface `.binary`, not an empty "successful" diff (the working-tree

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1117,7 +1117,7 @@ struct RemoteAppStateAccessTests {
         #expect(contentsResult == .failure(reason: .notFound, byteSize: nil, message: nil))
 
         let diffResult = await state.remoteFileDiff(sessionId: tab.sessionId, path: " secret.env")
-        if case .success(let hunks, _) = diffResult {
+        if case .success(let hunks, _, _) = diffResult {
             let text = hunks.flatMap(\.lines).map(\.text).joined()
             #expect(!text.contains("abc"), "secret content must never be served for a whitespace-padded path")
         }
@@ -1167,7 +1167,7 @@ struct RemoteAppStateAccessTests {
 
         let diffResult = await state.remoteFileDiff(sessionId: tab.sessionId, path: "public-env")
         #expect(diffResult == .failure(reason: .notFound, message: nil))
-        if case .success(let hunks, _) = diffResult {
+        if case .success(let hunks, _, _) = diffResult {
             let text = hunks.flatMap(\.lines).map(\.text).joined()
             #expect(!text.contains("super-secret"), "secret content must never be served through a symlink alias diff")
         }

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1130,7 +1130,7 @@ struct RemoteAppStateAccessTests {
     /// which is the whole point of a symlink alias — so the read/diff path
     /// itself must independently reject any symlink rather than trusting
     /// the ignore check alone.
-    @Test func remoteFileContentsAndDiffRejectATrackedSymlinkAliasingAGitignoredTarget() async throws {
+    @Test func remoteFileContentsRejectsButDiffSafelyShowsATrackedSymlinkAliasingAGitignoredTarget() async throws {
         let repository = try await makeRemoteBranchesRepository()
         defer { try? FileManager.default.removeItem(at: repository) }
         try ".env\n".write(
@@ -1150,6 +1150,12 @@ struct RemoteAppStateAccessTests {
             }
         }
         let state = makeRemoteGitBackedState(repositoryPath: repository)
+        // "feature/remote" still points at the initial commit, from before
+        // public-env existed — comparing against it makes public-env show
+        // up as a genuinely ADDED path in the diff, exercising the actual
+        // "does this leak secret content" question instead of trivially
+        // passing on an empty (nothing-changed-since-HEAD) diff.
+        state.config.worktrees.baseBranch = "feature/remote"
         let worktreeId = try #require(state.selectedWorktreeId)
         cleanupWorktreeId = worktreeId
         state.openNewACPSession(agentID: "test-agent")
@@ -1165,12 +1171,18 @@ struct RemoteAppStateAccessTests {
             Issue.record("secret content must never be served through a symlink alias, got: \(text)")
         }
 
+        // Unlike a direct content read, a DIFF of a symlink is safe: git
+        // tracks a symlink's blob as its destination path string only,
+        // never the target's content — this must SUCCEED and show `.env`
+        // (the destination), never the secret token inside it.
         let diffResult = await state.remoteFileDiff(sessionId: tab.sessionId, path: "public-env")
-        #expect(diffResult == .failure(reason: .notFound, message: nil))
-        if case .success(let hunks, _, _) = diffResult {
-            let text = hunks.flatMap(\.lines).map(\.text).joined()
-            #expect(!text.contains("super-secret"), "secret content must never be served through a symlink alias diff")
+        guard case let .success(hunks, _, _) = diffResult else {
+            Issue.record("expected a successful symlink diff, got \(diffResult)")
+            return
         }
+        let text = hunks.flatMap(\.lines).map(\.text).joined()
+        #expect(text.contains(".env"))
+        #expect(!text.contains("super-secret"), "secret content must never be served through a symlink alias diff")
     }
 
     @Test func remoteFileContentsAndDiffServeATrackedFileNormally() async throws {

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1398,6 +1398,83 @@ struct RemoteAppStateAccessTests {
         #expect(generated.kind == "dir")
     }
 
+    /// Regression for the Files-tab badge source: `remoteFileTree` used to
+    /// badge nodes from `GitService.status(worktreePath:)`, which is
+    /// working-tree/index-relative and so has nothing to say about a file
+    /// that was changed in a COMMIT already on the branch — the common case
+    /// when reviewing an agent's finished work on a clean checkout. The
+    /// Changes tab already badges this correctly via
+    /// `changedFilesAgainstRef(ref: comparisonRef)`; the Files tab must
+    /// report the same badge for the same file instead of showing it
+    /// unbadged just because the working tree itself is clean.
+    @Test func remoteFileTreeBadgesACommittedChangeEvenWithACleanWorkingTree() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        _ = try await Process.git(["checkout", "-q", "feature/remote"], cwd: repository)
+        try "hello\n".write(
+            to: repository.appendingPathComponent("example.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "example.txt"], cwd: repository)
+        _ = try await Process.git(["commit", "-q", "-m", "add example"], cwd: repository)
+
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+        let state = makeRemoteGitBackedState(repositoryPath: repository)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+
+        let result = await state.remoteFileTree(sessionId: tab.sessionId, path: nil)
+
+        guard case let .success(nodes, _) = result else {
+            Issue.record("expected a successful root file tree listing, got \(result)")
+            return
+        }
+        let example = try #require(nodes.first { $0.path == "example.txt" })
+        #expect(example.badge != nil)
+    }
+
+    /// Nested-directory counterpart: `fileTreeChildren` used to always build
+    /// its nodes with `badges: [:]`, so a change in a subdirectory lost its
+    /// badge the moment a client expanded into that directory, even though
+    /// the root listing (or the Changes tab) would show it badged.
+    @Test func remoteFileTreeChildrenBadgesACommittedChangeInASubdirectory() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        _ = try await Process.git(["checkout", "-q", "feature/remote"], cwd: repository)
+        try FileManager.default.createDirectory(
+            at: repository.appendingPathComponent("subdir"), withIntermediateDirectories: true)
+        try "hello\n".write(
+            to: repository.appendingPathComponent("subdir/example.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "subdir/example.txt"], cwd: repository)
+        _ = try await Process.git(["commit", "-q", "-m", "add example"], cwd: repository)
+
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+        let state = makeRemoteGitBackedState(repositoryPath: repository)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+
+        let result = await state.remoteFileTree(sessionId: tab.sessionId, path: "subdir")
+
+        guard case let .success(nodes, _) = result else {
+            Issue.record("expected a successful subdirectory file tree listing, got \(result)")
+            return
+        }
+        let example = try #require(nodes.first { $0.path == "subdir/example.txt" })
+        #expect(example.badge != nil)
+    }
+
     /// End-to-end reproduction of the bug: a binary file that existed at the
     /// comparison ref but was deleted from the working tree since must still
     /// surface `.binary`, not an empty "successful" diff (the working-tree

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1390,7 +1390,7 @@ struct RemoteAppStateAccessTests {
 
         let result = await state.remoteFileTree(sessionId: tab.sessionId, path: nil)
 
-        guard case let .success(nodes) = result else {
+        guard case let .success(nodes, _) = result else {
             Issue.record("expected a successful root file tree listing, got \(result)")
             return
         }

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -656,4 +656,86 @@ struct RemoteProtocolTests {
         #expect(!RemoteClientMessage.setModel(sessionId: "s", modelId: "m").isDriveOrdering)
         #expect(!RemoteClientMessage.listSessions.isDriveOrdering)
     }
+
+    @Test func changesAndFilesClientMessagesRoundTripAndEncodeRequiredFields() throws {
+        let listChanges = RemoteClientMessage.listChanges(sessionId: "s1")
+        #expect(try roundTrip(listChanges) == listChanges)
+
+        let fileDiff = RemoteClientMessage.fileDiff(sessionId: "s1", path: "src/main.swift")
+        #expect(try roundTrip(fileDiff) == fileDiff)
+
+        let listRoot = RemoteClientMessage.listFiles(sessionId: "s1", path: nil)
+        #expect(try roundTrip(listRoot) == listRoot)
+
+        let listDir = RemoteClientMessage.listFiles(sessionId: "s1", path: "src")
+        #expect(try roundTrip(listDir) == listDir)
+
+        let readFile = RemoteClientMessage.readFile(sessionId: "s1", path: "README.md")
+        #expect(try roundTrip(readFile) == readFile)
+
+        let object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(fileDiff)) as? [String: Any])
+        #expect(object["type"] as? String == "fileDiff")
+        #expect(object["sessionId"] as? String == "s1")
+        #expect(object["path"] as? String == "src/main.swift")
+    }
+
+    @Test func changesAndFilesServerMessagesRoundTripAndEncodeRequiredFields() throws {
+        let file = RemoteChangedFile(
+            path: "src/main.swift", status: "M", add: 12, del: 3,
+            conflict: nil, renameFrom: nil)
+        let changeList = RemoteServerMessage.changeList(
+            sessionId: "s1", comparisonRef: "origin/main", metricsAvailable: true,
+            files: [file], truncated: false)
+        #expect(try roundTrip(changeList) == changeList)
+
+        let changeFailure = RemoteServerMessage.changeListFailed(
+            sessionId: "s1", reason: .worktreeUnavailable, message: nil)
+        #expect(try roundTrip(changeFailure) == changeFailure)
+
+        let hunk = RemoteDiffHunk(
+            header: "@@ -1,2 +1,3 @@", oldStart: 1, newStart: 1,
+            lines: [
+                RemoteDiffLine(kind: "context", text: "import Foundation", oldNumber: 1, newNumber: 1),
+                RemoteDiffLine(kind: "add", text: "import Testing", oldNumber: nil, newNumber: 2)
+            ])
+        let diff = RemoteServerMessage.fileDiffResult(
+            sessionId: "s1", path: "src/main.swift", hunks: [hunk], truncated: true)
+        #expect(try roundTrip(diff) == diff)
+
+        let diffFailure = RemoteServerMessage.fileDiffFailed(
+            sessionId: "s1", path: "logo.png", reason: .binary, message: nil)
+        #expect(try roundTrip(diffFailure) == diffFailure)
+
+        let node = RemoteFileNode(
+            name: "src", path: "src", kind: "dir", badge: nil,
+            childrenState: "notLoaded", isSubmodule: false)
+        let tree = RemoteServerMessage.fileTree(sessionId: "s1", path: nil, nodes: [node])
+        #expect(try roundTrip(tree) == tree)
+
+        let treeFailure = RemoteServerMessage.fileTreeFailed(
+            sessionId: "s1", path: "../etc", reason: .pathRejected, message: nil)
+        #expect(try roundTrip(treeFailure) == treeFailure)
+
+        let contents = RemoteServerMessage.fileContents(
+            sessionId: "s1", path: "README.md", text: "# Alas\n", truncated: false)
+        #expect(try roundTrip(contents) == contents)
+
+        let unavailable = RemoteServerMessage.fileUnavailable(
+            sessionId: "s1", path: "big.bin", reason: .tooLarge, byteSize: 1_500_000, message: nil)
+        #expect(try roundTrip(unavailable) == unavailable)
+
+        let object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(changeList)) as? [String: Any])
+        #expect(object["type"] as? String == "changeList")
+        #expect(object["comparisonRef"] as? String == "origin/main")
+        #expect(object["metricsAvailable"] as? Bool == true)
+        #expect(object["truncated"] as? Bool == false)
+    }
+
+    @Test func unknownFileAccessReasonDecodesAsUnknown() throws {
+        let json = #"{"type":"fileDiffFailed","sessionId":"s1","path":"a.txt","reason":"someFutureReason"}"#
+        let decoded = try JSONDecoder().decode(RemoteServerMessage.self, from: Data(json.utf8))
+        #expect(decoded == .fileDiffFailed(sessionId: "s1", path: "a.txt", reason: .unknown, message: nil))
+    }
 }

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -697,11 +697,23 @@ struct RemoteProtocolTests {
             header: "@@ -1,2 +1,3 @@", oldStart: 1, newStart: 1,
             lines: [
                 RemoteDiffLine(kind: "context", text: "import Foundation", oldNumber: 1, newNumber: 1),
-                RemoteDiffLine(kind: "add", text: "import Testing", oldNumber: nil, newNumber: 2)
+                RemoteDiffLine(kind: "add", text: "import Testing", oldNumber: nil, newNumber: 2),
+                RemoteDiffLine(kind: "delete", text: "old", oldNumber: 3, newNumber: nil, noTrailingNewline: true)
             ])
         let diff = RemoteServerMessage.fileDiffResult(
             sessionId: "s1", path: "src/main.swift", hunks: [hunk], truncated: true)
         #expect(try roundTrip(diff) == diff)
+        #expect(try roundTrip(hunk) == hunk)
+        #expect(try roundTrip(hunk).lines.last?.noTrailingNewline == true)
+
+        // Decoded leniently when the field is absent entirely (an older
+        // host that hasn't been rebuilt yet), defaulting to `false` rather
+        // than failing to decode.
+        let legacyJSON = Data("""
+        {"kind": "context", "text": "hi", "oldNumber": 1, "newNumber": 1}
+        """.utf8)
+        let legacyLine = try JSONDecoder().decode(RemoteDiffLine.self, from: legacyJSON)
+        #expect(legacyLine.noTrailingNewline == false)
 
         let diffFailure = RemoteServerMessage.fileDiffFailed(
             sessionId: "s1", path: "logo.png", reason: .binary, message: nil)

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -740,6 +740,19 @@ struct RemoteProtocolTests {
         let legacyLine = try JSONDecoder().decode(RemoteDiffLine.self, from: legacyJSON)
         #expect(legacyLine.noTrailingNewline == false)
 
+        let metadataOnlyDiff = RemoteServerMessage.fileDiffResult(
+            sessionId: "s1", path: "old.swift", hunks: [], truncated: false,
+            metadataNote: "Renamed from old.swift to new.swift — no content changes.")
+        #expect(try roundTrip(metadataOnlyDiff) == metadataOnlyDiff)
+
+        // Lenient decoding: an older paired host wouldn't send `metadataNote`
+        // at all — must default to nil rather than failing to decode.
+        let legacyDiffJSON = Data("""
+        {"type": "fileDiffResult", "sessionId": "s1", "path": "a.txt", "hunks": [], "truncated": false}
+        """.utf8)
+        let legacyDiff = try JSONDecoder().decode(RemoteServerMessage.self, from: legacyDiffJSON)
+        #expect(legacyDiff == .fileDiffResult(sessionId: "s1", path: "a.txt", hunks: [], truncated: false))
+
         let diffFailure = RemoteServerMessage.fileDiffFailed(
             sessionId: "s1", path: "logo.png", reason: .binary, message: nil)
         #expect(try roundTrip(diffFailure) == diffFailure)

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -657,6 +657,31 @@ struct RemoteProtocolTests {
         #expect(!RemoteClientMessage.listSessions.isDriveOrdering)
     }
 
+    @Test func fileRequestDedupKeyCoversOnlyTheFourFileVerbs() {
+        #expect(RemoteClientMessage.listChanges(sessionId: "s1").fileRequestDedupKey == "listChanges\u{0}s1")
+        #expect(RemoteClientMessage.fileDiff(sessionId: "s1", path: "a.txt").fileRequestDedupKey == "fileDiff\u{0}s1\u{0}a.txt")
+        #expect(RemoteClientMessage.listFiles(sessionId: "s1", path: "src").fileRequestDedupKey == "listFiles\u{0}s1\u{0}src")
+        #expect(RemoteClientMessage.listFiles(sessionId: "s1", path: nil).fileRequestDedupKey == "listFiles\u{0}s1\u{0}")
+        #expect(RemoteClientMessage.readFile(sessionId: "s1", path: "a.txt").fileRequestDedupKey == "readFile\u{0}s1\u{0}a.txt")
+        #expect(RemoteClientMessage.listSessions.fileRequestDedupKey == nil)
+        #expect(RemoteClientMessage.stop(sessionId: "s1").fileRequestDedupKey == nil)
+        #expect(RemoteClientMessage.sendPrompt(sessionId: "s1", text: "hi", attachments: [], intent: "auto").fileRequestDedupKey == nil)
+    }
+
+    /// Two different sessions (or two different paths within the same
+    /// session) must never collide on the same key — the `\u{0}` separator
+    /// is what makes "s1" + path "2/x" distinguishable from "s12" + path "x".
+    @Test func fileRequestDedupKeyDoesNotCollideAcrossSessionsOrPaths() {
+        #expect(
+            RemoteClientMessage.fileDiff(sessionId: "s1", path: "a.txt").fileRequestDedupKey
+                != RemoteClientMessage.fileDiff(sessionId: "s2", path: "a.txt").fileRequestDedupKey
+        )
+        #expect(
+            RemoteClientMessage.listFiles(sessionId: "s1", path: "a").fileRequestDedupKey
+                != RemoteClientMessage.listFiles(sessionId: "s1", path: "b").fileRequestDedupKey
+        )
+    }
+
     @Test func changesAndFilesClientMessagesRoundTripAndEncodeRequiredFields() throws {
         let listChanges = RemoteClientMessage.listChanges(sessionId: "s1")
         #expect(try roundTrip(listChanges) == listChanges)

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -747,8 +747,16 @@ struct RemoteProtocolTests {
         let node = RemoteFileNode(
             name: "src", path: "src", kind: "dir", badge: nil,
             childrenState: "notLoaded", isSubmodule: false)
-        let tree = RemoteServerMessage.fileTree(sessionId: "s1", path: nil, nodes: [node])
+        let tree = RemoteServerMessage.fileTree(sessionId: "s1", path: nil, nodes: [node], truncated: false)
         #expect(try roundTrip(tree) == tree)
+
+        // Lenient decoding: an older paired host might not send `truncated`
+        // at all — must default to `false` rather than failing to decode.
+        let legacyTreeJSON = Data("""
+        {"type": "fileTree", "sessionId": "s1", "nodes": []}
+        """.utf8)
+        let legacyTree = try JSONDecoder().decode(RemoteServerMessage.self, from: legacyTreeJSON)
+        #expect(legacyTree == .fileTree(sessionId: "s1", path: nil, nodes: [], truncated: false))
 
         let treeFailure = RemoteServerMessage.fileTreeFailed(
             sessionId: "s1", path: "../etc", reason: .pathRejected, message: nil)

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -69,6 +69,7 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var pauseRemoteWorktrees = false
     var pauseRemoteProjects = false
     var pauseRemoteBranches = false
+    var pauseFileDiff = false
     /// 1-indexed call number of `fullToolCallContent` to suspend on (nil = never pause).
     /// Lets a test freeze exactly one in-flight fetch while later calls proceed normally.
     var pauseFullToolCallContentOnCall: Int?
@@ -80,6 +81,8 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     private var remoteProjectsCompletionWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
     private var remoteBranchesCallWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
     private var remoteBranchesCompletionWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+    private var fileDiffContinuation: CheckedContinuation<RemoteFileDiffResult, Never>?
+    private var fileDiffCallWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
     private var fullToolCallContentContinuation: CheckedContinuation<String?, Never>?
     func sessionSummaries() async -> [RemoteSessionSummary] {
         sessionSummariesCallCount += 1
@@ -189,6 +192,16 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
             remoteBranchesCompletionWaiters.append((count, continuation))
         }
     }
+    func resumeFileDiff() {
+        fileDiffContinuation?.resume(returning: fileDiffResult)
+        fileDiffContinuation = nil
+    }
+    func waitForFileDiffCall(_ count: Int) async {
+        guard fileDiffRequests.count < count else { return }
+        await withCheckedContinuation { continuation in
+            fileDiffCallWaiters.append((count, continuation))
+        }
+    }
     private func resumeWaiters(
         _ waiters: inout [(count: Int, continuation: CheckedContinuation<Void, Never>)],
         through count: Int
@@ -280,6 +293,12 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
 
     func remoteFileDiff(sessionId: String, path: String) async -> RemoteFileDiffResult {
         fileDiffRequests.append((sessionId, path))
+        resumeWaiters(&fileDiffCallWaiters, through: fileDiffRequests.count)
+        if pauseFileDiff {
+            return await withCheckedContinuation { continuation in
+                fileDiffContinuation = continuation
+            }
+        }
         return fileDiffResult
     }
 
@@ -2747,17 +2766,20 @@ struct RemoteSessionGatewayTests {
     @Test func duplicateInFlightRequestsForTheSamePathAreDropped() async {
         let provider = FakeSessionsProvider()
         provider.fileDiffResult = .success(hunks: [], truncated: false)
+        provider.pauseFileDiff = true
         var sent: [RemoteServerMessage] = []
         let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
 
         async let first: Void = gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt"))
-        async let second: Void = gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt"))
-        _ = await (first, second)
+        await provider.waitForFileDiffCall(1)   // first call has entered the provider and is now suspended — the gateway's dedup key is held
 
-        #expect(provider.fileDiffRequests.count <= 2)
-        #expect(sent.allSatisfy { message in
-            if case .fileDiffResult(_, let path, _, _) = message { return path == "a.txt" }
-            return false
-        })
+        await gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt"))   // must be dropped: the key is still held by the suspended first call
+        #expect(provider.fileDiffRequests.count == 1)   // second call never reached the provider
+        #expect(sent.isEmpty)   // dropped call sends nothing
+
+        provider.resumeFileDiff()
+        await first
+        #expect(provider.fileDiffRequests.count == 1)   // still just the one real call
+        #expect(sent == [.fileDiffResult(sessionId: "s1", path: "a.txt", hunks: [], truncated: false)])
     }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -2662,4 +2662,102 @@ struct RemoteSessionGatewayTests {
         #expect(provider.prompts.map(\.text) == ["queue me"])
         #expect(provider.steerPrompts.isEmpty)
     }
+
+    @Test func listChangesSendsChangeListFromTheProvider() async {
+        let provider = FakeSessionsProvider()
+        let file = RemoteChangedFile(
+            path: "a.txt", status: "M", add: 2, del: 1, conflict: nil, renameFrom: nil)
+        provider.changeListResult = .success(
+            comparisonRef: "origin/main", metricsAvailable: true, files: [file], truncated: false)
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gateway.handle(.listChanges(sessionId: "s1"))
+
+        #expect(provider.changeListRequests == ["s1"])
+        #expect(sent == [.changeList(
+            sessionId: "s1", comparisonRef: "origin/main", metricsAvailable: true,
+            files: [file], truncated: false)])
+    }
+
+    @Test func listChangesSendsFailureMessageOnProviderFailure() async {
+        let provider = FakeSessionsProvider()
+        provider.changeListResult = .failure(reason: .worktreeUnavailable, message: "gone")
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gateway.handle(.listChanges(sessionId: "s1"))
+
+        #expect(sent == [.changeListFailed(
+            sessionId: "s1", reason: .worktreeUnavailable, message: "gone")])
+    }
+
+    @Test func fileDiffSendsHunksAndFailures() async {
+        let provider = FakeSessionsProvider()
+        let hunk = RemoteDiffHunk(
+            header: "@@ -1 +1,2 @@", oldStart: 1, newStart: 1,
+            lines: [RemoteDiffLine(kind: "add", text: "new", oldNumber: nil, newNumber: 2)])
+        provider.fileDiffResult = .success(hunks: [hunk], truncated: true)
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt"))
+        #expect(provider.fileDiffRequests.map(\.path) == ["a.txt"])
+        #expect(sent == [.fileDiffResult(
+            sessionId: "s1", path: "a.txt", hunks: [hunk], truncated: true)])
+
+        provider.fileDiffResult = .failure(reason: .pathRejected, message: nil)
+        sent.removeAll()
+        await gateway.handle(.fileDiff(sessionId: "s1", path: "../etc/passwd"))
+        #expect(sent == [.fileDiffFailed(
+            sessionId: "s1", path: "../etc/passwd", reason: .pathRejected, message: nil)])
+    }
+
+    @Test func listFilesAndReadFileSendTreeAndContents() async {
+        let provider = FakeSessionsProvider()
+        let node = RemoteFileNode(
+            name: "src", path: "src", kind: "dir", badge: nil,
+            childrenState: "notLoaded", isSubmodule: false)
+        provider.fileTreeResult = .success(nodes: [node])
+        provider.fileContentsResult = .success(text: "# Alas\n", truncated: false)
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gateway.handle(.listFiles(sessionId: "s1", path: nil))
+        await gateway.handle(.readFile(sessionId: "s1", path: "README.md"))
+
+        #expect(sent == [
+            .fileTree(sessionId: "s1", path: nil, nodes: [node]),
+            .fileContents(sessionId: "s1", path: "README.md", text: "# Alas\n", truncated: false)
+        ])
+    }
+
+    @Test func readFileSendsUnavailableWithByteSize() async {
+        let provider = FakeSessionsProvider()
+        provider.fileContentsResult = .failure(reason: .tooLarge, byteSize: 900_000, message: nil)
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gateway.handle(.readFile(sessionId: "s1", path: "big.bin"))
+
+        #expect(sent == [.fileUnavailable(
+            sessionId: "s1", path: "big.bin", reason: .tooLarge, byteSize: 900_000, message: nil)])
+    }
+
+    @Test func duplicateInFlightRequestsForTheSamePathAreDropped() async {
+        let provider = FakeSessionsProvider()
+        provider.fileDiffResult = .success(hunks: [], truncated: false)
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        async let first: Void = gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt"))
+        async let second: Void = gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt"))
+        _ = await (first, second)
+
+        #expect(provider.fileDiffRequests.count <= 2)
+        #expect(sent.allSatisfy { message in
+            if case .fileDiffResult(_, let path, _, _) = message { return path == "a.txt" }
+            return false
+        })
+    }
 }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -31,6 +31,14 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var renamed: [(id: String, title: String)] = []
     var renameSucceeds = true
     var configs: [String: RemoteSessionConfig] = [:]
+    var changeListResult: RemoteChangeListResult = .failure(reason: .sessionUnknown, message: nil)
+    var fileDiffResult: RemoteFileDiffResult = .failure(reason: .sessionUnknown, message: nil)
+    var fileTreeResult: RemoteFileTreeResult = .failure(reason: .sessionUnknown, message: nil)
+    var fileContentsResult: RemoteFileContentsResult = .failure(reason: .sessionUnknown, byteSize: nil, message: nil)
+    var changeListRequests: [String] = []
+    var fileDiffRequests: [(sessionId: String, path: String)] = []
+    var fileTreeRequests: [(sessionId: String, path: String?)] = []
+    var fileContentsRequests: [(sessionId: String, path: String)] = []
     var queueForceSends: [(id: String, itemId: UUID)] = []
     var queueRemoves: [(id: String, itemId: UUID)] = []
     var queueRetries: [(id: String, itemId: UUID)] = []
@@ -264,6 +272,26 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
         return renameSucceeds
     }
     func sessionConfig(for id: String) -> RemoteSessionConfig? { configs[id] }
+
+    func remoteChangeList(sessionId: String) async -> RemoteChangeListResult {
+        changeListRequests.append(sessionId)
+        return changeListResult
+    }
+
+    func remoteFileDiff(sessionId: String, path: String) async -> RemoteFileDiffResult {
+        fileDiffRequests.append((sessionId, path))
+        return fileDiffResult
+    }
+
+    func remoteFileTree(sessionId: String, path: String?) async -> RemoteFileTreeResult {
+        fileTreeRequests.append((sessionId, path))
+        return fileTreeResult
+    }
+
+    func remoteFileContents(sessionId: String, path: String) async -> RemoteFileContentsResult {
+        fileContentsRequests.append((sessionId, path))
+        return fileContentsResult
+    }
 
     func queueForceSend(for id: String, itemId: UUID) { queueForceSends.append((id, itemId)) }
     func queueRemove(for id: String, itemId: UUID) { queueRemoves.append((id, itemId)) }

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -2737,7 +2737,7 @@ struct RemoteSessionGatewayTests {
         let node = RemoteFileNode(
             name: "src", path: "src", kind: "dir", badge: nil,
             childrenState: "notLoaded", isSubmodule: false)
-        provider.fileTreeResult = .success(nodes: [node])
+        provider.fileTreeResult = .success(nodes: [node], truncated: false)
         provider.fileContentsResult = .success(text: "# Alas\n", truncated: false)
         var sent: [RemoteServerMessage] = []
         let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
@@ -2746,7 +2746,7 @@ struct RemoteSessionGatewayTests {
         await gateway.handle(.readFile(sessionId: "s1", path: "README.md"))
 
         #expect(sent == [
-            .fileTree(sessionId: "s1", path: nil, nodes: [node]),
+            .fileTree(sessionId: "s1", path: nil, nodes: [node], truncated: false),
             .fileContents(sessionId: "s1", path: "README.md", text: "# Alas\n", truncated: false)
         ])
     }

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,12 +49,12 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=64"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=64"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=65"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=65"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v42";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v43";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=64""#))
+        #expect(sw.contains(#""/app.js?v=65""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -68,10 +68,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=64"#))
+        #expect(html.contains(#"/app.js?v=65"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v42";"#))
-        #expect(sw.contains(#""/app.js?v=64""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v43";"#))
+        #expect(sw.contains(#""/app.js?v=65""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -119,7 +119,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=64"))
+        #expect(html.contains("/app.js?v=65"))
         #expect(html.contains("/style.css?v=42"))
     }
 
@@ -145,7 +145,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=64""#))
+        #expect(sw.contains(#""/app.js?v=65""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -196,7 +196,7 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/worktree-creation.js?v=1"#))
-        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=64"#)!.lowerBound)
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=65"#)!.lowerBound)
         #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
         #expect(js.contains(#"case "projectList":"#))
         #expect(js.contains(#"case "branchList":"#))
@@ -334,9 +334,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v42"))
-        #expect(sw.contains("/app.js?v=64"))
-        #expect(html.contains("app.js?v=64"))
+        #expect(sw.contains("alas-remote-shell-v43"))
+        #expect(sw.contains("/app.js?v=65"))
+        #expect(html.contains("app.js?v=65"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -499,10 +499,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=64"#))
+        #expect(html.contains(#"/app.js?v=65"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v42";"#))
-        #expect(sw.contains(#""/app.js?v=64""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v43";"#))
+        #expect(sw.contains(#""/app.js?v=65""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -536,9 +536,9 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"/changes-view.js?v=1"#))
         #expect(html.contains(#"/file-browser.js?v=1"#))
         #expect(html.range(of: #"/changes-view.js?v=1"#)!.lowerBound
-            < html.range(of: #"/app.js?v=64"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=65"#)!.lowerBound)
         #expect(html.range(of: #"/file-browser.js?v=1"#)!.lowerBound
-            < html.range(of: #"/app.js?v=64"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=65"#)!.lowerBound)
         #expect(sw.contains(#""/changes-view.js?v=1""#))
         #expect(sw.contains(#""/file-browser.js?v=1""#))
     }
@@ -572,6 +572,25 @@ struct RemoteWebAssetTests {
     @Test func remoteWebRefreshesChangesWhenATurnGoesIdle() throws {
         let js = try asset("app.js")
         #expect(js.contains("function noteStreamingStateForChanges(state)"))
-        #expect(js.contains(#"activeTab === "changes""#))
+        #expect(js.contains(#"activeTab !== "changes""#))
+    }
+
+    // Regression (final whole-branch review, finding 4): a `listChanges` per
+    // idle DELTA (rather than per idle TRANSITION) can back up the gateway's
+    // serialized per-connection message queue behind a burst of git
+    // subprocess calls. The fix must edge-trigger on the transition into
+    // idle AND debounce as defense in depth — either alone was flagged as
+    // insufficient during the plan's self-review.
+    @Test func remoteWebEdgeTriggersAndDebouncesTheIdleChangesRefresh() throws {
+        let js = try asset("app.js")
+        let body = try #require(
+            js.range(of: "function noteStreamingStateForChanges(state) {")
+                .map { js[$0.lowerBound...].prefix(800) }
+        )
+        #expect(body.contains("previousChangesStreamingState"))
+        #expect(body.contains("wasIdle"))
+        #expect(body.contains("setTimeout"))
+        #expect(body.contains("clearTimeout"))
+        #expect(js.contains("let changesRefreshDebounceTimer = null;"))
     }
 }

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,13 +49,13 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=63"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=63"#))
-        #expect(html.contains(#"/style.css?v=41"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v41";"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=64"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=64"#))
+        #expect(html.contains(#"/style.css?v=42"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v42";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=63""#))
-        #expect(sw.contains(#""/style.css?v=41""#))
+        #expect(sw.contains(#""/app.js?v=64""#))
+        #expect(sw.contains(#""/style.css?v=42""#))
     }
 
     @Test func remoteWebToolRowsAvoidNativeButtonRenderingOnMobileSafari() throws {
@@ -68,11 +68,11 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=63"#))
-        #expect(html.contains(#"/style.css?v=41"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v41";"#))
-        #expect(sw.contains(#""/app.js?v=63""#))
-        #expect(sw.contains(#""/style.css?v=41""#))
+        #expect(html.contains(#"/app.js?v=64"#))
+        #expect(html.contains(#"/style.css?v=42"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v42";"#))
+        #expect(sw.contains(#""/app.js?v=64""#))
+        #expect(sw.contains(#""/style.css?v=42""#))
     }
 
     @Test func remoteBareURLLinkifierPreservesIndentedCodeBlocks() throws {
@@ -119,8 +119,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=63"))
-        #expect(html.contains("/style.css?v=41"))
+        #expect(html.contains("/app.js?v=64"))
+        #expect(html.contains("/style.css?v=42"))
     }
 
     @Test func remoteWebExposesSessionRenameControls() throws {
@@ -145,8 +145,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=63""#))
-        #expect(sw.contains(#""/style.css?v=41""#))
+        #expect(sw.contains(#""/app.js?v=64""#))
+        #expect(sw.contains(#""/style.css?v=42""#))
     }
 
     @Test func configSheetScrollsWhenModelListOverflows() throws {
@@ -196,7 +196,7 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/worktree-creation.js?v=1"#))
-        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=63"#)!.lowerBound)
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=64"#)!.lowerBound)
         #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
         #expect(js.contains(#"case "projectList":"#))
         #expect(js.contains(#"case "branchList":"#))
@@ -334,9 +334,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v41"))
-        #expect(sw.contains("/app.js?v=63"))
-        #expect(html.contains("app.js?v=63"))
+        #expect(sw.contains("alas-remote-shell-v42"))
+        #expect(sw.contains("/app.js?v=64"))
+        #expect(html.contains("app.js?v=64"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -499,11 +499,11 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=63"#))
-        #expect(html.contains(#"/style.css?v=41"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v41";"#))
-        #expect(sw.contains(#""/app.js?v=63""#))
-        #expect(sw.contains(#""/style.css?v=41""#))
+        #expect(html.contains(#"/app.js?v=64"#))
+        #expect(html.contains(#"/style.css?v=42"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v42";"#))
+        #expect(sw.contains(#""/app.js?v=64""#))
+        #expect(sw.contains(#""/style.css?v=42""#))
     }
 
     @Test func remoteWebOffersUndoAfterASteerDiscardsTheQueue() throws {
@@ -514,5 +514,40 @@ struct RemoteWebAssetTests {
         #expect(js.contains(#""queueSteerUndo""#))
         #expect(js.contains("Queue cleared by steer"))
         #expect(css.contains(".steer-undo"))
+    }
+
+    @Test func remoteWebShipsChangesAndFilesTabs() throws {
+        let html = try asset("index.html")
+        let sw = try asset("sw.js")
+
+        #expect(html.contains(#"id="detail-tabs""#))
+        #expect(html.contains(#"id="tab-chat""#))
+        #expect(html.contains(#"id="tab-changes""#))
+        #expect(html.contains(#"id="tab-files""#))
+        #expect(html.contains(#"<section id="changes" class="view hidden">"#))
+        #expect(html.contains(#"<section id="files" class="view hidden">"#))
+        #expect(html.contains(#"id="changes-summary""#))
+        #expect(html.contains(#"id="changes-refresh""#))
+        #expect(html.contains(#"id="changes-list""#))
+        #expect(html.contains(#"id="diff-rows""#))
+        #expect(html.contains(#"id="file-list""#))
+        #expect(html.contains(#"id="file-view-body""#))
+
+        #expect(html.contains(#"/changes-view.js?v=1"#))
+        #expect(html.contains(#"/file-browser.js?v=1"#))
+        #expect(html.range(of: #"/changes-view.js?v=1"#)!.lowerBound
+            < html.range(of: #"/app.js?v=64"#)!.lowerBound)
+        #expect(html.range(of: #"/file-browser.js?v=1"#)!.lowerBound
+            < html.range(of: #"/app.js?v=64"#)!.lowerBound)
+        #expect(sw.contains(#""/changes-view.js?v=1""#))
+        #expect(sw.contains(#""/file-browser.js?v=1""#))
+    }
+
+    @Test func remoteWebWiresTabSwitching() throws {
+        let js = try asset("app.js")
+        #expect(js.contains("function showTab(name)"))
+        #expect(js.contains("const changesTree = RemoteFileBrowser.createTree();"))
+        #expect(js.contains(#"type: "listChanges""#))
+        #expect(js.contains(#"type: "listFiles""#))
     }
 }

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -593,4 +593,20 @@ struct RemoteWebAssetTests {
         #expect(body.contains("clearTimeout"))
         #expect(js.contains("let changesRefreshDebounceTimer = null;"))
     }
+
+    // Regression (sixth review pass, finding 4): the server's byte cap alone
+    // does not bound the NUMBER of DOM rows `renderFileContents` creates — a
+    // file near that cap made of many short lines can still produce enough
+    // rows to freeze a phone browser. The client must cap rendered lines
+    // separately and surface a distinct notice, since this can trip even
+    // when the server reports `truncated: false`.
+    @Test func remoteWebCapsTheNumberOfRenderedFileLines() throws {
+        let js = try asset("app.js")
+        let changesView = try asset("changes-view.js")
+
+        #expect(js.contains("const MAX_RENDERED_FILE_LINES = 5000;"))
+        #expect(js.contains("const linesTruncated = lines.length > MAX_RENDERED_FILE_LINES;"))
+        #expect(js.contains(#"RemoteChangesView.truncationNotice(linesTruncated, "lines")"#))
+        #expect(changesView.contains(#"if (kind === "lines") return "File truncated — too many lines to show.";"#))
+    }
 }

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -550,4 +550,28 @@ struct RemoteWebAssetTests {
         #expect(js.contains(#"type: "listChanges""#))
         #expect(js.contains(#"type: "listFiles""#))
     }
+
+    @Test func remoteWebHandlesChangesAndFilesMessages() throws {
+        let js = try asset("app.js")
+
+        #expect(js.contains(#"case "changeList":"#))
+        #expect(js.contains(#"case "changeListFailed":"#))
+        #expect(js.contains(#"case "fileDiffResult":"#))
+        #expect(js.contains(#"case "fileDiffFailed":"#))
+        #expect(js.contains(#"case "fileTree":"#))
+        #expect(js.contains(#"case "fileTreeFailed":"#))
+        #expect(js.contains(#"case "fileContents":"#))
+        #expect(js.contains(#"case "fileUnavailable":"#))
+        #expect(js.contains("function renderChanges()"))
+        #expect(js.contains("function renderDiff("))
+        #expect(js.contains("function renderFileTree()"))
+        #expect(js.contains("RemoteChangesView.diffRows("))
+        #expect(js.contains("RemoteChangesView.formatSummary("))
+    }
+
+    @Test func remoteWebRefreshesChangesWhenATurnGoesIdle() throws {
+        let js = try asset("app.js")
+        #expect(js.contains("function noteStreamingStateForChanges(state)"))
+        #expect(js.contains(#"activeTab === "changes""#))
+    }
 }

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -52,7 +52,7 @@ struct RemoteWebAssetTests {
         #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=70"#)!.lowerBound)
         #expect(html.contains(#"/app.js?v=70"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v48";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v49";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
         #expect(sw.contains(#""/app.js?v=70""#))
         #expect(sw.contains(#""/style.css?v=42""#))
@@ -70,7 +70,7 @@ struct RemoteWebAssetTests {
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
         #expect(html.contains(#"/app.js?v=70"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v48";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v49";"#))
         #expect(sw.contains(#""/app.js?v=70""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
@@ -334,7 +334,7 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v48"))
+        #expect(sw.contains("alas-remote-shell-v49"))
         #expect(sw.contains("/app.js?v=70"))
         #expect(html.contains("app.js?v=70"))
     }
@@ -501,7 +501,7 @@ struct RemoteWebAssetTests {
 
         #expect(html.contains(#"/app.js?v=70"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v48";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v49";"#))
         #expect(sw.contains(#""/app.js?v=70""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
@@ -534,13 +534,13 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"id="file-view-body""#))
 
         #expect(html.contains(#"/changes-view.js?v=2"#))
-        #expect(html.contains(#"/file-browser.js?v=2"#))
+        #expect(html.contains(#"/file-browser.js?v=3"#))
         #expect(html.range(of: #"/changes-view.js?v=2"#)!.lowerBound
             < html.range(of: #"/app.js?v=70"#)!.lowerBound)
-        #expect(html.range(of: #"/file-browser.js?v=2"#)!.lowerBound
+        #expect(html.range(of: #"/file-browser.js?v=3"#)!.lowerBound
             < html.range(of: #"/app.js?v=70"#)!.lowerBound)
         #expect(sw.contains(#""/changes-view.js?v=2""#))
-        #expect(sw.contains(#""/file-browser.js?v=2""#))
+        #expect(sw.contains(#""/file-browser.js?v=3""#))
     }
 
     @Test func remoteWebWiresTabSwitching() throws {

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,12 +49,12 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=66"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=66"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=67"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=67"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v44";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v45";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=66""#))
+        #expect(sw.contains(#""/app.js?v=67""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -68,10 +68,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=66"#))
+        #expect(html.contains(#"/app.js?v=67"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v44";"#))
-        #expect(sw.contains(#""/app.js?v=66""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v45";"#))
+        #expect(sw.contains(#""/app.js?v=67""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -119,7 +119,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=66"))
+        #expect(html.contains("/app.js?v=67"))
         #expect(html.contains("/style.css?v=42"))
     }
 
@@ -145,7 +145,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=66""#))
+        #expect(sw.contains(#""/app.js?v=67""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -196,7 +196,7 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/worktree-creation.js?v=1"#))
-        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=66"#)!.lowerBound)
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=67"#)!.lowerBound)
         #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
         #expect(js.contains(#"case "projectList":"#))
         #expect(js.contains(#"case "branchList":"#))
@@ -334,9 +334,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v44"))
-        #expect(sw.contains("/app.js?v=66"))
-        #expect(html.contains("app.js?v=66"))
+        #expect(sw.contains("alas-remote-shell-v45"))
+        #expect(sw.contains("/app.js?v=67"))
+        #expect(html.contains("app.js?v=67"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -499,10 +499,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=66"#))
+        #expect(html.contains(#"/app.js?v=67"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v44";"#))
-        #expect(sw.contains(#""/app.js?v=66""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v45";"#))
+        #expect(sw.contains(#""/app.js?v=67""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -536,9 +536,9 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"/changes-view.js?v=1"#))
         #expect(html.contains(#"/file-browser.js?v=1"#))
         #expect(html.range(of: #"/changes-view.js?v=1"#)!.lowerBound
-            < html.range(of: #"/app.js?v=66"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=67"#)!.lowerBound)
         #expect(html.range(of: #"/file-browser.js?v=1"#)!.lowerBound
-            < html.range(of: #"/app.js?v=66"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=67"#)!.lowerBound)
         #expect(sw.contains(#""/changes-view.js?v=1""#))
         #expect(sw.contains(#""/file-browser.js?v=1""#))
     }

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,12 +49,12 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=70"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=70"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=71"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=71"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v49";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v50";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=70""#))
+        #expect(sw.contains(#""/app.js?v=71""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -68,10 +68,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=70"#))
+        #expect(html.contains(#"/app.js?v=71"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v49";"#))
-        #expect(sw.contains(#""/app.js?v=70""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v50";"#))
+        #expect(sw.contains(#""/app.js?v=71""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -119,7 +119,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=70"))
+        #expect(html.contains("/app.js?v=71"))
         #expect(html.contains("/style.css?v=42"))
     }
 
@@ -145,7 +145,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=70""#))
+        #expect(sw.contains(#""/app.js?v=71""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -196,7 +196,7 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/worktree-creation.js?v=1"#))
-        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=70"#)!.lowerBound)
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=71"#)!.lowerBound)
         #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
         #expect(js.contains(#"case "projectList":"#))
         #expect(js.contains(#"case "branchList":"#))
@@ -334,9 +334,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v49"))
-        #expect(sw.contains("/app.js?v=70"))
-        #expect(html.contains("app.js?v=70"))
+        #expect(sw.contains("alas-remote-shell-v50"))
+        #expect(sw.contains("/app.js?v=71"))
+        #expect(html.contains("app.js?v=71"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -499,10 +499,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=70"#))
+        #expect(html.contains(#"/app.js?v=71"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v49";"#))
-        #expect(sw.contains(#""/app.js?v=70""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v50";"#))
+        #expect(sw.contains(#""/app.js?v=71""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -536,9 +536,9 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"/changes-view.js?v=2"#))
         #expect(html.contains(#"/file-browser.js?v=3"#))
         #expect(html.range(of: #"/changes-view.js?v=2"#)!.lowerBound
-            < html.range(of: #"/app.js?v=70"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=71"#)!.lowerBound)
         #expect(html.range(of: #"/file-browser.js?v=3"#)!.lowerBound
-            < html.range(of: #"/app.js?v=70"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=71"#)!.lowerBound)
         #expect(sw.contains(#""/changes-view.js?v=2""#))
         #expect(sw.contains(#""/file-browser.js?v=3""#))
     }
@@ -600,6 +600,28 @@ struct RemoteWebAssetTests {
         let scheduleBody = try #require(
             js.range(of: "function scheduleListRefresh() {").map { js[$0.lowerBound...].prefix(400) })
         #expect(scheduleBody.contains("refreshFileTree()"))
+    }
+
+    /// Regression: `refreshFileTree()` used to send the root request AND
+    /// every expanded descendant's request in the same synchronous burst,
+    /// before the root response could prune a since-deleted/renamed
+    /// directory from `expandedPaths()` — so a vanished nested directory's
+    /// (now-invalid) request still went out, failing with `fileTreeFailed`
+    /// and leaving a stale error banner over the freshly refreshed tree.
+    /// Descendant requests must wait for the root response to be applied.
+    @Test func remoteWebRequestsExpandedDescendantsOnlyAfterTheRootResponseIsApplied() throws {
+        let js = try asset("app.js")
+        #expect(js.contains("let pendingExpandedPathsRefresh = false;"))
+        let refreshBody = try #require(
+            js.range(of: "function refreshFileTree() {").map { js[$0.lowerBound...].prefix(300) })
+        #expect(refreshBody.contains("pendingExpandedPathsRefresh = true;"))
+        #expect(!refreshBody.contains("expandedPaths()"))
+        let fileTreeBody = try #require(
+            js.range(of: #"case "fileTree": {"#).map { js[$0.lowerBound...].prefix(1200) })
+        #expect(fileTreeBody.contains("changesTree.applyNodes("))
+        #expect(fileTreeBody.range(of: "changesTree.applyNodes(")!.lowerBound
+            < fileTreeBody.range(of: "changesTree.expandedPaths()")!.lowerBound)
+        #expect(js.contains("if (msg.path === undefined || msg.path === null) pendingExpandedPathsRefresh = false;"))
     }
 
     // Regression (final whole-branch review, finding 4): a `listChanges` per

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,12 +49,12 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=67"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=67"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=68"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=68"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v45";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v46";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=67""#))
+        #expect(sw.contains(#""/app.js?v=68""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -68,10 +68,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=67"#))
+        #expect(html.contains(#"/app.js?v=68"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v45";"#))
-        #expect(sw.contains(#""/app.js?v=67""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v46";"#))
+        #expect(sw.contains(#""/app.js?v=68""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -119,7 +119,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=67"))
+        #expect(html.contains("/app.js?v=68"))
         #expect(html.contains("/style.css?v=42"))
     }
 
@@ -145,7 +145,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=67""#))
+        #expect(sw.contains(#""/app.js?v=68""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -196,7 +196,7 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/worktree-creation.js?v=1"#))
-        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=67"#)!.lowerBound)
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=68"#)!.lowerBound)
         #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
         #expect(js.contains(#"case "projectList":"#))
         #expect(js.contains(#"case "branchList":"#))
@@ -334,9 +334,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v45"))
-        #expect(sw.contains("/app.js?v=67"))
-        #expect(html.contains("app.js?v=67"))
+        #expect(sw.contains("alas-remote-shell-v46"))
+        #expect(sw.contains("/app.js?v=68"))
+        #expect(html.contains("app.js?v=68"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -499,10 +499,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=67"#))
+        #expect(html.contains(#"/app.js?v=68"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v45";"#))
-        #expect(sw.contains(#""/app.js?v=67""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v46";"#))
+        #expect(sw.contains(#""/app.js?v=68""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -533,13 +533,13 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"id="file-list""#))
         #expect(html.contains(#"id="file-view-body""#))
 
-        #expect(html.contains(#"/changes-view.js?v=1"#))
+        #expect(html.contains(#"/changes-view.js?v=2"#))
         #expect(html.contains(#"/file-browser.js?v=1"#))
-        #expect(html.range(of: #"/changes-view.js?v=1"#)!.lowerBound
-            < html.range(of: #"/app.js?v=67"#)!.lowerBound)
+        #expect(html.range(of: #"/changes-view.js?v=2"#)!.lowerBound
+            < html.range(of: #"/app.js?v=68"#)!.lowerBound)
         #expect(html.range(of: #"/file-browser.js?v=1"#)!.lowerBound
-            < html.range(of: #"/app.js?v=67"#)!.lowerBound)
-        #expect(sw.contains(#""/changes-view.js?v=1""#))
+            < html.range(of: #"/app.js?v=68"#)!.lowerBound)
+        #expect(sw.contains(#""/changes-view.js?v=2""#))
         #expect(sw.contains(#""/file-browser.js?v=1""#))
     }
 

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,12 +49,12 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=65"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=65"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=66"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=66"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v43";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v44";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=65""#))
+        #expect(sw.contains(#""/app.js?v=66""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -68,10 +68,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=65"#))
+        #expect(html.contains(#"/app.js?v=66"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v43";"#))
-        #expect(sw.contains(#""/app.js?v=65""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v44";"#))
+        #expect(sw.contains(#""/app.js?v=66""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -119,7 +119,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=65"))
+        #expect(html.contains("/app.js?v=66"))
         #expect(html.contains("/style.css?v=42"))
     }
 
@@ -145,7 +145,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=65""#))
+        #expect(sw.contains(#""/app.js?v=66""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -196,7 +196,7 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/worktree-creation.js?v=1"#))
-        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=65"#)!.lowerBound)
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=66"#)!.lowerBound)
         #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
         #expect(js.contains(#"case "projectList":"#))
         #expect(js.contains(#"case "branchList":"#))
@@ -334,9 +334,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v43"))
-        #expect(sw.contains("/app.js?v=65"))
-        #expect(html.contains("app.js?v=65"))
+        #expect(sw.contains("alas-remote-shell-v44"))
+        #expect(sw.contains("/app.js?v=66"))
+        #expect(html.contains("app.js?v=66"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -499,10 +499,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=65"#))
+        #expect(html.contains(#"/app.js?v=66"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v43";"#))
-        #expect(sw.contains(#""/app.js?v=65""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v44";"#))
+        #expect(sw.contains(#""/app.js?v=66""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -536,9 +536,9 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"/changes-view.js?v=1"#))
         #expect(html.contains(#"/file-browser.js?v=1"#))
         #expect(html.range(of: #"/changes-view.js?v=1"#)!.lowerBound
-            < html.range(of: #"/app.js?v=65"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=66"#)!.lowerBound)
         #expect(html.range(of: #"/file-browser.js?v=1"#)!.lowerBound
-            < html.range(of: #"/app.js?v=65"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=66"#)!.lowerBound)
         #expect(sw.contains(#""/changes-view.js?v=1""#))
         #expect(sw.contains(#""/file-browser.js?v=1""#))
     }

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -617,11 +617,48 @@ struct RemoteWebAssetTests {
         #expect(refreshBody.contains("pendingExpandedPathsRefresh = true;"))
         #expect(!refreshBody.contains("expandedPaths()"))
         let fileTreeBody = try #require(
-            js.range(of: #"case "fileTree": {"#).map { js[$0.lowerBound...].prefix(1200) })
+            js.range(of: #"case "fileTree": {"#).map { js[$0.lowerBound...].prefix(3000) })
         #expect(fileTreeBody.contains("changesTree.applyNodes("))
         #expect(fileTreeBody.range(of: "changesTree.applyNodes(")!.lowerBound
             < fileTreeBody.range(of: "changesTree.expandedPaths()")!.lowerBound)
-        #expect(js.contains("if (msg.path === undefined || msg.path === null) pendingExpandedPathsRefresh = false;"))
+        let fileTreeFailedBody = try #require(
+            js.range(of: #"case "fileTreeFailed":"#).map { js[$0.lowerBound...].prefix(300) })
+        #expect(fileTreeFailedBody.contains("pendingExpandedPathsRefresh = false;"))
+    }
+
+    /// Regression: refreshing several expanded directories in one
+    /// `refreshFileTree()` batch succeeds or fails per directory. The
+    /// `fileTree` success handler used to unconditionally hide the shared
+    /// error banner, so ONE sibling directory succeeding wiped out the
+    /// error a DIFFERENT sibling's failure had just shown — leaving that
+    /// failed directory's stale cached children on screen with no
+    /// indication anything went wrong. The banner must only clear once
+    /// every request in the batch has resolved AND none of them failed.
+    @Test func remoteWebPreservesTheFileErrorBannerAcrossASiblingDirectorysSuccessInTheSameRefreshBatch() throws {
+        let js = try asset("app.js")
+        #expect(js.contains("let expandedPathsRefreshInFlight = 0;"))
+        #expect(js.contains("let expandedPathsRefreshHadFailure = false;"))
+
+        // The unconditional top-of-case hide (any successful `fileTree`
+        // response, root or not, immediately clearing the banner) is gone.
+        #expect(!js.contains("""
+        $("file-error").classList.add("hidden");
+              const treeKey = msg.path === undefined || msg.path === null ? "" : msg.path;
+        """))
+
+        let fileTreeBody = try #require(
+            js.range(of: #"case "fileTree": {"#).map { js[$0.lowerBound...].prefix(3000) })
+        // Replaced by a gate that gives up clearing unless every in-flight
+        // sibling has resolved without a failure.
+        #expect(fileTreeBody.contains("expandedPathsRefreshInFlight -= 1;"))
+        #expect(fileTreeBody.contains("expandedPathsRefreshInFlight === 0 && !expandedPathsRefreshHadFailure"))
+        #expect(fileTreeBody.contains("expandedPathsRefreshInFlight = expandedPaths.length;"))
+        #expect(fileTreeBody.contains("expandedPathsRefreshHadFailure = false;"))
+
+        let fileTreeFailedBody = try #require(
+            js.range(of: #"case "fileTreeFailed":"#).map { js[$0.lowerBound...].prefix(500) })
+        #expect(fileTreeFailedBody.contains("expandedPathsRefreshInFlight -= 1;"))
+        #expect(fileTreeFailedBody.contains("expandedPathsRefreshHadFailure = true;"))
     }
 
     // Regression (final whole-branch review, finding 4): a `listChanges` per

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,12 +49,12 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=71"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=71"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=72"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=72"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v50";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v51";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=71""#))
+        #expect(sw.contains(#""/app.js?v=72""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -68,10 +68,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=71"#))
+        #expect(html.contains(#"/app.js?v=72"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v50";"#))
-        #expect(sw.contains(#""/app.js?v=71""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v51";"#))
+        #expect(sw.contains(#""/app.js?v=72""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -119,7 +119,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=71"))
+        #expect(html.contains("/app.js?v=72"))
         #expect(html.contains("/style.css?v=42"))
     }
 
@@ -145,7 +145,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=71""#))
+        #expect(sw.contains(#""/app.js?v=72""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -196,7 +196,7 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/worktree-creation.js?v=1"#))
-        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=71"#)!.lowerBound)
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=72"#)!.lowerBound)
         #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
         #expect(js.contains(#"case "projectList":"#))
         #expect(js.contains(#"case "branchList":"#))
@@ -334,9 +334,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v50"))
-        #expect(sw.contains("/app.js?v=71"))
-        #expect(html.contains("app.js?v=71"))
+        #expect(sw.contains("alas-remote-shell-v51"))
+        #expect(sw.contains("/app.js?v=72"))
+        #expect(html.contains("app.js?v=72"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -499,10 +499,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=71"#))
+        #expect(html.contains(#"/app.js?v=72"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v50";"#))
-        #expect(sw.contains(#""/app.js?v=71""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v51";"#))
+        #expect(sw.contains(#""/app.js?v=72""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -533,13 +533,13 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"id="file-list""#))
         #expect(html.contains(#"id="file-view-body""#))
 
-        #expect(html.contains(#"/changes-view.js?v=2"#))
+        #expect(html.contains(#"/changes-view.js?v=3"#))
         #expect(html.contains(#"/file-browser.js?v=3"#))
-        #expect(html.range(of: #"/changes-view.js?v=2"#)!.lowerBound
-            < html.range(of: #"/app.js?v=71"#)!.lowerBound)
+        #expect(html.range(of: #"/changes-view.js?v=3"#)!.lowerBound
+            < html.range(of: #"/app.js?v=72"#)!.lowerBound)
         #expect(html.range(of: #"/file-browser.js?v=3"#)!.lowerBound
-            < html.range(of: #"/app.js?v=71"#)!.lowerBound)
-        #expect(sw.contains(#""/changes-view.js?v=2""#))
+            < html.range(of: #"/app.js?v=72"#)!.lowerBound)
+        #expect(sw.contains(#""/changes-view.js?v=3""#))
         #expect(sw.contains(#""/file-browser.js?v=3""#))
     }
 

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,12 +49,12 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=69"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=69"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=70"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=70"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v47";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v48";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=69""#))
+        #expect(sw.contains(#""/app.js?v=70""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -68,10 +68,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=69"#))
+        #expect(html.contains(#"/app.js?v=70"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v47";"#))
-        #expect(sw.contains(#""/app.js?v=69""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v48";"#))
+        #expect(sw.contains(#""/app.js?v=70""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -119,7 +119,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=69"))
+        #expect(html.contains("/app.js?v=70"))
         #expect(html.contains("/style.css?v=42"))
     }
 
@@ -145,7 +145,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=69""#))
+        #expect(sw.contains(#""/app.js?v=70""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -196,7 +196,7 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/worktree-creation.js?v=1"#))
-        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=69"#)!.lowerBound)
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=70"#)!.lowerBound)
         #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
         #expect(js.contains(#"case "projectList":"#))
         #expect(js.contains(#"case "branchList":"#))
@@ -334,9 +334,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v47"))
-        #expect(sw.contains("/app.js?v=69"))
-        #expect(html.contains("app.js?v=69"))
+        #expect(sw.contains("alas-remote-shell-v48"))
+        #expect(sw.contains("/app.js?v=70"))
+        #expect(html.contains("app.js?v=70"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -499,10 +499,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=69"#))
+        #expect(html.contains(#"/app.js?v=70"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v47";"#))
-        #expect(sw.contains(#""/app.js?v=69""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v48";"#))
+        #expect(sw.contains(#""/app.js?v=70""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -534,13 +534,13 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"id="file-view-body""#))
 
         #expect(html.contains(#"/changes-view.js?v=2"#))
-        #expect(html.contains(#"/file-browser.js?v=1"#))
+        #expect(html.contains(#"/file-browser.js?v=2"#))
         #expect(html.range(of: #"/changes-view.js?v=2"#)!.lowerBound
-            < html.range(of: #"/app.js?v=69"#)!.lowerBound)
-        #expect(html.range(of: #"/file-browser.js?v=1"#)!.lowerBound
-            < html.range(of: #"/app.js?v=69"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=70"#)!.lowerBound)
+        #expect(html.range(of: #"/file-browser.js?v=2"#)!.lowerBound
+            < html.range(of: #"/app.js?v=70"#)!.lowerBound)
         #expect(sw.contains(#""/changes-view.js?v=2""#))
-        #expect(sw.contains(#""/file-browser.js?v=1""#))
+        #expect(sw.contains(#""/file-browser.js?v=2""#))
     }
 
     @Test func remoteWebWiresTabSwitching() throws {
@@ -592,12 +592,14 @@ struct RemoteWebAssetTests {
         // be gone from the live condition — a bare `needsChildren` check
         // isn't enough since the explanatory comment above mentions it too.
         #expect(!showTabBody.contains("changesTree.needsChildren"))
-        // The idle-transition refresh (shared with Changes) must also
-        // dispatch to Files when that's the open tab.
+        // The idle-transition refresh (shared with Changes) must also cover
+        // Files when that's the open tab.
         let idleBody = try #require(
-            js.range(of: "function noteStreamingStateForChanges(state) {").map { js[$0.lowerBound...].prefix(800) })
+            js.range(of: "function noteStreamingStateForChanges(state) {").map { js[$0.lowerBound...].prefix(500) })
         #expect(idleBody.contains(#"activeTab !== "files""#))
-        #expect(idleBody.contains("refreshFileTree()"))
+        let scheduleBody = try #require(
+            js.range(of: "function scheduleListRefresh() {").map { js[$0.lowerBound...].prefix(400) })
+        #expect(scheduleBody.contains("refreshFileTree()"))
     }
 
     // Regression (final whole-branch review, finding 4): a `listChanges` per
@@ -614,9 +616,32 @@ struct RemoteWebAssetTests {
         )
         #expect(body.contains("previousChangesStreamingState"))
         #expect(body.contains("wasIdle"))
-        #expect(body.contains("setTimeout"))
-        #expect(body.contains("clearTimeout"))
+        let scheduleBody = try #require(
+            js.range(of: "function scheduleListRefresh() {")
+                .map { js[$0.lowerBound...].prefix(400) }
+        )
+        #expect(scheduleBody.contains("setTimeout"))
+        #expect(scheduleBody.contains("clearTimeout"))
         #expect(js.contains("let changesRefreshDebounceTimer = null;"))
+    }
+
+    /// Regression: an idle transition while a diff/file detail view is open
+    /// used to be dropped entirely — `previousChangesStreamingState` was
+    /// already updated to "idle" before the `detailStack` check, so no LATER
+    /// edge would ever fire once the user closed the detail, leaving the
+    /// list showing the pre-turn snapshot until a manual refresh or tab
+    /// switch. The refresh must be deferred (not dropped) and delivered when
+    /// the detail view closes.
+    @Test func remoteWebDefersTheIdleRefreshUntilADetailViewCloses() throws {
+        let js = try asset("app.js")
+        #expect(js.contains("let pendingListRefresh = false;"))
+        let idleBody = try #require(
+            js.range(of: "function noteStreamingStateForChanges(state) {").map { js[$0.lowerBound...].prefix(500) })
+        #expect(idleBody.contains("pendingListRefresh = true;"))
+        let closeBody = try #require(
+            js.range(of: "function closeDetailLevel() {").map { js[$0.lowerBound...].prefix(400) })
+        #expect(closeBody.contains("pendingListRefresh"))
+        #expect(closeBody.contains("scheduleListRefresh()"))
     }
 
     // Regression (sixth review pass, finding 4): the server's byte cap alone

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,12 +49,12 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=68"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=68"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=69"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=69"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v46";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v47";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=68""#))
+        #expect(sw.contains(#""/app.js?v=69""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -68,10 +68,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=68"#))
+        #expect(html.contains(#"/app.js?v=69"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v46";"#))
-        #expect(sw.contains(#""/app.js?v=68""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v47";"#))
+        #expect(sw.contains(#""/app.js?v=69""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -119,7 +119,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=68"))
+        #expect(html.contains("/app.js?v=69"))
         #expect(html.contains("/style.css?v=42"))
     }
 
@@ -145,7 +145,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=68""#))
+        #expect(sw.contains(#""/app.js?v=69""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -196,7 +196,7 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/worktree-creation.js?v=1"#))
-        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=68"#)!.lowerBound)
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=69"#)!.lowerBound)
         #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
         #expect(js.contains(#"case "projectList":"#))
         #expect(js.contains(#"case "branchList":"#))
@@ -334,9 +334,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v46"))
-        #expect(sw.contains("/app.js?v=68"))
-        #expect(html.contains("app.js?v=68"))
+        #expect(sw.contains("alas-remote-shell-v47"))
+        #expect(sw.contains("/app.js?v=69"))
+        #expect(html.contains("app.js?v=69"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -499,10 +499,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=68"#))
+        #expect(html.contains(#"/app.js?v=69"#))
         #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v46";"#))
-        #expect(sw.contains(#""/app.js?v=68""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v47";"#))
+        #expect(sw.contains(#""/app.js?v=69""#))
         #expect(sw.contains(#""/style.css?v=42""#))
     }
 
@@ -536,9 +536,9 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"/changes-view.js?v=2"#))
         #expect(html.contains(#"/file-browser.js?v=1"#))
         #expect(html.range(of: #"/changes-view.js?v=2"#)!.lowerBound
-            < html.range(of: #"/app.js?v=68"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=69"#)!.lowerBound)
         #expect(html.range(of: #"/file-browser.js?v=1"#)!.lowerBound
-            < html.range(of: #"/app.js?v=68"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=69"#)!.lowerBound)
         #expect(sw.contains(#""/changes-view.js?v=2""#))
         #expect(sw.contains(#""/file-browser.js?v=1""#))
     }
@@ -573,6 +573,31 @@ struct RemoteWebAssetTests {
         let js = try asset("app.js")
         #expect(js.contains("function noteStreamingStateForChanges(state)"))
         #expect(js.contains(#"activeTab !== "changes""#))
+    }
+
+    /// Regression: the Files tab had no way to invalidate a stale cached
+    /// listing — once loaded, switching back to it (or an idle turn
+    /// transition while it was open) never re-requested the tree, so an
+    /// agent creating/deleting/renaming files left the tab showing the old
+    /// tree for the rest of the session.
+    @Test func remoteWebRefreshesFilesTreeOnReopenAndWhenATurnGoesIdle() throws {
+        let js = try asset("app.js")
+        #expect(js.contains("function refreshFileTree()"))
+        // `showTab`'s files branch must unconditionally refresh on every
+        // reopen, not just the first time (`needsChildren(null)`).
+        let showTabBody = try #require(
+            js.range(of: "function showTab(name) {").map { js[$0.lowerBound...].prefix(1200) })
+        #expect(showTabBody.contains(#"if (name === "files") refreshFileTree();"#))
+        // The old gate (only fetch the FIRST time this tab is opened) must
+        // be gone from the live condition — a bare `needsChildren` check
+        // isn't enough since the explanatory comment above mentions it too.
+        #expect(!showTabBody.contains("changesTree.needsChildren"))
+        // The idle-transition refresh (shared with Changes) must also
+        // dispatch to Files when that's the open tab.
+        let idleBody = try #require(
+            js.range(of: "function noteStreamingStateForChanges(state) {").map { js[$0.lowerBound...].prefix(800) })
+        #expect(idleBody.contains(#"activeTab !== "files""#))
+        #expect(idleBody.contains("refreshFileTree()"))
     }
 
     // Regression (final whole-branch review, finding 4): a `listChanges` per

--- a/AlasTests/Remote/RemoteWorktreeFileAccessTests.swift
+++ b/AlasTests/Remote/RemoteWorktreeFileAccessTests.swift
@@ -121,4 +121,71 @@ struct RemoteWorktreeFileAccessTests {
         #expect(RemoteWorktreeFileAccess.resolve(path: ".Git/config", in: root) == nil)
         #expect(RemoteWorktreeFileAccess.resolve(path: ".gIT/config", in: root) == nil)
     }
+
+    @Test func readFileContentsReportsTooLargeFromStatWithoutReadingTheWholeFile() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("big.txt")
+        let oversized = RemoteWorktreeFileAccess.maxFileBytes + 1
+        // A sparse file (seek-then-write) gets the real on-disk byte size
+        // reported by stat without materializing the buffer in memory —
+        // the point of this test is exercising the stat-before-read path,
+        // not proving multi-GB behavior.
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: url)
+        try handle.seek(toOffset: UInt64(oversized - 1))
+        handle.write(Data([0x41]))
+        try handle.close()
+
+        let outcome = await RemoteWorktreeFileAccess.readFileContents(at: url)
+
+        guard case .tooLarge(let byteSize) = outcome else {
+            Issue.record("expected .tooLarge, got \(outcome)")
+            return
+        }
+        #expect(byteSize == oversized)
+    }
+
+    @Test func readFileContentsReportsNotFoundForAMissingFile() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let outcome = await RemoteWorktreeFileAccess.readFileContents(at: root.appendingPathComponent("missing.txt"))
+
+        #expect(outcome == .notFound)
+    }
+
+    @Test func readFileContentsReturnsTextForASmallUTF8File() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("small.txt")
+        try "hello\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let outcome = await RemoteWorktreeFileAccess.readFileContents(at: url)
+
+        #expect(outcome == .text("hello\n"))
+    }
+
+    @Test func readFileContentsReportsBinaryForANulContainingFile() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("bin.dat")
+        try Data([0x41, 0x00, 0x42]).write(to: url)
+
+        let outcome = await RemoteWorktreeFileAccess.readFileContents(at: url)
+
+        #expect(outcome == .binary(byteSize: 3))
+    }
+
+    @Test func looksBinaryOnDiskSniffsWithoutReadingTheWholeFile() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let textURL = root.appendingPathComponent("text.txt")
+        try "clean text\n".write(to: textURL, atomically: true, encoding: .utf8)
+        let binaryURL = root.appendingPathComponent("binary.dat")
+        try Data([0x00, 0x01, 0x02]).write(to: binaryURL)
+
+        #expect(await RemoteWorktreeFileAccess.looksBinaryOnDisk(at: textURL) == false)
+        #expect(await RemoteWorktreeFileAccess.looksBinaryOnDisk(at: binaryURL) == true)
+    }
 }

--- a/AlasTests/Remote/RemoteWorktreeFileAccessTests.swift
+++ b/AlasTests/Remote/RemoteWorktreeFileAccessTests.swift
@@ -122,6 +122,22 @@ struct RemoteWorktreeFileAccessTests {
         #expect(RemoteWorktreeFileAccess.resolve(path: ".gIT/config", in: root) == nil)
     }
 
+    @Test func normalizedRelativePathTrimsWhitespaceToMatchTheTrimmedForm() {
+        #expect(RemoteWorktreeFileAccess.normalizedRelativePath(" secret.env") == "secret.env")
+        #expect(
+            RemoteWorktreeFileAccess.normalizedRelativePath(" secret.env")
+                == RemoteWorktreeFileAccess.normalizedRelativePath("secret.env"))
+        #expect(RemoteWorktreeFileAccess.normalizedRelativePath("\tsrc/file.txt\n") == "src/file.txt")
+    }
+
+    @Test func normalizedRelativePathRejectsTheSameInputsAsResolve() {
+        #expect(RemoteWorktreeFileAccess.normalizedRelativePath("") == nil)
+        #expect(RemoteWorktreeFileAccess.normalizedRelativePath("   ") == nil)
+        #expect(RemoteWorktreeFileAccess.normalizedRelativePath("/etc/passwd") == nil)
+        #expect(RemoteWorktreeFileAccess.normalizedRelativePath("../secrets.txt") == nil)
+        #expect(RemoteWorktreeFileAccess.normalizedRelativePath(".git/config") == nil)
+    }
+
     @Test func readFileContentsReportsTooLargeFromStatWithoutReadingTheWholeFile() async throws {
         let root = try makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/AlasTests/Remote/RemoteWorktreeFileAccessTests.swift
+++ b/AlasTests/Remote/RemoteWorktreeFileAccessTests.swift
@@ -163,12 +163,51 @@ struct RemoteWorktreeFileAccessTests {
         #expect(RemoteWorktreeFileAccess.resolve(path: ".gIT/config", in: root) == nil)
     }
 
-    @Test func normalizedRelativePathTrimsWhitespaceToMatchTheTrimmedForm() {
-        #expect(RemoteWorktreeFileAccess.normalizedRelativePath(" secret.env") == "secret.env")
-        #expect(
-            RemoteWorktreeFileAccess.normalizedRelativePath(" secret.env")
-                == RemoteWorktreeFileAccess.normalizedRelativePath("secret.env"))
-        #expect(RemoteWorktreeFileAccess.normalizedRelativePath("\tsrc/file.txt\n") == "src/file.txt")
+    /// Git does not trim filenames — a real file can legitimately be named
+    /// with leading or trailing whitespace. `normalizedRelativePath` used to
+    /// trim the path used for actual resolution, which meant a client
+    /// selecting a genuinely whitespace-padded filename (as reported by the
+    /// file/change list, which preserves such names byte-for-byte) would
+    /// have the server silently look up a DIFFERENT, trimmed path instead.
+    /// Trimming is only used to reject an empty/whitespace-only input; the
+    /// returned string must be byte-for-byte identical to the original.
+    @Test func normalizedRelativePathPreservesGenuineWhitespaceInAFilenameRatherThanTrimmingIt() {
+        #expect(RemoteWorktreeFileAccess.normalizedRelativePath(" secret.env") == " secret.env")
+        #expect(RemoteWorktreeFileAccess.normalizedRelativePath(" secret.env") != "secret.env")
+        #expect(RemoteWorktreeFileAccess.normalizedRelativePath("\tsrc/file.txt\n") == "\tsrc/file.txt\n")
+    }
+
+    /// A padded path like `" secret.env"` must resolve to a candidate named
+    /// literally `" secret.env"` (with the leading space as part of the
+    /// name) — not silently collapse onto a real file named `"secret.env"`.
+    /// This is the empirical half of the reasoning above: proves the
+    /// original whitespace-padding bypass this replaces doesn't reopen,
+    /// since the padded string simply fails to resolve to the real file.
+    @Test func resolvesAWhitespacePaddedPathToItsExactLiteralNameNotTheTrimmedFile() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "TOKEN=abc\n".write(to: root.appendingPathComponent("secret.env"), atomically: true, encoding: .utf8)
+
+        let resolved = try #require(RemoteWorktreeFileAccess.resolve(path: " secret.env", in: root))
+        #expect(resolved.lastPathComponent == " secret.env")
+        #expect(!FileManager.default.fileExists(atPath: resolved.path))
+    }
+
+    /// A file genuinely named with leading/trailing whitespace must still be
+    /// reachable by its exact name — the fix must not merely stop matching
+    /// the wrong file, it must keep matching the RIGHT one.
+    @Test func readsAFileWhoseRealNameHasLeadingAndTrailingWhitespace() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let realName = " padded name.txt "
+        try "content\n".write(to: root.appendingPathComponent(realName), atomically: true, encoding: .utf8)
+
+        #expect(RemoteWorktreeFileAccess.normalizedRelativePath(realName) == realName)
+        let resolved = try #require(RemoteWorktreeFileAccess.resolve(path: realName, in: root))
+        #expect(resolved.lastPathComponent == realName)
+
+        let outcome = await RemoteWorktreeFileAccess.readFileContents(at: resolved)
+        #expect(outcome == .text("content\n"))
     }
 
     @Test func normalizedRelativePathRejectsTheSameInputsAsResolve() {
@@ -232,6 +271,29 @@ struct RemoteWorktreeFileAccessTests {
         let outcome = await RemoteWorktreeFileAccess.readFileContents(at: url)
 
         #expect(outcome == .binary(byteSize: 3))
+    }
+
+    /// A TRACKED symlink whose own name isn't ignored (e.g. `public-env`)
+    /// but whose target IS (`.env`) must not have its target's content
+    /// served transparently. `resolve` deliberately returns the unresolved
+    /// alias URL (not the symlink-followed target), so a naive read via
+    /// `Data(contentsOf:)` would follow the link at the OS level regardless
+    /// of what `isPathIgnored` decided about the alias's own name. Reject
+    /// the alias outright — mirrors the SSH read path's `.symlink ->
+    /// .notFound` mapping, applied here for local reads.
+    @Test func readFileContentsRejectsASymlinkAliasRatherThanFollowingItToItsTarget() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let target = root.appendingPathComponent(".env")
+        try "TOKEN=super-secret\n".write(to: target, atomically: true, encoding: .utf8)
+        let alias = root.appendingPathComponent("public-env")
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: target)
+
+        let resolved = try #require(RemoteWorktreeFileAccess.resolve(path: "public-env", in: root))
+        #expect(RemoteWorktreeFileAccess.isSymlink(at: resolved))
+
+        let outcome = await RemoteWorktreeFileAccess.readFileContents(at: resolved)
+        #expect(outcome == .notFound)
     }
 
     @Test func looksBinaryOnDiskSniffsWithoutReadingTheWholeFile() async throws {

--- a/AlasTests/Remote/RemoteWorktreeFileAccessTests.swift
+++ b/AlasTests/Remote/RemoteWorktreeFileAccessTests.swift
@@ -1,0 +1,87 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct RemoteWorktreeFileAccessTests {
+    private func makeRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-file-access-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    @Test func resolvesPlainRelativePathInsideTheWorktree() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "hi\n".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+
+        let resolved = RemoteWorktreeFileAccess.resolve(path: "a.txt", in: root)
+        #expect(resolved?.lastPathComponent == "a.txt")
+    }
+
+    @Test func rejectsTraversalAbsoluteAndEmptyPaths() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(RemoteWorktreeFileAccess.resolve(path: "../secrets.txt", in: root) == nil)
+        #expect(RemoteWorktreeFileAccess.resolve(path: "src/../../secrets.txt", in: root) == nil)
+        #expect(RemoteWorktreeFileAccess.resolve(path: "/etc/passwd", in: root) == nil)
+        #expect(RemoteWorktreeFileAccess.resolve(path: "", in: root) == nil)
+        #expect(RemoteWorktreeFileAccess.resolve(path: "   ", in: root) == nil)
+    }
+
+    @Test func rejectsDotGitAtAnyDepth() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(RemoteWorktreeFileAccess.resolve(path: ".git", in: root) == nil)
+        #expect(RemoteWorktreeFileAccess.resolve(path: ".git/config", in: root) == nil)
+        #expect(RemoteWorktreeFileAccess.resolve(path: "src/.git/config", in: root) == nil)
+    }
+
+    @Test func rejectsSymlinkEscapingTheWorktree() throws {
+        let root = try makeRoot()
+        let outside = try makeRoot()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: outside)
+        }
+        try "secret\n".write(to: outside.appendingPathComponent("s.txt"), atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("escape"),
+            withDestinationURL: outside)
+
+        #expect(RemoteWorktreeFileAccess.resolve(path: "escape/s.txt", in: root) == nil)
+    }
+
+    @Test func truncatesHunksAtTheLineCap() {
+        let line = ParsedDiff.Hunk.Line(kind: .add, text: "x", oldNumber: nil, newNumber: 1)
+        let big = ParsedDiff.Hunk(
+            header: "@@ -0,0 +1,1 @@", oldStart: 0, newStart: 1,
+            lines: Array(repeating: line, count: RemoteWorktreeFileAccess.maxDiffLines + 10))
+        let small = ParsedDiff.Hunk(
+            header: "@@ -0,0 +1,1 @@", oldStart: 0, newStart: 1, lines: [line])
+
+        let truncated = RemoteWorktreeFileAccess.truncateHunks([big])
+        #expect(truncated.truncated)
+        #expect(truncated.hunks.reduce(0) { $0 + $1.lines.count } == RemoteWorktreeFileAccess.maxDiffLines)
+
+        let kept = RemoteWorktreeFileAccess.truncateHunks([small])
+        #expect(!kept.truncated)
+        #expect(kept.hunks.count == 1)
+    }
+
+    @Test func truncatesChangedFilesAtTheFileCap() {
+        let files = (0..<(RemoteWorktreeFileAccess.maxChangedFiles + 5)).map { index in
+            ChangedFile(path: "f\(index).txt", status: "M", stage: .unstaged,
+                        add: 1, del: 0, renameFrom: nil)
+        }
+        let result = RemoteWorktreeFileAccess.truncateFiles(files)
+        #expect(result.truncated)
+        #expect(result.files.count == RemoteWorktreeFileAccess.maxChangedFiles)
+
+        let short = RemoteWorktreeFileAccess.truncateFiles(Array(files.prefix(3)))
+        #expect(!short.truncated)
+        #expect(short.files.count == 3)
+    }
+}

--- a/AlasTests/Remote/RemoteWorktreeFileAccessTests.swift
+++ b/AlasTests/Remote/RemoteWorktreeFileAccessTests.swift
@@ -84,4 +84,41 @@ struct RemoteWorktreeFileAccessTests {
         #expect(!short.truncated)
         #expect(short.files.count == 3)
     }
+
+    @Test func rejectsSymlinkAliasToGit() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // Create a real .git directory inside the root
+        let gitDir = root.appendingPathComponent(".git")
+        try FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+
+        // Create a config file inside .git
+        try "secret\n".write(to: gitDir.appendingPathComponent("config"), atomically: true, encoding: .utf8)
+
+        // Create a symlink alias that points to .git
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("alias"),
+            withDestinationURL: gitDir)
+
+        // Accessing via the symlink alias should be rejected
+        #expect(RemoteWorktreeFileAccess.resolve(path: "alias", in: root) == nil)
+        #expect(RemoteWorktreeFileAccess.resolve(path: "alias/config", in: root) == nil)
+    }
+
+    @Test func rejectsCaseVariationOfGitOnResolvedPath() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // Create actual .git directory
+        let gitDir = root.appendingPathComponent(".git")
+        try FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        try "secret\n".write(to: gitDir.appendingPathComponent("config"), atomically: true, encoding: .utf8)
+
+        // Test various case variations - all should be rejected
+        // The resolved path check must compare case-insensitively
+        #expect(RemoteWorktreeFileAccess.resolve(path: ".GIT/config", in: root) == nil)
+        #expect(RemoteWorktreeFileAccess.resolve(path: ".Git/config", in: root) == nil)
+        #expect(RemoteWorktreeFileAccess.resolve(path: ".gIT/config", in: root) == nil)
+    }
 }

--- a/AlasTests/Remote/RemoteWorktreeFileAccessTests.swift
+++ b/AlasTests/Remote/RemoteWorktreeFileAccessTests.swift
@@ -71,6 +71,47 @@ struct RemoteWorktreeFileAccessTests {
         #expect(kept.hunks.count == 1)
     }
 
+    @Test func truncatesHunksAtTheByteBudgetBeforeTheLineCap() {
+        // Each line is 2KB; at 2KB/line the byte budget (512KB) is exhausted
+        // long before the 2,000-line cap would be, so this hunk must be
+        // stopped by the byte budget rather than the line count.
+        let text = String(repeating: "a", count: 2048)
+        let line = ParsedDiff.Hunk.Line(kind: .add, text: text, oldNumber: nil, newNumber: 1)
+        let hunk = ParsedDiff.Hunk(
+            header: "@@ -0,0 +1,1 @@", oldStart: 0, newStart: 1,
+            lines: Array(repeating: line, count: RemoteWorktreeFileAccess.maxDiffLines))
+
+        let result = RemoteWorktreeFileAccess.truncateHunks([hunk])
+
+        #expect(result.truncated)
+        let keptLines = result.hunks.reduce(0) { $0 + $1.lines.count }
+        #expect(keptLines < RemoteWorktreeFileAccess.maxDiffLines)
+        let totalBytes = result.hunks.reduce(0) { total, hunk in
+            total + hunk.lines.reduce(0) { $0 + $1.text.utf8.count }
+        }
+        #expect(totalBytes <= RemoteWorktreeFileAccess.maxDiffBytes)
+    }
+
+    @Test func truncatesASingleEnormousLineRatherThanShippingOrDroppingItWhole() throws {
+        let hugeText = String(repeating: "x", count: 2 * 1024 * 1024) // 2 MB single line
+        let hugeLine = ParsedDiff.Hunk.Line(kind: .add, text: hugeText, oldNumber: nil, newNumber: 1)
+        let normalLine = ParsedDiff.Hunk.Line(kind: .add, text: "y", oldNumber: nil, newNumber: 2)
+        let hunk = ParsedDiff.Hunk(
+            header: "@@ -0,0 +1,2 @@", oldStart: 0, newStart: 1,
+            lines: [hugeLine, normalLine])
+
+        let result = RemoteWorktreeFileAccess.truncateHunks([hunk])
+
+        #expect(result.truncated)
+        let totalBytes = result.hunks.reduce(0) { total, hunk in
+            total + hunk.lines.reduce(0) { $0 + $1.text.utf8.count }
+        }
+        #expect(totalBytes <= RemoteWorktreeFileAccess.maxDiffBytes)
+        let firstLine = try #require(result.hunks.first?.lines.first)
+        #expect(firstLine.text.utf8.count <= RemoteWorktreeFileAccess.maxDiffLineBytes)
+        #expect(firstLine.text.hasSuffix("(line truncated)"))
+    }
+
     @Test func truncatesChangedFilesAtTheFileCap() {
         let files = (0..<(RemoteWorktreeFileAccess.maxChangedFiles + 5)).map { index in
             ChangedFile(path: "f\(index).txt", status: "M", stage: .unstaged,

--- a/AlasTests/Remote/RemoteWorktreeFileAccessTests.swift
+++ b/AlasTests/Remote/RemoteWorktreeFileAccessTests.swift
@@ -143,6 +143,21 @@ struct RemoteWorktreeFileAccessTests {
         #expect(short.files.count == 3)
     }
 
+    @Test func truncatesFileTreeNodesAtTheNodeCap() {
+        let nodes = (0..<(RemoteWorktreeFileAccess.maxFileTreeNodes + 5)).map { index in
+            RemoteFileNode(
+                name: "f\(index).txt", path: "f\(index).txt", kind: "file",
+                badge: nil, childrenState: "loaded", isSubmodule: false)
+        }
+        let result = RemoteWorktreeFileAccess.truncateFileNodes(nodes)
+        #expect(result.truncated)
+        #expect(result.nodes.count == RemoteWorktreeFileAccess.maxFileTreeNodes)
+
+        let short = RemoteWorktreeFileAccess.truncateFileNodes(Array(nodes.prefix(3)))
+        #expect(!short.truncated)
+        #expect(short.nodes.count == 3)
+    }
+
     @Test func rejectsSymlinkAliasToGit() throws {
         let root = try makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/AlasTests/Remote/RemoteWorktreeFileAccessTests.swift
+++ b/AlasTests/Remote/RemoteWorktreeFileAccessTests.swift
@@ -1,6 +1,23 @@
 import Testing
 import Foundation
+import Darwin
 @testable import Alas
+
+/// Races `operation` against a timeout so a regression that reintroduces a
+/// blocking open/read (e.g. a FIFO with no writer) fails the test loudly
+/// and promptly instead of hanging the whole suite.
+private func withTimeout<T: Sendable>(seconds: Double, _ operation: @escaping @Sendable () async -> T) async -> T? {
+    await withTaskGroup(of: T?.self) { group in
+        group.addTask { await operation() }
+        group.addTask {
+            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            return nil
+        }
+        let result = await group.next() ?? nil
+        group.cancelAll()
+        return result
+    }
+}
 
 struct RemoteWorktreeFileAccessTests {
     private func makeRoot() throws -> URL {
@@ -306,5 +323,100 @@ struct RemoteWorktreeFileAccessTests {
 
         #expect(await RemoteWorktreeFileAccess.looksBinaryOnDisk(at: textURL) == false)
         #expect(await RemoteWorktreeFileAccess.looksBinaryOnDisk(at: binaryURL) == true)
+    }
+
+    /// `looksBinaryOnDisk` sniffs a file larger than its 8 KB sniff window
+    /// via a bounded prefix read (`openReadPrefix`), NOT the whole-file cap
+    /// path (`openReadCapped`) — a file whose total size exceeds 8 KB must
+    /// still be sniffed rather than being reported as "too large" and
+    /// treated as not-binary. This guards the read-prefix/read-capped split
+    /// introduced by the single-open TOCTOU fix.
+    @Test func looksBinaryOnDiskSniffsAFileLargerThanTheSniffWindow() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("large-text.txt")
+        let text = String(repeating: "clean text line\n", count: 4000) // well over 8 KB
+        try text.write(to: url, atomically: true, encoding: .utf8)
+
+        #expect(await RemoteWorktreeFileAccess.looksBinaryOnDisk(at: url) == false)
+    }
+
+    /// Both `readFileContents` and `looksBinaryOnDisk` open the target via
+    /// `O_NOFOLLOW | O_NONBLOCK`, so a FIFO with no writer must never block:
+    /// opening a named pipe for reading normally blocks indefinitely without
+    /// `O_NONBLOCK`, which (since ordinary remote-session messages are
+    /// processed serially per connection) would hang every subsequent
+    /// message too. `mkfifo` creates a real named pipe; nothing ever opens
+    /// it for writing, so a regression that drops `O_NONBLOCK` or the
+    /// regular-file `fstat` check would hang this test until the timeout —
+    /// asserted against explicitly so a real regression fails loudly rather
+    /// than hanging the whole suite.
+    @Test func readFileContentsReturnsPromptlyForAFIFOWithNoWriter() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fifoURL = root.appendingPathComponent("pipe")
+        #expect(fifoURL.path.withCString { mkfifo($0, 0o600) } == 0)
+
+        let outcome = await withTimeout(seconds: 5) {
+            await RemoteWorktreeFileAccess.readFileContents(at: fifoURL)
+        }
+        let result = try #require(outcome, "readFileContents hung on a writerless FIFO instead of returning promptly")
+        #expect(result == .notFound)
+    }
+
+    @Test func looksBinaryOnDiskReturnsPromptlyForAFIFOWithNoWriter() async throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fifoURL = root.appendingPathComponent("pipe")
+        #expect(fifoURL.path.withCString { mkfifo($0, 0o600) } == 0)
+
+        let outcome: Bool? = await withTimeout(seconds: 5) {
+            await RemoteWorktreeFileAccess.looksBinaryOnDisk(at: fifoURL)
+        }
+        let result = try #require(outcome as Bool?, "looksBinaryOnDisk hung on a writerless FIFO instead of returning promptly")
+        #expect(result == false)
+    }
+
+    /// Structural proof of the single-open TOCTOU fix: the last line
+    /// appended to a truncated diff must never itself push the payload past
+    /// `maxDiffBytes`, even when its (already per-line-clamped) size would
+    /// have fit under the OLD "check remainingBytes > 0 before the NEXT
+    /// line" logic while still exceeding what's actually left of the
+    /// budget.
+    @Test func truncateHunksNeverExceedsTheByteBudgetOnTheFinalKeptLine() {
+        // 8 filler lines, each individually UNDER `maxDiffLineBytes` (so
+        // `clampedLine` never touches them), consume all but a small sliver
+        // of the overall `maxDiffBytes` budget. The final line is also
+        // under `maxDiffLineBytes` but far larger than that sliver — the
+        // old "check `remainingBytes > 0` before the NEXT line" logic would
+        // have appended it anyway (0 > 0 is false, but the sliver here is
+        // small and positive), pushing the total thousands of bytes past
+        // the cap.
+        let fillerSize = 65_000
+        precondition(fillerSize < RemoteWorktreeFileAccess.maxDiffLineBytes)
+        let fillerLine = ParsedDiff.Hunk.Line(
+            kind: .add, text: String(repeating: "a", count: fillerSize), oldNumber: nil, newNumber: 1)
+        let fillerCount = 8
+        let remainingBeforeFinalLine = RemoteWorktreeFileAccess.maxDiffBytes - fillerCount * fillerSize
+        precondition(remainingBeforeFinalLine > 0)
+        let finalLineSize = 10_000
+        precondition(finalLineSize < RemoteWorktreeFileAccess.maxDiffLineBytes)
+        precondition(finalLineSize > remainingBeforeFinalLine, "final line must NOT fit in what's left of the budget")
+        let finalLine = ParsedDiff.Hunk.Line(
+            kind: .add, text: String(repeating: "b", count: finalLineSize), oldNumber: nil, newNumber: 2)
+        let hunk = ParsedDiff.Hunk(
+            header: "@@ -0,0 +1,2 @@", oldStart: 0, newStart: 1,
+            lines: Array(repeating: fillerLine, count: fillerCount) + [finalLine])
+
+        let result = RemoteWorktreeFileAccess.truncateHunks([hunk])
+
+        #expect(result.truncated)
+        let totalBytes = result.hunks.reduce(0) { total, hunk in
+            total + hunk.lines.reduce(0) { $0 + $1.text.utf8.count }
+        }
+        #expect(totalBytes <= RemoteWorktreeFileAccess.maxDiffBytes)
+        // The final line must have been dropped entirely (not partially
+        // appended) since it can't fit in the remaining budget.
+        #expect(result.hunks.first?.lines.count == fillerCount)
     }
 }

--- a/AlasTests/SSH/ACPRemoteFileServerTests.swift
+++ b/AlasTests/SSH/ACPRemoteFileServerTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Alas
 
@@ -35,5 +36,65 @@ struct ACPRemoteFileServerTests {
         )
 
         #expect(command == server.containmentProbeCommand(path: "/srv/repo/link/passwd"))
+    }
+
+    @Test func containmentExcludingGitProbeCommandShapeChecksFullyResolvedRelativePath() {
+        let command = RemotePathContainment.containmentExcludingGitProbeCommand(
+            path: "/srv/repo/alias/config",
+            worktreeRoot: "/srv/repo"
+        )
+
+        #expect(command.contains("root='/srv/repo'"))
+        #expect(command.contains("target='/srv/repo/alias/config'"))
+        #expect(command.contains("pwd -P"))
+        #expect(command.contains(".[Gg][Ii][Tt]"))
+        #expect(command.contains("exit 7"))
+    }
+
+    /// Verifies the shell script's actual behavior directly, without an SSH
+    /// connection: `RemoteExec.run` would run this exact string as a POSIX
+    /// shell command on the remote host, and since the script only uses
+    /// `cd`/`pwd -P`/`dirname`/`basename`/`case` its behavior is identical
+    /// run locally via `/bin/sh -c`. This proves the shell logic itself is
+    /// correct; it does not exercise `RemoteExec.run` or a real SSH host.
+    @Test func containmentExcludingGitProbeCommandRejectsADirectorySymlinkAliasToGit() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-containment-probe-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let gitDir = root.appendingPathComponent(".git")
+        try FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        try "fake git config".write(to: gitDir.appendingPathComponent("config"), atomically: true, encoding: .utf8)
+
+        let srcDir = root.appendingPathComponent("src")
+        try FileManager.default.createDirectory(at: srcDir, withIntermediateDirectories: true)
+        try "print(1)".write(to: srcDir.appendingPathComponent("main.swift"), atomically: true, encoding: .utf8)
+
+        let alias = root.appendingPathComponent("alias")
+        // Use the String-based API so the symlink target is written as the
+        // literal relative string ".git" (resolved relative to `alias`'s own
+        // directory when followed) — the URL-based overload would instead
+        // resolve `URL(fileURLWithPath: ".git")` against the PROCESS's
+        // current directory before writing the link, producing a broken
+        // symlink here.
+        try FileManager.default.createSymbolicLink(atPath: alias.path, withDestinationPath: ".git")
+
+        // The alias resolves (through the symlink) to inside `.git` — must be rejected.
+        #expect(try await exitCode(forTarget: alias.appendingPathComponent("config").path, root: root.path) == 7)
+        // Requesting the alias itself (a directory symlink to `.git`) must also be rejected.
+        #expect(try await exitCode(forTarget: alias.path, root: root.path) == 7)
+        // The real `.git` directory, addressed directly, must also be rejected.
+        #expect(try await exitCode(forTarget: gitDir.appendingPathComponent("config").path, root: root.path) == 7)
+        // A legitimate existing file must pass.
+        #expect(try await exitCode(forTarget: srcDir.appendingPathComponent("main.swift").path, root: root.path) == 0)
+        // A legitimate not-yet-existing file (about to be created) must pass.
+        #expect(try await exitCode(forTarget: srcDir.appendingPathComponent("new.swift").path, root: root.path) == 0)
+    }
+
+    private func exitCode(forTarget target: String, root: String) async throws -> Int32 {
+        let command = RemotePathContainment.containmentExcludingGitProbeCommand(path: target, worktreeRoot: root)
+        let result = try await Process.run("/bin/sh", args: ["-c", command])
+        return result.exitCode
     }
 }

--- a/AlasTests/SSH/ACPRemoteFileServerTests.swift
+++ b/AlasTests/SSH/ACPRemoteFileServerTests.swift
@@ -1,6 +1,23 @@
 import Foundation
 import Testing
+import Darwin
 @testable import Alas
+
+/// Races `operation` against a timeout so a regression that reintroduces a
+/// blocking read (e.g. `head` against a writerless FIFO) fails the test
+/// loudly and promptly instead of hanging the whole suite.
+private func withTimeout<T: Sendable>(seconds: Double, _ operation: @escaping @Sendable () async -> T) async -> T? {
+    await withTaskGroup(of: T?.self) { group in
+        group.addTask { await operation() }
+        group.addTask {
+            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            return nil
+        }
+        let result = await group.next() ?? nil
+        group.cancelAll()
+        return result
+    }
+}
 
 struct ACPRemoteFileServerTests {
     private let server = ACPRemoteFileServer(host: "devbox", worktreeRoot: "/srv/repo")
@@ -152,6 +169,29 @@ struct ACPRemoteFileServerTests {
         let result = try await runContainedRead(target: dir.path, root: root.path)
 
         #expect(result.exitCode == 9)
+    }
+
+    /// A FIFO passes the symlink/directory/existence checks above it, so
+    /// without an explicit regular-file check `head` would block
+    /// indefinitely waiting for a writer that never arrives. `mkfifo`
+    /// creates a real named pipe; nothing ever opens it for writing, so a
+    /// regression that drops the `[ -f ]` check would hang this test until
+    /// the timeout — asserted against explicitly so it fails loudly rather
+    /// than hanging the whole suite.
+    @Test func containedReadScriptRejectsAFIFOWithoutBlockingOnHead() async throws {
+        let root = try makeContainedReadRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fifo = root.appendingPathComponent("pipe")
+        #expect(fifo.path.withCString { mkfifo($0, 0o600) } == 0)
+
+        let outcome = await withTimeout(seconds: 5) {
+            try? await runContainedRead(target: fifo.path, root: root.path)
+        }
+        let result = try #require(
+            outcome.flatMap { $0 },
+            "containedReadScript hung on a writerless FIFO instead of returning promptly")
+
+        #expect(result.exitCode == 12)
     }
 
     @Test func containedReadScriptReportsMissingFile() async throws {

--- a/AlasTests/SSH/ACPRemoteFileServerTests.swift
+++ b/AlasTests/SSH/ACPRemoteFileServerTests.swift
@@ -97,4 +97,104 @@ struct ACPRemoteFileServerTests {
         let result = try await Process.run("/bin/sh", args: ["-c", command])
         return result.exitCode
     }
+
+    // MARK: - containedReadScript / containedRead
+
+    /// Same local-`/bin/sh` verification strategy as
+    /// `containmentExcludingGitProbeCommandRejectsADirectorySymlinkAliasToGit`:
+    /// `containedReadScript` only uses POSIX shell builtins plus
+    /// `stat`/`head`, so its behavior locally is identical to what
+    /// `RemoteExec.run` would produce against a real remote host.
+    private func runContainedRead(target: String, root: String, maxBytes: Int = 1_000_000) async throws -> ProcessResultData {
+        let command = RemotePathContainment.containedReadScript(path: target, worktreeRoot: root, maxBytes: maxBytes)
+        return try await Process.runData("/bin/sh", args: ["-c", command])
+    }
+
+    private func makeContainedReadRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-contained-read-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    @Test func containedReadScriptReadsAnOrdinaryFileInOneShellInvocation() async throws {
+        let root = try makeContainedReadRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let file = root.appendingPathComponent("a.txt")
+        try "hello\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let result = try await runContainedRead(target: file.path, root: root.path)
+
+        #expect(result.exitCode == 0)
+        let text = String(data: result.stdout, encoding: .utf8)
+        #expect(text == "6\nhello\n")
+    }
+
+    @Test func containedReadScriptRejectsASymlink() async throws {
+        let root = try makeContainedReadRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let target = root.appendingPathComponent("real.txt")
+        try "secret\n".write(to: target, atomically: true, encoding: .utf8)
+        let alias = root.appendingPathComponent("alias.txt")
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: target)
+
+        let result = try await runContainedRead(target: alias.path, root: root.path)
+
+        #expect(result.exitCode == 8)
+    }
+
+    @Test func containedReadScriptRejectsADirectory() async throws {
+        let root = try makeContainedReadRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let dir = root.appendingPathComponent("subdir")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let result = try await runContainedRead(target: dir.path, root: root.path)
+
+        #expect(result.exitCode == 9)
+    }
+
+    @Test func containedReadScriptReportsMissingFile() async throws {
+        let root = try makeContainedReadRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let result = try await runContainedRead(target: root.appendingPathComponent("nope.txt").path, root: root.path)
+
+        #expect(result.exitCode == 10)
+    }
+
+    @Test func containedReadScriptRejectsPathsOutsideTheWorktree() async throws {
+        let root = try makeContainedReadRoot()
+        let outside = try makeContainedReadRoot()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: outside)
+        }
+        let file = outside.appendingPathComponent("secret.txt")
+        try "nope\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let result = try await runContainedRead(target: file.path, root: root.path)
+
+        #expect(result.exitCode == 6)
+    }
+
+    @Test func containedReadScriptCapsTheTransferredBodyWithoutMisreportingSize() async throws {
+        let root = try makeContainedReadRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let file = root.appendingPathComponent("big.txt")
+        let content = String(repeating: "x", count: 1000)
+        try content.write(to: file, atomically: true, encoding: .utf8)
+
+        let result = try await runContainedRead(target: file.path, root: root.path, maxBytes: 10)
+
+        #expect(result.exitCode == 0)
+        guard let newline = result.stdout.firstIndex(of: UInt8(ascii: "\n")) else {
+            Issue.record("expected a size header line")
+            return
+        }
+        let header = String(data: result.stdout[..<newline], encoding: .utf8)
+        #expect(header == "1000")
+        let body = result.stdout[result.stdout.index(after: newline)...]
+        #expect(body.count == 10)
+    }
 }

--- a/AlasTests/SSH/ACPRemoteFileServerTests.swift
+++ b/AlasTests/SSH/ACPRemoteFileServerTests.swift
@@ -178,6 +178,10 @@ struct ACPRemoteFileServerTests {
         #expect(result.exitCode == 6)
     }
 
+    /// The script itself reads `maxBytes + 1` bytes (not exactly `maxBytes`)
+    /// — see `containedReadScript`'s doc comment: that extra byte is how
+    /// `parseContainedReadResult` detects a file that grew past `maxBytes`
+    /// between the earlier `stat` and this `head` call.
     @Test func containedReadScriptCapsTheTransferredBodyWithoutMisreportingSize() async throws {
         let root = try makeContainedReadRoot()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -195,7 +199,44 @@ struct ACPRemoteFileServerTests {
         let header = String(data: result.stdout[..<newline], encoding: .utf8)
         #expect(header == "1000")
         let body = result.stdout[result.stdout.index(after: newline)...]
-        #expect(body.count == 10)
+        #expect(body.count == 11)
+    }
+
+    // MARK: - parseContainedReadResult
+
+    @Test func parseContainedReadResultReportsSizeAndPrefixForAnOrdinaryFile() {
+        let stdout = "6\nhello\n".data(using: .utf8)!
+        let outcome = RemotePathContainment.parseContainedReadResult(exitCode: 0, stdout: stdout, maxBytes: 1_000_000)
+        #expect(outcome == .ok(byteSize: 6, prefix: "hello\n".data(using: .utf8)!))
+    }
+
+    /// The exact race the finding described: `stat` observed the file at
+    /// 50 bytes (comfortably under `maxBytes`), but by the time `head -c
+    /// maxBytes + 1` ran, a concurrent write had grown it — so the actual
+    /// transferred body is `maxBytes + 1` bytes despite the stale "50"
+    /// header. The parsed outcome must report the file as over the cap
+    /// (`byteSize > maxBytes`) rather than trusting the header and handing
+    /// back a truncated prefix as if it were the complete file.
+    @Test func parseContainedReadResultOverridesAStaleSmallHeaderWhenTheActualBodyExceedsMaxBytes() {
+        let maxBytes = 10
+        let header = "50\n".data(using: .utf8)!
+        let body = Data(repeating: UInt8(ascii: "x"), count: maxBytes + 1)
+        let outcome = RemotePathContainment.parseContainedReadResult(exitCode: 0, stdout: header + body, maxBytes: maxBytes)
+        guard case let .ok(byteSize, prefix) = outcome else {
+            Issue.record("expected .ok, got \(outcome)")
+            return
+        }
+        #expect(byteSize > maxBytes)
+        #expect(prefix.count == maxBytes)
+    }
+
+    @Test func parseContainedReadResultMapsNonZeroExitCodes() {
+        #expect(RemotePathContainment.parseContainedReadResult(exitCode: 6, stdout: Data(), maxBytes: 10) == .outsideWorktree)
+        #expect(RemotePathContainment.parseContainedReadResult(exitCode: 7, stdout: Data(), maxBytes: 10) == .outsideWorktree)
+        #expect(RemotePathContainment.parseContainedReadResult(exitCode: 8, stdout: Data(), maxBytes: 10) == .symlink)
+        #expect(RemotePathContainment.parseContainedReadResult(exitCode: 9, stdout: Data(), maxBytes: 10) == .directory)
+        #expect(RemotePathContainment.parseContainedReadResult(exitCode: 10, stdout: Data(), maxBytes: 10) == .missing)
+        #expect(RemotePathContainment.parseContainedReadResult(exitCode: 11, stdout: Data(), maxBytes: 10) == .unreadable)
     }
 
     // MARK: - containedListScript / containedList

--- a/AlasTests/SSH/ACPRemoteFileServerTests.swift
+++ b/AlasTests/SSH/ACPRemoteFileServerTests.swift
@@ -283,7 +283,7 @@ struct ACPRemoteFileServerTests {
 
     /// Same local-`/bin/sh` verification strategy as the read-script tests
     /// above: `containedListScript` only uses POSIX shell builtins plus
-    /// `ls`, so its behavior locally is identical to what `RemoteExec.run`
+    /// `find`, so its behavior locally is identical to what `RemoteExec.run`
     /// would produce against a real remote host.
     private func runContainedList(target: String, root: String) async throws -> ProcessResultData {
         let command = RemotePathContainment.containedListScript(path: target, worktreeRoot: root)
@@ -304,6 +304,23 @@ struct ACPRemoteFileServerTests {
         #expect(entries.map(\.name) == ["main.swift", "src"])
         #expect(entries.first { $0.name == "src" }?.isDirectory == true)
         #expect(entries.first { $0.name == "main.swift" }?.isDirectory == false)
+    }
+
+    /// Regression: `find -print0` (unlike `ls --zero`, which BSD `ls` has
+    /// no equivalent for at all) is NUL-safe on both GNU findutils and BSD
+    /// `find`, so a filename containing an embedded newline byte must stay
+    /// intact as one entry here too.
+    @Test func containedListScriptKeepsAnEmbeddedNewlineIntact() async throws {
+        let root = try makeContainedReadRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "".write(to: root.appendingPathComponent("weird\nname.txt"), atomically: true, encoding: .utf8)
+
+        let result = try await runContainedList(target: root.path, root: root.path)
+
+        #expect(result.exitCode == 0)
+        let entries = RemoteFileStats.parseLsEntries(String(data: result.stdout, encoding: .utf8) ?? "")
+        #expect(entries.map(\.name) == ["weird\nname.txt"])
+        #expect(entries.first?.isDirectory == false)
     }
 
     @Test func containedListScriptRejectsAFile() async throws {

--- a/AlasTests/SSH/ACPRemoteFileServerTests.swift
+++ b/AlasTests/SSH/ACPRemoteFileServerTests.swift
@@ -197,4 +197,71 @@ struct ACPRemoteFileServerTests {
         let body = result.stdout[result.stdout.index(after: newline)...]
         #expect(body.count == 10)
     }
+
+    // MARK: - containedListScript / containedList
+
+    /// Same local-`/bin/sh` verification strategy as the read-script tests
+    /// above: `containedListScript` only uses POSIX shell builtins plus
+    /// `ls`, so its behavior locally is identical to what `RemoteExec.run`
+    /// would produce against a real remote host.
+    private func runContainedList(target: String, root: String) async throws -> ProcessResultData {
+        let command = RemotePathContainment.containedListScript(path: target, worktreeRoot: root)
+        return try await Process.runData("/bin/sh", args: ["-c", command])
+    }
+
+    @Test func containedListScriptListsADirectoryInOneShellInvocation() async throws {
+        let root = try makeContainedReadRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "print(1)".write(to: root.appendingPathComponent("main.swift"), atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(at: root.appendingPathComponent("src"), withIntermediateDirectories: true)
+
+        let result = try await runContainedList(target: root.path, root: root.path)
+
+        #expect(result.exitCode == 0)
+        let entries = RemoteFileStats.parseLsEntries(String(data: result.stdout, encoding: .utf8) ?? "")
+            .sorted { $0.name < $1.name }
+        #expect(entries.map(\.name) == ["main.swift", "src"])
+        #expect(entries.first { $0.name == "src" }?.isDirectory == true)
+        #expect(entries.first { $0.name == "main.swift" }?.isDirectory == false)
+    }
+
+    @Test func containedListScriptRejectsAFile() async throws {
+        let root = try makeContainedReadRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let file = root.appendingPathComponent("a.txt")
+        try "hello\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let result = try await runContainedList(target: file.path, root: root.path)
+
+        #expect(result.exitCode == 9)
+    }
+
+    @Test func containedListScriptRejectsPathsOutsideTheWorktree() async throws {
+        let root = try makeContainedReadRoot()
+        let outside = try makeContainedReadRoot()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: outside)
+        }
+
+        let result = try await runContainedList(target: outside.path, root: root.path)
+
+        #expect(result.exitCode == 6)
+    }
+
+    /// The exact scenario the finding described: containment and the
+    /// listing must resolve the SAME physical path, so a directory symlink
+    /// alias to `.git` is rejected here just as it is for reads.
+    @Test func containedListScriptRejectsADirectorySymlinkAliasToGit() async throws {
+        let root = try makeContainedReadRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let gitDir = root.appendingPathComponent(".git")
+        try FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        let alias = root.appendingPathComponent("alias")
+        try FileManager.default.createSymbolicLink(atPath: alias.path, withDestinationPath: ".git")
+
+        let result = try await runContainedList(target: alias.path, root: root.path)
+
+        #expect(result.exitCode == 7)
+    }
 }

--- a/AlasTests/SSH/RemoteFileAccessTests.swift
+++ b/AlasTests/SSH/RemoteFileAccessTests.swift
@@ -89,6 +89,35 @@ struct RemoteFileAccessTests {
         #expect(RemoteSaveGate.decision(originalMtime: t2, remoteMtime: t1) == .proceed)
     }
 
+    @Test func sizeScriptChainsGnuThenBsdStat() {
+        let script = RemoteFileAccess.sizeScript(path: "/srv/repo/a.txt")
+        #expect(script.contains("f='/srv/repo/a.txt'"))
+        #expect(script.contains("stat -c %s -- \"$f\" 2>/dev/null || stat -f %z \"$f\""))
+    }
+
+    /// Runs the exact generated `sizeScript` locally via `/bin/sh -c` against
+    /// a real file of known size — proving the GNU/BSD `stat` fallback chain
+    /// actually parses to the right byte count on this host's shell, without
+    /// a real SSH connection. `RemoteFileAccess.size`'s helper-first /
+    /// exec-fallback dispatch and its threading into
+    /// `AppState.readRemoteWorktreeFileRaw`'s new `.tooLarge` outcome are
+    /// NOT covered by this test — there is no reachable SSH host, and no
+    /// mock seam for `RemoteHelperClient`/`RemoteExec`, to drive that
+    /// end-to-end in this environment.
+    @Test func sizeScriptReportsTheRealByteCountWhenRunLocally() async throws {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-size-script-\(UUID().uuidString).txt")
+        defer { try? FileManager.default.removeItem(at: file) }
+        let content = String(repeating: "x", count: 12345)
+        try content.write(to: file, atomically: true, encoding: .utf8)
+
+        let script = RemoteFileAccess.sizeScript(path: file.path)
+        let result = try await Process.run("/bin/sh", args: ["-c", script])
+
+        #expect(result.exitCode == 0)
+        #expect(UInt64(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)) == 12345)
+    }
+
     @Test func saveGateTreatsEqualMtimeAsAmbiguousForCallerContentCheck() {
         let baseline = Date(timeIntervalSince1970: 100)
         #expect(RemoteSaveGate.requiresContentCheck(originalMtime: baseline, remoteMtime: baseline))

--- a/AlasTests/SSH/RemoteFileStatsTests.swift
+++ b/AlasTests/SSH/RemoteFileStatsTests.swift
@@ -1,21 +1,69 @@
+import Foundation
 import Testing
 @testable import Alas
 
 struct RemoteFileStatsTests {
     @Test func wcCommandQuotesPathsAndAvoidsEmptyInput() {
         #expect(RemoteFileStats.wcCommand(paths: []) == nil)
-        #expect(RemoteFileStats.wcCommand(paths: ["a.txt", "dir/o'brien.txt"]) == "wc -l -- 'a.txt' 'dir/o'\\''brien.txt'")
+        let command = RemoteFileStats.wcCommand(paths: ["a.txt", "dir/o'brien.txt"])
+        #expect(command == [
+            "n=$(wc -l < 'a.txt'); if [ -s 'a.txt' ] && [ \"$(tail -c1 -- 'a.txt' | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; printf '%s %s\\n' \"$n\" 'a.txt'",
+            "n=$(wc -l < 'dir/o'\\''brien.txt'); if [ -s 'dir/o'\\''brien.txt' ] && [ \"$(tail -c1 -- 'dir/o'\\''brien.txt' | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; printf '%s %s\\n' \"$n\" 'dir/o'\\''brien.txt'",
+        ].joined(separator: "; "))
     }
 
     /// Without `--`, a filename starting with `-` (e.g. `-c`) is parsed by
-    /// `wc` as an OPTION rather than a filename, silently dropping it from
-    /// the output — and so silently reporting 0 for its line count.
+    /// `tail` as an OPTION rather than a filename, silently misclassifying
+    /// its trailing-newline check.
     @Test func wcCommandSeparatesOptionsFromFilenamesStartingWithADash() {
-        #expect(RemoteFileStats.wcCommand(paths: ["-c"]) == "wc -l -- '-c'")
+        let command = RemoteFileStats.wcCommand(paths: ["-c"])
+        #expect(command == "n=$(wc -l < '-c'); if [ -s '-c' ] && [ \"$(tail -c1 -- '-c' | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; printf '%s %s\\n' \"$n\" '-c'")
     }
 
     @Test func parsesWcOutput() {
         #expect(RemoteFileStats.parseWcOutput("      12 a.txt\n       0 b.txt\n      12 total", requested: ["a.txt", "b.txt"]) == ["a.txt": 12, "b.txt": 0])
+    }
+
+    /// End-to-end regression for the trailing-newline undercount: runs the
+    /// generated script through `/bin/sh` against real files, mirroring
+    /// what the SSH exec fallback actually executes remotely.
+    @Test func wcCommandCorrectlyCountsFilesWithoutATrailingNewline() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let cases: [(name: String, contents: String, expected: Int)] = [
+            ("empty.txt", "", 0),
+            ("one-line-no-newline.txt", "hello", 1),
+            ("one-line-with-newline.txt", "hello\n", 1),
+            ("two-lines-no-trailing-newline.txt", "a\nb", 2),
+            ("two-lines-with-trailing-newline.txt", "a\nb\n", 2),
+        ]
+        for testCase in cases {
+            try testCase.contents.write(
+                to: directory.appendingPathComponent(testCase.name),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+
+        let paths = cases.map(\.name)
+        let command = try #require(RemoteFileStats.wcCommand(paths: paths))
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        process.currentDirectoryURL = directory
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+        let counts = RemoteFileStats.parseWcOutput(output, requested: paths)
+        for testCase in cases {
+            #expect(counts[testCase.name] == testCase.expected, "\(testCase.name)")
+        }
     }
     @Test func helperLineCountsMergeDuplicatePaths() {
         let entries = [

--- a/AlasTests/SSH/RemoteFileStatsTests.swift
+++ b/AlasTests/SSH/RemoteFileStatsTests.swift
@@ -19,8 +19,8 @@ struct RemoteFileStatsTests {
         #expect(RemoteFileStats.wcCommand(paths: []) == nil)
         let command = RemoteFileStats.wcCommand(paths: ["a.txt", "dir/o'brien.txt"])
         #expect(command == [
-            "n=$(wc -l < 'a.txt'); if [ -s 'a.txt' ] && [ \"$(tail -c1 -- 'a.txt' | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; printf '%s %s\\n' \"$n\" 'a.txt'",
-            "n=$(wc -l < 'dir/o'\\''brien.txt'); if [ -s 'dir/o'\\''brien.txt' ] && [ \"$(tail -c1 -- 'dir/o'\\''brien.txt' | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; printf '%s %s\\n' \"$n\" 'dir/o'\\''brien.txt'",
+            "n=$(wc -l < 'a.txt'); if [ -s 'a.txt' ] && [ \"$(tail -c1 -- 'a.txt' | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; printf '%s %s\\0' \"$n\" 'a.txt'",
+            "n=$(wc -l < 'dir/o'\\''brien.txt'); if [ -s 'dir/o'\\''brien.txt' ] && [ \"$(tail -c1 -- 'dir/o'\\''brien.txt' | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; printf '%s %s\\0' \"$n\" 'dir/o'\\''brien.txt'",
         ].joined(separator: "; "))
     }
 
@@ -29,11 +29,20 @@ struct RemoteFileStatsTests {
     /// its trailing-newline check.
     @Test func wcCommandSeparatesOptionsFromFilenamesStartingWithADash() {
         let command = RemoteFileStats.wcCommand(paths: ["-c"])
-        #expect(command == "n=$(wc -l < '-c'); if [ -s '-c' ] && [ \"$(tail -c1 -- '-c' | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; printf '%s %s\\n' \"$n\" '-c'")
+        #expect(command == "n=$(wc -l < '-c'); if [ -s '-c' ] && [ \"$(tail -c1 -- '-c' | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; printf '%s %s\\0' \"$n\" '-c'")
     }
 
     @Test func parsesWcOutput() {
-        #expect(RemoteFileStats.parseWcOutput("      12 a.txt\n       0 b.txt\n      12 total", requested: ["a.txt", "b.txt"]) == ["a.txt": 12, "b.txt": 0])
+        #expect(RemoteFileStats.parseWcOutput("      12 a.txt\u{0}       0 b.txt\u{0}", requested: ["a.txt", "b.txt"]) == ["a.txt": 12, "b.txt": 0])
+    }
+
+    /// A newline in the path used to fragment a `\n`-delimited record into
+    /// two, losing the path→count association (and so silently reporting
+    /// `0`). NUL-delimiting fixes this since NUL can't appear in a POSIX
+    /// path.
+    @Test func parsesWcOutputPreservesANewlineContainingPath() {
+        let path = "weird\nname.txt"
+        #expect(RemoteFileStats.parseWcOutput("3 \(path)\u{0}", requested: [path]) == [path: 3])
     }
 
     /// End-to-end regression for the trailing-newline undercount: runs the
@@ -77,6 +86,34 @@ struct RemoteFileStatsTests {
             #expect(counts[testCase.name] == testCase.expected, "\(testCase.name)")
         }
     }
+
+    /// End-to-end regression for the newline-fragmentation bug: runs the
+    /// generated script through `/bin/sh` against a real file whose name
+    /// contains an embedded newline byte, mirroring what the SSH exec
+    /// fallback actually executes remotely.
+    @Test func wcCommandCorrectlyCountsAFileWithANewlineInItsName() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let name = "weird\nname.txt"
+        try "a\nb\n".write(to: directory.appendingPathComponent(name), atomically: true, encoding: .utf8)
+
+        let command = try #require(RemoteFileStats.wcCommand(paths: [name]))
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        process.currentDirectoryURL = directory
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+        let counts = RemoteFileStats.parseWcOutput(output, requested: [name])
+        #expect(counts[name] == 2)
+    }
+
     @Test func helperLineCountsMergeDuplicatePaths() {
         let entries = [
             RemoteHelperFSLineCountEntry(path: "file.txt", lineCount: 10),

--- a/AlasTests/SSH/RemoteFileStatsTests.swift
+++ b/AlasTests/SSH/RemoteFileStatsTests.swift
@@ -3,6 +3,18 @@ import Testing
 @testable import Alas
 
 struct RemoteFileStatsTests {
+    @Test func batchesSplitsIntoMaxBatchedPathsSizedChunksInOrder() {
+        #expect(RemoteFileStats.batches([]).isEmpty)
+        let single = ["a", "b", "c"]
+        #expect(RemoteFileStats.batches(single) == [single])
+
+        // 450 paths -> 200/200/50, not silently truncated to the first 200.
+        let paths = (0 ..< 450).map { "f\($0).txt" }
+        let batches = RemoteFileStats.batches(paths)
+        #expect(batches.map(\.count) == [200, 200, 50])
+        #expect(batches.flatMap { $0 } == paths)
+    }
+
     @Test func wcCommandQuotesPathsAndAvoidsEmptyInput() {
         #expect(RemoteFileStats.wcCommand(paths: []) == nil)
         let command = RemoteFileStats.wcCommand(paths: ["a.txt", "dir/o'brien.txt"])

--- a/AlasTests/SSH/RemoteFileStatsTests.swift
+++ b/AlasTests/SSH/RemoteFileStatsTests.swift
@@ -17,19 +17,52 @@ struct RemoteFileStatsTests {
 
     @Test func wcCommandQuotesPathsAndAvoidsEmptyInput() {
         #expect(RemoteFileStats.wcCommand(paths: []) == nil)
+        let cap = RemoteWorktreeFileAccess.maxFileBytes
         let command = RemoteFileStats.wcCommand(paths: ["a.txt", "dir/o'brien.txt"])
         #expect(command == [
-            "n=$(wc -l < 'a.txt'); if [ -s 'a.txt' ] && [ \"$(tail -c1 -- 'a.txt' | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; printf '%s %s\\0' \"$n\" 'a.txt'",
-            "n=$(wc -l < 'dir/o'\\''brien.txt'); if [ -s 'dir/o'\\''brien.txt' ] && [ \"$(tail -c1 -- 'dir/o'\\''brien.txt' | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; printf '%s %s\\0' \"$n\" 'dir/o'\\''brien.txt'",
+            "size=$(wc -c < 'a.txt'); if [ \"$size\" -gt \(cap) ]; then n=$(head -c \(cap) -- 'a.txt' | wc -l); else n=$(wc -l < 'a.txt'); if [ -s 'a.txt' ] && [ \"$(tail -c1 -- 'a.txt' | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; fi; printf '%s %s\\0' \"$n\" 'a.txt'",
+            "size=$(wc -c < 'dir/o'\\''brien.txt'); if [ \"$size\" -gt \(cap) ]; then n=$(head -c \(cap) -- 'dir/o'\\''brien.txt' | wc -l); else n=$(wc -l < 'dir/o'\\''brien.txt'); if [ -s 'dir/o'\\''brien.txt' ] && [ \"$(tail -c1 -- 'dir/o'\\''brien.txt' | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; fi; printf '%s %s\\0' \"$n\" 'dir/o'\\''brien.txt'",
         ].joined(separator: "; "))
     }
 
     /// Without `--`, a filename starting with `-` (e.g. `-c`) is parsed by
-    /// `tail` as an OPTION rather than a filename, silently misclassifying
-    /// its trailing-newline check.
+    /// `tail`/`head` as an OPTION rather than a filename, silently
+    /// misclassifying its trailing-newline check or size cap.
     @Test func wcCommandSeparatesOptionsFromFilenamesStartingWithADash() {
+        let cap = RemoteWorktreeFileAccess.maxFileBytes
         let command = RemoteFileStats.wcCommand(paths: ["-c"])
-        #expect(command == "n=$(wc -l < '-c'); if [ -s '-c' ] && [ \"$(tail -c1 -- '-c' | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; printf '%s %s\\0' \"$n\" '-c'")
+        #expect(command == "size=$(wc -c < '-c'); if [ \"$size\" -gt \(cap) ]; then n=$(head -c \(cap) -- '-c' | wc -l); else n=$(wc -l < '-c'); if [ -s '-c' ] && [ \"$(tail -c1 -- '-c' | wc -l)\" -eq 0 ]; then n=$((n + 1)); fi; fi; printf '%s %s\\0' \"$n\" '-c'")
+    }
+
+    /// End-to-end regression for the size cap: a file larger than
+    /// `RemoteWorktreeFileAccess.maxFileBytes` must be counted via the
+    /// capped `head -c` prefix (an approximate lower bound), not read to
+    /// EOF via `wc -l < file` — proven by using a deliberately tiny cap
+    /// and a file just past it.
+    @Test func wcCommandCapsTheReadForAnOversizedFile() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // One line, no newline, comfortably past a real (512 KiB) cap: a
+        // full read would report 1 (the no-trailing-newline adjustment); a
+        // capped read of a newline-free prefix must report 0 instead.
+        let contents = String(repeating: "x", count: RemoteWorktreeFileAccess.maxFileBytes + 1024)
+        try contents.write(to: directory.appendingPathComponent("huge.txt"), atomically: true, encoding: .utf8)
+
+        let command = try #require(RemoteFileStats.wcCommand(paths: ["huge.txt"]))
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        process.currentDirectoryURL = directory
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+        let counts = RemoteFileStats.parseWcOutput(output, requested: ["huge.txt"])
+        #expect(counts["huge.txt"] == 0)
     }
 
     @Test func parsesWcOutput() {
@@ -122,27 +155,63 @@ struct RemoteFileStatsTests {
         #expect(RemoteFileStats.lineCountDictionary(entries) == ["file.txt": 12])
     }
     @Test func parsesLsEntries() {
-        let entries = RemoteFileStats.parseLsEntries("src/\nREADME.md\n")
+        let output = "/root/src\u{0}\(RemoteFileStats.lsSplitMarker)\u{0}/root/README.md\u{0}"
+        let entries = RemoteFileStats.parseLsEntries(output)
         #expect(entries.count == 2)
         #expect(entries[0].name == "src" && entries[0].isDirectory)
         #expect(entries[1].name == "README.md" && !entries[1].isDirectory)
     }
 
-    /// The GNU (`--zero`) branch of `lsCommand`'s fallback chain emits
-    /// NUL-separated entries — a filename containing an embedded newline
-    /// byte must stay intact as ONE entry rather than fragmenting into
-    /// bogus extras the way newline-splitting would.
-    @Test func parsesNULDelimitedLsEntriesKeepingAnEmbeddedNewlineIntact() {
-        let output = "weird\nname.txt\0src/\0README.md\0"
+    /// `find -print0` is NUL-safe on BOTH GNU findutils and BSD `find` (`ls
+    /// --zero`, which this used to be, has no BSD equivalent at all) — a
+    /// filename containing an embedded newline byte must stay intact as ONE
+    /// entry rather than fragmenting into bogus extras.
+    @Test func parsesLsEntriesKeepingAnEmbeddedNewlineIntact() {
+        let output = "/root/src\u{0}\(RemoteFileStats.lsSplitMarker)\u{0}/root/weird\nname.txt\u{0}/root/README.md\u{0}"
         let entries = RemoteFileStats.parseLsEntries(output)
         #expect(entries.count == 3)
-        #expect(entries[0].name == "weird\nname.txt" && !entries[0].isDirectory)
-        #expect(entries[1].name == "src" && entries[1].isDirectory)
+        #expect(entries[0].name == "src" && entries[0].isDirectory)
+        #expect(entries[1].name == "weird\nname.txt" && !entries[1].isDirectory)
         #expect(entries[2].name == "README.md" && !entries[2].isDirectory)
     }
 
-    @Test func lsCommandChainsGNUZeroThenBSDFallback() {
+    @Test func lsCommandUsesFindForPortableNULSafety() {
         let command = RemoteFileStats.lsCommand(path: "/srv/repo/src")
-        #expect(command == "ls -1Ap --zero -- '/srv/repo/src' 2>/dev/null || ls -1Ap -- '/srv/repo/src'")
+        #expect(command == [
+            "find '/srv/repo/src' -mindepth 1 -maxdepth 1 -type d -print0",
+            "printf '\\0\(RemoteFileStats.lsSplitMarker)\\0'",
+            "find '/srv/repo/src' -mindepth 1 -maxdepth 1 ! -type d -print0",
+        ].joined(separator: "; "))
+    }
+
+    /// End-to-end regression: runs the generated script through `/bin/sh`
+    /// against a real directory containing a subdirectory, an ordinary
+    /// file, and a file whose name contains an embedded newline byte —
+    /// mirroring what the SSH exec fallback actually executes remotely.
+    @Test func lsCommandCorrectlyListsADirectoryContainingANewlineNamedFile() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(
+            at: directory.appendingPathComponent("subdir"), withIntermediateDirectories: true)
+        try "".write(to: directory.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+        try "".write(to: directory.appendingPathComponent("weird\nname.txt"), atomically: true, encoding: .utf8)
+
+        let command = RemoteFileStats.lsCommand(path: directory.path)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+        let entries = RemoteFileStats.parseLsEntries(output)
+        let names = Set(entries.map(\.name))
+        #expect(names == ["subdir", "README.md", "weird\nname.txt"])
+        #expect(entries.first { $0.name == "subdir" }?.isDirectory == true)
+        #expect(entries.first { $0.name == "README.md" }?.isDirectory == false)
+        #expect(entries.first { $0.name == "weird\nname.txt" }?.isDirectory == false)
     }
 }

--- a/AlasTests/SSH/RemoteFileStatsTests.swift
+++ b/AlasTests/SSH/RemoteFileStatsTests.swift
@@ -4,8 +4,16 @@ import Testing
 struct RemoteFileStatsTests {
     @Test func wcCommandQuotesPathsAndAvoidsEmptyInput() {
         #expect(RemoteFileStats.wcCommand(paths: []) == nil)
-        #expect(RemoteFileStats.wcCommand(paths: ["a.txt", "dir/o'brien.txt"]) == "wc -l 'a.txt' 'dir/o'\\''brien.txt'")
+        #expect(RemoteFileStats.wcCommand(paths: ["a.txt", "dir/o'brien.txt"]) == "wc -l -- 'a.txt' 'dir/o'\\''brien.txt'")
     }
+
+    /// Without `--`, a filename starting with `-` (e.g. `-c`) is parsed by
+    /// `wc` as an OPTION rather than a filename, silently dropping it from
+    /// the output — and so silently reporting 0 for its line count.
+    @Test func wcCommandSeparatesOptionsFromFilenamesStartingWithADash() {
+        #expect(RemoteFileStats.wcCommand(paths: ["-c"]) == "wc -l -- '-c'")
+    }
+
     @Test func parsesWcOutput() {
         #expect(RemoteFileStats.parseWcOutput("      12 a.txt\n       0 b.txt\n      12 total", requested: ["a.txt", "b.txt"]) == ["a.txt": 12, "b.txt": 0])
     }
@@ -21,5 +29,23 @@ struct RemoteFileStatsTests {
         #expect(entries.count == 2)
         #expect(entries[0].name == "src" && entries[0].isDirectory)
         #expect(entries[1].name == "README.md" && !entries[1].isDirectory)
+    }
+
+    /// The GNU (`--zero`) branch of `lsCommand`'s fallback chain emits
+    /// NUL-separated entries — a filename containing an embedded newline
+    /// byte must stay intact as ONE entry rather than fragmenting into
+    /// bogus extras the way newline-splitting would.
+    @Test func parsesNULDelimitedLsEntriesKeepingAnEmbeddedNewlineIntact() {
+        let output = "weird\nname.txt\0src/\0README.md\0"
+        let entries = RemoteFileStats.parseLsEntries(output)
+        #expect(entries.count == 3)
+        #expect(entries[0].name == "weird\nname.txt" && !entries[0].isDirectory)
+        #expect(entries[1].name == "src" && entries[1].isDirectory)
+        #expect(entries[2].name == "README.md" && !entries[2].isDirectory)
+    }
+
+    @Test func lsCommandChainsGNUZeroThenBSDFallback() {
+        let command = RemoteFileStats.lsCommand(path: "/srv/repo/src")
+        #expect(command == "ls -1Ap --zero -- '/srv/repo/src' 2>/dev/null || ls -1Ap -- '/srv/repo/src'")
     }
 }

--- a/AlasTests/SSH/SSHIntegrationTests.swift
+++ b/AlasTests/SSH/SSHIntegrationTests.swift
@@ -303,4 +303,148 @@ struct SSHIntegrationTests {
         )
         #expect(exists.exitCode != 0)
     }
+
+    /// Finding 1 (2nd Codex pass on PR #1124): a directory symlink alias to
+    /// `.git` used to pass `RemotePathContainment.verifyRemoteContainment`
+    /// because only the physical PARENT's location was checked — the
+    /// resolved path landed inside `.git`, which is still under the
+    /// worktree root. Requires a real SSH connection (the containment probe
+    /// runs remote `cd`/`pwd -P`), so this is gated behind
+    /// `ALAS_SSH_INTEGRATION=1` like the rest of this suite.
+    @Test func containmentRejectsADirectorySymlinkAliasToGitOverSSHLocalhost() async throws {
+        try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ssh-git-alias-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let gitDir = directory.appendingPathComponent(".git")
+        try FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        try Data("[remote \"origin\"]\n\turl = https://user:secret@example.com/repo.git\n".utf8)
+            .write(to: gitDir.appendingPathComponent("config"))
+        try FileManager.default.createSymbolicLink(
+            atPath: directory.appendingPathComponent("alias").path, withDestinationPath: ".git")
+
+        await #expect(throws: RemotePathContainment.ContainmentError.self) {
+            try await RemotePathContainment.verifyRemoteContainment(
+                host: "localhost",
+                path: directory.appendingPathComponent("alias/config").path,
+                worktreeRoot: directory.path
+            )
+        }
+        // A legitimate file must still pass.
+        try Data("print(1)".utf8).write(to: directory.appendingPathComponent("main.swift"))
+        try await RemotePathContainment.verifyRemoteContainment(
+            host: "localhost",
+            path: directory.appendingPathComponent("main.swift").path,
+            worktreeRoot: directory.path
+        )
+    }
+
+    /// Finding 2: `RemoteFileAccess.size` must report the real remote byte
+    /// count via a cheap `stat`, without transferring the file's contents.
+    @Test func remoteFileAccessSizeReportsByteCountOverSSHLocalhost() async throws {
+        try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ssh-size-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("big.txt")
+        try String(repeating: "x", count: 10_000).write(to: file, atomically: true, encoding: .utf8)
+
+        let size = try await RemoteFileAccess.size(host: "localhost", path: file.path)
+        #expect(size == 10_000)
+
+        let missing = try await RemoteFileAccess.size(
+            host: "localhost", path: directory.appendingPathComponent("missing.txt").path)
+        #expect(missing == nil)
+    }
+
+    /// Finding 2 end-to-end: `AppState.readRemoteWorktreeFileRaw` must
+    /// report `.tooLarge` with the real byte count for an oversized remote
+    /// file WITHOUT ever downloading it.
+    @Test @MainActor func readRemoteWorktreeFileRawReportsTooLargeWithoutDownloadingOverSSHLocalhost() async throws {
+        try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ssh-toolarge-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("huge.txt")
+        let byteCount = RemoteWorktreeFileAccess.maxFileBytes + 1
+        try String(repeating: "x", count: byteCount).write(to: file, atomically: true, encoding: .utf8)
+
+        let state = AppState(store: ProjectMemoryStore(projectsFile: ProjectsFile(projects: [])))
+        let outcome = await state.readRemoteWorktreeFileRaw(
+            host: "localhost", worktreeRoot: directory.path, relativePath: "huge.txt")
+
+        guard case let .tooLarge(byteSize) = outcome else {
+            Issue.record("expected .tooLarge, got \(outcome)")
+            return
+        }
+        #expect(byteSize == byteCount)
+    }
+
+    /// Finding 3: the remote branch of `fileTreeChildren` must classify
+    /// gitignored entries as `.ignored` (not `.tracked`, which would leak
+    /// their names past `AppState.remoteFileNodes`' visibility filter).
+    @Test func fileTreeChildrenFiltersIgnoredEntriesOverSSHLocalhost() async throws {
+        try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ssh-ignored-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            RemoteHostRegistry.shared.unregister(root: directory.path)
+            try? FileManager.default.removeItem(at: directory)
+        }
+        _ = try await Process.run("/usr/bin/env", args: ["git", "init", "-q", "-b", "main"], cwd: directory)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "config", "user.email", "t@e"], cwd: directory)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "config", "user.name", "t"], cwd: directory)
+        try Data("node_modules/\n".utf8).write(to: directory.appendingPathComponent(".gitignore"))
+        _ = try await Process.run("/usr/bin/env", args: ["git", "add", ".gitignore"], cwd: directory)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "commit", "-q", "-m", "init"], cwd: directory)
+        try FileManager.default.createDirectory(
+            at: directory.appendingPathComponent("node_modules"), withIntermediateDirectories: true)
+        try Data("x".utf8).write(to: directory.appendingPathComponent("node_modules/pkg.js"))
+        try Data("keep".utf8).write(to: directory.appendingPathComponent("keep.txt"))
+        _ = try await Process.run("/usr/bin/env", args: ["git", "add", "keep.txt"], cwd: directory)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "commit", "-q", "-m", "add keep"], cwd: directory)
+        RemoteHostRegistry.shared.register(root: directory.path, host: "localhost")
+
+        let children = try await GitService().fileTreeChildren(worktreePath: directory, path: "")
+
+        let ignoredNode = try #require(children.first { $0.path == "node_modules" })
+        #expect(ignoredNode.visibility == .ignored)
+        #expect(children.first { $0.path == "keep.txt" }?.visibility == .tracked)
+    }
+
+    /// Finding 5: untracked-file line counts in the remote base-relative
+    /// changes view must use the real remote byte content, not a local
+    /// `Data(contentsOf:)` read against a path with no local file behind it
+    /// (which silently reports 0 lines).
+    @Test func changedFilesAgainstRefUsesRemoteLineCountsForUntrackedFilesOverSSHLocalhost() async throws {
+        try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ssh-linecounts-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            RemoteHostRegistry.shared.unregister(root: directory.path)
+            try? FileManager.default.removeItem(at: directory)
+        }
+        _ = try await Process.run("/usr/bin/env", args: ["git", "init", "-q", "-b", "main"], cwd: directory)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "config", "user.email", "t@e"], cwd: directory)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "config", "user.name", "t"], cwd: directory)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "commit", "-q", "--allow-empty", "-m", "init"], cwd: directory)
+        _ = try await Process.run("/usr/bin/env", args: ["git", "branch", "start"], cwd: directory)
+        try Data("one\ntwo\nthree\n".utf8).write(to: directory.appendingPathComponent("untracked.txt"))
+        RemoteHostRegistry.shared.register(root: directory.path, host: "localhost")
+
+        let files = try await GitService().changedFilesAgainstRef(worktreePath: directory, ref: "start")
+
+        let untracked = try #require(files.first { $0.path == "untracked.txt" })
+        #expect(untracked.add == 3)
+    }
 }

--- a/AlasTests/SSH/SSHIntegrationTests.swift
+++ b/AlasTests/SSH/SSHIntegrationTests.swift
@@ -304,13 +304,13 @@ struct SSHIntegrationTests {
         #expect(exists.exitCode != 0)
     }
 
-    /// Finding 1 (2nd Codex pass on PR #1124): a directory symlink alias to
-    /// `.git` used to pass `RemotePathContainment.verifyRemoteContainment`
-    /// because only the physical PARENT's location was checked — the
-    /// resolved path landed inside `.git`, which is still under the
-    /// worktree root. Requires a real SSH connection (the containment probe
-    /// runs remote `cd`/`pwd -P`), so this is gated behind
-    /// `ALAS_SSH_INTEGRATION=1` like the rest of this suite.
+    /// Regression: a directory symlink alias to `.git` used to pass
+    /// `RemotePathContainment.verifyRemoteContainment` because only the
+    /// physical PARENT's location was checked — the resolved path landed
+    /// inside `.git`, which is still under the worktree root. Requires a
+    /// real SSH connection (the containment probe runs remote `cd`/`pwd
+    /// -P`), so this is gated behind `ALAS_SSH_INTEGRATION=1` like the rest
+    /// of this suite.
     @Test func containmentRejectsADirectorySymlinkAliasToGitOverSSHLocalhost() async throws {
         try #require(enabled, "set ALAS_SSH_INTEGRATION=1 to run")
 

--- a/docs/superpowers/plans/2026-09-06-remote-web-changes-and-files.md
+++ b/docs/superpowers/plans/2026-09-06-remote-web-changes-and-files.md
@@ -1,0 +1,2292 @@
+# Remote Web Changes and Files Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add read-only Changes and Files tabs to the remote web client so a paired phone can review a session's diff and browse its worktree.
+
+**Architecture:** Four request/response pairs ride the existing WebSocket, keyed by `sessionId`; the server resolves session → worktree. New `RemoteSessionsProvider` methods on `AppState` delegate to `GitService` (one new base-relative changed-file query, one new against-ref file diff) behind a pure path-safety and caps helper. The web client gains two `.view` sections, a segmented tab control, and two standalone logic scripts with node tests, following the `worktree-creation.js` convention.
+
+**Tech Stack:** Swift 5.9+, Swift Testing (`import Testing`, not XCTest), SwiftUI/AppKit macOS app, vanilla ES5-style browser JS with `globalThis` namespaces, node for JS unit tests.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-remote-web-changes-and-files-design.md`
+
+## Global Constraints
+
+- All code, comments, logs, and UI strings in English.
+- Tests use the Swift Testing framework (`import Testing`), never XCTest.
+- No agent attributions anywhere: no `Co-Authored-By` trailers, no "Generated with" footers, no 🤖 markers, no AI notes in code, comments, docs, or commit bodies.
+- After adding or removing files, run `xcodegen` to regenerate `Alas.xcodeproj`, and commit both the sources and the regenerated project.
+- `Info.plist` keys live in `project.yml` under `info: properties:` — this plan touches neither.
+- Read-only feature: no git mutation, no writer lease required, no editing.
+- Server-enforced caps, copied verbatim from the spec: file read **512 KB**, per-file diff **2,000 lines**, change list **500 files**.
+- `.git` is excluded from both the file tree and file reads.
+- Every failure is reported with a typed reason; no code path may return a silently empty list.
+- Browser JS matches the existing style in `Alas/Resources/RemoteWeb/`: no build step, no imports, `globalThis.<Namespace> = {...}` exports, double-quoted strings.
+- The full `xcodebuild` sweep is heavy on this machine. Run focused suites locally with `-only-testing:`; leave the full build to CI.
+
+---
+
+### Task 1: Protocol messages and wire types
+
+**Files:**
+- Modify: `Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift`
+- Modify: `Alas/Sources/Remote/Protocol/RemoteProtocol.swift`
+- Test: `AlasTests/Remote/RemoteProtocolTests.swift`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `RemoteChangedFile`, `RemoteDiffLine`, `RemoteDiffHunk`, `RemoteFileNode`, `RemoteFileAccessReason`; client cases `listChanges(sessionId:)`, `fileDiff(sessionId:path:)`, `listFiles(sessionId:path:)`, `readFile(sessionId:path:)`; server cases `changeList(sessionId:comparisonRef:metricsAvailable:files:truncated:)`, `changeListFailed(sessionId:reason:message:)`, `fileDiffResult(sessionId:path:hunks:truncated:)`, `fileDiffFailed(sessionId:path:reason:message:)`, `fileTree(sessionId:path:nodes:)`, `fileTreeFailed(sessionId:path:reason:message:)`, `fileContents(sessionId:path:text:truncated:)`, `fileUnavailable(sessionId:path:reason:byteSize:message:)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `AlasTests/Remote/RemoteProtocolTests.swift`, inside `struct RemoteProtocolTests`:
+
+```swift
+    @Test func changesAndFilesClientMessagesRoundTripAndEncodeRequiredFields() throws {
+        let listChanges = RemoteClientMessage.listChanges(sessionId: "s1")
+        #expect(try roundTrip(listChanges) == listChanges)
+
+        let fileDiff = RemoteClientMessage.fileDiff(sessionId: "s1", path: "src/main.swift")
+        #expect(try roundTrip(fileDiff) == fileDiff)
+
+        let listRoot = RemoteClientMessage.listFiles(sessionId: "s1", path: nil)
+        #expect(try roundTrip(listRoot) == listRoot)
+
+        let listDir = RemoteClientMessage.listFiles(sessionId: "s1", path: "src")
+        #expect(try roundTrip(listDir) == listDir)
+
+        let readFile = RemoteClientMessage.readFile(sessionId: "s1", path: "README.md")
+        #expect(try roundTrip(readFile) == readFile)
+
+        let object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(fileDiff)) as? [String: Any])
+        #expect(object["type"] as? String == "fileDiff")
+        #expect(object["sessionId"] as? String == "s1")
+        #expect(object["path"] as? String == "src/main.swift")
+    }
+
+    @Test func changesAndFilesServerMessagesRoundTripAndEncodeRequiredFields() throws {
+        let file = RemoteChangedFile(
+            path: "src/main.swift", status: "M", add: 12, del: 3,
+            conflict: nil, renameFrom: nil)
+        let changeList = RemoteServerMessage.changeList(
+            sessionId: "s1", comparisonRef: "origin/main", metricsAvailable: true,
+            files: [file], truncated: false)
+        #expect(try roundTrip(changeList) == changeList)
+
+        let changeFailure = RemoteServerMessage.changeListFailed(
+            sessionId: "s1", reason: .worktreeUnavailable, message: nil)
+        #expect(try roundTrip(changeFailure) == changeFailure)
+
+        let hunk = RemoteDiffHunk(
+            header: "@@ -1,2 +1,3 @@", oldStart: 1, newStart: 1,
+            lines: [
+                RemoteDiffLine(kind: "context", text: "import Foundation", oldNumber: 1, newNumber: 1),
+                RemoteDiffLine(kind: "add", text: "import Testing", oldNumber: nil, newNumber: 2)
+            ])
+        let diff = RemoteServerMessage.fileDiffResult(
+            sessionId: "s1", path: "src/main.swift", hunks: [hunk], truncated: true)
+        #expect(try roundTrip(diff) == diff)
+
+        let diffFailure = RemoteServerMessage.fileDiffFailed(
+            sessionId: "s1", path: "logo.png", reason: .binary, message: nil)
+        #expect(try roundTrip(diffFailure) == diffFailure)
+
+        let node = RemoteFileNode(
+            name: "src", path: "src", kind: "dir", badge: nil,
+            childrenState: "notLoaded", isSubmodule: false)
+        let tree = RemoteServerMessage.fileTree(sessionId: "s1", path: nil, nodes: [node])
+        #expect(try roundTrip(tree) == tree)
+
+        let treeFailure = RemoteServerMessage.fileTreeFailed(
+            sessionId: "s1", path: "../etc", reason: .pathRejected, message: nil)
+        #expect(try roundTrip(treeFailure) == treeFailure)
+
+        let contents = RemoteServerMessage.fileContents(
+            sessionId: "s1", path: "README.md", text: "# Alas\n", truncated: false)
+        #expect(try roundTrip(contents) == contents)
+
+        let unavailable = RemoteServerMessage.fileUnavailable(
+            sessionId: "s1", path: "big.bin", reason: .tooLarge, byteSize: 1_500_000, message: nil)
+        #expect(try roundTrip(unavailable) == unavailable)
+
+        let object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(changeList)) as? [String: Any])
+        #expect(object["type"] as? String == "changeList")
+        #expect(object["comparisonRef"] as? String == "origin/main")
+        #expect(object["metricsAvailable"] as? Bool == true)
+        #expect(object["truncated"] as? Bool == false)
+    }
+
+    @Test func unknownFileAccessReasonDecodesAsUnknown() throws {
+        let json = #"{"type":"fileDiffFailed","sessionId":"s1","path":"a.txt","reason":"someFutureReason"}"#
+        let decoded = try JSONDecoder().decode(RemoteServerMessage.self, from: Data(json.utf8))
+        #expect(decoded == .fileDiffFailed(sessionId: "s1", path: "a.txt", reason: .unknown, message: nil))
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RemoteProtocolTests test 2>&1 | tail -30`
+Expected: compile failure — `listChanges` and the other cases do not exist.
+
+- [ ] **Step 3: Add the wire types**
+
+Append to `Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift`:
+
+```swift
+/// Why a changes/files request could not be served. Decoded leniently so an
+/// older client keeps working against a newer host that adds reasons.
+enum RemoteFileAccessReason: String, Codable, Equatable, Sendable {
+    case sessionUnknown
+    case worktreeUnavailable
+    case pathRejected
+    case notFound
+    case binary
+    case tooLarge
+    case gitFailed
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = RemoteFileAccessReason(rawValue: raw) ?? .unknown
+    }
+}
+
+/// Wire projection of `ChangedFile`. `conflict` carries `ConflictKind`'s raw
+/// value so the client can mark conflicted files without knowing the enum.
+struct RemoteChangedFile: Codable, Equatable, Sendable {
+    let path: String
+    let status: String
+    let add: Int
+    let del: Int
+    let conflict: String?
+    let renameFrom: String?
+}
+
+/// Wire projection of `ParsedDiff.Hunk.Line`. `kind` is "context", "add", or
+/// "delete"; `text` has no leading +/-/space.
+struct RemoteDiffLine: Codable, Equatable, Sendable {
+    let kind: String
+    let text: String
+    let oldNumber: Int?
+    let newNumber: Int?
+}
+
+/// Wire projection of `ParsedDiff.Hunk`.
+struct RemoteDiffHunk: Codable, Equatable, Sendable {
+    let header: String
+    let oldStart: Int
+    let newStart: Int
+    let lines: [RemoteDiffLine]
+}
+
+/// Wire projection of `FileTreeNode`. `kind` is "dir" or "file";
+/// `childrenState` carries `DirectoryChildrenState`'s raw value.
+struct RemoteFileNode: Codable, Equatable, Sendable {
+    let name: String
+    let path: String
+    let kind: String
+    let badge: String?
+    let childrenState: String
+    let isSubmodule: Bool
+}
+```
+
+- [ ] **Step 4: Add the client message cases**
+
+In `Alas/Sources/Remote/Protocol/RemoteProtocol.swift`, add to `RemoteClientMessage` after `case queueSteerUndo(sessionId: String)`:
+
+```swift
+    case listChanges(sessionId: String)
+    case fileDiff(sessionId: String, path: String)
+    case listFiles(sessionId: String, path: String?)
+    case readFile(sessionId: String, path: String)
+```
+
+Add `path`, `files`, `comparisonRef`, `metricsAvailable`, `truncated`, `hunks`, `nodes`, `reason`, and `byteSize` to the `RemoteClientMessage.CodingKeys` enum and to the `RemoteServerMessage` coding keys enum (both already list `sessionId`, `text`, and `message`).
+
+In `init(from:)`, alongside the other `case "..."` arms:
+
+```swift
+        case "listChanges":
+            self = .listChanges(sessionId: try c.decode(String.self, forKey: .sessionId))
+        case "fileDiff":
+            self = .fileDiff(sessionId: try c.decode(String.self, forKey: .sessionId),
+                             path: try c.decode(String.self, forKey: .path))
+        case "listFiles":
+            self = .listFiles(sessionId: try c.decode(String.self, forKey: .sessionId),
+                              path: try c.decodeIfPresent(String.self, forKey: .path))
+        case "readFile":
+            self = .readFile(sessionId: try c.decode(String.self, forKey: .sessionId),
+                             path: try c.decode(String.self, forKey: .path))
+```
+
+In `encode(to:)`:
+
+```swift
+        case .listChanges(let s):
+            try c.encode("listChanges", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+        case .fileDiff(let s, let path):
+            try c.encode("fileDiff", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(path, forKey: .path)
+        case .listFiles(let s, let path):
+            try c.encode("listFiles", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encodeIfPresent(path, forKey: .path)
+        case .readFile(let s, let path):
+            try c.encode("readFile", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(path, forKey: .path)
+```
+
+Leave `isControl` and `isDriveOrdering` untouched: these are read verbs, and `isDriveOrdering`'s `default: return false` already covers them, which is the documented behavior (stop stays fast during a backfill).
+
+- [ ] **Step 5: Add the server message cases**
+
+In `RemoteServerMessage`, add:
+
+```swift
+    case changeList(
+        sessionId: String, comparisonRef: String?, metricsAvailable: Bool,
+        files: [RemoteChangedFile], truncated: Bool)
+    case changeListFailed(sessionId: String, reason: RemoteFileAccessReason, message: String?)
+    case fileDiffResult(sessionId: String, path: String, hunks: [RemoteDiffHunk], truncated: Bool)
+    case fileDiffFailed(sessionId: String, path: String, reason: RemoteFileAccessReason, message: String?)
+    case fileTree(sessionId: String, path: String?, nodes: [RemoteFileNode])
+    case fileTreeFailed(sessionId: String, path: String?, reason: RemoteFileAccessReason, message: String?)
+    case fileContents(sessionId: String, path: String, text: String, truncated: Bool)
+    case fileUnavailable(
+        sessionId: String, path: String, reason: RemoteFileAccessReason,
+        byteSize: Int?, message: String?)
+```
+
+Decoding arms:
+
+```swift
+        case "changeList":
+            self = .changeList(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                comparisonRef: try c.decodeIfPresent(String.self, forKey: .comparisonRef),
+                metricsAvailable: try c.decode(Bool.self, forKey: .metricsAvailable),
+                files: try c.decode([RemoteChangedFile].self, forKey: .files),
+                truncated: try c.decodeIfPresent(Bool.self, forKey: .truncated) ?? false)
+        case "changeListFailed":
+            self = .changeListFailed(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                reason: try c.decode(RemoteFileAccessReason.self, forKey: .reason),
+                message: try c.decodeIfPresent(String.self, forKey: .message))
+        case "fileDiffResult":
+            self = .fileDiffResult(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                path: try c.decode(String.self, forKey: .path),
+                hunks: try c.decode([RemoteDiffHunk].self, forKey: .hunks),
+                truncated: try c.decodeIfPresent(Bool.self, forKey: .truncated) ?? false)
+        case "fileDiffFailed":
+            self = .fileDiffFailed(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                path: try c.decode(String.self, forKey: .path),
+                reason: try c.decode(RemoteFileAccessReason.self, forKey: .reason),
+                message: try c.decodeIfPresent(String.self, forKey: .message))
+        case "fileTree":
+            self = .fileTree(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                path: try c.decodeIfPresent(String.self, forKey: .path),
+                nodes: try c.decode([RemoteFileNode].self, forKey: .nodes))
+        case "fileTreeFailed":
+            self = .fileTreeFailed(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                path: try c.decodeIfPresent(String.self, forKey: .path),
+                reason: try c.decode(RemoteFileAccessReason.self, forKey: .reason),
+                message: try c.decodeIfPresent(String.self, forKey: .message))
+        case "fileContents":
+            self = .fileContents(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                path: try c.decode(String.self, forKey: .path),
+                text: try c.decode(String.self, forKey: .text),
+                truncated: try c.decodeIfPresent(Bool.self, forKey: .truncated) ?? false)
+        case "fileUnavailable":
+            self = .fileUnavailable(
+                sessionId: try c.decode(String.self, forKey: .sessionId),
+                path: try c.decode(String.self, forKey: .path),
+                reason: try c.decode(RemoteFileAccessReason.self, forKey: .reason),
+                byteSize: try c.decodeIfPresent(Int.self, forKey: .byteSize),
+                message: try c.decodeIfPresent(String.self, forKey: .message))
+```
+
+Encoding arms:
+
+```swift
+        case .changeList(let s, let ref, let available, let files, let truncated):
+            try c.encode("changeList", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encodeIfPresent(ref, forKey: .comparisonRef)
+            try c.encode(available, forKey: .metricsAvailable)
+            try c.encode(files, forKey: .files)
+            try c.encode(truncated, forKey: .truncated)
+        case .changeListFailed(let s, let reason, let message):
+            try c.encode("changeListFailed", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(reason.rawValue, forKey: .reason)
+            try c.encodeIfPresent(message, forKey: .message)
+        case .fileDiffResult(let s, let path, let hunks, let truncated):
+            try c.encode("fileDiffResult", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(path, forKey: .path)
+            try c.encode(hunks, forKey: .hunks)
+            try c.encode(truncated, forKey: .truncated)
+        case .fileDiffFailed(let s, let path, let reason, let message):
+            try c.encode("fileDiffFailed", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(path, forKey: .path)
+            try c.encode(reason.rawValue, forKey: .reason)
+            try c.encodeIfPresent(message, forKey: .message)
+        case .fileTree(let s, let path, let nodes):
+            try c.encode("fileTree", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encodeIfPresent(path, forKey: .path)
+            try c.encode(nodes, forKey: .nodes)
+        case .fileTreeFailed(let s, let path, let reason, let message):
+            try c.encode("fileTreeFailed", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encodeIfPresent(path, forKey: .path)
+            try c.encode(reason.rawValue, forKey: .reason)
+            try c.encodeIfPresent(message, forKey: .message)
+        case .fileContents(let s, let path, let text, let truncated):
+            try c.encode("fileContents", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(path, forKey: .path)
+            try c.encode(text, forKey: .text)
+            try c.encode(truncated, forKey: .truncated)
+        case .fileUnavailable(let s, let path, let reason, let byteSize, let message):
+            try c.encode("fileUnavailable", forKey: .type)
+            try c.encode(s, forKey: .sessionId)
+            try c.encode(path, forKey: .path)
+            try c.encode(reason.rawValue, forKey: .reason)
+            try c.encodeIfPresent(byteSize, forKey: .byteSize)
+            try c.encodeIfPresent(message, forKey: .message)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RemoteProtocolTests test 2>&1 | tail -20`
+Expected: PASS, including the three new tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift Alas/Sources/Remote/Protocol/RemoteProtocol.swift AlasTests/Remote/RemoteProtocolTests.swift
+git commit -m "feat(remote): protocol messages for changes and files"
+```
+
+---
+
+### Task 2: Path safety and payload caps
+
+**Files:**
+- Create: `Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift`
+- Test: `AlasTests/Remote/RemoteWorktreeFileAccessTests.swift`
+
+**Interfaces:**
+- Consumes: `ParsedDiff`, `ChangedFile` (existing git types).
+- Produces: `RemoteWorktreeFileAccess.maxFileBytes: Int`, `.maxDiffLines: Int`, `.maxChangedFiles: Int`, `resolve(path:in:) -> URL?`, `truncateHunks(_:) -> (hunks: [ParsedDiff.Hunk], truncated: Bool)`, `truncateFiles(_:) -> (files: [ChangedFile], truncated: Bool)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `AlasTests/Remote/RemoteWorktreeFileAccessTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import Alas
+
+struct RemoteWorktreeFileAccessTests {
+    private func makeRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-file-access-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    @Test func resolvesPlainRelativePathInsideTheWorktree() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "hi\n".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+
+        let resolved = RemoteWorktreeFileAccess.resolve(path: "a.txt", in: root)
+        #expect(resolved?.lastPathComponent == "a.txt")
+    }
+
+    @Test func rejectsTraversalAbsoluteAndEmptyPaths() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(RemoteWorktreeFileAccess.resolve(path: "../secrets.txt", in: root) == nil)
+        #expect(RemoteWorktreeFileAccess.resolve(path: "src/../../secrets.txt", in: root) == nil)
+        #expect(RemoteWorktreeFileAccess.resolve(path: "/etc/passwd", in: root) == nil)
+        #expect(RemoteWorktreeFileAccess.resolve(path: "", in: root) == nil)
+        #expect(RemoteWorktreeFileAccess.resolve(path: "   ", in: root) == nil)
+    }
+
+    @Test func rejectsDotGitAtAnyDepth() throws {
+        let root = try makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(RemoteWorktreeFileAccess.resolve(path: ".git", in: root) == nil)
+        #expect(RemoteWorktreeFileAccess.resolve(path: ".git/config", in: root) == nil)
+        #expect(RemoteWorktreeFileAccess.resolve(path: "src/.git/config", in: root) == nil)
+    }
+
+    @Test func rejectsSymlinkEscapingTheWorktree() throws {
+        let root = try makeRoot()
+        let outside = try makeRoot()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: outside)
+        }
+        try "secret\n".write(to: outside.appendingPathComponent("s.txt"), atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("escape"),
+            withDestinationURL: outside)
+
+        #expect(RemoteWorktreeFileAccess.resolve(path: "escape/s.txt", in: root) == nil)
+    }
+
+    @Test func truncatesHunksAtTheLineCap() {
+        let line = ParsedDiff.Hunk.Line(kind: .add, text: "x", oldNumber: nil, newNumber: 1)
+        let big = ParsedDiff.Hunk(
+            header: "@@ -0,0 +1,1 @@", oldStart: 0, newStart: 1,
+            lines: Array(repeating: line, count: RemoteWorktreeFileAccess.maxDiffLines + 10))
+        let small = ParsedDiff.Hunk(
+            header: "@@ -0,0 +1,1 @@", oldStart: 0, newStart: 1, lines: [line])
+
+        let truncated = RemoteWorktreeFileAccess.truncateHunks([big])
+        #expect(truncated.truncated)
+        #expect(truncated.hunks.reduce(0) { $0 + $1.lines.count } == RemoteWorktreeFileAccess.maxDiffLines)
+
+        let kept = RemoteWorktreeFileAccess.truncateHunks([small])
+        #expect(!kept.truncated)
+        #expect(kept.hunks.count == 1)
+    }
+
+    @Test func truncatesChangedFilesAtTheFileCap() {
+        let files = (0..<(RemoteWorktreeFileAccess.maxChangedFiles + 5)).map { index in
+            ChangedFile(path: "f\(index).txt", status: "M", stage: .unstaged,
+                        add: 1, del: 0, renameFrom: nil)
+        }
+        let result = RemoteWorktreeFileAccess.truncateFiles(files)
+        #expect(result.truncated)
+        #expect(result.files.count == RemoteWorktreeFileAccess.maxChangedFiles)
+
+        let short = RemoteWorktreeFileAccess.truncateFiles(Array(files.prefix(3)))
+        #expect(!short.truncated)
+        #expect(short.files.count == 3)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodegen && xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RemoteWorktreeFileAccessTests test 2>&1 | tail -20`
+Expected: compile failure — `RemoteWorktreeFileAccess` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift`:
+
+```swift
+import Foundation
+
+/// Path validation and payload caps for the remote changes/files surface.
+///
+/// Every path here arrives from a paired device, so containment is enforced on
+/// the resolved (symlink-followed) path, not the string. `.git` is excluded
+/// entirely: a worktree's git config can hold remote URLs with embedded
+/// credentials.
+enum RemoteWorktreeFileAccess {
+    static let maxFileBytes = 512 * 1024
+    static let maxDiffLines = 2_000
+    static let maxChangedFiles = 500
+
+    /// Returns the on-disk URL for a worktree-relative path, or nil when the
+    /// path is empty, absolute, traverses upward, names `.git`, or resolves
+    /// outside the worktree through a symlink.
+    static func resolve(path: String, in worktreeRoot: URL) -> URL? {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("/") else { return nil }
+
+        let components = trimmed.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+        guard !components.isEmpty else { return nil }
+        guard !components.contains(".."), !components.contains(".git") else { return nil }
+
+        let candidate = components.reduce(worktreeRoot) { $0.appendingPathComponent($1) }
+        let resolvedRoot = worktreeRoot.resolvingSymlinksInPath().standardizedFileURL
+        let resolved = candidate.resolvingSymlinksInPath().standardizedFileURL
+
+        let rootPath = resolvedRoot.path.hasSuffix("/") ? resolvedRoot.path : resolvedRoot.path + "/"
+        guard resolved.path.hasPrefix(rootPath) else { return nil }
+        return candidate
+    }
+
+    /// Caps a diff at `maxDiffLines` total lines, dropping whole trailing
+    /// lines from the hunk that crosses the cap. Reports whether anything was
+    /// dropped so the client can render a truncation footer.
+    static func truncateHunks(_ hunks: [ParsedDiff.Hunk]) -> (hunks: [ParsedDiff.Hunk], truncated: Bool) {
+        var remaining = maxDiffLines
+        var kept: [ParsedDiff.Hunk] = []
+        for hunk in hunks {
+            if remaining <= 0 { return (kept, true) }
+            if hunk.lines.count <= remaining {
+                kept.append(hunk)
+                remaining -= hunk.lines.count
+                continue
+            }
+            kept.append(ParsedDiff.Hunk(
+                header: hunk.header,
+                oldStart: hunk.oldStart,
+                newStart: hunk.newStart,
+                lines: Array(hunk.lines.prefix(remaining))))
+            return (kept, true)
+        }
+        return (kept, false)
+    }
+
+    /// Caps a change list at `maxChangedFiles` entries.
+    static func truncateFiles(_ files: [ChangedFile]) -> (files: [ChangedFile], truncated: Bool) {
+        guard files.count > maxChangedFiles else { return (files, false) }
+        return (Array(files.prefix(maxChangedFiles)), true)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `xcodegen && xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RemoteWorktreeFileAccessTests test 2>&1 | tail -20`
+Expected: PASS, six tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Remote/Gateway/RemoteWorktreeFileAccess.swift AlasTests/Remote/RemoteWorktreeFileAccessTests.swift Alas.xcodeproj
+git commit -m "feat(remote): path safety and payload caps for file access"
+```
+
+---
+
+### Task 3: Base-relative changed files and against-ref diff
+
+**Files:**
+- Create: `Alas/Sources/Git/GitService+RemoteChanges.swift`
+- Test: `AlasTests/GitServiceRemoteChangesTests.swift`
+
+**Interfaces:**
+- Consumes: `Process.git(_:cwd:)`, `NumstatParser.parse(_:)`, `NumstatParser.destinationPath(from:)`, `DiffParser.parse(_:)`, `GitService.status(worktreePath:)`, `GitService.diff(worktreePath:file:staged:originalPath:)`, `GitService.looksBinary(_:)`.
+- Produces: `GitService.changedFilesAgainstRef(worktreePath:ref:) async throws -> [ChangedFile]` and `GitService.diff(worktreePath:againstRef:file:) async throws -> ParsedDiff`.
+
+Both take `ref: String?`. A nil ref means no base could be resolved (unborn branch, no upstream); both then fall back to the working-tree view (`status` / `diff(worktreePath:file:)`), so the tab still shows uncommitted work instead of nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `AlasTests/GitServiceRemoteChangesTests.swift`:
+
+```swift
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct GitServiceRemoteChangesTests {
+    private func makeRepo() async throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-remote-changes-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: tmp)
+        _ = try await Process.git(["config", "user.email", "test@example.com"], cwd: tmp)
+        _ = try await Process.git(["config", "user.name", "test user"], cwd: tmp)
+        return tmp
+    }
+
+    @Test func changedFilesAgainstRef_includesCommittedAndUncommittedAndUntracked() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "one\n".write(to: repo.appendingPathComponent("base.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "base.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+
+        try "one\ntwo\n".write(to: repo.appendingPathComponent("base.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "base.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "committed change"], cwd: repo)
+
+        try "dirty\n".write(to: repo.appendingPathComponent("dirty.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "dirty.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "add dirty"], cwd: repo)
+        try "dirty\nedited\n".write(to: repo.appendingPathComponent("dirty.txt"), atomically: true, encoding: .utf8)
+
+        try "new\n".write(to: repo.appendingPathComponent("untracked.txt"), atomically: true, encoding: .utf8)
+
+        let files = try await GitService().changedFilesAgainstRef(worktreePath: repo, ref: "start")
+        #expect(files.map(\.path).sorted() == ["base.txt", "dirty.txt", "untracked.txt"])
+        let base = try #require(files.first { $0.path == "base.txt" })
+        #expect(base.status == "M")
+        #expect(base.add == 1)
+        let untracked = try #require(files.first { $0.path == "untracked.txt" })
+        #expect(untracked.status == "A")
+        #expect(untracked.add == 1)
+    }
+
+    @Test func changedFilesAgainstRef_fallsBackToStatusWhenRefIsNil() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["commit", "--allow-empty", "-m", "init"], cwd: repo)
+        try "hello\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+
+        let files = try await GitService().changedFilesAgainstRef(worktreePath: repo, ref: nil)
+        #expect(files.map(\.path) == ["a.txt"])
+    }
+
+    @Test func diffAgainstRef_returnsHunksForACommittedChange() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "one\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+        try "one\ntwo\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "second line"], cwd: repo)
+
+        let diff = try await GitService().diff(worktreePath: repo, againstRef: "start", file: "a.txt")
+        let added = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }
+        #expect(added.map(\.text) == ["two"])
+    }
+
+    @Test func diffAgainstRef_showsUntrackedFileAsAllAdd() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["commit", "--allow-empty", "-m", "init"], cwd: repo)
+        _ = try await Process.git(["branch", "start"], cwd: repo)
+        try "fresh\n".write(to: repo.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+
+        let diff = try await GitService().diff(worktreePath: repo, againstRef: "start", file: "new.txt")
+        let added = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }
+        #expect(added.map(\.text) == ["fresh"])
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodegen && xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitServiceRemoteChangesTests test 2>&1 | tail -20`
+Expected: compile failure — `changedFilesAgainstRef` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Alas/Sources/Git/GitService+RemoteChanges.swift`:
+
+```swift
+import Foundation
+
+/// Base-relative views used by the remote changes surface. Unlike the desktop
+/// Changes panel (working tree vs index/HEAD), these compare the whole
+/// worktree — commits plus uncommitted work — against the comparison ref, so
+/// the remote client shows everything an agent did on this branch.
+extension GitService {
+    /// Changed files between `ref` and the working tree, plus untracked files.
+    /// A nil `ref` (unborn branch, no resolvable base) falls back to `status`.
+    func changedFilesAgainstRef(worktreePath: URL, ref: String?) async throws -> [ChangedFile] {
+        guard let ref, !ref.isEmpty else {
+            return try await status(worktreePath: worktreePath)
+        }
+
+        let numstat = try await Process.git(
+            ["diff", "--numstat", "-M", "-C", ref, "--"], cwd: worktreePath)
+        guard numstat.exitCode == 0 else {
+            return try await status(worktreePath: worktreePath)
+        }
+        let counts = NumstatParser.parse(numstat.stdout)
+
+        let nameStatus = try await Process.git(
+            ["diff", "--name-status", "-M", "-C", ref, "--"], cwd: worktreePath)
+        let statusEntries = try await status(worktreePath: worktreePath)
+        let conflicts = Dictionary(
+            statusEntries.compactMap { entry in entry.conflict.map { (entry.path, $0) } },
+            uniquingKeysWith: { first, _ in first })
+
+        var files: [ChangedFile] = []
+        var seen = Set<String>()
+        for line in nameStatus.stdout.split(separator: "\n") {
+            let parts = line.split(separator: "\t").map(String.init)
+            guard let code = parts.first, parts.count >= 2 else { continue }
+            let letter = String(code.prefix(1))
+            // Rename/copy entries carry both the source and destination path.
+            let path = parts.count >= 3 ? parts[2] : parts[1]
+            let renameFrom = parts.count >= 3 ? parts[1] : nil
+            guard seen.insert(path).inserted else { continue }
+            let count = counts[path] ?? (add: 0, del: 0)
+            files.append(ChangedFile(
+                path: path,
+                status: letter,
+                stage: .unstaged,   // not meaningful for a base-relative view
+                add: count.add,
+                del: count.del,
+                renameFrom: renameFrom,
+                conflict: conflicts[path]))
+        }
+
+        let untracked = try await Process.git(
+            ["ls-files", "--others", "--exclude-standard"], cwd: worktreePath)
+        for raw in untracked.stdout.split(separator: "\n") {
+            let path = String(raw)
+            guard !path.isEmpty, seen.insert(path).inserted else { continue }
+            files.append(ChangedFile(
+                path: path,
+                status: "A",
+                stage: .unstaged,
+                add: Self.addedLineCount(worktreePath: worktreePath, path: path),
+                del: 0,
+                renameFrom: nil,
+                conflict: nil))
+        }
+
+        return files.sorted { $0.path < $1.path }
+    }
+
+    /// Diff of one file between `ref` and the working tree. Untracked files
+    /// diff against /dev/null so they render as a single all-add hunk. A nil
+    /// `ref` falls back to the working-tree diff.
+    func diff(worktreePath: URL, againstRef ref: String?, file: String) async throws -> ParsedDiff {
+        guard let ref, !ref.isEmpty else {
+            return try await diff(worktreePath: worktreePath, file: file)
+        }
+
+        let tracked = try await Process.git(
+            ["ls-files", "--error-unmatch", "--", file], cwd: worktreePath)
+        if tracked.exitCode != 0 {
+            let result = try await Process.git(
+                ["diff", "--no-color", "--no-index", "--", "/dev/null", file], cwd: worktreePath)
+            // `--no-index` exits 1 when there ARE differences, which is the
+            // normal case here; only >= 2 is a real failure.
+            guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+            return DiffParser.parse(result.stdout)
+        }
+
+        let result = try await Process.git(
+            ["diff", "--no-color", "-M", "-C", ref, "--", file], cwd: worktreePath)
+        guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+        return DiffParser.parse(result.stdout)
+    }
+
+    /// Line count for an untracked file, or 0 when it is binary or unreadable.
+    private static func addedLineCount(worktreePath: URL, path: String) -> Int {
+        let url = worktreePath.appendingPathComponent(path)
+        guard let data = try? Data(contentsOf: url), !looksBinary(data),
+              let text = String(data: data, encoding: .utf8) else { return 0 }
+        if text.isEmpty { return 0 }
+        return text.hasSuffix("\n")
+            ? text.split(separator: "\n", omittingEmptySubsequences: false).count - 1
+            : text.split(separator: "\n", omittingEmptySubsequences: false).count
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `xcodegen && xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitServiceRemoteChangesTests test 2>&1 | tail -20`
+Expected: PASS, four tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Git/GitService+RemoteChanges.swift AlasTests/GitServiceRemoteChangesTests.swift Alas.xcodeproj
+git commit -m "feat(git): base-relative changed files and against-ref diff"
+```
+
+---
+
+### Task 4: Provider methods and AppState implementation
+
+**Files:**
+- Modify: `Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift` (result enums)
+- Modify: `Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift`
+- Modify: `Alas/Sources/App/AppState.swift` (the `extension AppState: RemoteSessionsProvider` block that already holds `remoteWorktreeSummary`, near line 7256)
+- Modify: `AlasTests/Remote/RemoteSessionGatewayTests.swift` (`FakeSessionsProvider`, near line 6)
+- Test: `AlasTests/Remote/RemoteAppStateAccessTests.swift`
+
+**Interfaces:**
+- Consumes: `RemoteChangedFile`, `RemoteDiffHunk`, `RemoteDiffLine`, `RemoteFileNode`, `RemoteFileAccessReason` (Task 1); `RemoteWorktreeFileAccess` (Task 2); `changedFilesAgainstRef(worktreePath:ref:)`, `diff(worktreePath:againstRef:file:)` (Task 3); existing `GitService.fileTree(worktreePath:statusEntries:)`, `fileTreeChildren(worktreePath:path:)`, `commitsAhead(at:baseBranch:resolution:)`, `looksBinary(_:)`; existing `AppState.projectAndWorktree(withWorktreeId:)`.
+- Produces: `RemoteChangeListResult`, `RemoteFileDiffResult`, `RemoteFileTreeResult`, `RemoteFileContentsResult`; provider methods `remoteChangeList(sessionId:)`, `remoteFileDiff(sessionId:path:)`, `remoteFileTree(sessionId:path:)`, `remoteFileContents(sessionId:path:)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `AlasTests/Remote/RemoteAppStateAccessTests.swift`, inside `struct RemoteAppStateAccessTests`:
+
+```swift
+    @Test func remoteChangeListReportsSessionUnknownForAnUnknownSession() async throws {
+        let state = AppState(store: MemoryStore())
+        let result = await state.remoteChangeList(sessionId: "no-such-session")
+        #expect(result == .failure(reason: .sessionUnknown, message: nil))
+    }
+
+    @Test func remoteFileDiffReportsSessionUnknownForAnUnknownSession() async throws {
+        let state = AppState(store: MemoryStore())
+        let result = await state.remoteFileDiff(sessionId: "no-such-session", path: "a.txt")
+        #expect(result == .failure(reason: .sessionUnknown, message: nil))
+    }
+
+    @Test func remoteFileTreeReportsSessionUnknownForAnUnknownSession() async throws {
+        let state = AppState(store: MemoryStore())
+        let result = await state.remoteFileTree(sessionId: "no-such-session", path: nil)
+        #expect(result == .failure(reason: .sessionUnknown, message: nil))
+    }
+
+    @Test func remoteFileContentsReportsSessionUnknownForAnUnknownSession() async throws {
+        let state = AppState(store: MemoryStore())
+        let result = await state.remoteFileContents(sessionId: "no-such-session", path: "a.txt")
+        #expect(result == .failure(reason: .sessionUnknown, byteSize: nil, message: nil))
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RemoteAppStateAccessTests test 2>&1 | tail -20`
+Expected: compile failure — `remoteChangeList` does not exist.
+
+- [ ] **Step 3: Add the result enums**
+
+Append to `Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift`:
+
+```swift
+enum RemoteChangeListResult: Equatable, Sendable {
+    case success(
+        comparisonRef: String?, metricsAvailable: Bool,
+        files: [RemoteChangedFile], truncated: Bool)
+    case failure(reason: RemoteFileAccessReason, message: String?)
+}
+
+enum RemoteFileDiffResult: Equatable, Sendable {
+    case success(hunks: [RemoteDiffHunk], truncated: Bool)
+    case failure(reason: RemoteFileAccessReason, message: String?)
+}
+
+enum RemoteFileTreeResult: Equatable, Sendable {
+    case success(nodes: [RemoteFileNode])
+    case failure(reason: RemoteFileAccessReason, message: String?)
+}
+
+enum RemoteFileContentsResult: Equatable, Sendable {
+    case success(text: String, truncated: Bool)
+    case failure(reason: RemoteFileAccessReason, byteSize: Int?, message: String?)
+}
+```
+
+- [ ] **Step 4: Extend the provider protocol**
+
+In `Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift`, add after `func sessionConfig(for id: String) -> RemoteSessionConfig?`:
+
+```swift
+    /// Read-only worktree inspection for the remote changes/files tabs. All
+    /// four resolve the session's worktree first and are ungated by the writer
+    /// lease: seeing a session is enough to read its code.
+    func remoteChangeList(sessionId: String) async -> RemoteChangeListResult
+    func remoteFileDiff(sessionId: String, path: String) async -> RemoteFileDiffResult
+    func remoteFileTree(sessionId: String, path: String?) async -> RemoteFileTreeResult
+    func remoteFileContents(sessionId: String, path: String) async -> RemoteFileContentsResult
+```
+
+- [ ] **Step 5: Implement on AppState**
+
+In `Alas/Sources/App/AppState.swift`, inside `extension AppState: RemoteSessionsProvider`, add:
+
+```swift
+    /// Resolves the worktree backing a session id by scanning the live
+    /// per-worktree managers, mirroring how `session(for:)` looks sessions up.
+    private func remoteWorktreeContext(sessionId: String) -> (project: ProjectConfig, worktree: Worktree)? {
+        for mgr in acpManagers.values where mgr.sessionRows.contains(where: { $0.id == sessionId }) {
+            return projectAndWorktree(withWorktreeId: mgr.worktreeId)
+        }
+        return nil
+    }
+
+    private static func remoteChangedFile(_ file: ChangedFile) -> RemoteChangedFile {
+        RemoteChangedFile(
+            path: file.path,
+            status: file.status,
+            add: file.add,
+            del: file.del,
+            conflict: file.conflict?.rawValue,
+            renameFrom: file.renameFrom)
+    }
+
+    private static func remoteDiffHunk(_ hunk: ParsedDiff.Hunk) -> RemoteDiffHunk {
+        RemoteDiffHunk(
+            header: hunk.header,
+            oldStart: hunk.oldStart,
+            newStart: hunk.newStart,
+            lines: hunk.lines.map { line in
+                let kind: String
+                switch line.kind {
+                case .context: kind = "context"
+                case .add: kind = "add"
+                case .delete: kind = "delete"
+                }
+                return RemoteDiffLine(
+                    kind: kind, text: line.text,
+                    oldNumber: line.oldNumber, newNumber: line.newNumber)
+            })
+    }
+
+    /// Drops ignored and excluded nodes at the wire boundary: the remote file
+    /// browser is git-aware, so build output never reaches the phone.
+    private static func remoteFileNodes(_ nodes: [FileTreeNode]) -> [RemoteFileNode] {
+        nodes.compactMap { node in
+            guard node.visibility != .ignored, node.visibility != .excluded else { return nil }
+            return RemoteFileNode(
+                name: node.name,
+                path: node.path,
+                kind: node.kind.rawValue,
+                badge: node.badge,
+                childrenState: node.childrenState.rawValue,
+                isSubmodule: node.isSubmodule)
+        }
+    }
+
+    func remoteChangeList(sessionId: String) async -> RemoteChangeListResult {
+        guard let context = remoteWorktreeContext(sessionId: sessionId) else {
+            return .failure(reason: .sessionUnknown, message: nil)
+        }
+        let git = GitService()
+        do {
+            let commits = try await git.commitsAhead(
+                at: context.worktree.path,
+                baseBranch: config.worktrees.baseBranch,
+                resolution: GitService.BaseResolution.forCommits(
+                    mode: config.changes.comparisonMode, userOverrodeBaseBranch: false))
+            let changed = try await git.changedFilesAgainstRef(
+                worktreePath: context.worktree.path, ref: commits.comparisonRef)
+            let capped = RemoteWorktreeFileAccess.truncateFiles(changed)
+            return .success(
+                comparisonRef: commits.comparisonRef,
+                metricsAvailable: true,
+                files: capped.files.map(Self.remoteChangedFile),
+                truncated: capped.truncated)
+        } catch {
+            return .failure(reason: .gitFailed, message: error.localizedDescription)
+        }
+    }
+
+    func remoteFileDiff(sessionId: String, path: String) async -> RemoteFileDiffResult {
+        guard let context = remoteWorktreeContext(sessionId: sessionId) else {
+            return .failure(reason: .sessionUnknown, message: nil)
+        }
+        guard let url = RemoteWorktreeFileAccess.resolve(path: path, in: context.worktree.path) else {
+            return .failure(reason: .pathRejected, message: nil)
+        }
+        if let data = try? Data(contentsOf: url), GitService.looksBinary(data) {
+            return .failure(reason: .binary, message: nil)
+        }
+        let git = GitService()
+        do {
+            let commits = try await git.commitsAhead(
+                at: context.worktree.path,
+                baseBranch: config.worktrees.baseBranch,
+                resolution: GitService.BaseResolution.forCommits(
+                    mode: config.changes.comparisonMode, userOverrodeBaseBranch: false))
+            let parsed = try await git.diff(
+                worktreePath: context.worktree.path,
+                againstRef: commits.comparisonRef,
+                file: path)
+            let capped = RemoteWorktreeFileAccess.truncateHunks(parsed.hunks)
+            return .success(
+                hunks: capped.hunks.map(Self.remoteDiffHunk),
+                truncated: capped.truncated)
+        } catch {
+            return .failure(reason: .gitFailed, message: error.localizedDescription)
+        }
+    }
+
+    func remoteFileTree(sessionId: String, path: String?) async -> RemoteFileTreeResult {
+        guard let context = remoteWorktreeContext(sessionId: sessionId) else {
+            return .failure(reason: .sessionUnknown, message: nil)
+        }
+        let git = GitService()
+        do {
+            guard let path, !path.isEmpty else {
+                let statusEntries = try await git.status(worktreePath: context.worktree.path)
+                let nodes = try await git.fileTree(
+                    worktreePath: context.worktree.path, statusEntries: statusEntries)
+                return .success(nodes: Self.remoteFileNodes(nodes))
+            }
+            guard RemoteWorktreeFileAccess.resolve(path: path, in: context.worktree.path) != nil else {
+                return .failure(reason: .pathRejected, message: nil)
+            }
+            let nodes = try await git.fileTreeChildren(
+                worktreePath: context.worktree.path, path: path)
+            return .success(nodes: Self.remoteFileNodes(nodes))
+        } catch {
+            return .failure(reason: .gitFailed, message: error.localizedDescription)
+        }
+    }
+
+    func remoteFileContents(sessionId: String, path: String) async -> RemoteFileContentsResult {
+        guard let context = remoteWorktreeContext(sessionId: sessionId) else {
+            return .failure(reason: .sessionUnknown, byteSize: nil, message: nil)
+        }
+        guard let url = RemoteWorktreeFileAccess.resolve(path: path, in: context.worktree.path) else {
+            return .failure(reason: .pathRejected, byteSize: nil, message: nil)
+        }
+        guard let data = try? Data(contentsOf: url) else {
+            return .failure(reason: .notFound, byteSize: nil, message: nil)
+        }
+        guard !GitService.looksBinary(data) else {
+            return .failure(reason: .binary, byteSize: data.count, message: nil)
+        }
+        guard data.count <= RemoteWorktreeFileAccess.maxFileBytes else {
+            return .failure(reason: .tooLarge, byteSize: data.count, message: nil)
+        }
+        guard let text = String(data: data, encoding: .utf8) else {
+            return .failure(reason: .binary, byteSize: data.count, message: nil)
+        }
+        return .success(text: text, truncated: false)
+    }
+```
+
+- [ ] **Step 6: Conform the test fake**
+
+In `AlasTests/Remote/RemoteSessionGatewayTests.swift`, add to `final class FakeSessionsProvider` — stored results plus recorded requests, so Task 5 can assert dispatch:
+
+```swift
+    var changeListResult: RemoteChangeListResult = .failure(reason: .sessionUnknown, message: nil)
+    var fileDiffResult: RemoteFileDiffResult = .failure(reason: .sessionUnknown, message: nil)
+    var fileTreeResult: RemoteFileTreeResult = .failure(reason: .sessionUnknown, message: nil)
+    var fileContentsResult: RemoteFileContentsResult = .failure(reason: .sessionUnknown, byteSize: nil, message: nil)
+    var changeListRequests: [String] = []
+    var fileDiffRequests: [(sessionId: String, path: String)] = []
+    var fileTreeRequests: [(sessionId: String, path: String?)] = []
+    var fileContentsRequests: [(sessionId: String, path: String)] = []
+
+    func remoteChangeList(sessionId: String) async -> RemoteChangeListResult {
+        changeListRequests.append(sessionId)
+        return changeListResult
+    }
+
+    func remoteFileDiff(sessionId: String, path: String) async -> RemoteFileDiffResult {
+        fileDiffRequests.append((sessionId, path))
+        return fileDiffResult
+    }
+
+    func remoteFileTree(sessionId: String, path: String?) async -> RemoteFileTreeResult {
+        fileTreeRequests.append((sessionId, path))
+        return fileTreeResult
+    }
+
+    func remoteFileContents(sessionId: String, path: String) async -> RemoteFileContentsResult {
+        fileContentsRequests.append((sessionId, path))
+        return fileContentsResult
+    }
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RemoteAppStateAccessTests -only-testing:AlasTests/RemoteSessionGatewayTests test 2>&1 | tail -20`
+Expected: PASS — the four new AppState tests plus the existing gateway suite still green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Alas/Sources/Remote Alas/Sources/App/AppState.swift AlasTests/Remote
+git commit -m "feat(remote): worktree changes and files provider methods"
+```
+
+---
+
+### Task 5: Gateway dispatch and in-flight deduplication
+
+**Files:**
+- Modify: `Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift` (the `handle(_:)` switch, near line 47)
+- Test: `AlasTests/Remote/RemoteSessionGatewayTests.swift`
+
+**Interfaces:**
+- Consumes: provider methods and result enums from Task 4; server message cases from Task 1.
+- Produces: gateway handling for `listChanges`, `fileDiff`, `listFiles`, `readFile`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `AlasTests/Remote/RemoteSessionGatewayTests.swift`, following the file's existing test style (build a `FakeSessionsProvider`, construct `RemoteSessionGateway`, capture sent messages):
+
+```swift
+    @Test func listChangesSendsChangeListFromTheProvider() async {
+        let provider = FakeSessionsProvider()
+        let file = RemoteChangedFile(
+            path: "a.txt", status: "M", add: 2, del: 1, conflict: nil, renameFrom: nil)
+        provider.changeListResult = .success(
+            comparisonRef: "origin/main", metricsAvailable: true, files: [file], truncated: false)
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gateway.handle(.listChanges(sessionId: "s1"))
+
+        #expect(provider.changeListRequests == ["s1"])
+        #expect(sent == [.changeList(
+            sessionId: "s1", comparisonRef: "origin/main", metricsAvailable: true,
+            files: [file], truncated: false)])
+    }
+
+    @Test func listChangesSendsFailureMessageOnProviderFailure() async {
+        let provider = FakeSessionsProvider()
+        provider.changeListResult = .failure(reason: .worktreeUnavailable, message: "gone")
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gateway.handle(.listChanges(sessionId: "s1"))
+
+        #expect(sent == [.changeListFailed(
+            sessionId: "s1", reason: .worktreeUnavailable, message: "gone")])
+    }
+
+    @Test func fileDiffSendsHunksAndFailures() async {
+        let provider = FakeSessionsProvider()
+        let hunk = RemoteDiffHunk(
+            header: "@@ -1 +1,2 @@", oldStart: 1, newStart: 1,
+            lines: [RemoteDiffLine(kind: "add", text: "new", oldNumber: nil, newNumber: 2)])
+        provider.fileDiffResult = .success(hunks: [hunk], truncated: true)
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt"))
+        #expect(provider.fileDiffRequests.map(\.path) == ["a.txt"])
+        #expect(sent == [.fileDiffResult(
+            sessionId: "s1", path: "a.txt", hunks: [hunk], truncated: true)])
+
+        provider.fileDiffResult = .failure(reason: .pathRejected, message: nil)
+        sent.removeAll()
+        await gateway.handle(.fileDiff(sessionId: "s1", path: "../etc/passwd"))
+        #expect(sent == [.fileDiffFailed(
+            sessionId: "s1", path: "../etc/passwd", reason: .pathRejected, message: nil)])
+    }
+
+    @Test func listFilesAndReadFileSendTreeAndContents() async {
+        let provider = FakeSessionsProvider()
+        let node = RemoteFileNode(
+            name: "src", path: "src", kind: "dir", badge: nil,
+            childrenState: "notLoaded", isSubmodule: false)
+        provider.fileTreeResult = .success(nodes: [node])
+        provider.fileContentsResult = .success(text: "# Alas\n", truncated: false)
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gateway.handle(.listFiles(sessionId: "s1", path: nil))
+        await gateway.handle(.readFile(sessionId: "s1", path: "README.md"))
+
+        #expect(sent == [
+            .fileTree(sessionId: "s1", path: nil, nodes: [node]),
+            .fileContents(sessionId: "s1", path: "README.md", text: "# Alas\n", truncated: false)
+        ])
+    }
+
+    @Test func readFileSendsUnavailableWithByteSize() async {
+        let provider = FakeSessionsProvider()
+        provider.fileContentsResult = .failure(reason: .tooLarge, byteSize: 900_000, message: nil)
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        await gateway.handle(.readFile(sessionId: "s1", path: "big.bin"))
+
+        #expect(sent == [.fileUnavailable(
+            sessionId: "s1", path: "big.bin", reason: .tooLarge, byteSize: 900_000, message: nil)])
+    }
+
+    @Test func duplicateInFlightRequestsForTheSamePathAreDropped() async {
+        let provider = FakeSessionsProvider()
+        provider.fileDiffResult = .success(hunks: [], truncated: false)
+        var sent: [RemoteServerMessage] = []
+        let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
+
+        async let first: Void = gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt"))
+        async let second: Void = gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt"))
+        _ = await (first, second)
+
+        #expect(provider.fileDiffRequests.count <= 2)
+        #expect(sent.allSatisfy { message in
+            if case .fileDiffResult(_, let path, _, _) = message { return path == "a.txt" }
+            return false
+        })
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RemoteSessionGatewayTests test 2>&1 | tail -30`
+Expected: compile failure — `handle` has no case for `.listChanges`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift`, add a stored property next to the other per-connection state:
+
+```swift
+    /// Requests currently being served, keyed by "<verb>\0<sessionId>\0<path>".
+    /// A repeat while one is in flight is dropped: the client re-renders from
+    /// the response either way, and each of these spawns a git process.
+    private var inFlightFileRequests: Set<String> = []
+```
+
+Add to the `handle(_:)` switch:
+
+```swift
+        case .listChanges(let id):
+            let key = "listChanges\u{0}\(id)"
+            guard inFlightFileRequests.insert(key).inserted else { return }
+            defer { inFlightFileRequests.remove(key) }
+            switch await provider.remoteChangeList(sessionId: id) {
+            case .success(let ref, let available, let files, let truncated):
+                send(.changeList(
+                    sessionId: id, comparisonRef: ref, metricsAvailable: available,
+                    files: files, truncated: truncated))
+            case .failure(let reason, let message):
+                send(.changeListFailed(sessionId: id, reason: reason, message: message))
+            }
+        case .fileDiff(let id, let path):
+            let key = "fileDiff\u{0}\(id)\u{0}\(path)"
+            guard inFlightFileRequests.insert(key).inserted else { return }
+            defer { inFlightFileRequests.remove(key) }
+            switch await provider.remoteFileDiff(sessionId: id, path: path) {
+            case .success(let hunks, let truncated):
+                send(.fileDiffResult(sessionId: id, path: path, hunks: hunks, truncated: truncated))
+            case .failure(let reason, let message):
+                send(.fileDiffFailed(sessionId: id, path: path, reason: reason, message: message))
+            }
+        case .listFiles(let id, let path):
+            let key = "listFiles\u{0}\(id)\u{0}\(path ?? "")"
+            guard inFlightFileRequests.insert(key).inserted else { return }
+            defer { inFlightFileRequests.remove(key) }
+            switch await provider.remoteFileTree(sessionId: id, path: path) {
+            case .success(let nodes):
+                send(.fileTree(sessionId: id, path: path, nodes: nodes))
+            case .failure(let reason, let message):
+                send(.fileTreeFailed(sessionId: id, path: path, reason: reason, message: message))
+            }
+        case .readFile(let id, let path):
+            let key = "readFile\u{0}\(id)\u{0}\(path)"
+            guard inFlightFileRequests.insert(key).inserted else { return }
+            defer { inFlightFileRequests.remove(key) }
+            switch await provider.remoteFileContents(sessionId: id, path: path) {
+            case .success(let text, let truncated):
+                send(.fileContents(sessionId: id, path: path, text: text, truncated: truncated))
+            case .failure(let reason, let byteSize, let message):
+                send(.fileUnavailable(
+                    sessionId: id, path: path, reason: reason,
+                    byteSize: byteSize, message: message))
+            }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RemoteSessionGatewayTests test 2>&1 | tail -20`
+Expected: PASS, six new tests plus the existing suite.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift AlasTests/Remote/RemoteSessionGatewayTests.swift
+git commit -m "feat(remote): gateway dispatch for changes and files requests"
+```
+
+---
+
+### Task 6: `changes-view.js` logic module
+
+**Files:**
+- Create: `Alas/Resources/RemoteWeb/changes-view.js`
+- Create: `scripts/tests/remote-web-changes/test-changes-view.js`
+- Create: `scripts/tests/remote-web-changes/run.sh`
+
+**Interfaces:**
+- Consumes: nothing (pure functions over the wire shapes from Task 1).
+- Produces: `globalThis.RemoteChangesView = { sortFiles, splitPath, formatSummary, formatFileCounts, diffRows, truncationNotice }`.
+  - `sortFiles(files)` → new array sorted by `path`.
+  - `splitPath(path)` → `{ dir, name }`, `dir` is `""` at the root and otherwise ends with `/`.
+  - `formatSummary({ comparisonRef, files, truncated })` → e.g. `"vs origin/main · 2 files · +14 −3"`.
+  - `formatFileCounts(file)` → e.g. `"+12 −3"`.
+  - `diffRows(hunks)` → flat array of `{ type: "hunk"|"line", text, kind, oldNumber, newNumber }`.
+  - `truncationNotice(truncated, kind)` → string or `""`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/tests/remote-web-changes/test-changes-view.js`:
+
+```javascript
+const assert = require("node:assert/strict");
+
+require("../../../Alas/Resources/RemoteWeb/changes-view.js");
+
+const view = globalThis.RemoteChangesView;
+
+{
+  const sorted = view.sortFiles([
+    { path: "src/b.txt" },
+    { path: "a.txt" },
+    { path: "src/a.txt" }
+  ]);
+  assert.deepEqual(sorted.map((f) => f.path), ["a.txt", "src/a.txt", "src/b.txt"]);
+}
+
+{
+  assert.deepEqual(view.splitPath("a.txt"), { dir: "", name: "a.txt" });
+  assert.deepEqual(view.splitPath("src/app/main.swift"), { dir: "src/app/", name: "main.swift" });
+}
+
+{
+  const summary = view.formatSummary({
+    comparisonRef: "origin/main",
+    files: [
+      { path: "a.txt", add: 12, del: 3 },
+      { path: "b.txt", add: 2, del: 0 }
+    ],
+    truncated: false
+  });
+  assert.equal(summary, "vs origin/main · 2 files · +14 −3");
+}
+
+{
+  const summary = view.formatSummary({ comparisonRef: null, files: [{ path: "a.txt", add: 1, del: 0 }], truncated: false });
+  assert.equal(summary, "1 file · +1 −0");
+}
+
+{
+  assert.equal(view.formatFileCounts({ add: 12, del: 3 }), "+12 −3");
+}
+
+{
+  const rows = view.diffRows([
+    {
+      header: "@@ -1,2 +1,3 @@",
+      oldStart: 1,
+      newStart: 1,
+      lines: [
+        { kind: "context", text: "import Foundation", oldNumber: 1, newNumber: 1 },
+        { kind: "add", text: "import Testing", oldNumber: null, newNumber: 2 }
+      ]
+    }
+  ]);
+  assert.equal(rows.length, 3);
+  assert.equal(rows[0].type, "hunk");
+  assert.equal(rows[0].text, "@@ -1,2 +1,3 @@");
+  assert.equal(rows[1].type, "line");
+  assert.equal(rows[1].kind, "context");
+  assert.equal(rows[2].kind, "add");
+  assert.equal(rows[2].newNumber, 2);
+}
+
+{
+  assert.equal(view.truncationNotice(false, "diff"), "");
+  assert.equal(view.truncationNotice(true, "diff"), "Diff truncated — open this file on the desktop to see the rest.");
+  assert.equal(view.truncationNotice(true, "files"), "File list truncated — too many changed files to show.");
+}
+
+console.log("remote-web-changes: ok");
+```
+
+Create `scripts/tests/remote-web-changes/run.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+node "$(dirname "$0")/test-changes-view.js"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `chmod +x scripts/tests/remote-web-changes/run.sh && bash scripts/tests/remote-web-changes/run.sh`
+Expected: FAIL — `Cannot find module '.../changes-view.js'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Alas/Resources/RemoteWeb/changes-view.js`:
+
+```javascript
+// Pure logic for the Changes tab: ordering, labels, and the diff row model.
+// DOM wiring lives in app.js; everything here is unit-tested under
+// scripts/tests/remote-web-changes.
+
+function sortFiles(files) {
+  return (files || []).slice().sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+}
+
+function splitPath(path) {
+  const value = path || "";
+  const index = value.lastIndexOf("/");
+  if (index < 0) return { dir: "", name: value };
+  return { dir: value.slice(0, index + 1), name: value.slice(index + 1) };
+}
+
+function formatFileCounts(file) {
+  const add = file && file.add ? file.add : 0;
+  const del = file && file.del ? file.del : 0;
+  return "+" + add + " −" + del;
+}
+
+function formatSummary(state) {
+  const files = (state && state.files) || [];
+  let add = 0;
+  let del = 0;
+  for (const file of files) {
+    add += file.add || 0;
+    del += file.del || 0;
+  }
+  const count = files.length + (files.length === 1 ? " file" : " files");
+  const totals = count + " · +" + add + " −" + del;
+  const ref = state && state.comparisonRef;
+  return ref ? "vs " + ref + " · " + totals : totals;
+}
+
+function diffRows(hunks) {
+  const rows = [];
+  for (const hunk of hunks || []) {
+    rows.push({ type: "hunk", text: hunk.header, kind: null, oldNumber: null, newNumber: null });
+    for (const line of hunk.lines || []) {
+      rows.push({
+        type: "line",
+        text: line.text,
+        kind: line.kind,
+        oldNumber: typeof line.oldNumber === "number" ? line.oldNumber : null,
+        newNumber: typeof line.newNumber === "number" ? line.newNumber : null
+      });
+    }
+  }
+  return rows;
+}
+
+function truncationNotice(truncated, kind) {
+  if (!truncated) return "";
+  if (kind === "files") return "File list truncated — too many changed files to show.";
+  return "Diff truncated — open this file on the desktop to see the rest.";
+}
+
+globalThis.RemoteChangesView = {
+  sortFiles,
+  splitPath,
+  formatSummary,
+  formatFileCounts,
+  diffRows,
+  truncationNotice
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash scripts/tests/remote-web-changes/run.sh`
+Expected: `remote-web-changes: ok`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Resources/RemoteWeb/changes-view.js scripts/tests/remote-web-changes
+git commit -m "feat(remote): changes view logic module"
+```
+
+---
+
+### Task 7: `file-browser.js` logic module
+
+**Files:**
+- Create: `Alas/Resources/RemoteWeb/file-browser.js`
+- Create: `scripts/tests/remote-web-file-browser/test-file-browser.js`
+- Create: `scripts/tests/remote-web-file-browser/run.sh`
+
+**Interfaces:**
+- Consumes: nothing (pure functions over `RemoteFileNode` from Task 1).
+- Produces: `globalThis.RemoteFileBrowser = { createTree, applyNodes, toggle, visibleRows, isExpanded, needsChildren, reset }` where `createTree()` returns a controller object with those methods bound to its own state.
+  - `applyNodes(path, nodes)` stores a directory's children (`path` is `null` for the root).
+  - `toggle(path)` flips a directory's expanded flag and returns `true` when its children still need fetching.
+  - `visibleRows()` returns a flat array of `{ node, depth, expanded }` in display order, directories before files, each group alphabetical.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/tests/remote-web-file-browser/test-file-browser.js`:
+
+```javascript
+const assert = require("node:assert/strict");
+
+require("../../../Alas/Resources/RemoteWeb/file-browser.js");
+
+const browser = globalThis.RemoteFileBrowser;
+
+function dir(name, path) {
+  return { name, path, kind: "dir", badge: null, childrenState: "notLoaded", isSubmodule: false };
+}
+
+function file(name, path, badge) {
+  return { name, path, kind: "file", badge: badge || null, childrenState: "loaded", isSubmodule: false };
+}
+
+{
+  const tree = browser.createTree();
+  tree.applyNodes(null, [file("z.txt", "z.txt"), dir("src", "src")]);
+  const rows = tree.visibleRows();
+  assert.deepEqual(rows.map((r) => r.node.path), ["src", "z.txt"]);
+  assert.deepEqual(rows.map((r) => r.depth), [0, 0]);
+  assert.equal(rows[0].expanded, false);
+}
+
+{
+  const tree = browser.createTree();
+  tree.applyNodes(null, [dir("src", "src")]);
+  assert.equal(tree.needsChildren("src"), true);
+  assert.equal(tree.toggle("src"), true);
+  assert.equal(tree.isExpanded("src"), true);
+
+  tree.applyNodes("src", [file("main.swift", "src/main.swift", "M")]);
+  assert.equal(tree.needsChildren("src"), false);
+
+  const rows = tree.visibleRows();
+  assert.deepEqual(rows.map((r) => r.node.path), ["src", "src/main.swift"]);
+  assert.deepEqual(rows.map((r) => r.depth), [0, 1]);
+  assert.equal(rows[1].node.badge, "M");
+
+  assert.equal(tree.toggle("src"), false);
+  assert.equal(tree.isExpanded("src"), false);
+  assert.deepEqual(tree.visibleRows().map((r) => r.node.path), ["src"]);
+}
+
+{
+  const tree = browser.createTree();
+  tree.applyNodes(null, [dir("a", "a")]);
+  tree.toggle("a");
+  tree.applyNodes("a", [file("x.txt", "a/x.txt")]);
+  tree.reset();
+  assert.deepEqual(tree.visibleRows(), []);
+  assert.equal(tree.isExpanded("a"), false);
+}
+
+console.log("remote-web-file-browser: ok");
+```
+
+Create `scripts/tests/remote-web-file-browser/run.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+node "$(dirname "$0")/test-file-browser.js"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `chmod +x scripts/tests/remote-web-file-browser/run.sh && bash scripts/tests/remote-web-file-browser/run.sh`
+Expected: FAIL — `Cannot find module '.../file-browser.js'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `Alas/Resources/RemoteWeb/file-browser.js`:
+
+```javascript
+// Pure state for the lazy file tree in the Files tab. The server sends one
+// directory's children at a time; this module remembers what has arrived, what
+// is expanded, and flattens it into display rows. DOM wiring lives in app.js.
+
+function nodeOrder(a, b) {
+  if (a.kind !== b.kind) return a.kind === "dir" ? -1 : 1;
+  return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+}
+
+function createTree() {
+  const childrenByPath = new Map();   // key: "" for root, else directory path
+  const expanded = new Set();
+
+  function key(path) {
+    return path === null || path === undefined ? "" : path;
+  }
+
+  function applyNodes(path, nodes) {
+    childrenByPath.set(key(path), (nodes || []).slice().sort(nodeOrder));
+  }
+
+  function isExpanded(path) {
+    return expanded.has(key(path));
+  }
+
+  function needsChildren(path) {
+    return !childrenByPath.has(key(path));
+  }
+
+  function toggle(path) {
+    const id = key(path);
+    if (expanded.has(id)) {
+      expanded.delete(id);
+      return false;
+    }
+    expanded.add(id);
+    return needsChildren(path);
+  }
+
+  function collect(path, depth, rows) {
+    const nodes = childrenByPath.get(key(path)) || [];
+    for (const node of nodes) {
+      const open = node.kind === "dir" && expanded.has(node.path);
+      rows.push({ node, depth, expanded: open });
+      if (open) collect(node.path, depth + 1, rows);
+    }
+  }
+
+  function visibleRows() {
+    const rows = [];
+    collect(null, 0, rows);
+    return rows;
+  }
+
+  function reset() {
+    childrenByPath.clear();
+    expanded.clear();
+  }
+
+  return { applyNodes, isExpanded, needsChildren, toggle, visibleRows, reset };
+}
+
+globalThis.RemoteFileBrowser = { createTree };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash scripts/tests/remote-web-file-browser/run.sh`
+Expected: `remote-web-file-browser: ok`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Resources/RemoteWeb/file-browser.js scripts/tests/remote-web-file-browser
+git commit -m "feat(remote): file browser tree state module"
+```
+
+---
+
+### Task 8: Tabs, markup, styles, and asset wiring
+
+**Files:**
+- Modify: `Alas/Resources/RemoteWeb/index.html`
+- Modify: `Alas/Resources/RemoteWeb/style.css`
+- Modify: `Alas/Resources/RemoteWeb/sw.js`
+- Modify: `Alas/Resources/RemoteWeb/app.js`
+- Test: `AlasTests/Remote/RemoteWebAssetTests.swift`
+
+**Interfaces:**
+- Consumes: `RemoteChangesView` (Task 6), `RemoteFileBrowser` (Task 7).
+- Produces: DOM ids `detail-tabs`, `tab-chat`, `tab-changes`, `tab-files`, `changes`, `changes-summary`, `changes-refresh`, `changes-list`, `changes-error`, `diff-view`, `diff-path`, `diff-rows`, `files`, `file-list`, `file-error`, `file-view`, `file-view-path`, `file-view-body`; and `app.js` functions `showTab(name)`, `requestChanges()`, `openDiff(path)`, `openFileView(path)`, consumed by Task 9's handlers.
+
+This task lands the shell: markup, styling, tab switching, script/version wiring, and the asset test. Task 9 lands the message handlers that fill it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `AlasTests/Remote/RemoteWebAssetTests.swift`, inside the existing struct:
+
+```swift
+    @Test func remoteWebShipsChangesAndFilesTabs() throws {
+        let html = try asset("index.html")
+        let sw = try asset("sw.js")
+
+        #expect(html.contains(#"id="detail-tabs""#))
+        #expect(html.contains(#"id="tab-chat""#))
+        #expect(html.contains(#"id="tab-changes""#))
+        #expect(html.contains(#"id="tab-files""#))
+        #expect(html.contains(#"<section id="changes" class="view hidden">"#))
+        #expect(html.contains(#"<section id="files" class="view hidden">"#))
+        #expect(html.contains(#"id="changes-summary""#))
+        #expect(html.contains(#"id="changes-refresh""#))
+        #expect(html.contains(#"id="changes-list""#))
+        #expect(html.contains(#"id="diff-rows""#))
+        #expect(html.contains(#"id="file-list""#))
+        #expect(html.contains(#"id="file-view-body""#))
+
+        #expect(html.contains(#"/changes-view.js?v=1"#))
+        #expect(html.contains(#"/file-browser.js?v=1"#))
+        #expect(html.range(of: #"/changes-view.js?v=1"#)!.lowerBound
+            < html.range(of: #"/app.js?v=64"#)!.lowerBound)
+        #expect(html.range(of: #"/file-browser.js?v=1"#)!.lowerBound
+            < html.range(of: #"/app.js?v=64"#)!.lowerBound)
+        #expect(sw.contains(#""/changes-view.js?v=1""#))
+        #expect(sw.contains(#""/file-browser.js?v=1""#))
+    }
+
+    @Test func remoteWebWiresTabSwitching() throws {
+        let js = try asset("app.js")
+        #expect(js.contains("function showTab(name)"))
+        #expect(js.contains("const changesTree = RemoteFileBrowser.createTree();"))
+        #expect(js.contains(#"type: "listChanges""#))
+        #expect(js.contains(#"type: "listFiles""#))
+    }
+```
+
+Also bump every existing version assertion in that file:
+
+```bash
+sed -i '' 's|app\.js?v=63|app.js?v=64|g; s|style\.css?v=41|style.css?v=42|g; s|alas-remote-shell-v41|alas-remote-shell-v42|g' AlasTests/Remote/RemoteWebAssetTests.swift
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RemoteWebAssetTests test 2>&1 | tail -20`
+Expected: FAIL — the new ids and script tags are absent, and the bumped versions do not match the assets yet.
+
+- [ ] **Step 3: Add the markup**
+
+In `Alas/Resources/RemoteWeb/index.html`, inside `<header id="bar">` after `#detail-rename`, add the tab strip:
+
+```html
+    <div id="detail-tabs" class="tabs hidden" role="tablist">
+      <button id="tab-chat" class="tab is-active" role="tab" type="button">Chat</button>
+      <button id="tab-changes" class="tab" role="tab" type="button">Changes</button>
+      <button id="tab-files" class="tab" role="tab" type="button">Files</button>
+    </div>
+```
+
+After the `<section id="transcript">` element, add the two new views:
+
+```html
+    <section id="changes" class="view hidden">
+      <div id="changes-header">
+        <span id="changes-summary"></span>
+        <button id="changes-refresh" type="button" aria-label="Refresh changes">↻</button>
+      </div>
+      <p id="changes-error" class="sheet-error hidden" role="alert"></p>
+      <div id="changes-list"></div>
+      <div id="diff-view" class="hidden">
+        <p id="diff-path" class="detail-path"></p>
+        <div id="diff-rows"></div>
+      </div>
+    </section>
+    <section id="files" class="view hidden">
+      <p id="file-error" class="sheet-error hidden" role="alert"></p>
+      <div id="file-list"></div>
+      <div id="file-view" class="hidden">
+        <p id="file-view-path" class="detail-path"></p>
+        <div id="file-view-body"></div>
+      </div>
+    </section>
+```
+
+Update the script tags and the stylesheet query string:
+
+```html
+  <script src="/changes-view.js?v=1"></script>
+  <script src="/file-browser.js?v=1"></script>
+  <script src="/app.js?v=64"></script>
+```
+
+and change `style.css?v=41` to `style.css?v=42`.
+
+- [ ] **Step 4: Update the service worker**
+
+In `Alas/Resources/RemoteWeb/sw.js`, set `CACHE_NAME` to `"alas-remote-shell-v42"` and update `SHELL_ASSETS`:
+
+```javascript
+  "/style.css?v=42",
+  "/session-ordering.js?v=1",
+  "/worktree-creation.js?v=1",
+  "/changes-view.js?v=1",
+  "/file-browser.js?v=1",
+  "/app.js?v=64",
+```
+
+- [ ] **Step 5: Add the styles**
+
+Append to `Alas/Resources/RemoteWeb/style.css`, using the file's existing custom
+properties (`--fg`, `--fg-muted`, `--fg-faint`, `--line`, `--line-soft`,
+`--bg-3`, `--add`, `--del`) — the same tokens `.sheet-error` and `#status.chip`
+already build on with `color-mix(in oklab, ...)`:
+
+```css
+.tabs { display: flex; gap: 2px; }
+.tab {
+  background: none; border: none; padding: 6px 10px;
+  font: inherit; color: var(--fg-muted); border-radius: 6px;
+}
+.tab.is-active { color: var(--fg); background: color-mix(in oklab, var(--bg-3) 70%, transparent); }
+
+#changes-header {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 8px; padding: 10px 12px; color: var(--fg-muted);
+}
+#changes-refresh { background: none; border: none; color: var(--fg-muted); font-size: 16px; }
+.change-row, .file-row {
+  display: flex; align-items: baseline; gap: 8px; width: 100%;
+  padding: 10px 12px; background: none; border: none;
+  border-bottom: 0.5px solid var(--line-soft); text-align: left; font: inherit; color: var(--fg);
+}
+.change-dir { color: var(--fg-faint); }
+.change-name { font-weight: 600; }
+.change-counts { margin-left: auto; font-variant-numeric: tabular-nums; color: var(--fg-muted); }
+.change-conflict { color: var(--del); }
+
+#diff-rows, #file-view-body {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px; overflow-x: auto;
+}
+.diff-hunk {
+  padding: 6px 12px; color: var(--fg-muted);
+  background: color-mix(in oklab, var(--bg-3) 70%, transparent); position: sticky; top: 0;
+}
+.diff-line { display: flex; gap: 8px; padding: 0 12px; white-space: pre; }
+.diff-line.add { background: color-mix(in oklab, var(--add) 16%, transparent); }
+.diff-line.delete { background: color-mix(in oklab, var(--del) 16%, transparent); }
+.diff-gutter { min-width: 4ch; text-align: right; color: var(--fg-faint); }
+.detail-path { padding: 8px 12px; color: var(--fg-muted); word-break: break-all; }
+.placeholder-card {
+  margin: 16px 12px; padding: 12px; border: 0.5px solid var(--line);
+  border-radius: 10px; color: var(--fg-muted);
+}
+```
+
+These are all existing tokens — no new `:root` entries are needed.
+
+- [ ] **Step 6: Add tab switching to app.js**
+
+In `Alas/Resources/RemoteWeb/app.js`, near the other module instances, add state and the tab controller:
+
+```javascript
+const changesTree = RemoteFileBrowser.createTree();
+let activeTab = "chat";
+let changesState = { comparisonRef: null, metricsAvailable: true, files: [], truncated: false, loaded: false };
+let detailStack = [];   // [{ tab, path }] for the in-tab list → detail level
+
+function showTab(name) {
+  activeTab = name;
+  detailStack = [];
+  $("diff-view").classList.add("hidden");
+  $("file-view").classList.add("hidden");
+  for (const [id, tab] of [["tab-chat", "chat"], ["tab-changes", "changes"], ["tab-files", "files"]]) {
+    $(id).classList.toggle("is-active", tab === name);
+  }
+  $("transcript").classList.toggle("hidden", name !== "chat");
+  $("changes").classList.toggle("hidden", name !== "changes");
+  $("files").classList.toggle("hidden", name !== "files");
+  if (name === "changes") requestChanges();
+  if (name === "files" && changesTree.needsChildren(null)) {
+    send({ type: "listFiles", sessionId: currentSession });
+  }
+}
+
+function requestChanges() {
+  if (!currentSession) return;
+  send({ type: "listChanges", sessionId: currentSession });
+}
+
+$("tab-chat").addEventListener("click", () => showTab("chat"));
+$("tab-changes").addEventListener("click", () => showTab("changes"));
+$("tab-files").addEventListener("click", () => showTab("files"));
+$("changes-refresh").addEventListener("click", requestChanges);
+```
+
+In `openSession(id)`, after the existing state resets, add:
+
+```javascript
+  changesTree.reset();
+  changesState = { comparisonRef: null, metricsAvailable: true, files: [], truncated: false, loaded: false };
+  detailStack = [];
+  const summary = listedSessions.get(id);
+  $("detail-tabs").classList.toggle("hidden", !summary || !summary.worktree);
+  showTab("chat");
+```
+
+In `showSessions()`, add:
+
+```javascript
+  changesTree.reset();
+  changesState = { comparisonRef: null, metricsAvailable: true, files: [], truncated: false, loaded: false };
+  detailStack = [];
+  activeTab = "chat";
+  $("detail-tabs").classList.add("hidden");
+  $("changes").classList.add("hidden");
+  $("files").classList.add("hidden");
+```
+
+`listedSessions` (a `Map` from session id to the full session object, populated
+in `renderSessions`) already carries `.worktree` — no new map is needed.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RemoteWebAssetTests test 2>&1 | tail -20`
+Expected: PASS, including the two new tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Alas/Resources/RemoteWeb AlasTests/Remote/RemoteWebAssetTests.swift
+git commit -m "feat(remote): changes and files tab shell in the web client"
+```
+
+---
+
+### Task 9: Rendering and message handling
+
+**Files:**
+- Modify: `Alas/Resources/RemoteWeb/app.js`
+- Test: `AlasTests/Remote/RemoteWebAssetTests.swift`
+
+**Interfaces:**
+- Consumes: `showTab`, `requestChanges`, `changesTree`, `changesState`, `detailStack` (Task 8); `RemoteChangesView` (Task 6); server messages from Task 1.
+- Produces: complete Changes and Files behavior — nothing downstream depends on it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `AlasTests/Remote/RemoteWebAssetTests.swift`:
+
+```swift
+    @Test func remoteWebHandlesChangesAndFilesMessages() throws {
+        let js = try asset("app.js")
+
+        #expect(js.contains(#"case "changeList":"#))
+        #expect(js.contains(#"case "changeListFailed":"#))
+        #expect(js.contains(#"case "fileDiffResult":"#))
+        #expect(js.contains(#"case "fileDiffFailed":"#))
+        #expect(js.contains(#"case "fileTree":"#))
+        #expect(js.contains(#"case "fileTreeFailed":"#))
+        #expect(js.contains(#"case "fileContents":"#))
+        #expect(js.contains(#"case "fileUnavailable":"#))
+        #expect(js.contains("function renderChanges()"))
+        #expect(js.contains("function renderDiff("))
+        #expect(js.contains("function renderFileTree()"))
+        #expect(js.contains("RemoteChangesView.diffRows("))
+        #expect(js.contains("RemoteChangesView.formatSummary("))
+    }
+
+    @Test func remoteWebRefreshesChangesWhenATurnGoesIdle() throws {
+        let js = try asset("app.js")
+        #expect(js.contains("function noteStreamingStateForChanges(state)"))
+        #expect(js.contains(#"activeTab === "changes""#))
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RemoteWebAssetTests test 2>&1 | tail -20`
+Expected: FAIL — the handlers and render functions do not exist.
+
+- [ ] **Step 3: Add the renderers**
+
+In `Alas/Resources/RemoteWeb/app.js`:
+
+```javascript
+function renderChanges() {
+  const list = $("changes-list");
+  list.innerHTML = "";
+  $("changes-summary").textContent = changesState.loaded
+    ? RemoteChangesView.formatSummary(changesState)
+    : "Loading changes…";
+
+  if (changesState.loaded && !changesState.metricsAvailable) {
+    list.append(el("p", "placeholder-card", "Change metrics are unavailable for this worktree."));
+    return;
+  }
+
+  if (changesState.loaded && changesState.files.length === 0) {
+    list.append(el("p", "placeholder-card", "No changes yet."));
+    return;
+  }
+
+  for (const file of RemoteChangesView.sortFiles(changesState.files)) {
+    const parts = RemoteChangesView.splitPath(file.path);
+    const row = document.createElement("button");
+    row.type = "button";
+    row.className = "change-row";
+    row.onclick = () => openDiff(file.path);
+
+    row.append(el("span", "change-dir", parts.dir), el("span", "change-name", parts.name));
+    if (file.conflict) row.append(el("span", "change-conflict", "conflict"));
+    row.append(el("span", "change-counts", RemoteChangesView.formatFileCounts(file)));
+    list.appendChild(row);
+  }
+
+  const notice = RemoteChangesView.truncationNotice(changesState.truncated, "files");
+  if (notice) list.append(el("p", "placeholder-card", notice));
+}
+
+function openDiff(path) {
+  detailStack.push({ tab: "changes", path });
+  $("changes-list").classList.add("hidden");
+  $("changes-header").classList.add("hidden");
+  $("diff-view").classList.remove("hidden");
+  $("diff-path").textContent = path;
+  $("diff-rows").innerHTML = "";
+  send({ type: "fileDiff", sessionId: currentSession, path });
+}
+
+function closeDetailLevel() {
+  detailStack.pop();
+  $("diff-view").classList.add("hidden");
+  $("file-view").classList.add("hidden");
+  $("changes-list").classList.remove("hidden");
+  $("changes-header").classList.remove("hidden");
+  $("file-list").classList.remove("hidden");
+}
+
+function renderDiff(path, hunks, truncated) {
+  if ($("diff-path").textContent !== path) return;   // a newer file is open
+  const container = $("diff-rows");
+  container.innerHTML = "";
+  for (const row of RemoteChangesView.diffRows(hunks)) {
+    if (row.type === "hunk") {
+      container.append(el("div", "diff-hunk", row.text));
+      continue;
+    }
+    const line = el("div", "diff-line " + row.kind);
+    line.append(
+      el("span", "diff-gutter", row.oldNumber === null ? "" : String(row.oldNumber)),
+      el("span", "diff-gutter", row.newNumber === null ? "" : String(row.newNumber)),
+      el("span", "", row.text));
+    container.appendChild(line);
+  }
+  const notice = RemoteChangesView.truncationNotice(truncated, "diff");
+  if (notice) container.append(el("p", "placeholder-card", notice));
+}
+
+function renderFileTree() {
+  const list = $("file-list");
+  list.innerHTML = "";
+  for (const row of changesTree.visibleRows()) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "file-row";
+    button.style.paddingLeft = 12 + row.depth * 14 + "px";
+
+    const label = row.node.kind === "dir"
+      ? (row.expanded ? "▾ " : "▸ ") + row.node.name
+      : row.node.name;
+    button.append(el("span", "", label));
+    if (row.node.badge) button.append(el("span", "change-counts", row.node.badge));
+
+    button.onclick = () => {
+      if (row.node.kind === "dir") {
+        if (changesTree.toggle(row.node.path)) {
+          send({ type: "listFiles", sessionId: currentSession, path: row.node.path });
+        }
+        renderFileTree();
+        return;
+      }
+      openFileView(row.node.path);
+    };
+    list.appendChild(button);
+  }
+}
+
+function openFileView(path) {
+  detailStack.push({ tab: "files", path });
+  $("file-list").classList.add("hidden");
+  $("file-view").classList.remove("hidden");
+  $("file-view-path").textContent = path;
+  $("file-view-body").textContent = "Loading…";
+  send({ type: "readFile", sessionId: currentSession, path });
+}
+
+function renderFileContents(path, text, truncated) {
+  if ($("file-view-path").textContent !== path) return;
+  const body = $("file-view-body");
+  body.innerHTML = "";
+  text.split("\n").forEach((line, index) => {
+    const row = el("div", "diff-line");
+    row.append(el("span", "diff-gutter", String(index + 1)), el("span", "", line));
+    body.appendChild(row);
+  });
+  if (truncated) body.append(el("p", "placeholder-card", "File truncated."));
+}
+
+function fileAccessMessage(reason, byteSize) {
+  switch (reason) {
+    case "binary": return "Binary file — not shown.";
+    case "tooLarge": return byteSize
+      ? "File is " + Math.round(byteSize / 1024) + " KB — too large to view."
+      : "File is too large to view.";
+    case "pathRejected": return "That path is outside this worktree.";
+    case "notFound": return "File not found.";
+    case "worktreeUnavailable": return "This session's worktree is unavailable.";
+    case "sessionUnknown": return "This session is no longer open on the host.";
+    default: return "Could not read this file.";
+  }
+}
+
+function showChangesError(text) {
+  const error = $("changes-error");
+  error.textContent = text;
+  error.classList.remove("hidden");
+}
+
+function showFileError(text) {
+  const error = $("file-error");
+  error.textContent = text;
+  error.classList.remove("hidden");
+}
+
+/// Re-fetch the change list when the agent stops, but only while the tab is
+/// open — the server keeps no per-tab state.
+function noteStreamingStateForChanges(state) {
+  if (state !== "idle") return;
+  if (activeTab === "changes" && detailStack.length === 0) requestChanges();
+}
+```
+
+- [ ] **Step 4: Add the message handlers**
+
+In the websocket message switch in `app.js`, alongside the existing `case "..."` arms:
+
+```javascript
+    case "changeList":
+      if (msg.sessionId !== currentSession) break;
+      $("changes-error").classList.add("hidden");
+      changesState = {
+        comparisonRef: msg.comparisonRef || null,
+        metricsAvailable: msg.metricsAvailable !== false,
+        files: msg.files || [],
+        truncated: !!msg.truncated,
+        loaded: true
+      };
+      renderChanges();
+      break;
+    case "changeListFailed":
+      if (msg.sessionId !== currentSession) break;
+      changesState.loaded = true;
+      showChangesError(fileAccessMessage(msg.reason, null));
+      break;
+    case "fileDiffResult":
+      if (msg.sessionId !== currentSession) break;
+      renderDiff(msg.path, msg.hunks || [], !!msg.truncated);
+      break;
+    case "fileDiffFailed":
+      if (msg.sessionId !== currentSession) break;
+      if ($("diff-path").textContent === msg.path) {
+        $("diff-rows").innerHTML = "";
+        $("diff-rows").append(el("p", "placeholder-card", fileAccessMessage(msg.reason, null)));
+      }
+      break;
+    case "fileTree":
+      if (msg.sessionId !== currentSession) break;
+      $("file-error").classList.add("hidden");
+      changesTree.applyNodes(msg.path === undefined ? null : msg.path, msg.nodes || []);
+      renderFileTree();
+      break;
+    case "fileTreeFailed":
+      if (msg.sessionId !== currentSession) break;
+      showFileError(fileAccessMessage(msg.reason, null));
+      break;
+    case "fileContents":
+      if (msg.sessionId !== currentSession) break;
+      renderFileContents(msg.path, msg.text || "", !!msg.truncated);
+      break;
+    case "fileUnavailable":
+      if (msg.sessionId !== currentSession) break;
+      if ($("file-view-path").textContent === msg.path) {
+        $("file-view-body").innerHTML = "";
+        $("file-view-body").append(el("p", "placeholder-card", fileAccessMessage(msg.reason, msg.byteSize)));
+      }
+      break;
+```
+
+Both `applySnapshot` and `applyDelta` already end by calling
+`syncStreamingState(msg.streamingState)` — that is the single choke point both
+transcript paths funnel through, so hook the refresh there instead of touching
+each handler:
+
+```javascript
+function syncStreamingState(streamingState) {
+  if (streamingState === "idle" && stopPending) markStopping(false);
+  renderDriveBar(streamingState);
+  noteStreamingStateForChanges(streamingState);
+}
+```
+
+Replace the existing `$("back").onclick = showSessions;` (near the end of
+`app.js`) so a diff or file view closes before the whole detail screen does:
+
+```javascript
+$("back").onclick = () => {
+  if (detailStack.length > 0) { closeDetailLevel(); return; }
+  showSessions();
+};
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RemoteWebAssetTests test 2>&1 | tail -20`
+Expected: PASS, including the two new tests.
+
+- [ ] **Step 6: Verify by hand in a browser**
+
+Start Alas, enable the remote server in Settings, pair a browser, open a session whose worktree has changes, and confirm: the tab strip appears; Changes lists files with the comparison ref in the header; tapping a file shows a unified diff; `‹` returns to the list, then to Sessions; Files expands directories lazily and opens a text file; a binary file shows the placeholder card.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Alas/Resources/RemoteWeb/app.js AlasTests/Remote/RemoteWebAssetTests.swift
+git commit -m "feat(remote): render changes and files in the web client"
+```
+
+---
+
+### Task 10: Full verification
+
+**Files:**
+- Modify: none expected. Fix whatever the sweep surfaces.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-9.
+- Produces: a branch ready for review.
+
+- [ ] **Step 1: Regenerate the project**
+
+Run: `xcodegen`
+Expected: `Alas.xcodeproj` regenerated with the new Swift files and no diff noise beyond them.
+
+- [ ] **Step 2: Build**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
+Expected: build succeeds with no warnings introduced by these changes.
+
+- [ ] **Step 3: Run the JS suites**
+
+Run:
+
+```bash
+bash scripts/tests/remote-web-changes/run.sh
+bash scripts/tests/remote-web-file-browser/run.sh
+bash scripts/tests/remote-web-session-ordering/run.sh
+bash scripts/tests/remote-web-worktree-creation/run.sh
+```
+
+Expected: each prints its `ok` line.
+
+- [ ] **Step 4: Run the affected Swift suites**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/RemoteProtocolTests \
+  -only-testing:AlasTests/RemoteWorktreeFileAccessTests \
+  -only-testing:AlasTests/GitServiceRemoteChangesTests \
+  -only-testing:AlasTests/RemoteAppStateAccessTests \
+  -only-testing:AlasTests/RemoteSessionGatewayTests \
+  -only-testing:AlasTests/RemoteWebAssetTests \
+  -only-testing:AlasTests/RemoteServerIntegrationTests \
+  test 2>&1 | tail -30
+```
+
+Expected: all suites pass. Report actual output; do not claim success without it.
+
+- [ ] **Step 5: Commit any fixes and push**
+
+```bash
+git add -A
+git commit -m "fix(remote): address verification findings"
+git push
+```
+
+Skip the commit if the sweep was clean. The full `xcodebuild ... test` sweep runs in CI.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Transport → Task 1. Protocol table and wire types → Task 1. Failure reasons → Task 1. Provider methods → Task 4. Git work → Task 3 (changed files, against-ref diff) and Task 4 (tree, file read). Caps → Task 2 (constants and truncation) applied in Task 4. Load discipline → Task 5 (in-flight dedupe) and Task 4 (`@MainActor` entry, immediate `await`). Security → Task 2 (path resolution, `.git`, symlinks), enforced in Task 4, dispatch-tested in Task 5. Client navigation, tabs, per-session state → Task 8. Changes tab, diff view, Files tab, refresh, errors → Task 9. File layout → Tasks 6, 7, 8. Testing → every task, gathered in Task 10.
+
+**Deliberate deviation from the spec, flagged for the executor.** The spec's refresh rule says "when `streamingState` transitions to `idle` while the tab is open." Task 9 implements `noteStreamingStateForChanges` as a check on each delta rather than a true edge transition, so a burst of idle deltas could re-request the list. The gateway's in-flight dedupe (Task 5) absorbs the duplicates. If that proves chatty in the browser test in Task 9 Step 6, track the previous state in a variable and fire only on the transition.
+
+**Debounce.** The spec calls for a debounced idle refresh; the dedupe set in Task 5 plus the single-request-per-idle path in Task 9 covers the same ground without a timer. If Task 9's hand-check shows repeated fetches, add a 500 ms client-side debounce around `requestChanges`.

--- a/docs/superpowers/specs/2026-09-06-remote-web-changes-and-files-design.md
+++ b/docs/superpowers/specs/2026-09-06-remote-web-changes-and-files-design.md
@@ -1,0 +1,253 @@
+# Remote Web Changes and Files Design
+
+## Context
+
+The remote web client can drive sessions but cannot inspect the code those
+sessions produce. It renders a session list grouped by repository, a transcript
+with paging, a composer with queue and steer, permission/question/elicitation
+sheets, session config, and worktree-plus-session creation. Reviewing what an
+agent actually changed requires walking back to the Mac.
+
+Comparable mobile harness clients (T3 Code) treat diff review and file browsing
+as core surfaces. Alas already owns the pieces on the Swift side: `DiffParser`,
+`FileTreeBuilder`, `ChangesTreeBuilder`, `GitIgnoreService`, `GitService`
+status/diff/tree entry points, and `RemoteWorktreeSummaryBuilder`, which already
+ships per-worktree changed-file and line counts over the wire. What is missing
+is protocol surface and client views, not git plumbing.
+
+`RemoteSessionSummary` carries a `RemoteWorktreeSummary` but no worktree id, so
+the client can name a session but not a worktree. Client navigation is
+imperative show/hide over `.view` sections with no router and no History API.
+Pure client logic is conventionally extracted into standalone scripts
+(`worktree-creation.js`, `session-ordering.js`) with node tests under
+`scripts/tests/`, while `RemoteWebAssetTests` asserts script tag order, the
+`sw.js` precache list, and `?v=` bumps.
+
+## Goals
+
+- Browse the changed files of a session's worktree, relative to its comparison
+  ref, and read a per-file diff.
+- Browse the worktree's file tree and read a file's contents.
+- Keep both surfaces read-only and available to any paired device that can
+  already see the session, without a writer lease.
+- Refresh changed files when a turn ends, and on explicit request.
+- Reuse the existing WebSocket transport, pairing, and test spine.
+
+## Non-Goals
+
+- No git mutations: no staging, discarding, committing, or pushing.
+- No terminal.
+- No turn-by-turn diff attribution, which would require per-turn tree snapshots
+  Alas does not record.
+- No syntax highlighting, client-side or server-side, in this version.
+- No split diff view. The hunk payload keeps it available later.
+- No editing of files.
+- No change to the session-list badges. They keep their current meaning
+  (`git status` counts plus a separate `commitCount`), and the Changes tab
+  labels its own comparison ref and counts so each number is legible where it
+  appears.
+
+## Transport
+
+All four features ride the existing WebSocket. `RemoteHTTPResponder` serves
+static assets only and gains no data endpoints: adding an authenticated HTTP
+path would duplicate the pairing and authorization story that
+`RemoteAccessPolicy` already solves for the socket, and the payload caps below
+keep frames far under the 16 MB `WebSocketFrame.maxPayloadLength`.
+
+Requests key off `sessionId`, not a worktree id. The server resolves
+`sessionId -> ACPSession -> worktree -> project`. This avoids widening
+`RemoteSessionSummary` and confines a device to worktrees it can already see.
+
+## Protocol
+
+Four request/response pairs are added to `RemoteClientMessage` and
+`RemoteServerMessage` in the existing hand-rolled `Codable` style, correlated by
+natural key as `listBranches` -> `branchList` already is.
+
+| Client message | Server response | Failure response | Correlation |
+| --- | --- | --- | --- |
+| `listChanges(sessionId)` | `changeList(sessionId, comparisonRef, metricsAvailable, files, truncated)` | `changeListFailed(sessionId, reason)` | `sessionId` |
+| `fileDiff(sessionId, path)` | `fileDiffResult(sessionId, path, hunks, truncated)` | `fileDiffFailed(sessionId, path, reason)` | `sessionId` + `path` |
+| `listFiles(sessionId, path?)` | `fileTree(sessionId, path?, nodes)` | `fileTreeFailed(sessionId, path?, reason)` | `sessionId` + `path` |
+| `readFile(sessionId, path)` | `fileContents(sessionId, path, text, truncated)` | `fileUnavailable(sessionId, path, reason, byteSize?)` | `sessionId` + `path` |
+
+`listFiles` with a nil `path` fetches the worktree root; a non-nil `path`
+fetches one directory's children.
+
+### Wire types
+
+Lossy projections, not the git types themselves, so the wire format stays
+independent of internal refactors:
+
+- `RemoteChangedFile`: `path`, `status`, `add`, `del`, `conflict`, `renameFrom`.
+- `RemoteDiffHunk`: `header`, `oldStart`, `newStart`, and `lines` of
+  `{ kind, oldNumber, newNumber, text }` where `kind` is `context`, `add`, or
+  `delete`.
+- `RemoteFileNode`: `name`, `path`, `kind`, `badge`, `childrenState`,
+  `isSubmodule`.
+
+### Failure reasons
+
+A single `RemoteFileAccessReason` string enum shared across the failure
+messages: `sessionUnknown`, `worktreeUnavailable`, `pathRejected`, `notFound`,
+`binary`, `tooLarge`, `gitFailed`. `gitFailed` carries a message string.
+Decoding an unrecognized reason maps to a generic case so an older client keeps
+working against a newer host.
+
+## Server
+
+### Provider methods
+
+Four methods are added to `RemoteSessionsProvider` and implemented in the
+`AppState` extension that already holds `remoteWorktreeSummary`:
+
+```swift
+func remoteChangeList(sessionId: String) async -> RemoteChangeListResult
+func remoteFileDiff(sessionId: String, path: String) async -> RemoteFileDiffResult
+func remoteFileTree(sessionId: String, path: String?) async -> RemoteFileTreeResult
+func remoteFileContents(sessionId: String, path: String) async -> RemoteFileContentsResult
+```
+
+Each resolves the session and its worktree first and returns
+`sessionUnknown` or `worktreeUnavailable` when that fails. Each is `@MainActor`
+at the entry point and immediately awaits `GitService`'s process-backed calls,
+matching `remoteWorktreeSummary`.
+
+### Git work
+
+- **Changed files vs base.** `commitsAhead(at:baseBranch:resolution:)` supplies
+  `comparisonRef`, using the same resolution `remoteWorktreeSummary` already
+  uses, so the tab and the badges agree on which base. Tracked changes come from
+  a new base-relative numstat (`git diff --numstat <ref>`); untracked entries
+  come from `status(worktreePath:)`. Results are merged per path and sorted by
+  path.
+- **Per-file diff.** A new `GitService.diff(worktreePath:againstRef:file:)`,
+  sibling to the existing `diff(worktreePath:sha:file:)` and
+  `diffAgainstHEAD(...)`, returning `ParsedDiff`. Untracked files diff against
+  `/dev/null`.
+- **File tree.** `fileTree(worktreePath:statusEntries:)` for the root and
+  `fileTreeChildren(worktreePath:path:)` for lazy expansion. Both already fold
+  in `.gitignore` visibility; nodes whose visibility is `ignored` or `excluded`
+  are filtered at the wire boundary.
+- **File read.** Bytes are read from disk under the cap below, with
+  `GitService.looksBinary` deciding the `binary` reason before any decode.
+
+### Caps
+
+Server-enforced and always reported, never silently applied:
+
+- File read: 512 KB. Over the cap returns `tooLarge` with `byteSize` so the
+  client can name the actual size.
+- Per-file diff: 2,000 lines. Beyond it hunks are truncated and `truncated` is
+  true. Binary files short-circuit to `binary` before diffing.
+- Change list: 500 files, truncated with a count.
+
+### Load discipline
+
+Requests are deduplicated per `(sessionId, path)` while one is in flight, and
+the idle-triggered refresh is debounced, so a session flipping repeatedly
+between streaming and idle cannot queue a pile of `git diff` runs. There is no
+server-side caching in this version.
+
+## Security
+
+1. Every incoming `path` is canonicalized with symlinks resolved and must
+   resolve under the resolved worktree root. Absolute paths, `..` traversal, and
+   symlinks escaping the tree return `pathRejected`.
+2. `.git` is excluded from both the tree and `readFile`. A worktree's git config
+   can hold remote URLs with embedded credentials.
+3. These operations are read-only and require no writer lease. A device that can
+   see a session can browse its diffs without taking over. This is a deliberate
+   widening relative to the drive-gated commands, and it holds only because no
+   mutation is in scope.
+
+## Client
+
+### Navigation
+
+The detail header gains a segmented control: **Chat | Changes | Files**. It
+renders only when the open session's summary has a non-null `worktree`;
+worktree-less sessions keep the current layout. Two sections join `#transcript`
+as siblings: `#changes` and `#files`. The composer and drivebar are already
+children of `#transcript` and therefore hide with the Chat tab.
+
+The subscription stays alive across tabs, so returning to Chat is instant and
+the client keeps receiving `transcriptDelta.streamingState`.
+
+List-to-detail within a tab is a second level, tracked by an explicit
+`{ tab, path }` stack that the existing `‹` button consults: diff or viewer back
+to the tab's list, then back to Sessions. No History API is introduced.
+
+Per-session state (change list, fetched diffs, expanded directories, active tab)
+is cleared in `openSession` and `showSessions` alongside `messages` and
+`messageNodes`, so switching sessions cannot show another worktree's files.
+
+### Changes tab
+
+A header line shows the comparison ref and totals (`vs origin/main · 7 files ·
++214 −31`) with a refresh button. Below it, a flat, path-sorted file list with
+the directory prefix dimmed, the basename emphasized, and the status letter plus
+± counts trailing. Flat rather than a tree: expand/collapse costs taps and buys
+little for the list sizes this serves, and `ChangesTreeBuilder` remains
+available if that proves wrong.
+
+Conflicted files carry a distinct marker. `metricsAvailable: false` renders an
+explanatory empty state rather than a misleading zero.
+
+### Diff view
+
+Tapping a file opens a full-screen unified diff for that path: hunk headers as
+sticky separators, one row per line with old and new line numbers and add/delete
+backgrounds, horizontal scroll for long lines, and a truncation footer when
+`truncated` is set.
+
+### Files tab
+
+A lazy tree. Directories render collapsed; expanding issues
+`listFiles(sessionId, path)`. `RemoteFileNode.badge` marks changed files inline
+so the two tabs cross-reference visually. Tapping a file opens the viewer:
+monospace text, line numbers, horizontal scroll, and a placeholder card for
+binary or over-cap files.
+
+### Refresh
+
+The change list is fetched when the Changes tab opens, on the explicit refresh
+control, and when `streamingState` transitions to `idle` while the tab is open.
+The last of these is entirely client-side; the server holds no per-tab state and
+gains no push machinery.
+
+### Errors
+
+Every failure response renders an inline card naming the reason. No path
+produces a silently empty list.
+
+### File layout
+
+Pure logic goes into two new scripts loaded before `app.js`:
+
+- `changes-view.js`: change-list sorting and merging, diff row model, ±
+  aggregation, truncation labels.
+- `file-browser.js`: tree node merge, lazy-children bookkeeping, path
+  formatting.
+
+DOM wiring and event handlers land in `app.js`. Each new script requires a
+script tag in `index.html`, an entry in the `sw.js` precache list, `?v=` bumps,
+and matching `RemoteWebAssetTests` assertions.
+
+## Testing
+
+- `RemoteProtocolTests`: round-trip encode/decode for all twelve new messages
+  (four client requests, eight server responses), including forward
+  compatibility for an unrecognized failure reason.
+- `RemoteSessionGatewayTests`: dispatch for each request, every failure path,
+  and path rejection cases against the existing fake provider.
+- `RemoteAppStateAccessTests`: the four new provider methods.
+- `scripts/tests/remote-web-changes` and `scripts/tests/remote-web-file-browser`:
+  node tests for the two extracted scripts.
+- `RemoteWebAssetTests`: script tags, ordering, `sw.js` precache, `?v=` bumps.
+
+## Open Questions
+
+None. Split diff, syntax highlighting, git mutations, and a terminal are
+deferred by choice and recorded as non-goals.

--- a/scripts/tests/remote-web-changes/run.sh
+++ b/scripts/tests/remote-web-changes/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+node "$(dirname "$0")/test-changes-view.js"

--- a/scripts/tests/remote-web-changes/test-changes-view.js
+++ b/scripts/tests/remote-web-changes/test-changes-view.js
@@ -1,0 +1,69 @@
+const assert = require("node:assert/strict");
+
+require("../../../Alas/Resources/RemoteWeb/changes-view.js");
+
+const view = globalThis.RemoteChangesView;
+
+{
+  const sorted = view.sortFiles([
+    { path: "src/b.txt" },
+    { path: "a.txt" },
+    { path: "src/a.txt" }
+  ]);
+  assert.deepEqual(sorted.map((f) => f.path), ["a.txt", "src/a.txt", "src/b.txt"]);
+}
+
+{
+  assert.deepEqual(view.splitPath("a.txt"), { dir: "", name: "a.txt" });
+  assert.deepEqual(view.splitPath("src/app/main.swift"), { dir: "src/app/", name: "main.swift" });
+}
+
+{
+  const summary = view.formatSummary({
+    comparisonRef: "origin/main",
+    files: [
+      { path: "a.txt", add: 12, del: 3 },
+      { path: "b.txt", add: 2, del: 0 }
+    ],
+    truncated: false
+  });
+  assert.equal(summary, "vs origin/main · 2 files · +14 −3");
+}
+
+{
+  const summary = view.formatSummary({ comparisonRef: null, files: [{ path: "a.txt", add: 1, del: 0 }], truncated: false });
+  assert.equal(summary, "1 file · +1 −0");
+}
+
+{
+  assert.equal(view.formatFileCounts({ add: 12, del: 3 }), "+12 −3");
+}
+
+{
+  const rows = view.diffRows([
+    {
+      header: "@@ -1,2 +1,3 @@",
+      oldStart: 1,
+      newStart: 1,
+      lines: [
+        { kind: "context", text: "import Foundation", oldNumber: 1, newNumber: 1 },
+        { kind: "add", text: "import Testing", oldNumber: null, newNumber: 2 }
+      ]
+    }
+  ]);
+  assert.equal(rows.length, 3);
+  assert.equal(rows[0].type, "hunk");
+  assert.equal(rows[0].text, "@@ -1,2 +1,3 @@");
+  assert.equal(rows[1].type, "line");
+  assert.equal(rows[1].kind, "context");
+  assert.equal(rows[2].kind, "add");
+  assert.equal(rows[2].newNumber, 2);
+}
+
+{
+  assert.equal(view.truncationNotice(false, "diff"), "");
+  assert.equal(view.truncationNotice(true, "diff"), "Diff truncated — open this file on the desktop to see the rest.");
+  assert.equal(view.truncationNotice(true, "files"), "File list truncated — too many changed files to show.");
+}
+
+console.log("remote-web-changes: ok");

--- a/scripts/tests/remote-web-changes/test-changes-view.js
+++ b/scripts/tests/remote-web-changes/test-changes-view.js
@@ -64,6 +64,8 @@ const view = globalThis.RemoteChangesView;
   assert.equal(view.truncationNotice(false, "diff"), "");
   assert.equal(view.truncationNotice(true, "diff"), "Diff truncated — open this file on the desktop to see the rest.");
   assert.equal(view.truncationNotice(true, "files"), "File list truncated — too many changed files to show.");
+  assert.equal(view.truncationNotice(true, "lines"), "File truncated — too many lines to show.");
+  assert.equal(view.truncationNotice(false, "lines"), "");
 }
 
 console.log("remote-web-changes: ok");

--- a/scripts/tests/remote-web-changes/test-changes-view.js
+++ b/scripts/tests/remote-web-changes/test-changes-view.js
@@ -68,4 +68,23 @@ const view = globalThis.RemoteChangesView;
   assert.equal(view.truncationNotice(false, "lines"), "");
 }
 
+{
+  // `noTrailingNewline` must round-trip through `diffRows` so a diff that
+  // only adds/removes a trailing newline doesn't render as two
+  // identical-looking lines with no visual distinction.
+  const rows = view.diffRows([
+    {
+      header: "@@ -1,1 +1,1 @@",
+      oldStart: 1,
+      newStart: 1,
+      lines: [
+        { kind: "delete", text: "old", oldNumber: 1, newNumber: null, noTrailingNewline: true },
+        { kind: "add", text: "new", oldNumber: null, newNumber: 1 }
+      ]
+    }
+  ]);
+  assert.equal(rows[1].noTrailingNewline, true);
+  assert.equal(rows[2].noTrailingNewline, false);
+}
+
 console.log("remote-web-changes: ok");

--- a/scripts/tests/remote-web-changes/test-changes-view.js
+++ b/scripts/tests/remote-web-changes/test-changes-view.js
@@ -89,4 +89,23 @@ const view = globalThis.RemoteChangesView;
   assert.equal(rows[2].noTrailingNewline, false);
 }
 
+{
+  // No hunks and no note: a genuinely empty diff (shouldn't normally
+  // happen, but must not crash or show a stray empty banner).
+  assert.equal(view.metadataOnlyNotice([], null), "");
+  assert.equal(view.metadataOnlyNotice([], undefined), "");
+
+  // No hunks, note present: a pure rename/copy/mode change — the note IS
+  // the payload.
+  assert.equal(
+    view.metadataOnlyNotice([], "Renamed from old.txt to new.txt — no content changes."),
+    "Renamed from old.txt to new.txt — no content changes."
+  );
+
+  // Hunks present alongside a note: real content changes take priority —
+  // the note would just be noise over an actual diff.
+  const hunks = [{ header: "@@ -1,1 +1,1 @@", oldStart: 1, newStart: 1, lines: [] }];
+  assert.equal(view.metadataOnlyNotice(hunks, "should not surface"), "");
+}
+
 console.log("remote-web-changes: ok");

--- a/scripts/tests/remote-web-changes/test-changes-view.js
+++ b/scripts/tests/remote-web-changes/test-changes-view.js
@@ -66,6 +66,8 @@ const view = globalThis.RemoteChangesView;
   assert.equal(view.truncationNotice(true, "files"), "File list truncated — too many changed files to show.");
   assert.equal(view.truncationNotice(true, "lines"), "File truncated — too many lines to show.");
   assert.equal(view.truncationNotice(false, "lines"), "");
+  assert.equal(view.truncationNotice(true, "directory"), "Directory truncated — too many entries to show.");
+  assert.equal(view.truncationNotice(false, "directory"), "");
 }
 
 {

--- a/scripts/tests/remote-web-file-browser/run.sh
+++ b/scripts/tests/remote-web-file-browser/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+node "$(dirname "$0")/test-file-browser.js"

--- a/scripts/tests/remote-web-file-browser/test-file-browser.js
+++ b/scripts/tests/remote-web-file-browser/test-file-browser.js
@@ -1,0 +1,54 @@
+const assert = require("node:assert/strict");
+
+require("../../../Alas/Resources/RemoteWeb/file-browser.js");
+
+const browser = globalThis.RemoteFileBrowser;
+
+function dir(name, path) {
+  return { name, path, kind: "dir", badge: null, childrenState: "notLoaded", isSubmodule: false };
+}
+
+function file(name, path, badge) {
+  return { name, path, kind: "file", badge: badge || null, childrenState: "loaded", isSubmodule: false };
+}
+
+{
+  const tree = browser.createTree();
+  tree.applyNodes(null, [file("z.txt", "z.txt"), dir("src", "src")]);
+  const rows = tree.visibleRows();
+  assert.deepEqual(rows.map((r) => r.node.path), ["src", "z.txt"]);
+  assert.deepEqual(rows.map((r) => r.depth), [0, 0]);
+  assert.equal(rows[0].expanded, false);
+}
+
+{
+  const tree = browser.createTree();
+  tree.applyNodes(null, [dir("src", "src")]);
+  assert.equal(tree.needsChildren("src"), true);
+  assert.equal(tree.toggle("src"), true);
+  assert.equal(tree.isExpanded("src"), true);
+
+  tree.applyNodes("src", [file("main.swift", "src/main.swift", "M")]);
+  assert.equal(tree.needsChildren("src"), false);
+
+  const rows = tree.visibleRows();
+  assert.deepEqual(rows.map((r) => r.node.path), ["src", "src/main.swift"]);
+  assert.deepEqual(rows.map((r) => r.depth), [0, 1]);
+  assert.equal(rows[1].node.badge, "M");
+
+  assert.equal(tree.toggle("src"), false);
+  assert.equal(tree.isExpanded("src"), false);
+  assert.deepEqual(tree.visibleRows().map((r) => r.node.path), ["src"]);
+}
+
+{
+  const tree = browser.createTree();
+  tree.applyNodes(null, [dir("a", "a")]);
+  tree.toggle("a");
+  tree.applyNodes("a", [file("x.txt", "a/x.txt")]);
+  tree.reset();
+  assert.deepEqual(tree.visibleRows(), []);
+  assert.equal(tree.isExpanded("a"), false);
+}
+
+console.log("remote-web-file-browser: ok");

--- a/scripts/tests/remote-web-file-browser/test-file-browser.js
+++ b/scripts/tests/remote-web-file-browser/test-file-browser.js
@@ -76,4 +76,32 @@ function file(name, path, badge) {
   );
 }
 
+{
+  // Regression: an expanded directory deleted or renamed by the agent must
+  // be forgotten (not just left in `expanded` forever) once a fresh
+  // listing of its PARENT reveals it's gone — otherwise a refresh keeps
+  // re-requesting a path that no longer exists, failing every time.
+  const tree = browser.createTree();
+  tree.applyNodes(null, [dir("a", "a"), dir("b", "b")]);
+  tree.toggle("a");
+  tree.applyNodes("a", [file("x.txt", "a/x.txt")]);
+  tree.toggle("b");
+  tree.applyNodes("b", [dir("c", "b/c")]);
+  tree.toggle("b/c");
+  tree.applyNodes("b/c", [file("y.txt", "b/c/y.txt")]);
+  assert.deepEqual(tree.expandedPaths().sort(), ["a", "b", "b/c"]);
+
+  // Root refresh: "a" is gone (deleted/renamed), "b" remains.
+  tree.applyNodes(null, [dir("b", "b")]);
+  assert.deepEqual(tree.expandedPaths().sort(), ["b", "b/c"]);
+  assert.equal(tree.isExpanded("a"), false);
+  assert.equal(tree.needsChildren("a"), true);   // forgotten, not just collapsed
+
+  // "b" refresh: "b/c" is gone too — forgetting it recurses into anything
+  // cached under it as well.
+  tree.applyNodes("b", []);
+  assert.deepEqual(tree.expandedPaths(), ["b"]);
+  assert.equal(tree.needsChildren("b/c"), true);
+}
+
 console.log("remote-web-file-browser: ok");

--- a/scripts/tests/remote-web-file-browser/test-file-browser.js
+++ b/scripts/tests/remote-web-file-browser/test-file-browser.js
@@ -51,4 +51,29 @@ function file(name, path, badge) {
   assert.equal(tree.isExpanded("a"), false);
 }
 
+{
+  // expandedPaths() must survive a collapsed ancestor: expand a, then a/b,
+  // then collapse a. `a/b` is no longer visible (its parent is collapsed)
+  // but is still in the expanded set, so a refresh that walks
+  // expandedPaths() (not visibleRows()) must still request it — otherwise
+  // re-expanding "a" later would render "a/b" from stale cached children.
+  const tree = browser.createTree();
+  tree.applyNodes(null, [dir("a", "a")]);
+  tree.toggle("a");
+  tree.applyNodes("a", [dir("b", "a/b")]);
+  tree.toggle("a/b");
+  tree.applyNodes("a/b", [file("x.txt", "a/b/x.txt")]);
+  assert.deepEqual(tree.expandedPaths().sort(), ["a", "a/b"]);
+
+  tree.toggle("a");   // collapse a; a/b's OWN expanded state is untouched
+  assert.deepEqual(tree.visibleRows().map((r) => r.node.path), ["a"]);
+  assert.deepEqual(tree.expandedPaths().sort(), ["a/b"]);
+
+  tree.toggle("a");   // re-expand a; a/b reappears, still expanded
+  assert.deepEqual(
+    tree.visibleRows().map((r) => r.node.path),
+    ["a", "a/b", "a/b/x.txt"]
+  );
+}
+
 console.log("remote-web-file-browser: ok");


### PR DESCRIPTION
## Summary

- Adds read-only **Changes** and **Files** tabs to the remote web client, so a paired phone/browser can review a session's diff and browse its worktree without a Mac.
- Rides the existing WebSocket protocol; no git mutation, no writer-lease requirement — seeing a session is enough to browse its code.
- Ships with a design spec and implementation plan under `docs/superpowers/`.

### What changed

- **Protocol** (`RemoteProtocol.swift`, `RemoteMessageWireJSON.swift`): four new client verbs (`listChanges`, `fileDiff`, `listFiles`, `readFile`) and their server responses/failures, plus lossy wire projections (`RemoteChangedFile`, `RemoteDiffHunk`, `RemoteFileNode`) independent of internal git types.
- **Git** (`GitService+RemoteChanges.swift`): base-relative changed-file listing and per-file diff against a comparison ref (commits + uncommitted work, not just the working tree).
- **Path safety & caps** (`RemoteWorktreeFileAccess.swift`): validates every remote-supplied path against traversal, absolute paths, and `.git` exclusion (including symlink-alias and case-variation bypasses); enforces the 512KB file / 2,000-line diff / 500-file caps; the heavy file read runs off the main actor.
- **Provider + gateway** (`AppState.swift`, `RemoteSessionGateway.swift`): four read-only provider methods and their dispatch, with in-flight deduplication per `(verb, sessionId, path)`.
- **Client** (`app.js`, `changes-view.js`, `file-browser.js`, markup/CSS): a Chat | Changes | Files tab strip, a flat sorted change list with status/± counts, a unified diff viewer, and a lazy file tree with a plain-text viewer.

### Reviewer notes

- This is the first feature giving remote devices filesystem read access, so path/git-ignore handling got extra scrutiny across several review rounds: gitignored files (`.env`, `*.pem`, etc.) are blocked from both the file tree and direct read/diff, with the ignore check normalized against the same trimmed path used to resolve the file (a whitespace-padded path bypass and a `--no-index` over-block regression were both caught and fixed in review — see `23775c9b`/final commit history).
- Two client-side state bugs were only visible at the whole-branch level, not from individual task diffs: switching tabs while a diff/file view was open could permanently blank a tab, and switching sessions didn't clear rendered DOM (stale content/error banners could leak across sessions). Both are fixed (`c77aae89` equivalent, folded into this branch's history).
- No syntax highlighting, no split-diff view, no editing, no git actions, no terminal — deliberate non-goals for this version, recorded in the spec.

### Testing

- 277 new/updated Swift tests across `RemoteProtocolTests`, `RemoteWorktreeFileAccessTests`, `GitServiceRemoteChangesTests`, `RemoteAppStateAccessTests`, `RemoteSessionGatewayTests`, `RemoteWebAssetTests`, `RemoteServerIntegrationTests` — all passing.
- 2 new Node test suites for the client-side logic modules (`changes-view.js`, `file-browser.js`), plus the existing remote-web suites — all passing.
- Full `xcodebuild build` clean.