### PR TITLE
feat(changes): add commit and publish workflow

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -581,6 +581,7 @@
 		599A6D9A3A1CCF1F618146C8 /* LegacyHookSweepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */; };
 		59AF95D3DFDFE7736051EF4A /* DiffReviewModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A172B476A5BF7E4016431E6A /* DiffReviewModelsTests.swift */; };
 		59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */; };
+		59B17D350C99DE91889B1A90 /* CommitPublishLiveOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082F9EE37D7B3CD585F1382C /* CommitPublishLiveOperationsTests.swift */; };
 		59EFDD354514B21BBA4206AD /* AiSplitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359D6646D12B66B70B5BB43 /* AiSplitButton.swift */; };
 		59F07BEDA39E5266B33DC47A /* ACPOrchestrationPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD014AF7EB850F639BE7FC4 /* ACPOrchestrationPersistence.swift */; };
 		59F39BAAD57023F090AEDA4F /* ACPImageStagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53358B7D4D68BE2471187D4 /* ACPImageStagingTests.swift */; };
@@ -1667,6 +1668,7 @@
 		07A17183B064CAB5EB5D5C11 /* ReviewRequestPromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestPromptEditorWindow.swift; sourceTree = "<group>"; };
 		07BC4D03723CEB1B6C2F9D15 /* TabActivityIconTintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityIconTintTests.swift; sourceTree = "<group>"; };
 		07BD2664AF3A3B7665A1382A /* MermaidDiagramBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidDiagramBlockView.swift; sourceTree = "<group>"; };
+		082F9EE37D7B3CD585F1382C /* CommitPublishLiveOperationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPublishLiveOperationsTests.swift; sourceTree = "<group>"; };
 		08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransportTests.swift; sourceTree = "<group>"; };
 		08C66CE5C7DDA561C0970A50 /* ACPWorktreeSessionBootstrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPWorktreeSessionBootstrapperTests.swift; sourceTree = "<group>"; };
 		08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCLIRoutingTests.swift; sourceTree = "<group>"; };
@@ -5569,6 +5571,7 @@
 		E53B7655C8A8FB0CEC069C7B /* Center */ = {
 			isa = PBXGroup;
 			children = (
+				082F9EE37D7B3CD585F1382C /* CommitPublishLiveOperationsTests.swift */,
 				ADC9DC3DFC2DB5006B624937 /* CommitPublishModelsTests.swift */,
 				FB4F9A895080F7AF8E0F0C40 /* CommitPublishWorkflowTests.swift */,
 				A5F05845D656B4B93B09AF5C /* GGSplitTabsManagerTests.swift */,
@@ -7235,6 +7238,7 @@
 				F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */,
 				7D087329E7B873B1E7A1CE89 /* CommitMessageEditorViewTests.swift in Sources */,
 				AE179E24A9E308150D1FD1D5 /* CommitPromptStatusTests.swift in Sources */,
+				59B17D350C99DE91889B1A90 /* CommitPublishLiveOperationsTests.swift in Sources */,
 				BA5D8E327F37D4C84CC80F95 /* CommitPublishModelsTests.swift in Sources */,
 				1E538F29F561E8A1DABAE2BD /* CommitPublishWorkflowTests.swift in Sources */,
 				C3B1121E68B4F36F1540C2E1 /* CommitReviewLoaderTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 		1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */; };
 		1DD03B5760B7FCDF5E1B13A2 /* ACPTranscriptRowSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC94CFEB59F22E028DA462F /* ACPTranscriptRowSpec.swift */; };
 		1DF096E0925EFA91B9033642 /* AppConfigChangesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333EA07C2BCA5E18F55E2613 /* AppConfigChangesTests.swift */; };
+		1E538F29F561E8A1DABAE2BD /* CommitPublishWorkflowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB4F9A895080F7AF8E0F0C40 /* CommitPublishWorkflowTests.swift */; };
 		1E5EA96E9798649521CE1427 /* ACPAdapterInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAFB40F5FACBC726C7E4172 /* ACPAdapterInstaller.swift */; };
 		1E775E7F3C9F47C676C61B09 /* SwiftTreeSitter in Frameworks */ = {isa = PBXBuildFile; productRef = F1A519F1F3F2B01C1D2E13A7 /* SwiftTreeSitter */; };
 		1E822C74947023E654F3F50E /* TrackedRevisionTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D1CCD3078AD3C2A24E5E23 /* TrackedRevisionTarget.swift */; };
@@ -873,6 +874,7 @@
 		8D43C0AEB98BC9F3F5A08CC5 /* PendingReviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43F393A27EF521D4A73B050 /* PendingReviewTests.swift */; };
 		8D5D146F9BF86EE4D058A309 /* CodeHostProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2449596651B3FE84E8E3832B /* CodeHostProviderTests.swift */; };
 		8D86580619CA83FE832ACB25 /* AppConfigHarnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A216C9D856D2A6C43964E74 /* AppConfigHarnessTests.swift */; };
+		8D9DDC3172E19530B07400F1 /* CommitPublishWorkflow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DB0DE9A36E07CA414AECFD /* CommitPublishWorkflow.swift */; };
 		8DBA8F6E781ADBD5D59EDA13 /* CompletionDocumentationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECFB48AF581F74C564ACBCF5 /* CompletionDocumentationRenderer.swift */; };
 		8DC2ADB1F7CC8D4B9667BD94 /* MermaidRenderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515AFF3BF580DA12B16CD4BE /* MermaidRenderService.swift */; };
 		8E2FB28D4C7681611BC67537 /* WorkspaceLSPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */; };
@@ -2922,6 +2924,7 @@
 		D5BAC2BE2CEAFDD462D9116F /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		D5D9C87FA802239BCCC9F4F4 /* PairedDelimiterDeadKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedDelimiterDeadKeyTests.swift; sourceTree = "<group>"; };
 		D5DAD29A75E3651CA720017D /* RemoteAccessPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteAccessPolicy.swift; sourceTree = "<group>"; };
+		D5DB0DE9A36E07CA414AECFD /* CommitPublishWorkflow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPublishWorkflow.swift; sourceTree = "<group>"; };
 		D60051A6C7BEE35773F3FBB9 /* tool-call-content-terminal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tool-call-content-terminal.json"; sourceTree = "<group>"; };
 		D6128B044F59DB08F2383F7B /* RunScriptCreationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptCreationTests.swift; sourceTree = "<group>"; };
 		D64C0B7363363C77718B446C /* CopilotInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotInstaller.swift; sourceTree = "<group>"; };
@@ -3161,6 +3164,7 @@
 		FB02326DBD7A82431A33C50F /* DraftAmendPrefillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftAmendPrefillTests.swift; sourceTree = "<group>"; };
 		FB12D651DACE6AED9923BAC3 /* RepositoryImportServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryImportServiceTests.swift; sourceTree = "<group>"; };
 		FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServerCLITests.swift; sourceTree = "<group>"; };
+		FB4F9A895080F7AF8E0F0C40 /* CommitPublishWorkflowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPublishWorkflowTests.swift; sourceTree = "<group>"; };
 		FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerTests.swift; sourceTree = "<group>"; };
 		FB73E99357B77163006FA511 /* ACPManagedAdapterDescriptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPManagedAdapterDescriptorTests.swift; sourceTree = "<group>"; };
 		FB86F9BBBDDEF3D9BB3B9F0D /* CommitPublishModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPublishModels.swift; sourceTree = "<group>"; };
@@ -5566,6 +5570,7 @@
 			isa = PBXGroup;
 			children = (
 				ADC9DC3DFC2DB5006B624937 /* CommitPublishModelsTests.swift */,
+				FB4F9A895080F7AF8E0F0C40 /* CommitPublishWorkflowTests.swift */,
 				A5F05845D656B4B93B09AF5C /* GGSplitTabsManagerTests.swift */,
 				1686C9F25D69FDDC4A4A21FF /* Diff */,
 				F49FC1F7280807BA9B8075E0 /* DiffReview */,
@@ -5612,6 +5617,7 @@
 				D65BEFA85B6671FDE505A30D /* CommitMessageEditorView.swift */,
 				45413FEBB779051893272FC7 /* CommitPrimaryAction.swift */,
 				FB86F9BBBDDEF3D9BB3B9F0D /* CommitPublishModels.swift */,
+				D5DB0DE9A36E07CA414AECFD /* CommitPublishWorkflow.swift */,
 				7A240CD3EF074300828A1214 /* CommitReviewLoader.swift */,
 				59DBB72EE97F0E906442919B /* CommitTabView.swift */,
 				71F9CE2A0C76E75E95A641AE /* DraftAmendPrefill.swift */,
@@ -6407,6 +6413,7 @@
 				C4E0EADB37C91E54DCB897AB /* CommitPromptEditorWindow.swift in Sources */,
 				39DE92AE4B12D2CD03655562 /* CommitPromptStatus.swift in Sources */,
 				0C8C81114DDC3629F90619B3 /* CommitPublishModels.swift in Sources */,
+				8D9DDC3172E19530B07400F1 /* CommitPublishWorkflow.swift in Sources */,
 				F72AFDC819B805B3F1FFFB9A /* CommitReviewLoader.swift in Sources */,
 				11315A703B2F9C4CBB3CABD3 /* CommitRow.swift in Sources */,
 				BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */,
@@ -7229,6 +7236,7 @@
 				7D087329E7B873B1E7A1CE89 /* CommitMessageEditorViewTests.swift in Sources */,
 				AE179E24A9E308150D1FD1D5 /* CommitPromptStatusTests.swift in Sources */,
 				BA5D8E327F37D4C84CC80F95 /* CommitPublishModelsTests.swift in Sources */,
+				1E538F29F561E8A1DABAE2BD /* CommitPublishWorkflowTests.swift in Sources */,
 				C3B1121E68B4F36F1540C2E1 /* CommitReviewLoaderTests.swift in Sources */,
 				B35BD3304D3A9EC5BABBC56E /* CommitRowTests.swift in Sources */,
 				363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */; };
 		0C74DD1581313ABE6DA6F6D9 /* MermaidDiagramBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07BD2664AF3A3B7665A1382A /* MermaidDiagramBlockView.swift */; };
 		0C7A044AC34BF225A4149556 /* RemoteTerminalLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E25D0520B813E8AC9A7174 /* RemoteTerminalLaunchTests.swift */; };
+		0C8C81114DDC3629F90619B3 /* CommitPublishModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB86F9BBBDDEF3D9BB3B9F0D /* CommitPublishModels.swift */; };
 		0CDC1232955139B230B6600C /* ReviewDraftCommentAgentModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7344582814CCAF81B0E354 /* ReviewDraftCommentAgentModelTests.swift */; };
 		0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */; };
 		0D17211026C6790B96CC6578 /* CopyFeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */; };
@@ -1149,6 +1150,7 @@
 		B9D15679A5E813254E1DDCB6 /* ProviderReviewMutationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0AE27D70E34430C71AAF84 /* ProviderReviewMutationController.swift */; };
 		B9F3258E4AE2DB1E7481690A /* SubprocessRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E06BA06E4A620EEE773E1672 /* SubprocessRunner.swift */; };
 		B9F75C605157BA01FD10DEE5 /* AppKitDiffRowSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E9E696C1C8F5817524752F /* AppKitDiffRowSpec.swift */; };
+		BA5D8E327F37D4C84CC80F95 /* CommitPublishModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADC9DC3DFC2DB5006B624937 /* CommitPublishModelsTests.swift */; };
 		BACDEEE3791E66405294B328 /* ACPFirstRunConnectingPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6EDDD4D22267C26B496A6FF /* ACPFirstRunConnectingPolicyTests.swift */; };
 		BAE4D422FC3950E61FEE1D15 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
 		BAE6B1D93387807ADD7ED0CC /* ACPImageThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E1462C85D0E49127BCED81 /* ACPImageThumbnail.swift */; };
@@ -2656,6 +2658,7 @@
 		AD920E9E496F1DC3BB894B8B /* DiffPaneLSPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneLSPTests.swift; sourceTree = "<group>"; };
 		ADACDD363C5E4637A3113EFB /* RangeReviewLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeReviewLoaderTests.swift; sourceTree = "<group>"; };
 		ADC27B340A795F13EA4E0765 /* ReviewSessionLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionLoaderTests.swift; sourceTree = "<group>"; };
+		ADC9DC3DFC2DB5006B624937 /* CommitPublishModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPublishModelsTests.swift; sourceTree = "<group>"; };
 		AE0235A58C8825D42F1C406C /* ACPDelegatedSessionsPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDelegatedSessionsPolicyTests.swift; sourceTree = "<group>"; };
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
 		AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRecoveryPill.swift; sourceTree = "<group>"; };
@@ -3160,6 +3163,7 @@
 		FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServerCLITests.swift; sourceTree = "<group>"; };
 		FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerTests.swift; sourceTree = "<group>"; };
 		FB73E99357B77163006FA511 /* ACPManagedAdapterDescriptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPManagedAdapterDescriptorTests.swift; sourceTree = "<group>"; };
+		FB86F9BBBDDEF3D9BB3B9F0D /* CommitPublishModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPublishModels.swift; sourceTree = "<group>"; };
 		FB9E78C70091168556C9669B /* ReviewChangesTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesTabViewTests.swift; sourceTree = "<group>"; };
 		FBB8BF6C61840B9F972ABACC /* RemoteFileStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileStats.swift; sourceTree = "<group>"; };
 		FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextView.swift; sourceTree = "<group>"; };
@@ -5561,6 +5565,7 @@
 		E53B7655C8A8FB0CEC069C7B /* Center */ = {
 			isa = PBXGroup;
 			children = (
+				ADC9DC3DFC2DB5006B624937 /* CommitPublishModelsTests.swift */,
 				A5F05845D656B4B93B09AF5C /* GGSplitTabsManagerTests.swift */,
 				1686C9F25D69FDDC4A4A21FF /* Diff */,
 				F49FC1F7280807BA9B8075E0 /* DiffReview */,
@@ -5606,6 +5611,7 @@
 				D02E429B37288215EBC89571 /* CommitHeaderView.swift */,
 				D65BEFA85B6671FDE505A30D /* CommitMessageEditorView.swift */,
 				45413FEBB779051893272FC7 /* CommitPrimaryAction.swift */,
+				FB86F9BBBDDEF3D9BB3B9F0D /* CommitPublishModels.swift */,
 				7A240CD3EF074300828A1214 /* CommitReviewLoader.swift */,
 				59DBB72EE97F0E906442919B /* CommitTabView.swift */,
 				71F9CE2A0C76E75E95A641AE /* DraftAmendPrefill.swift */,
@@ -6400,6 +6406,7 @@
 				A5F5FBA73F2E50F7FC86E960 /* CommitPrimaryAction.swift in Sources */,
 				C4E0EADB37C91E54DCB897AB /* CommitPromptEditorWindow.swift in Sources */,
 				39DE92AE4B12D2CD03655562 /* CommitPromptStatus.swift in Sources */,
+				0C8C81114DDC3629F90619B3 /* CommitPublishModels.swift in Sources */,
 				F72AFDC819B805B3F1FFFB9A /* CommitReviewLoader.swift in Sources */,
 				11315A703B2F9C4CBB3CABD3 /* CommitRow.swift in Sources */,
 				BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */,
@@ -7221,6 +7228,7 @@
 				F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */,
 				7D087329E7B873B1E7A1CE89 /* CommitMessageEditorViewTests.swift in Sources */,
 				AE179E24A9E308150D1FD1D5 /* CommitPromptStatusTests.swift in Sources */,
+				BA5D8E327F37D4C84CC80F95 /* CommitPublishModelsTests.swift in Sources */,
 				C3B1121E68B4F36F1540C2E1 /* CommitReviewLoaderTests.swift in Sources */,
 				B35BD3304D3A9EC5BABBC56E /* CommitRowTests.swift in Sources */,
 				363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -71,7 +71,7 @@ final class AppState {
         if let _tabs { return _tabs }
         let manager = TabsManager(lsp: lsp)
         manager.onCommitPublishCompletion = { [weak self] worktreeId, tabId in
-            self?.closedTabHistory.purgeCompletedCommitPublishDraft(worktreeID: worktreeId, tabID: tabId)
+            self?.closedTabHistory.purgeCommitPublishDraft(worktreeID: worktreeId, tabID: tabId)
         }
         _tabs = manager
         return manager

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -70,6 +70,9 @@ final class AppState {
     var tabs: TabsManager {
         if let _tabs { return _tabs }
         let manager = TabsManager(lsp: lsp)
+        manager.onCommitPublishCompletion = { [weak self] worktreeId, tabId in
+            self?.closedTabHistory.purgeCompletedCommitPublishDraft(worktreeID: worktreeId, tabID: tabId)
+        }
         _tabs = manager
         return manager
     }

--- a/Alas/Sources/Center/ClosedTabHistory.swift
+++ b/Alas/Sources/Center/ClosedTabHistory.swift
@@ -84,6 +84,17 @@ struct ClosedTabHistory: Equatable {
     mutating func purge(worktreeID: String) {
         entries.removeAll { $0.snapshot.worktreeID == worktreeID }
     }
+
+    mutating func purgeCompletedCommitPublishDraft(worktreeID: String, tabID: TabID) {
+        entries.removeAll { entry in
+            guard case .worktree(let entryWorktreeID, .draftCommit(let state)) = entry.snapshot else {
+                return false
+            }
+            return entryWorktreeID == worktreeID
+                && state.id == tabID
+                && state.publishCheckpoint != nil
+        }
+    }
 }
 
 extension PaneNode {

--- a/Alas/Sources/Center/ClosedTabHistory.swift
+++ b/Alas/Sources/Center/ClosedTabHistory.swift
@@ -85,14 +85,13 @@ struct ClosedTabHistory: Equatable {
         entries.removeAll { $0.snapshot.worktreeID == worktreeID }
     }
 
-    mutating func purgeCompletedCommitPublishDraft(worktreeID: String, tabID: TabID) {
+    mutating func purgeCommitPublishDraft(worktreeID: String, tabID: TabID) {
         entries.removeAll { entry in
             guard case .worktree(let entryWorktreeID, .draftCommit(let state)) = entry.snapshot else {
                 return false
             }
             return entryWorktreeID == worktreeID
                 && state.id == tabID
-                && state.publishCheckpoint != nil
         }
     }
 }

--- a/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
+++ b/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
@@ -11,6 +11,8 @@ struct CommitMessageEditorView: View {
     let availableAgents: [AgentDefinition]
     let onGenerate: () -> Void
     let primaryAction: CommitPrimaryAction
+    var alternateAction: CommitPrimaryAction? = nil
+    var preferredActionPosition: CommitComposerActionPosition = .leading
     var iconName: String = "commit"
     var editorDisabled: Bool = false
     var onDismissError: () -> Void = {}
@@ -20,15 +22,15 @@ struct CommitMessageEditorView: View {
     @State private var focused: Field?
     private enum Field: Hashable { case subject, body }
 
-    private var canRunPrimary: Bool {
-        primaryAction.isEnabled && !busy
+    private func canRun(_ action: CommitPrimaryAction) -> Bool {
+        action.isEnabled && !busy
     }
 
-    private var displayedLabel: String {
-        if primaryAction.showSavedState, let saved = primaryAction.savedLabel {
+    private func displayedLabel(for action: CommitPrimaryAction) -> String {
+        if action.showSavedState, let saved = action.savedLabel {
             return saved
         }
-        return primaryAction.label
+        return action.label
     }
 
     var body: some View {
@@ -81,31 +83,70 @@ struct CommitMessageEditorView: View {
                 busy: busy,
                 onGenerate: onGenerate
             )
-            let effectiveShortcut = primaryAction.keyboardShortcut
-                ?? KeyboardShortcut(.return, modifiers: .command)
-            Button(action: primaryAction.handler) {
-                HStack(spacing: 8) {
-                    Text(displayedLabel)
-                        .font(.system(size: 12, weight: .semibold))
-                    HStack(spacing: 2) {
-                        ForEach(Array(kbdGlyphs(for: effectiveShortcut).enumerated()), id: \.offset) { _, g in
-                            kbdBadge(g)
-                        }
+            actionButton(primaryAction, position: .leading)
+            if let alternateAction {
+                actionButton(alternateAction, position: .trailing)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func actionButton(
+        _ action: CommitPrimaryAction,
+        position: CommitComposerActionPosition
+    ) -> some View {
+        let shortcut = shortcut(for: position)
+        let isPreferred = alternateAction == nil || position == preferredActionPosition
+        let enabled = canRun(action)
+        Button(action: action.handler) {
+            HStack(spacing: 8) {
+                Text(displayedLabel(for: action))
+                    .font(.system(size: 12, weight: .semibold))
+                HStack(spacing: 2) {
+                    ForEach(Array(kbdGlyphs(for: shortcut).enumerated()), id: \.offset) { _, glyph in
+                        kbdBadge(glyph)
                     }
                 }
-                .padding(.leading, 14).padding(.trailing, 12)
-                .frame(height: 28)
-                .foregroundColor(.white)
-                .background(canRunPrimary ? theme.color("accent") : theme.color("accent").opacity(0.4))
-                .clipShape(RoundedRectangle(cornerRadius: 6))
             }
-            .buttonStyle(.plain)
-            .disabled(!canRunPrimary)
-            // Default to ⌘⏎ so existing-commit callers (which pass
-            // nil) keep their save shortcut. Draft callers pass their
-            // own value (which is also ⌘⏎ via shortcut settings).
-            .keyboardShortcut(effectiveShortcut)
+            .padding(.leading, 14)
+            .padding(.trailing, 12)
+            .frame(height: 28)
+            .foregroundColor(isPreferred ? .white : theme.color("fg"))
+            .background(buttonBackground(isPreferred: isPreferred, enabled: enabled))
+            .overlay {
+                if !isPreferred {
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(theme.color("line"), lineWidth: 0.5)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 6))
         }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+        .keyboardShortcut(shortcut)
+    }
+
+    private func buttonBackground(isPreferred: Bool, enabled: Bool) -> Color {
+        if isPreferred {
+            return enabled ? theme.color("accent") : theme.color("accent").opacity(0.4)
+        }
+        return enabled ? theme.color("field-bg") : theme.color("field-bg").opacity(0.6)
+    }
+
+    private func shortcut(for position: CommitComposerActionPosition) -> KeyboardShortcut {
+        let base = primaryAction.keyboardShortcut
+            ?? KeyboardShortcut(.return, modifiers: .command)
+        guard alternateAction != nil, position != preferredActionPosition else {
+            return base
+        }
+
+        var modifiers = base.modifiers
+        if modifiers.contains(.shift) {
+            modifiers.remove(.shift)
+        } else {
+            modifiers.insert(.shift)
+        }
+        return KeyboardShortcut(base.key, modifiers: modifiers)
     }
 
     private var subjectField: some View {

--- a/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
+++ b/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
@@ -97,6 +97,7 @@ struct CommitMessageEditorView: View {
     ) -> some View {
         let shortcut = shortcut(for: position)
         let isPreferred = alternateAction == nil || position == preferredActionPosition
+        let emphasis: CommitComposerActionEmphasis = isPreferred ? .preferred : .subtle
         let enabled = canRun(action)
         Button(action: action.handler) {
             HStack(spacing: 8) {
@@ -104,7 +105,7 @@ struct CommitMessageEditorView: View {
                     .font(.system(size: 12, weight: .semibold))
                 HStack(spacing: 2) {
                     ForEach(Array(kbdGlyphs(for: shortcut).enumerated()), id: \.offset) { _, glyph in
-                        kbdBadge(glyph)
+                        kbdBadge(glyph, emphasis: emphasis)
                     }
                 }
             }
@@ -135,18 +136,15 @@ struct CommitMessageEditorView: View {
 
     private func shortcut(for position: CommitComposerActionPosition) -> KeyboardShortcut {
         let base = primaryAction.keyboardShortcut
-            ?? KeyboardShortcut(.return, modifiers: .command)
-        guard alternateAction != nil, position != preferredActionPosition else {
-            return base
+            .flatMap { ShortcutBinding(keyboardShortcut: $0) }
+            ?? ShortcutBinding(key: "return", modifiers: [.command])
+        let preferred = alternateAction == nil ? CommitComposerActionPosition.leading : preferredActionPosition
+        let binding = CommitComposerActionPair.shortcuts(preferred: preferred, base: base)
+            .shortcut(at: position)
+        if let shortcut = binding.asKeyboardShortcut() {
+            return shortcut
         }
-
-        var modifiers = base.modifiers
-        if modifiers.contains(.shift) {
-            modifiers.remove(.shift)
-        } else {
-            modifiers.insert(.shift)
-        }
-        return KeyboardShortcut(base.key, modifiers: modifiers)
+        return KeyboardShortcut(.return, modifiers: .command)
     }
 
     private var subjectField: some View {
@@ -259,13 +257,22 @@ struct CommitMessageEditorView: View {
     }
 
     @ViewBuilder
-    private func kbdBadge(_ text: String) -> some View {
+    private func kbdBadge(_ text: String, emphasis: CommitComposerActionEmphasis) -> some View {
+        let style = emphasis.badgeStyle
         Text(text)
             .font(.system(size: 9.5, weight: .semibold))
             .frame(minWidth: 14, minHeight: 14)
             .padding(.horizontal, 3)
-            .background(Color.black.opacity(0.25))
-            .foregroundColor(.white.opacity(0.85))
+            .background(badgeColor(style.background).opacity(style.backgroundOpacity))
+            .foregroundColor(badgeColor(style.foreground).opacity(style.foregroundOpacity))
             .clipShape(RoundedRectangle(cornerRadius: 2))
+    }
+
+    private func badgeColor(_ color: CommitComposerActionBadgeColor) -> Color {
+        switch color {
+        case .systemWhite: return .white
+        case .systemBlack: return .black
+        case .theme(let token): return theme.color(token)
+        }
     }
 }

--- a/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
+++ b/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
@@ -126,6 +126,8 @@ struct CommitMessageEditorView: View {
         .buttonStyle(.plain)
         .disabled(!enabled)
         .keyboardShortcut(shortcut)
+        .help(action.help ?? displayedLabel(for: action))
+        .accessibilityIdentifier(action.accessibilityIdentifier ?? "commit-composer-\(position == .leading ? "primary" : "alternate")")
     }
 
     private func buttonBackground(isPreferred: Bool, enabled: Bool) -> Color {

--- a/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
+++ b/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
@@ -83,6 +83,7 @@ struct CommitMessageEditorView: View {
                 busy: busy,
                 onGenerate: onGenerate
             )
+            .disabled(editorDisabled)
             actionButton(primaryAction, position: .leading)
             if let alternateAction {
                 actionButton(alternateAction, position: .trailing)

--- a/Alas/Sources/Center/Commit/CommitPrimaryAction.swift
+++ b/Alas/Sources/Center/Commit/CommitPrimaryAction.swift
@@ -6,6 +6,43 @@ enum CommitComposerActionPosition: Sendable {
     case trailing
 }
 
+enum CommitComposerActionBadgeColor: Equatable, Sendable {
+    case systemWhite
+    case systemBlack
+    case theme(String)
+}
+
+struct CommitComposerActionBadgeStyle: Equatable, Sendable {
+    let foreground: CommitComposerActionBadgeColor
+    let foregroundOpacity: Double
+    let background: CommitComposerActionBadgeColor
+    let backgroundOpacity: Double
+}
+
+enum CommitComposerActionEmphasis: Sendable {
+    case preferred
+    case subtle
+
+    var badgeStyle: CommitComposerActionBadgeStyle {
+        switch self {
+        case .preferred:
+            .init(
+                foreground: .systemWhite,
+                foregroundOpacity: 0.85,
+                background: .systemBlack,
+                backgroundOpacity: 0.25
+            )
+        case .subtle:
+            .init(
+                foreground: .theme("fg"),
+                foregroundOpacity: 1,
+                background: .theme("fg"),
+                backgroundOpacity: 0.12
+            )
+        }
+    }
+}
+
 struct CommitComposerActionPair: Equatable, Sendable {
     let leading: ShortcutBinding
     let trailing: ShortcutBinding
@@ -19,6 +56,13 @@ struct CommitComposerActionPair: Equatable, Sendable {
             Self(leading: base, trailing: base.togglingShift())
         case .trailing:
             Self(leading: base.togglingShift(), trailing: base)
+        }
+    }
+
+    func shortcut(at position: CommitComposerActionPosition) -> ShortcutBinding {
+        switch position {
+        case .leading: leading
+        case .trailing: trailing
         }
     }
 }

--- a/Alas/Sources/Center/Commit/CommitPrimaryAction.swift
+++ b/Alas/Sources/Center/Commit/CommitPrimaryAction.swift
@@ -77,6 +77,8 @@ struct CommitPrimaryAction {
     let showSavedState: Bool
     /// Optional keyboard shortcut applied to the primary action button.
     let keyboardShortcut: KeyboardShortcut?
+    let help: String?
+    let accessibilityIdentifier: String?
     let handler: () -> Void
 
     init(
@@ -85,6 +87,8 @@ struct CommitPrimaryAction {
         isEnabled: Bool,
         showSavedState: Bool = false,
         keyboardShortcut: KeyboardShortcut? = nil,
+        help: String? = nil,
+        accessibilityIdentifier: String? = nil,
         handler: @escaping () -> Void
     ) {
         self.label = label
@@ -92,6 +96,8 @@ struct CommitPrimaryAction {
         self.isEnabled = isEnabled
         self.showSavedState = showSavedState
         self.keyboardShortcut = keyboardShortcut
+        self.help = help
+        self.accessibilityIdentifier = accessibilityIdentifier
         self.handler = handler
     }
 }

--- a/Alas/Sources/Center/Commit/CommitPrimaryAction.swift
+++ b/Alas/Sources/Center/Commit/CommitPrimaryAction.swift
@@ -1,6 +1,28 @@
 import Foundation
 import SwiftUI
 
+enum CommitComposerActionPosition: Sendable {
+    case leading
+    case trailing
+}
+
+struct CommitComposerActionPair: Equatable, Sendable {
+    let leading: ShortcutBinding
+    let trailing: ShortcutBinding
+
+    static func shortcuts(
+        preferred: CommitComposerActionPosition,
+        base: ShortcutBinding
+    ) -> Self {
+        switch preferred {
+        case .leading:
+            Self(leading: base, trailing: base.togglingShift())
+        case .trailing:
+            Self(leading: base.togglingShift(), trailing: base)
+        }
+    }
+}
+
 struct CommitPrimaryAction {
     let label: String
     let savedLabel: String?     // shown when showSavedState is true (and non-nil)

--- a/Alas/Sources/Center/Commit/CommitPublishModels.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishModels.swift
@@ -53,8 +53,13 @@ struct CommitPublishAvailability: Equatable, Sendable {
     let detail: String
     let disabledReason: String?
     let showsDraftToggle: Bool
+    var reviewRequestLabel: String = "PR"
 
     var isEnabled: Bool { disabledReason == nil }
+
+    static func gg(disabledReason: String? = nil) -> Self {
+        Self(label: "Commit & sync", detail: "Sync stack", disabledReason: disabledReason, showsDraftToggle: false)
+    }
 
     static func review(
         snapshot: ReviewLoopSnapshot?,
@@ -84,7 +89,8 @@ struct CommitPublishAvailability: Equatable, Sendable {
         } else {
             reason = "Wait for review state to load."
         }
-        return Self(label: label, detail: detail, disabledReason: reason, showsDraftToggle: !hasRequest)
+        return Self(label: label, detail: detail, disabledReason: reason, showsDraftToggle: !hasRequest,
+            reviewRequestLabel: remote.kind.reviewRequestLabel)
     }
 
     private static func reviewDisabledReason(
@@ -113,6 +119,77 @@ struct CommitPublishAvailability: Equatable, Sendable {
             return "Creating a \(remote.kind.reviewRequestLabel) is unavailable."
         }
         return nil
+    }
+}
+
+struct CommitPublishPresentation: Sendable {
+    struct Action: Equatable, Sendable {
+        let label: String
+        let disabledReason: String?
+        let detail: String
+
+        var isEnabled: Bool { disabledReason == nil }
+        var help: String { disabledReason ?? detail }
+    }
+
+    let commit: Action
+    let publish: Action?
+    let preferredActionPosition: CommitComposerActionPosition
+    let activityText: String?
+    let draftToggleLabel: String?
+    let draftToggleHelp: String
+    let draftToggleEnabled: Bool
+    let editorDisabled: Bool
+    let mutationsDisabled: Bool
+
+    init(
+        subject: String,
+        hasStaged: Bool,
+        amend: Bool = false,
+        busy: Bool = false,
+        activity: CommitPublishActivity = .idle,
+        checkpoint: CommitPublishCheckpoint? = nil,
+        preferredAction: DraftCommitPreferredAction = .commit,
+        availability: CommitPublishAvailability? = nil
+    ) {
+        let reviewRequestLabel: String
+        if let checkpoint, case .review(let target) = checkpoint.destination {
+            reviewRequestLabel = target.provider.reviewRequestLabel
+        } else {
+            reviewRequestLabel = availability?.reviewRequestLabel ?? "PR"
+        }
+        let isBusy = busy || activity != .idle
+        activityText = activity.actionLabel(reviewRequestLabel: reviewRequestLabel)
+        editorDisabled = checkpoint != nil
+        mutationsDisabled = isBusy || editorDisabled
+        let initialDisabledReason: String?
+        if !hasStaged {
+            initialDisabledReason = "Stage changes before committing."
+        } else if subject.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            initialDisabledReason = "Enter a commit subject."
+        } else {
+            initialDisabledReason = nil
+        }
+        let busyReason = isBusy ? "Another operation is running." : nil
+        commit = Action(
+            label: activity == .committing ? "Committing..." : amend ? "Amend" : "Commit",
+            disabledReason: busyReason ?? (checkpoint != nil ? "Finish publishing this commit first." : initialDisabledReason),
+            detail: amend ? "Amend the local commit." : "Commit staged changes locally."
+        )
+        if let checkpoint {
+            let label = checkpoint.nextPhase.retryLabel(reviewRequestLabel: reviewRequestLabel)
+            publish = Action(label: activityText ?? label, disabledReason: busyReason, detail: label)
+        } else if let availability {
+            publish = Action(label: activityText ?? availability.label,
+                disabledReason: busyReason ?? availability.disabledReason ?? initialDisabledReason,
+                detail: availability.detail)
+        } else {
+            publish = nil
+        }
+        preferredActionPosition = publish != nil && (checkpoint != nil || preferredAction == .publish) ? .trailing : .leading
+        draftToggleLabel = availability?.showsDraftToggle == true ? "Draft \(reviewRequestLabel)" : nil
+        draftToggleHelp = "Create the \(reviewRequestLabel) as a draft."
+        draftToggleEnabled = draftToggleLabel != nil && !mutationsDisabled
     }
 }
 

--- a/Alas/Sources/Center/Commit/CommitPublishModels.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishModels.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+enum DraftCommitPreferredAction: String, Codable, Equatable, Sendable {
+    case commit
+    case publish
+}
+
+enum CommitPublishPhase: String, Codable, Equatable, Sendable {
+    case push
+    case createReviewRequest
+    case sync
+}
+
+struct CommitPublishReviewTarget: Codable, Equatable, Sendable {
+    let provider: CodeHostKind
+    let host: String
+    let owner: String
+    let repository: String
+    let repositorySlug: String
+    let remoteName: String
+    let webURL: URL
+    let branch: String
+    let upstreamBranch: String?
+    let headOwner: String?
+    let baseBranch: String
+    let reviewRequestExisted: Bool
+    let createAsDraft: Bool
+
+    var remote: CodeHostRemote {
+        CodeHostRemote(
+            kind: provider,
+            host: host,
+            owner: owner,
+            repository: repository,
+            remoteName: remoteName,
+            webURL: webURL
+        )
+    }
+}
+
+enum CommitPublishDestination: Codable, Equatable, Sendable {
+    case review(CommitPublishReviewTarget)
+    case gg
+}
+
+struct CommitPublishCheckpoint: Codable, Equatable, Sendable {
+    let commitSHA: String
+    let baseRef: String
+    let commitTitle: String
+    let subject: String
+    let body: String
+    let destination: CommitPublishDestination
+    var nextPhase: CommitPublishPhase
+}

--- a/Alas/Sources/Center/Commit/CommitPublishModels.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishModels.swift
@@ -279,6 +279,7 @@ struct CommitPublishReviewTarget: Codable, Equatable, Sendable {
         try GitService.assertSuccess(result, op: "Resolve push destination")
         let pushURLs = result.stdout.split(whereSeparator: \.isNewline).map(String.init)
         guard let pushURL = pushURLs.first, !pushURL.isEmpty else { throw CommitPublishWorkflowError.missingPushDestination }
+        try validatePushDestinations(pushURLs, remoteName: pushRemote, snapshotRemote: remote, local: local)
         return Self(
             provider: remote.kind, host: remote.host, owner: remote.owner, repository: remote.repository,
             repositorySlug: remote.repositorySlug, remoteName: remote.remoteName, webURL: remote.webURL,
@@ -287,6 +288,27 @@ struct CommitPublishReviewTarget: Codable, Equatable, Sendable {
             reviewRequestExisted: snapshot.reviewRequest != nil, createAsDraft: createAsDraft,
             pushURL: pushURL, pushURLs: pushURLs, pushRemoteName: pushRemote
         )
+    }
+
+    private static func validatePushDestinations(
+        _ urls: [String],
+        remoteName: String,
+        snapshotRemote: CodeHostRemote,
+        local: ReviewLoopLocalState
+    ) throws {
+        let expectedOwner = local.headRemoteOwner ?? snapshotRemote.owner
+        for url in urls {
+            guard let destination = CodeHostRemoteDetector.detect(from: [GitRemote(name: remoteName, url: url)]) else {
+                continue
+            }
+            guard destination.kind == snapshotRemote.kind,
+                  destination.host == snapshotRemote.host,
+                  destination.repository == snapshotRemote.repository,
+                  destination.owner == expectedOwner
+            else {
+                throw CommitPublishWorkflowError.pushDestinationChanged
+            }
+        }
     }
 }
 

--- a/Alas/Sources/Center/Commit/CommitPublishModels.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishModels.swift
@@ -297,6 +297,7 @@ struct CommitPublishReviewTarget: Codable, Equatable, Sendable {
         local: ReviewLoopLocalState
     ) throws {
         let expectedOwner = local.headRemoteOwner ?? snapshotRemote.owner
+        var matchedCodeHostDestination = false
         for url in urls {
             guard let destination = CodeHostRemoteDetector.detect(from: [GitRemote(name: remoteName, url: url)]) else {
                 continue
@@ -308,6 +309,10 @@ struct CommitPublishReviewTarget: Codable, Equatable, Sendable {
             else {
                 throw CommitPublishWorkflowError.pushDestinationChanged
             }
+            matchedCodeHostDestination = true
+        }
+        guard matchedCodeHostDestination else {
+            throw CommitPublishWorkflowError.pushDestinationChanged
         }
     }
 }

--- a/Alas/Sources/Center/Commit/CommitPublishModels.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishModels.swift
@@ -278,7 +278,40 @@ struct CommitPublishReviewTarget: Codable, Equatable, Sendable {
 
 enum CommitPublishDestination: Codable, Equatable, Sendable {
     case review(CommitPublishReviewTarget)
-    case gg
+    case gg(GGStackTargetIdentity? = nil)
+
+    private enum CodingKeys: String, CodingKey {
+        case review, gg
+    }
+
+    private enum AssociatedValueKeys: String, CodingKey {
+        case value = "_0"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if container.contains(.review) {
+            let review = try container.nestedContainer(keyedBy: AssociatedValueKeys.self, forKey: .review)
+            self = .review(try review.decode(CommitPublishReviewTarget.self, forKey: .value))
+        } else if container.contains(.gg) {
+            let gg = try container.nestedContainer(keyedBy: AssociatedValueKeys.self, forKey: .gg)
+            self = .gg(try gg.decodeIfPresent(GGStackTargetIdentity.self, forKey: .value))
+        } else {
+            throw DecodingError.dataCorruptedError(forKey: .review, in: container, debugDescription: "Unknown publish destination.")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .review(let target):
+            var review = container.nestedContainer(keyedBy: AssociatedValueKeys.self, forKey: .review)
+            try review.encode(target, forKey: .value)
+        case .gg(let target):
+            var gg = container.nestedContainer(keyedBy: AssociatedValueKeys.self, forKey: .gg)
+            try gg.encodeIfPresent(target, forKey: .value)
+        }
+    }
 }
 
 struct CommitPublishCheckpoint: Codable, Equatable, Sendable {

--- a/Alas/Sources/Center/Commit/CommitPublishModels.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishModels.swift
@@ -363,4 +363,42 @@ struct CommitPublishCheckpoint: Codable, Equatable, Sendable {
     let body: String
     let destination: CommitPublishDestination
     var nextPhase: CommitPublishPhase
+    var allowsGGRecoveryHeadReconciliation: Bool
+
+    init(
+        commitSHA: String,
+        baseRef: String,
+        commitTitle: String,
+        subject: String,
+        body: String,
+        destination: CommitPublishDestination,
+        nextPhase: CommitPublishPhase,
+        allowsGGRecoveryHeadReconciliation: Bool = false
+    ) {
+        self.commitSHA = commitSHA
+        self.baseRef = baseRef
+        self.commitTitle = commitTitle
+        self.subject = subject
+        self.body = body
+        self.destination = destination
+        self.nextPhase = nextPhase
+        self.allowsGGRecoveryHeadReconciliation = allowsGGRecoveryHeadReconciliation
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case commitSHA, baseRef, commitTitle, subject, body, destination, nextPhase, allowsGGRecoveryHeadReconciliation
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        commitSHA = try container.decode(String.self, forKey: .commitSHA)
+        baseRef = try container.decode(String.self, forKey: .baseRef)
+        commitTitle = try container.decode(String.self, forKey: .commitTitle)
+        subject = try container.decode(String.self, forKey: .subject)
+        body = try container.decode(String.self, forKey: .body)
+        destination = try container.decode(CommitPublishDestination.self, forKey: .destination)
+        nextPhase = try container.decode(CommitPublishPhase.self, forKey: .nextPhase)
+        allowsGGRecoveryHeadReconciliation = try container.decodeIfPresent(Bool.self,
+            forKey: .allowsGGRecoveryHeadReconciliation) ?? false
+    }
 }

--- a/Alas/Sources/Center/Commit/CommitPublishModels.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishModels.swift
@@ -125,6 +125,14 @@ enum CommitPublishPhase: String, Codable, Equatable, Sendable {
     case push
     case createReviewRequest
     case sync
+
+    func retryLabel(reviewRequestLabel: String) -> String {
+        switch self {
+        case .push: "Retry push"
+        case .createReviewRequest: "Retry create \(reviewRequestLabel)"
+        case .sync: "Retry sync"
+        }
+    }
 }
 
 struct CommitPublishReviewTarget: Codable, Equatable, Sendable {

--- a/Alas/Sources/Center/Commit/CommitPublishModels.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishModels.swift
@@ -150,7 +150,10 @@ struct CommitPublishReviewTarget: Codable, Equatable, Sendable {
     let reviewRequestExisted: Bool
     let createAsDraft: Bool
     var pushURL: String? = nil
+    var pushURLs: [String]? = nil
     var pushRemoteName: String? = nil
+
+    var capturedPushURLs: [String] { pushURLs ?? pushURL.map { [$0] } ?? [] }
 
     var remote: CodeHostRemote {
         CodeHostRemote(
@@ -174,17 +177,17 @@ struct CommitPublishReviewTarget: Codable, Equatable, Sendable {
         }
         let local = snapshot.local
         let pushRemote = local.upstreamRemoteName ?? local.headRemoteName ?? remote.remoteName
-        let result = try await runGit(["remote", "get-url", "--push", pushRemote])
+        let result = try await runGit(["remote", "get-url", "--push", "--all", pushRemote])
         try GitService.assertSuccess(result, op: "Resolve push destination")
-        let pushURL = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !pushURL.isEmpty else { throw CommitPublishWorkflowError.missingPushDestination }
+        let pushURLs = result.stdout.split(whereSeparator: \.isNewline).map(String.init)
+        guard let pushURL = pushURLs.first, !pushURL.isEmpty else { throw CommitPublishWorkflowError.missingPushDestination }
         return Self(
             provider: remote.kind, host: remote.host, owner: remote.owner, repository: remote.repository,
             repositorySlug: remote.repositorySlug, remoteName: remote.remoteName, webURL: remote.webURL,
             branch: local.branchName, upstreamBranch: local.upstreamBranchName,
             headOwner: local.headRemoteOwner, baseBranch: local.baseBranch,
             reviewRequestExisted: snapshot.reviewRequest != nil, createAsDraft: createAsDraft,
-            pushURL: pushURL, pushRemoteName: pushRemote
+            pushURL: pushURL, pushURLs: pushURLs, pushRemoteName: pushRemote
         )
     }
 }

--- a/Alas/Sources/Center/Commit/CommitPublishModels.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishModels.swift
@@ -266,9 +266,15 @@ struct CommitPublishReviewTarget: Codable, Equatable, Sendable {
         let branchResult = try await runGit(["symbolic-ref", "--short", "HEAD"])
         try GitService.assertSuccess(branchResult, op: "Resolve current branch")
         let branch = branchResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard branch == local.branchName else {
+            throw CommitPublishWorkflowError.branchMismatch(expected: local.branchName, actual: branch)
+        }
         let headResult = try await runGit(["rev-parse", "--verify", "HEAD"])
         try GitService.assertSuccess(headResult, op: "Resolve HEAD")
         let headSHA = headResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard headSHA == local.headSHA else {
+            throw CommitPublishWorkflowError.headMismatch(expected: local.headSHA, actual: headSHA)
+        }
         let result = try await runGit(["remote", "get-url", "--push", "--all", pushRemote])
         try GitService.assertSuccess(result, op: "Resolve push destination")
         let pushURLs = result.stdout.split(whereSeparator: \.isNewline).map(String.init)

--- a/Alas/Sources/Center/Commit/CommitPublishModels.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishModels.swift
@@ -221,6 +221,7 @@ struct CommitPublishReviewTarget: Codable, Equatable, Sendable {
     let remoteName: String
     let webURL: URL
     let branch: String
+    var expectedHeadSHA: String? = nil
     let upstreamBranch: String?
     let headOwner: String?
     let baseBranch: String
@@ -254,6 +255,12 @@ struct CommitPublishReviewTarget: Codable, Equatable, Sendable {
         }
         let local = snapshot.local
         let pushRemote = local.upstreamRemoteName ?? local.headRemoteName ?? remote.remoteName
+        let branchResult = try await runGit(["symbolic-ref", "--short", "HEAD"])
+        try GitService.assertSuccess(branchResult, op: "Resolve current branch")
+        let branch = branchResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        let headResult = try await runGit(["rev-parse", "--verify", "HEAD"])
+        try GitService.assertSuccess(headResult, op: "Resolve HEAD")
+        let headSHA = headResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         let result = try await runGit(["remote", "get-url", "--push", "--all", pushRemote])
         try GitService.assertSuccess(result, op: "Resolve push destination")
         let pushURLs = result.stdout.split(whereSeparator: \.isNewline).map(String.init)
@@ -261,7 +268,7 @@ struct CommitPublishReviewTarget: Codable, Equatable, Sendable {
         return Self(
             provider: remote.kind, host: remote.host, owner: remote.owner, repository: remote.repository,
             repositorySlug: remote.repositorySlug, remoteName: remote.remoteName, webURL: remote.webURL,
-            branch: local.branchName, upstreamBranch: local.upstreamBranchName,
+            branch: branch, expectedHeadSHA: headSHA, upstreamBranch: local.upstreamBranchName,
             headOwner: local.headRemoteOwner, baseBranch: local.baseBranch,
             reviewRequestExisted: snapshot.reviewRequest != nil, createAsDraft: createAsDraft,
             pushURL: pushURL, pushURLs: pushURLs, pushRemoteName: pushRemote

--- a/Alas/Sources/Center/Commit/CommitPublishModels.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishModels.swift
@@ -1,5 +1,93 @@
 import Foundation
 
+enum CommitPublishAmendProbe: Equatable, Sendable {
+    case loading
+    case notPublished
+    case published
+    case failed(String)
+
+    init(_ state: HeadPublicationState) {
+        self = state == .published ? .published : .notPublished
+    }
+
+    var disabledReason: String? {
+        switch self {
+        case .loading: "Checking whether HEAD is published."
+        case .notPublished: nil
+        case .published: "This commit is already published. Commit locally or turn off Amend before publishing."
+        case .failed(let message): message
+        }
+    }
+}
+
+struct CommitPublishAvailability: Equatable, Sendable {
+    let label: String
+    let detail: String
+    let disabledReason: String?
+    let showsDraftToggle: Bool
+
+    var isEnabled: Bool { disabledReason == nil }
+
+    static func review(
+        snapshot: ReviewLoopSnapshot?,
+        supportedRemote: CodeHostRemote? = nil,
+        isRefreshing: Bool = false,
+        currentBranch: String? = nil,
+        currentBaseBranch: String? = nil,
+        lastError: String? = nil,
+        mutationDisabledReason: String? = nil,
+        amend: Bool = false,
+        amendProbe: CommitPublishAmendProbe = .loading
+    ) -> Self? {
+        guard let remote = snapshot == nil ? supportedRemote : snapshot?.remote else { return nil }
+        let hasRequest = snapshot?.reviewRequest != nil
+        let label = hasRequest ? "Commit & push" : "Commit & \(remote.kind.reviewRequestLabel)"
+        let detail = hasRequest ? "Push to \(remote.repositorySlug)" : "Create \(remote.kind.reviewRequestLabel) in \(remote.repositorySlug)"
+        let reason: String?
+        if let mutationDisabledReason {
+            reason = mutationDisabledReason
+        } else if let lastError {
+            reason = lastError
+        } else if isRefreshing || snapshot == nil {
+            reason = "Wait for review state to load."
+        } else if let snapshot {
+            reason = reviewDisabledReason(snapshot, currentBranch: currentBranch, currentBaseBranch: currentBaseBranch)
+                ?? (amend ? amendProbe.disabledReason : nil)
+        } else {
+            reason = "Wait for review state to load."
+        }
+        return Self(label: label, detail: detail, disabledReason: reason, showsDraftToggle: !hasRequest)
+    }
+
+    private static func reviewDisabledReason(
+        _ snapshot: ReviewLoopSnapshot, currentBranch: String?, currentBaseBranch: String?
+    ) -> String? {
+        if let error = snapshot.errorMessage { return error }
+        guard let remote = snapshot.remote else { return "No supported review host." }
+        if !snapshot.providerAvailable { return "\(remote.kind.displayName) CLI missing." }
+        if !snapshot.providerAuthenticated { return "\(remote.kind.displayName) authentication required." }
+        if let currentBranch, currentBranch != snapshot.local.branchName {
+            return "Refresh review state for the current branch."
+        }
+        if let currentBaseBranch, currentBaseBranch != snapshot.local.baseBranch {
+            return "Refresh review state for the selected base."
+        }
+        let branch = currentBranch ?? snapshot.local.branchName
+        let base = currentBaseBranch ?? snapshot.local.baseBranch
+        let remotePrefix = "\(remote.remoteName)/"
+        let normalizedBase = base.hasPrefix(remotePrefix) ? String(base.dropFirst(remotePrefix.count)) : base
+        if branch.isEmpty || branch == "HEAD" { return "Checkout a branch before publishing." }
+        if branch == normalizedBase { return "Checkout a feature branch before publishing." }
+        if snapshot.local.pushState == .stale || snapshot.local.pushState == .diverged {
+            return "Remote has commits not in this branch. Pull or rebase before publishing."
+        }
+        if snapshot.reviewRequest == nil && !snapshot.providerCapabilities.canCreateReviewRequest {
+            return "Creating a \(remote.kind.reviewRequestLabel) is unavailable."
+        }
+        return nil
+    }
+}
+
 enum DraftCommitPreferredAction: String, Codable, Equatable, Sendable {
     case commit
     case publish

--- a/Alas/Sources/Center/Commit/CommitPublishModels.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishModels.swift
@@ -141,6 +141,8 @@ struct CommitPublishReviewTarget: Codable, Equatable, Sendable {
     let baseBranch: String
     let reviewRequestExisted: Bool
     let createAsDraft: Bool
+    var pushURL: String? = nil
+    var pushRemoteName: String? = nil
 
     var remote: CodeHostRemote {
         CodeHostRemote(
@@ -150,6 +152,31 @@ struct CommitPublishReviewTarget: Codable, Equatable, Sendable {
             repository: repository,
             remoteName: remoteName,
             webURL: webURL
+        )
+    }
+
+    @MainActor
+    static func capture(
+        snapshot: ReviewLoopSnapshot,
+        createAsDraft: Bool,
+        runGit: ([String]) async throws -> ProcessResult
+    ) async throws -> Self {
+        guard let remote = snapshot.remote else {
+            throw CommitPublishWorkflowError.invalidDestination(phase: .push)
+        }
+        let local = snapshot.local
+        let pushRemote = local.upstreamRemoteName ?? local.headRemoteName ?? remote.remoteName
+        let result = try await runGit(["remote", "get-url", "--push", pushRemote])
+        try GitService.assertSuccess(result, op: "Resolve push destination")
+        let pushURL = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !pushURL.isEmpty else { throw CommitPublishWorkflowError.missingPushDestination }
+        return Self(
+            provider: remote.kind, host: remote.host, owner: remote.owner, repository: remote.repository,
+            repositorySlug: remote.repositorySlug, remoteName: remote.remoteName, webURL: remote.webURL,
+            branch: local.branchName, upstreamBranch: local.upstreamBranchName,
+            headOwner: local.headRemoteOwner, baseBranch: local.baseBranch,
+            reviewRequestExisted: snapshot.reviewRequest != nil, createAsDraft: createAsDraft,
+            pushURL: pushURL, pushRemoteName: pushRemote
         )
     }
 }

--- a/Alas/Sources/Center/Commit/CommitPublishModels.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishModels.swift
@@ -1,4 +1,32 @@
 import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class CommitPublishAmendProbeLoader {
+    private var key: String?
+    private var generation = 0
+    private var state: CommitPublishAmendProbe = .loading
+
+    func result(for key: String) -> CommitPublishAmendProbe {
+        self.key == key ? state : .loading
+    }
+
+    func load(key: String, operation: () async throws -> HeadPublicationState) async {
+        generation += 1
+        let requestGeneration = generation
+        self.key = key
+        state = .loading
+        let result: CommitPublishAmendProbe
+        do {
+            result = .init(try await operation())
+        } catch {
+            result = .failed(error.localizedDescription)
+        }
+        guard !Task.isCancelled, generation == requestGeneration else { return }
+        state = result
+    }
+}
 
 enum CommitPublishAmendProbe: Equatable, Sendable {
     case loading

--- a/Alas/Sources/Center/Commit/CommitPublishModels.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishModels.swift
@@ -363,7 +363,7 @@ struct CommitPublishCheckpoint: Codable, Equatable, Sendable {
     let body: String
     let destination: CommitPublishDestination
     var nextPhase: CommitPublishPhase
-    var allowsGGRecoveryHeadReconciliation: Bool
+    var ggRecoveryOperationID: String?
 
     init(
         commitSHA: String,
@@ -373,7 +373,7 @@ struct CommitPublishCheckpoint: Codable, Equatable, Sendable {
         body: String,
         destination: CommitPublishDestination,
         nextPhase: CommitPublishPhase,
-        allowsGGRecoveryHeadReconciliation: Bool = false
+        ggRecoveryOperationID: String? = nil
     ) {
         self.commitSHA = commitSHA
         self.baseRef = baseRef
@@ -382,11 +382,11 @@ struct CommitPublishCheckpoint: Codable, Equatable, Sendable {
         self.body = body
         self.destination = destination
         self.nextPhase = nextPhase
-        self.allowsGGRecoveryHeadReconciliation = allowsGGRecoveryHeadReconciliation
+        self.ggRecoveryOperationID = ggRecoveryOperationID
     }
 
     private enum CodingKeys: String, CodingKey {
-        case commitSHA, baseRef, commitTitle, subject, body, destination, nextPhase, allowsGGRecoveryHeadReconciliation
+        case commitSHA, baseRef, commitTitle, subject, body, destination, nextPhase, ggRecoveryOperationID
     }
 
     init(from decoder: Decoder) throws {
@@ -398,7 +398,6 @@ struct CommitPublishCheckpoint: Codable, Equatable, Sendable {
         body = try container.decode(String.self, forKey: .body)
         destination = try container.decode(CommitPublishDestination.self, forKey: .destination)
         nextPhase = try container.decode(CommitPublishPhase.self, forKey: .nextPhase)
-        allowsGGRecoveryHeadReconciliation = try container.decodeIfPresent(Bool.self,
-            forKey: .allowsGGRecoveryHeadReconciliation) ?? false
+        ggRecoveryOperationID = try container.decodeIfPresent(String.self, forKey: .ggRecoveryOperationID)
     }
 }

--- a/Alas/Sources/Center/Commit/CommitPublishModels.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishModels.swift
@@ -254,7 +254,15 @@ struct CommitPublishReviewTarget: Codable, Equatable, Sendable {
             throw CommitPublishWorkflowError.invalidDestination(phase: .push)
         }
         let local = snapshot.local
-        let pushRemote = local.upstreamRemoteName ?? local.headRemoteName ?? remote.remoteName
+        let pushRemote: String
+        if let upstreamRemoteName = local.upstreamRemoteName {
+            guard local.headRemoteName == upstreamRemoteName else {
+                throw CommitPublishWorkflowError.incompatiblePushRemote
+            }
+            pushRemote = upstreamRemoteName
+        } else {
+            pushRemote = local.headRemoteName ?? remote.remoteName
+        }
         let branchResult = try await runGit(["symbolic-ref", "--short", "HEAD"])
         try GitService.assertSuccess(branchResult, op: "Resolve current branch")
         let branch = branchResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 
 struct CommitPublishCreatedCommit: Equatable, Sendable {
     let commitSHA: String
@@ -16,6 +17,78 @@ struct CommitPublishOperations {
     var createReviewRequest: (_ target: CommitPublishReviewTarget, _ subject: String, _ body: String) async throws -> URL
     var syncGG: () async throws -> Void
     var refreshAfterCompletion: () async -> Void
+
+    static func live(
+        worktreePath: URL,
+        reviewLoop: ReviewLoopState,
+        comparisonBase: String?,
+        syncGG: @escaping () async throws -> Void,
+        refreshAfterCompletion: @escaping () async -> Void,
+        runGit: (([String]) async throws -> ProcessResult)? = nil,
+        commit: ((String, String, Bool) async throws -> String)? = nil,
+        publicationState: (() async throws -> HeadPublicationState)? = nil,
+        containsCommit: ((String, String, String) async throws -> Bool)? = nil
+    ) -> Self {
+        let git = GitService()
+        let run = runGit ?? { try await Process.git($0, cwd: worktreePath) }
+        let commit = commit ?? { try await git.commit(worktreePath: worktreePath, subject: $0, body: $1, amend: $2) }
+        let publication = publicationState ?? { try await git.headPublicationState(worktreePath: worktreePath) }
+        let contains = containsCommit ?? {
+            try await git.remoteBranchContainsCommit(worktreePath: worktreePath, remote: $0, branch: $1, commitSHA: $2)
+        }
+        return Self(
+            createCommit: { subject, body, amend in
+                if amend, try await publication() == .published {
+                    throw CommitPublishWorkflowError.publishedAmend
+                }
+                let sha = try await commit(subject, body, amend)
+                let base: String
+                if let comparisonBase {
+                    base = comparisonBase
+                } else if let parent = try? await run(["rev-parse", "--verify", "\(sha)^"]), parent.exitCode == 0 {
+                    base = parent.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                } else {
+                    base = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+                }
+                return .init(commitSHA: sha, comparisonBase: base, editorTitle: "\(sha.prefix(7)) \(subject)")
+            },
+            currentHeadSHA: {
+                let result = try await run(["rev-parse", "--verify", "HEAD"])
+                try GitService.assertSuccess(result, op: "Resolve HEAD")
+                return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            },
+            remoteBranchContainsCommit: { target, sha in
+                guard let pushURL = target.pushURL else { throw CommitPublishWorkflowError.missingPushDestination }
+                return try await contains(pushURL, target.upstreamBranch ?? target.branch, sha)
+            },
+            push: { target, _ in
+                guard let pushURL = target.pushURL else { throw CommitPublishWorkflowError.missingPushDestination }
+                let remote = target.pushRemoteName ?? target.remoteName
+                let destination = try await run(["remote", "get-url", "--push", remote])
+                try GitService.assertSuccess(destination, op: "Resolve push destination")
+                guard destination.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == pushURL else {
+                    throw CommitPublishWorkflowError.pushDestinationChanged
+                }
+                let ref = target.upstreamBranch.map { "HEAD:\($0)" } ?? target.branch
+                let result = try await run(["push", "-u", remote, ref])
+                guard result.exitCode == 0 else {
+                    throw NSError(domain: "CommitPublish", code: Int(result.exitCode),
+                        userInfo: [NSLocalizedDescriptionKey: RightPaneState.reviewLoopPushFailureMessage(result)])
+                }
+            },
+            currentReviewRequestExists: { target in
+                try await reviewLoop.currentReviewRequest(remote: target.remote, branch: target.branch,
+                    headOwner: target.headOwner, baseBranch: target.baseBranch) != nil
+            },
+            createReviewRequest: { target, subject, body in
+                try await reviewLoop.createReviewRequest(remote: target.remote, branch: target.branch,
+                    headOwner: target.headOwner, baseBranch: target.baseBranch,
+                    title: subject, body: body, draft: target.createAsDraft)
+            },
+            syncGG: syncGG,
+            refreshAfterCompletion: refreshAfterCompletion
+        )
+    }
 }
 
 enum CommitPublishActivity: Equatable {
@@ -29,6 +102,9 @@ enum CommitPublishActivity: Equatable {
 enum CommitPublishWorkflowError: LocalizedError, Equatable {
     case headMismatch(expected: String, actual: String)
     case invalidDestination(phase: CommitPublishPhase)
+    case missingPushDestination
+    case pushDestinationChanged
+    case publishedAmend
 
     var errorDescription: String? {
         switch self {
@@ -36,11 +112,18 @@ enum CommitPublishWorkflowError: LocalizedError, Equatable {
             return "The current commit changed before publishing could resume."
         case .invalidDestination(let phase):
             return "The publish checkpoint cannot continue its \(phase.rawValue) phase."
+        case .missingPushDestination:
+            return "The publish checkpoint has no captured push destination."
+        case .pushDestinationChanged:
+            return "The push destination changed. Restore the captured remote URL before retrying."
+        case .publishedAmend:
+            return "This commit is already published. Commit locally or turn off Amend before publishing."
         }
     }
 }
 
 @MainActor
+@Observable
 final class CommitPublishWorkflow {
     private let operations: CommitPublishOperations
     private let onCheckpointChange: (CommitPublishCheckpoint?) -> Void

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -120,6 +120,10 @@ struct CommitPublishOperations {
     var createReviewRequest: (_ target: CommitPublishReviewTarget, _ subject: String, _ body: String) async throws -> URL
     var syncGG: (_ execution: CommitPublishSyncExecutionMarker) async throws -> Void
     var syncGGForTarget: (_ target: GGStackTargetIdentity, _ execution: CommitPublishSyncExecutionMarker) async throws -> Void = { _, _ in }
+    var currentGGRecoveryOperationID: () async throws -> String? = { nil }
+    var validateGGRecoveryHead: (_ operationID: String, _ headSHA: String) async throws -> Void = { _, _ in
+        throw GGMutationError.staleConfirmation
+    }
     var refreshAfterCompletion: () async -> Void
 
     static func live(
@@ -384,7 +388,9 @@ final class CommitPublishWorkflow {
         try Task.checkCancellation()
         var checkpoint = initialCheckpoint
         if currentHeadSHA != checkpoint.commitSHA,
+           let recoveryOperationID = checkpoint.ggRecoveryOperationID,
            let recoveredCheckpoint = checkpoint.reconcilingGGRecoveryHead(currentHeadSHA) {
+            try await operations.validateGGRecoveryHead(recoveryOperationID, currentHeadSHA)
             checkpoint = recoveredCheckpoint
             try onCheckpointChange(checkpoint)
             try Task.checkCancellation()
@@ -450,9 +456,12 @@ final class CommitPublishWorkflow {
                     }
                 } catch {
                     if syncExecution.started {
+                        let recoveryOperationID = error.isGGPausedConflict
+                            ? try await operations.currentGGRecoveryOperationID()
+                            : nil
                         try await persistPostGGSyncHeadIfNeeded(
                             &checkpoint,
-                            allowRecoveryHeadReconciliation: error.isGGPausedConflict
+                            recoveryOperationID: recoveryOperationID
                         )
                     }
                     throw error
@@ -466,7 +475,7 @@ final class CommitPublishWorkflow {
 
     private func persistPostGGSyncHeadIfNeeded(
         _ checkpoint: inout CommitPublishCheckpoint,
-        allowRecoveryHeadReconciliation: Bool = false
+        recoveryOperationID: String? = nil
     ) async throws {
         let postSyncHeadSHA = try await operations.currentHeadSHA()
         try Task.checkCancellation()
@@ -474,8 +483,8 @@ final class CommitPublishWorkflow {
         if postSyncHeadSHA != checkpoint.commitSHA {
             updatedCheckpoint = checkpoint.resolvingGGCommitSHA(postSyncHeadSHA)
         }
-        if allowRecoveryHeadReconciliation {
-            updatedCheckpoint.allowsGGRecoveryHeadReconciliation = true
+        if let recoveryOperationID {
+            updatedCheckpoint.ggRecoveryOperationID = recoveryOperationID
         }
         guard updatedCheckpoint != checkpoint else { return }
         checkpoint = updatedCheckpoint
@@ -529,11 +538,11 @@ final class CommitPublishWorkflow {
 private extension CommitPublishCheckpoint {
     func reconcilingGGRecoveryHead(_ commitSHA: String) -> Self? {
         guard nextPhase == .sync,
-              allowsGGRecoveryHeadReconciliation,
+              ggRecoveryOperationID != nil,
               case .gg = destination
         else { return nil }
         var checkpoint = resolvingGGCommitSHA(commitSHA)
-        checkpoint.allowsGGRecoveryHeadReconciliation = false
+        checkpoint.ggRecoveryOperationID = nil
         return checkpoint
     }
 

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -15,7 +15,7 @@ final class CommitPublishSession {
     private(set) var lastError: Error?
     private var workflow: CommitPublishWorkflow?
     @ObservationIgnored private var task: Task<Void, Never>?
-    private let onCheckpointChange: (CommitPublishCheckpoint?) -> Void
+    private let onCheckpointChange: (CommitPublishCheckpoint?) throws -> Void
     private let onCompletion: (CommitPublishCheckpoint) -> Void
 
     var activity: CommitPublishActivity { workflow?.activity ?? .idle }
@@ -23,7 +23,7 @@ final class CommitPublishSession {
 
     init(
         checkpoint: CommitPublishCheckpoint?,
-        onCheckpointChange: @escaping (CommitPublishCheckpoint?) -> Void,
+        onCheckpointChange: @escaping (CommitPublishCheckpoint?) throws -> Void,
         onCompletion: @escaping (CommitPublishCheckpoint) -> Void
     ) {
         self.checkpoint = checkpoint
@@ -50,9 +50,12 @@ final class CommitPublishSession {
             let workflow = CommitPublishWorkflow(operations: operations) { [weak self] next in
                 guard let self, activeRunID == runID else { return }
                 let previous = checkpoint
-                checkpoint = next
-                onCheckpointChange(next)
+                if next != nil {
+                    checkpoint = next
+                }
+                try onCheckpointChange(next)
                 if next == nil, let previous {
+                    checkpoint = nil
                     finish(runID)
                     onCompletion(previous)
                 }
@@ -82,6 +85,15 @@ final class CommitPublishSession {
         activeRunID = nil
         task = nil
     }
+
+    func abandonCheckpoint() -> Bool {
+        guard !isRunning else { return false }
+        checkpoint = nil
+        lastError = nil
+        workflow = nil
+        task = nil
+        return true
+    }
 }
 
 @MainActor
@@ -92,6 +104,7 @@ struct CommitPublishOperations {
     var currentHeadSHA: () async throws -> String
     var remoteBranchContainsCommit: (_ target: CommitPublishReviewTarget, _ commitSHA: String) async throws -> Bool
     var push: (_ target: CommitPublishReviewTarget, _ commitSHA: String) async throws -> Void
+    var configureUpstreamTracking: (_ target: CommitPublishReviewTarget) async throws -> Void = { _ in }
     var currentReviewRequestExists: (_ target: CommitPublishReviewTarget) async throws -> Bool
     var createReviewRequest: (_ target: CommitPublishReviewTarget, _ subject: String, _ body: String) async throws -> URL
     var syncGG: () async throws -> Void
@@ -176,12 +189,14 @@ struct CommitPublishOperations {
                     throw NSError(domain: "CommitPublish", code: Int(result.exitCode),
                         userInfo: [NSLocalizedDescriptionKey: RightPaneState.reviewLoopPushFailureMessage(result)])
                 }
-                if target.upstreamBranch == nil {
-                    // An explicit SHA source gives `push -u` no local branch to configure.
-                    for (key, value) in [("remote", remote), ("merge", "refs/heads/\(branch)")] {
-                        let configuration = try await run(["config", "--local", "branch.\(target.branch).\(key)", value])
-                        try GitService.assertSuccess(configuration, op: "Configure branch upstream")
-                    }
+            },
+            configureUpstreamTracking: { target in
+                guard target.upstreamBranch == nil else { return }
+                let remote = target.pushRemoteName ?? target.remoteName
+                let branch = target.branch
+                for (key, value) in [("remote", remote), ("merge", "refs/heads/\(branch)")] {
+                    let configuration = try await run(["config", "--local", "branch.\(target.branch).\(key)", value])
+                    try GitService.assertSuccess(configuration, op: "Configure branch upstream")
                 }
             },
             currentReviewRequestExists: { target in
@@ -250,7 +265,7 @@ enum CommitPublishWorkflowError: LocalizedError, Equatable {
 @Observable
 final class CommitPublishWorkflow {
     private let operations: CommitPublishOperations
-    private let onCheckpointChange: (CommitPublishCheckpoint?) -> Void
+    private let onCheckpointChange: (CommitPublishCheckpoint?) throws -> Void
 
     private(set) var activity: CommitPublishActivity = .idle
     private(set) var lastError: Error?
@@ -258,7 +273,7 @@ final class CommitPublishWorkflow {
 
     init(
         operations: CommitPublishOperations,
-        onCheckpointChange: @escaping (CommitPublishCheckpoint?) -> Void
+        onCheckpointChange: @escaping (CommitPublishCheckpoint?) throws -> Void
     ) {
         self.operations = operations
         self.onCheckpointChange = onCheckpointChange
@@ -304,7 +319,7 @@ final class CommitPublishWorkflow {
                 destination: checkpointDestination,
                 nextPhase: nextPhase(for: checkpointDestination)
             )
-            onCheckpointChange(checkpoint)
+            try onCheckpointChange(checkpoint)
             try Task.checkCancellation()
             try await continueResuming(checkpoint, runID: runID)
         } catch is CancellationError {
@@ -355,8 +370,9 @@ final class CommitPublishWorkflow {
                 if !alreadyPublished {
                     try await operations.push(target, checkpoint.commitSHA)
                 }
+                try await operations.configureUpstreamTracking(target)
                 checkpoint.nextPhase = .createReviewRequest
-                onCheckpointChange(checkpoint)
+                try onCheckpointChange(checkpoint)
                 try Task.checkCancellation()
 
             case .createReviewRequest:
@@ -406,7 +422,7 @@ final class CommitPublishWorkflow {
     }
 
     private func complete(_ runID: UUID) async throws {
-        onCheckpointChange(nil)
+        try onCheckpointChange(nil)
         activity = .idle
         lastError = nil
         endRun(runID)

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -383,6 +383,12 @@ final class CommitPublishWorkflow {
         let currentHeadSHA = try await operations.currentHeadSHA()
         try Task.checkCancellation()
         var checkpoint = initialCheckpoint
+        if currentHeadSHA != checkpoint.commitSHA,
+           let recoveredCheckpoint = checkpoint.reconcilingGGRecoveryHead(currentHeadSHA) {
+            checkpoint = recoveredCheckpoint
+            try onCheckpointChange(checkpoint)
+            try Task.checkCancellation()
+        }
         guard currentHeadSHA == checkpoint.commitSHA else {
             throw CommitPublishWorkflowError.headMismatch(
                 expected: checkpoint.commitSHA,
@@ -444,7 +450,10 @@ final class CommitPublishWorkflow {
                     }
                 } catch {
                     if syncExecution.started {
-                        try await persistPostGGSyncHeadIfNeeded(&checkpoint)
+                        try await persistPostGGSyncHeadIfNeeded(
+                            &checkpoint,
+                            allowRecoveryHeadReconciliation: error.isGGPausedConflict
+                        )
                     }
                     throw error
                 }
@@ -455,11 +464,21 @@ final class CommitPublishWorkflow {
         }
     }
 
-    private func persistPostGGSyncHeadIfNeeded(_ checkpoint: inout CommitPublishCheckpoint) async throws {
+    private func persistPostGGSyncHeadIfNeeded(
+        _ checkpoint: inout CommitPublishCheckpoint,
+        allowRecoveryHeadReconciliation: Bool = false
+    ) async throws {
         let postSyncHeadSHA = try await operations.currentHeadSHA()
         try Task.checkCancellation()
-        guard postSyncHeadSHA != checkpoint.commitSHA else { return }
-        checkpoint = checkpoint.resolvingGGCommitSHA(postSyncHeadSHA)
+        var updatedCheckpoint = checkpoint
+        if postSyncHeadSHA != checkpoint.commitSHA {
+            updatedCheckpoint = checkpoint.resolvingGGCommitSHA(postSyncHeadSHA)
+        }
+        if allowRecoveryHeadReconciliation {
+            updatedCheckpoint.allowsGGRecoveryHeadReconciliation = true
+        }
+        guard updatedCheckpoint != checkpoint else { return }
+        checkpoint = updatedCheckpoint
         try onCheckpointChange(checkpoint)
         try Task.checkCancellation()
     }
@@ -508,6 +527,16 @@ final class CommitPublishWorkflow {
 }
 
 private extension CommitPublishCheckpoint {
+    func reconcilingGGRecoveryHead(_ commitSHA: String) -> Self? {
+        guard nextPhase == .sync,
+              allowsGGRecoveryHeadReconciliation,
+              case .gg = destination
+        else { return nil }
+        var checkpoint = resolvingGGCommitSHA(commitSHA)
+        checkpoint.allowsGGRecoveryHeadReconciliation = false
+        return checkpoint
+    }
+
     func resolvingGGCommitSHA(_ commitSHA: String) -> Self {
         var destination = destination
         if case .gg(var target) = destination {
@@ -523,5 +552,13 @@ private extension CommitPublishCheckpoint {
             destination: destination,
             nextPhase: nextPhase
         )
+    }
+}
+
+private extension Error {
+    var isGGPausedConflict: Bool {
+        guard let error = self as? GGServiceError else { return false }
+        if case .pausedConflict = error { return true }
+        return false
     }
 }

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -371,14 +371,19 @@ final class CommitPublishWorkflow {
         try Task.checkCancellation()
         let currentHeadSHA = try await operations.currentHeadSHA()
         try Task.checkCancellation()
-        guard currentHeadSHA == initialCheckpoint.commitSHA else {
+        var checkpoint = initialCheckpoint
+        if currentHeadSHA != checkpoint.commitSHA, checkpoint.canReconcileGGHeadRewrite {
+            checkpoint = checkpoint.resolvingGGCommitSHA(currentHeadSHA)
+            try onCheckpointChange(checkpoint)
+            try Task.checkCancellation()
+        }
+        guard currentHeadSHA == checkpoint.commitSHA else {
             throw CommitPublishWorkflowError.headMismatch(
-                expected: initialCheckpoint.commitSHA,
+                expected: checkpoint.commitSHA,
                 actual: currentHeadSHA
             )
         }
 
-        var checkpoint = initialCheckpoint
         while true {
             switch checkpoint.nextPhase {
             case .push:
@@ -429,6 +434,13 @@ final class CommitPublishWorkflow {
                 } else {
                     try await operations.syncGG()
                 }
+                let postSyncHeadSHA = try await operations.currentHeadSHA()
+                try Task.checkCancellation()
+                if postSyncHeadSHA != checkpoint.commitSHA {
+                    checkpoint = checkpoint.resolvingGGCommitSHA(postSyncHeadSHA)
+                    try onCheckpointChange(checkpoint)
+                    try Task.checkCancellation()
+                }
                 try await complete(runID)
                 return
             }
@@ -475,5 +487,31 @@ final class CommitPublishWorkflow {
         guard activeRunID == runID else { return }
         activity = .idle
         lastError = error
+    }
+}
+
+private extension CommitPublishCheckpoint {
+    var canReconcileGGHeadRewrite: Bool {
+        guard nextPhase == .sync,
+              case .gg(.some) = destination
+        else { return false }
+        return true
+    }
+
+    func resolvingGGCommitSHA(_ commitSHA: String) -> Self {
+        var destination = destination
+        if case .gg(var target) = destination {
+            target?.expectedHeadSHA = commitSHA
+            destination = .gg(target)
+        }
+        return .init(
+            commitSHA: commitSHA,
+            baseRef: baseRef,
+            commitTitle: "\(commitSHA.prefix(7)) \(subject)",
+            subject: subject,
+            body: body,
+            destination: destination,
+            nextPhase: nextPhase
+        )
     }
 }

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -222,6 +222,7 @@ enum CommitPublishWorkflowError: LocalizedError, Equatable {
     case headMismatch(expected: String, actual: String)
     case invalidDestination(phase: CommitPublishPhase)
     case missingPushDestination
+    case incompatiblePushRemote
     case pushDestinationChanged
     case publishedAmend
 
@@ -235,6 +236,8 @@ enum CommitPublishWorkflowError: LocalizedError, Equatable {
             return "The publish checkpoint cannot continue its \(phase.rawValue) phase."
         case .missingPushDestination:
             return "The publish checkpoint has no captured push destination."
+        case .incompatiblePushRemote:
+            return "The branch upstream is incompatible with the selected review host."
         case .pushDestinationChanged:
             return "The push destination changed. Restore the captured remote URL before retrying."
         case .publishedAmend:

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -86,6 +86,7 @@ final class CommitPublishSession {
 
 @MainActor
 struct CommitPublishOperations {
+    var validateReviewTarget: (_ target: CommitPublishReviewTarget) async throws -> Void = { _ in }
     var createCommit: (_ subject: String, _ body: String, _ amend: Bool) async throws -> CommitPublishCreatedCommit
     var currentHeadSHA: () async throws -> String
     var remoteBranchContainsCommit: (_ target: CommitPublishReviewTarget, _ commitSHA: String) async throws -> Bool
@@ -114,6 +115,20 @@ struct CommitPublishOperations {
             try await git.remoteBranchContainsCommit(worktreePath: worktreePath, remote: $0, branch: $1, commitSHA: $2)
         }
         return Self(
+            validateReviewTarget: { target in
+                let branchResult = try await run(["symbolic-ref", "--short", "HEAD"])
+                let currentBranch = branchResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard branchResult.exitCode == 0, currentBranch == target.branch else {
+                    throw CommitPublishWorkflowError.branchMismatch(expected: target.branch, actual: currentBranch)
+                }
+                guard let expectedHeadSHA = target.expectedHeadSHA else { return }
+                let headResult = try await run(["rev-parse", "--verify", "HEAD"])
+                try GitService.assertSuccess(headResult, op: "Resolve HEAD")
+                let currentHeadSHA = headResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard currentHeadSHA == expectedHeadSHA else {
+                    throw CommitPublishWorkflowError.headMismatch(expected: expectedHeadSHA, actual: currentHeadSHA)
+                }
+            },
             createCommit: { subject, body, amend in
                 if amend, try await publication() == .published {
                     throw CommitPublishWorkflowError.publishedAmend
@@ -168,11 +183,11 @@ struct CommitPublishOperations {
                 }
             },
             currentReviewRequestExists: { target in
-                try await reviewLoop.currentReviewRequest(remote: target.remote, branch: target.branch,
+                try await reviewLoop.currentReviewRequest(remote: target.remote, branch: target.upstreamBranch ?? target.branch,
                     headOwner: target.headOwner, baseBranch: target.baseBranch) != nil
             },
             createReviewRequest: { target, subject, body in
-                try await reviewLoop.createReviewRequest(remote: target.remote, branch: target.branch,
+                try await reviewLoop.createReviewRequest(remote: target.remote, branch: target.upstreamBranch ?? target.branch,
                     headOwner: target.headOwner, baseBranch: target.baseBranch,
                     title: subject, body: body, draft: target.createAsDraft)
             },
@@ -201,6 +216,7 @@ enum CommitPublishActivity: Equatable {
 }
 
 enum CommitPublishWorkflowError: LocalizedError, Equatable {
+    case branchMismatch(expected: String, actual: String)
     case headMismatch(expected: String, actual: String)
     case invalidDestination(phase: CommitPublishPhase)
     case missingPushDestination
@@ -209,6 +225,8 @@ enum CommitPublishWorkflowError: LocalizedError, Equatable {
 
     var errorDescription: String? {
         switch self {
+        case .branchMismatch:
+            return "The current branch changed before publishing could begin."
         case .headMismatch:
             return "The current commit changed before publishing could resume."
         case .invalidDestination(let phase):
@@ -256,6 +274,10 @@ final class CommitPublishWorkflow {
         let body = body.trimmingCharacters(in: .whitespacesAndNewlines)
 
         do {
+            if case .review(let target) = destination {
+                try await operations.validateReviewTarget(target)
+                try Task.checkCancellation()
+            }
             let createdCommit = try await operations.createCommit(subject, body, amend)
             let checkpoint = CommitPublishCheckpoint(
                 commitSHA: createdCommit.commitSHA,
@@ -326,12 +348,14 @@ final class CommitPublishWorkflow {
                     throw CommitPublishWorkflowError.invalidDestination(phase: .createReviewRequest)
                 }
 
-                activity = .creatingReviewRequest
-                try Task.checkCancellation()
-                let requestExists = try await operations.currentReviewRequestExists(target)
-                try Task.checkCancellation()
-                if !requestExists {
-                    _ = try await operations.createReviewRequest(target, checkpoint.subject, checkpoint.body)
+                if !target.reviewRequestExisted {
+                    activity = .creatingReviewRequest
+                    try Task.checkCancellation()
+                    let requestExists = try await operations.currentReviewRequestExists(target)
+                    try Task.checkCancellation()
+                    if !requestExists {
+                        _ = try await operations.createReviewRequest(target, checkpoint.subject, checkpoint.body)
+                    }
                 }
                 try await complete(runID)
                 return

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -192,8 +192,29 @@ struct CommitPublishOperations {
             },
             configureUpstreamTracking: { target in
                 guard target.upstreamBranch == nil else { return }
+                let urls = target.capturedPushURLs
+                guard let pushURL = urls.first, !pushURL.isEmpty else {
+                    throw CommitPublishWorkflowError.missingPushDestination
+                }
                 let remote = target.pushRemoteName ?? target.remoteName
                 let branch = target.branch
+                let destination = try await run(["remote", "get-url", "--push", "--all", remote])
+                try GitService.assertSuccess(destination, op: "Resolve push destination")
+                let currentURLs = destination.stdout.split(whereSeparator: \.isNewline).map(String.init)
+                guard currentURLs.sorted() == urls.sorted() else {
+                    throw CommitPublishWorkflowError.pushDestinationChanged
+                }
+                let branchRef = "refs/heads/\(branch)"
+                let trackingRef = "refs/remotes/\(remote)/\(branch)"
+                for ref in [branchRef, trackingRef] {
+                    let validation = try await run(["check-ref-format", ref])
+                    try GitService.assertSuccess(validation, op: "Validate tracking ref")
+                }
+                let fetch = try await run([
+                    "fetch", "--no-tags", "--no-write-fetch-head", "--no-recurse-submodules", "--refmap=",
+                    "--", pushURL, "+\(branchRef):\(trackingRef)",
+                ])
+                try GitService.assertSuccess(fetch, op: "Fetch remote tracking ref")
                 for (key, value) in [("remote", remote), ("merge", "refs/heads/\(branch)")] {
                     let configuration = try await run(["config", "--local", "branch.\(target.branch).\(key)", value])
                     try GitService.assertSuccess(configuration, op: "Configure branch upstream")

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -357,6 +357,8 @@ final class CommitPublishWorkflow {
         lastError = nil
 
         do {
+            try onCheckpointChange(checkpoint)
+            try Task.checkCancellation()
             try await continueResuming(checkpoint, runID: runID)
         } catch is CancellationError {
             finishCancellation(runID)

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -372,11 +372,6 @@ final class CommitPublishWorkflow {
         let currentHeadSHA = try await operations.currentHeadSHA()
         try Task.checkCancellation()
         var checkpoint = initialCheckpoint
-        if currentHeadSHA != checkpoint.commitSHA, checkpoint.canReconcileGGHeadRewrite {
-            checkpoint = checkpoint.resolvingGGCommitSHA(currentHeadSHA)
-            try onCheckpointChange(checkpoint)
-            try Task.checkCancellation()
-        }
         guard currentHeadSHA == checkpoint.commitSHA else {
             throw CommitPublishWorkflowError.headMismatch(
                 expected: checkpoint.commitSHA,
@@ -427,24 +422,32 @@ final class CommitPublishWorkflow {
 
                 activity = .syncing
                 try Task.checkCancellation()
-                if let target {
-                    try await operations.validateGGTarget(target)
-                    try Task.checkCancellation()
-                    try await operations.syncGGForTarget(target)
-                } else {
-                    try await operations.syncGG()
+                do {
+                    if let target {
+                        try await operations.validateGGTarget(target)
+                        try Task.checkCancellation()
+                        try await operations.syncGGForTarget(target)
+                    } else {
+                        try await operations.syncGG()
+                    }
+                } catch {
+                    try await persistPostGGSyncHeadIfNeeded(&checkpoint)
+                    throw error
                 }
-                let postSyncHeadSHA = try await operations.currentHeadSHA()
-                try Task.checkCancellation()
-                if postSyncHeadSHA != checkpoint.commitSHA {
-                    checkpoint = checkpoint.resolvingGGCommitSHA(postSyncHeadSHA)
-                    try onCheckpointChange(checkpoint)
-                    try Task.checkCancellation()
-                }
+                try await persistPostGGSyncHeadIfNeeded(&checkpoint)
                 try await complete(runID)
                 return
             }
         }
+    }
+
+    private func persistPostGGSyncHeadIfNeeded(_ checkpoint: inout CommitPublishCheckpoint) async throws {
+        let postSyncHeadSHA = try await operations.currentHeadSHA()
+        try Task.checkCancellation()
+        guard postSyncHeadSHA != checkpoint.commitSHA else { return }
+        checkpoint = checkpoint.resolvingGGCommitSHA(postSyncHeadSHA)
+        try onCheckpointChange(checkpoint)
+        try Task.checkCancellation()
     }
 
     private func nextPhase(for destination: CommitPublishDestination) -> CommitPublishPhase {
@@ -491,13 +494,6 @@ final class CommitPublishWorkflow {
 }
 
 private extension CommitPublishCheckpoint {
-    var canReconcileGGHeadRewrite: Bool {
-        guard nextPhase == .sync,
-              case .gg(.some) = destination
-        else { return false }
-        return true
-    }
-
     func resolvingGGCommitSHA(_ commitSHA: String) -> Self {
         var destination = destination
         if case .gg(var target) = destination {

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -87,6 +87,7 @@ final class CommitPublishSession {
 @MainActor
 struct CommitPublishOperations {
     var validateReviewTarget: (_ target: CommitPublishReviewTarget) async throws -> Void = { _ in }
+    var validateGGTarget: (_ target: GGStackTargetIdentity) async throws -> Void = { _ in }
     var createCommit: (_ subject: String, _ body: String, _ amend: Bool) async throws -> CommitPublishCreatedCommit
     var currentHeadSHA: () async throws -> String
     var remoteBranchContainsCommit: (_ target: CommitPublishReviewTarget, _ commitSHA: String) async throws -> Bool
@@ -94,6 +95,7 @@ struct CommitPublishOperations {
     var currentReviewRequestExists: (_ target: CommitPublishReviewTarget) async throws -> Bool
     var createReviewRequest: (_ target: CommitPublishReviewTarget, _ subject: String, _ body: String) async throws -> URL
     var syncGG: () async throws -> Void
+    var syncGGForTarget: (_ target: GGStackTargetIdentity) async throws -> Void = { _ in }
     var refreshAfterCompletion: () async -> Void
 
     static func live(
@@ -277,16 +279,27 @@ final class CommitPublishWorkflow {
             if case .review(let target) = destination {
                 try await operations.validateReviewTarget(target)
                 try Task.checkCancellation()
+            } else if case .gg(let target) = destination, let target {
+                try await operations.validateGGTarget(target)
+                try Task.checkCancellation()
             }
             let createdCommit = try await operations.createCommit(subject, body, amend)
+            let checkpointDestination: CommitPublishDestination
+            switch destination {
+            case .review:
+                checkpointDestination = destination
+            case .gg(var target):
+                target?.expectedHeadSHA = createdCommit.commitSHA
+                checkpointDestination = .gg(target)
+            }
             let checkpoint = CommitPublishCheckpoint(
                 commitSHA: createdCommit.commitSHA,
                 baseRef: createdCommit.comparisonBase,
                 commitTitle: createdCommit.editorTitle,
                 subject: subject,
                 body: body,
-                destination: destination,
-                nextPhase: nextPhase(for: destination)
+                destination: checkpointDestination,
+                nextPhase: nextPhase(for: checkpointDestination)
             )
             onCheckpointChange(checkpoint)
             try Task.checkCancellation()
@@ -361,13 +374,19 @@ final class CommitPublishWorkflow {
                 return
 
             case .sync:
-                guard case .gg = checkpoint.destination else {
+                guard case .gg(let target) = checkpoint.destination else {
                     throw CommitPublishWorkflowError.invalidDestination(phase: .sync)
                 }
 
                 activity = .syncing
                 try Task.checkCancellation()
-                try await operations.syncGG()
+                if let target {
+                    try await operations.validateGGTarget(target)
+                    try Task.checkCancellation()
+                    try await operations.syncGGForTarget(target)
+                } else {
+                    try await operations.syncGG()
+                }
                 try await complete(runID)
                 return
             }

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -47,6 +47,7 @@ final class CommitPublishWorkflow {
 
     private(set) var activity: CommitPublishActivity = .idle
     private(set) var lastError: Error?
+    private var isRunning = false
 
     init(
         operations: CommitPublishOperations,
@@ -62,6 +63,9 @@ final class CommitPublishWorkflow {
         amend: Bool,
         destination: CommitPublishDestination
     ) async {
+        guard beginRun() else { return }
+        defer { isRunning = false }
+
         lastError = nil
         activity = .committing
 
@@ -77,66 +81,86 @@ final class CommitPublishWorkflow {
                 nextPhase: nextPhase(for: destination)
             )
             onCheckpointChange(checkpoint)
-            await resume(checkpoint)
+            try Task.checkCancellation()
+            try await continueResuming(checkpoint)
+        } catch is CancellationError {
+            finishCancellation()
         } catch {
             finish(with: error)
         }
     }
 
     func resume(_ checkpoint: CommitPublishCheckpoint) async {
+        guard beginRun() else { return }
+        defer { isRunning = false }
+
         lastError = nil
 
         do {
-            let currentHeadSHA = try await operations.currentHeadSHA()
-            guard currentHeadSHA == checkpoint.commitSHA else {
-                throw CommitPublishWorkflowError.headMismatch(
-                    expected: checkpoint.commitSHA,
-                    actual: currentHeadSHA
-                )
-            }
-
-            var checkpoint = checkpoint
-            while true {
-                switch checkpoint.nextPhase {
-                case .push:
-                    guard case .review(let target) = checkpoint.destination else {
-                        throw CommitPublishWorkflowError.invalidDestination(phase: .push)
-                    }
-
-                    activity = .pushing
-                    let alreadyPublished = try await operations.remoteBranchContainsCommit(target, checkpoint.commitSHA)
-                    if !alreadyPublished {
-                        try await operations.push(target, checkpoint.commitSHA)
-                    }
-                    checkpoint.nextPhase = .createReviewRequest
-                    onCheckpointChange(checkpoint)
-
-                case .createReviewRequest:
-                    guard case .review(let target) = checkpoint.destination else {
-                        throw CommitPublishWorkflowError.invalidDestination(phase: .createReviewRequest)
-                    }
-
-                    activity = .creatingReviewRequest
-                    let requestExists = try await operations.currentReviewRequestExists(target)
-                    if !requestExists {
-                        _ = try await operations.createReviewRequest(target, checkpoint.subject, checkpoint.body)
-                    }
-                    await complete()
-                    return
-
-                case .sync:
-                    guard case .gg = checkpoint.destination else {
-                        throw CommitPublishWorkflowError.invalidDestination(phase: .sync)
-                    }
-
-                    activity = .syncing
-                    try await operations.syncGG()
-                    await complete()
-                    return
-                }
-            }
+            try await continueResuming(checkpoint)
+        } catch is CancellationError {
+            finishCancellation()
         } catch {
             finish(with: error)
+        }
+    }
+
+    private func continueResuming(_ initialCheckpoint: CommitPublishCheckpoint) async throws {
+        try Task.checkCancellation()
+        let currentHeadSHA = try await operations.currentHeadSHA()
+        try Task.checkCancellation()
+        guard currentHeadSHA == initialCheckpoint.commitSHA else {
+            throw CommitPublishWorkflowError.headMismatch(
+                expected: initialCheckpoint.commitSHA,
+                actual: currentHeadSHA
+            )
+        }
+
+        var checkpoint = initialCheckpoint
+        while true {
+            switch checkpoint.nextPhase {
+            case .push:
+                guard case .review(let target) = checkpoint.destination else {
+                    throw CommitPublishWorkflowError.invalidDestination(phase: .push)
+                }
+
+                activity = .pushing
+                try Task.checkCancellation()
+                let alreadyPublished = try await operations.remoteBranchContainsCommit(target, checkpoint.commitSHA)
+                try Task.checkCancellation()
+                if !alreadyPublished {
+                    try await operations.push(target, checkpoint.commitSHA)
+                }
+                checkpoint.nextPhase = .createReviewRequest
+                onCheckpointChange(checkpoint)
+                try Task.checkCancellation()
+
+            case .createReviewRequest:
+                guard case .review(let target) = checkpoint.destination else {
+                    throw CommitPublishWorkflowError.invalidDestination(phase: .createReviewRequest)
+                }
+
+                activity = .creatingReviewRequest
+                try Task.checkCancellation()
+                let requestExists = try await operations.currentReviewRequestExists(target)
+                try Task.checkCancellation()
+                if !requestExists {
+                    _ = try await operations.createReviewRequest(target, checkpoint.subject, checkpoint.body)
+                }
+                try await complete()
+                return
+
+            case .sync:
+                guard case .gg = checkpoint.destination else {
+                    throw CommitPublishWorkflowError.invalidDestination(phase: .sync)
+                }
+
+                activity = .syncing
+                try Task.checkCancellation()
+                try await operations.syncGG()
+                try await complete()
+                return
+            }
         }
     }
 
@@ -149,11 +173,23 @@ final class CommitPublishWorkflow {
         }
     }
 
-    private func complete() async {
+    private func complete() async throws {
         onCheckpointChange(nil)
+        try Task.checkCancellation()
         activity = .idle
         lastError = nil
         await operations.refreshAfterCompletion()
+    }
+
+    private func beginRun() -> Bool {
+        guard !isRunning else { return false }
+        isRunning = true
+        return true
+    }
+
+    private func finishCancellation() {
+        activity = .idle
+        lastError = nil
     }
 
     private func finish(with error: Error) {

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+struct CommitPublishCreatedCommit: Equatable, Sendable {
+    let commitSHA: String
+    let comparisonBase: String
+    let editorTitle: String
+}
+
+@MainActor
+struct CommitPublishOperations {
+    var createCommit: (_ subject: String, _ body: String, _ amend: Bool) async throws -> CommitPublishCreatedCommit
+    var currentHeadSHA: () async throws -> String
+    var remoteBranchContainsCommit: (_ target: CommitPublishReviewTarget, _ commitSHA: String) async throws -> Bool
+    var push: (_ target: CommitPublishReviewTarget, _ commitSHA: String) async throws -> Void
+    var currentReviewRequestExists: (_ target: CommitPublishReviewTarget) async throws -> Bool
+    var createReviewRequest: (_ target: CommitPublishReviewTarget, _ subject: String, _ body: String) async throws -> URL
+    var syncGG: () async throws -> Void
+    var refreshAfterCompletion: () async -> Void
+}
+
+enum CommitPublishActivity: Equatable {
+    case idle
+    case committing
+    case pushing
+    case creatingReviewRequest
+    case syncing
+}
+
+enum CommitPublishWorkflowError: LocalizedError, Equatable {
+    case headMismatch(expected: String, actual: String)
+    case invalidDestination(phase: CommitPublishPhase)
+
+    var errorDescription: String? {
+        switch self {
+        case .headMismatch:
+            return "The current commit changed before publishing could resume."
+        case .invalidDestination(let phase):
+            return "The publish checkpoint cannot continue its \(phase.rawValue) phase."
+        }
+    }
+}
+
+@MainActor
+final class CommitPublishWorkflow {
+    private let operations: CommitPublishOperations
+    private let onCheckpointChange: (CommitPublishCheckpoint?) -> Void
+
+    private(set) var activity: CommitPublishActivity = .idle
+    private(set) var lastError: Error?
+
+    init(
+        operations: CommitPublishOperations,
+        onCheckpointChange: @escaping (CommitPublishCheckpoint?) -> Void
+    ) {
+        self.operations = operations
+        self.onCheckpointChange = onCheckpointChange
+    }
+
+    func start(
+        subject: String,
+        body: String,
+        amend: Bool,
+        destination: CommitPublishDestination
+    ) async {
+        lastError = nil
+        activity = .committing
+
+        do {
+            let createdCommit = try await operations.createCommit(subject, body, amend)
+            let checkpoint = CommitPublishCheckpoint(
+                commitSHA: createdCommit.commitSHA,
+                baseRef: createdCommit.comparisonBase,
+                commitTitle: createdCommit.editorTitle,
+                subject: subject,
+                body: body,
+                destination: destination,
+                nextPhase: nextPhase(for: destination)
+            )
+            onCheckpointChange(checkpoint)
+            await resume(checkpoint)
+        } catch {
+            finish(with: error)
+        }
+    }
+
+    func resume(_ checkpoint: CommitPublishCheckpoint) async {
+        lastError = nil
+
+        do {
+            let currentHeadSHA = try await operations.currentHeadSHA()
+            guard currentHeadSHA == checkpoint.commitSHA else {
+                throw CommitPublishWorkflowError.headMismatch(
+                    expected: checkpoint.commitSHA,
+                    actual: currentHeadSHA
+                )
+            }
+
+            var checkpoint = checkpoint
+            while true {
+                switch checkpoint.nextPhase {
+                case .push:
+                    guard case .review(let target) = checkpoint.destination else {
+                        throw CommitPublishWorkflowError.invalidDestination(phase: .push)
+                    }
+
+                    activity = .pushing
+                    let alreadyPublished = try await operations.remoteBranchContainsCommit(target, checkpoint.commitSHA)
+                    if !alreadyPublished {
+                        try await operations.push(target, checkpoint.commitSHA)
+                    }
+                    checkpoint.nextPhase = .createReviewRequest
+                    onCheckpointChange(checkpoint)
+
+                case .createReviewRequest:
+                    guard case .review(let target) = checkpoint.destination else {
+                        throw CommitPublishWorkflowError.invalidDestination(phase: .createReviewRequest)
+                    }
+
+                    activity = .creatingReviewRequest
+                    let requestExists = try await operations.currentReviewRequestExists(target)
+                    if !requestExists {
+                        _ = try await operations.createReviewRequest(target, checkpoint.subject, checkpoint.body)
+                    }
+                    await complete()
+                    return
+
+                case .sync:
+                    guard case .gg = checkpoint.destination else {
+                        throw CommitPublishWorkflowError.invalidDestination(phase: .sync)
+                    }
+
+                    activity = .syncing
+                    try await operations.syncGG()
+                    await complete()
+                    return
+                }
+            }
+        } catch {
+            finish(with: error)
+        }
+    }
+
+    private func nextPhase(for destination: CommitPublishDestination) -> CommitPublishPhase {
+        switch destination {
+        case .review:
+            return .push
+        case .gg:
+            return .sync
+        }
+    }
+
+    private func complete() async {
+        onCheckpointChange(nil)
+        activity = .idle
+        lastError = nil
+        await operations.refreshAfterCompletion()
+    }
+
+    private func finish(with error: Error) {
+        activity = .idle
+        lastError = error
+    }
+}

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -422,16 +422,21 @@ final class CommitPublishWorkflow {
 
                 activity = .syncing
                 try Task.checkCancellation()
+                var syncStarted = false
                 do {
                     if let target {
                         try await operations.validateGGTarget(target)
                         try Task.checkCancellation()
+                        syncStarted = true
                         try await operations.syncGGForTarget(target)
                     } else {
+                        syncStarted = true
                         try await operations.syncGG()
                     }
                 } catch {
-                    try await persistPostGGSyncHeadIfNeeded(&checkpoint)
+                    if syncStarted {
+                        try await persistPostGGSyncHeadIfNeeded(&checkpoint)
+                    }
                     throw error
                 }
                 try await persistPostGGSyncHeadIfNeeded(&checkpoint)

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -25,7 +25,7 @@ final class CommitPublishSession {
     private var workflow: CommitPublishWorkflow?
     @ObservationIgnored private var task: Task<Void, Never>?
     private let onCheckpointChange: (CommitPublishCheckpoint?) throws -> Void
-    private let onCompletion: (CommitPublishCheckpoint) -> Void
+    private let onCompletion: (CommitPublishCheckpoint) throws -> Void
 
     var activity: CommitPublishActivity { workflow?.activity ?? .idle }
     var isRunning: Bool { activeRunID != nil }
@@ -33,7 +33,7 @@ final class CommitPublishSession {
     init(
         checkpoint: CommitPublishCheckpoint?,
         onCheckpointChange: @escaping (CommitPublishCheckpoint?) throws -> Void,
-        onCompletion: @escaping (CommitPublishCheckpoint) -> Void
+        onCompletion: @escaping (CommitPublishCheckpoint) throws -> Void
     ) {
         self.checkpoint = checkpoint
         self.onCheckpointChange = onCheckpointChange
@@ -58,16 +58,18 @@ final class CommitPublishSession {
             defer { finish(runID) }
             let workflow = CommitPublishWorkflow(operations: operations) { [weak self] next in
                 guard let self, activeRunID == runID else { return }
-                let previous = checkpoint
-                if next != nil {
+                if let next {
                     checkpoint = next
+                    try onCheckpointChange(next)
+                    return
                 }
-                try onCheckpointChange(next)
-                if next == nil, let previous {
-                    checkpoint = nil
-                    finish(runID)
-                    onCompletion(previous)
+                guard let previous = checkpoint else {
+                    try onCheckpointChange(nil)
+                    return
                 }
+                try onCompletion(previous)
+                checkpoint = nil
+                finish(runID)
             }
             self.workflow = workflow
             do {

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -8,6 +8,83 @@ struct CommitPublishCreatedCommit: Equatable, Sendable {
 }
 
 @MainActor
+@Observable
+final class CommitPublishSession {
+    private(set) var checkpoint: CommitPublishCheckpoint?
+    private var activeRunID: UUID?
+    private(set) var lastError: Error?
+    private var workflow: CommitPublishWorkflow?
+    @ObservationIgnored private var task: Task<Void, Never>?
+    private let onCheckpointChange: (CommitPublishCheckpoint?) -> Void
+    private let onCompletion: (CommitPublishCheckpoint) -> Void
+
+    var activity: CommitPublishActivity { workflow?.activity ?? .idle }
+    var isRunning: Bool { activeRunID != nil }
+
+    init(
+        checkpoint: CommitPublishCheckpoint?,
+        onCheckpointChange: @escaping (CommitPublishCheckpoint?) -> Void,
+        onCompletion: @escaping (CommitPublishCheckpoint) -> Void
+    ) {
+        self.checkpoint = checkpoint
+        self.onCheckpointChange = onCheckpointChange
+        self.onCompletion = onCompletion
+    }
+
+    func clearError() { lastError = nil }
+
+    @discardableResult
+    func run(
+        subject: String,
+        body: String,
+        amend: Bool,
+        operations: CommitPublishOperations,
+        prepareDestination: @escaping () async throws -> CommitPublishDestination
+    ) -> Task<Void, Never>? {
+        guard !isRunning else { return nil }
+        let runID = UUID()
+        activeRunID = runID
+        lastError = nil
+        let task = Task { @MainActor in
+            defer { finish(runID) }
+            let workflow = CommitPublishWorkflow(operations: operations) { [weak self] next in
+                guard let self, activeRunID == runID else { return }
+                let previous = checkpoint
+                checkpoint = next
+                onCheckpointChange(next)
+                if next == nil, let previous {
+                    finish(runID)
+                    onCompletion(previous)
+                }
+            }
+            self.workflow = workflow
+            do {
+                if let checkpoint {
+                    await workflow.resume(checkpoint)
+                } else {
+                    let destination = try await prepareDestination()
+                    try Task.checkCancellation()
+                    await workflow.start(subject: subject, body: body, amend: amend, destination: destination)
+                }
+                if activeRunID == runID { lastError = workflow.lastError }
+            } catch is CancellationError {
+                if activeRunID == runID { lastError = nil }
+            } catch {
+                if activeRunID == runID { lastError = error }
+            }
+        }
+        self.task = task
+        return task
+    }
+
+    private func finish(_ runID: UUID) {
+        guard activeRunID == runID else { return }
+        activeRunID = nil
+        task = nil
+    }
+}
+
+@MainActor
 struct CommitPublishOperations {
     var createCommit: (_ subject: String, _ body: String, _ amend: Bool) async throws -> CommitPublishCreatedCommit
     var currentHeadSHA: () async throws -> String
@@ -58,22 +135,36 @@ struct CommitPublishOperations {
                 return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
             },
             remoteBranchContainsCommit: { target, sha in
-                guard let pushURL = target.pushURL else { throw CommitPublishWorkflowError.missingPushDestination }
-                return try await contains(pushURL, target.upstreamBranch ?? target.branch, sha)
+                let urls = target.capturedPushURLs
+                guard !urls.isEmpty else { throw CommitPublishWorkflowError.missingPushDestination }
+                for url in urls {
+                    if try await !contains(url, target.upstreamBranch ?? target.branch, sha) { return false }
+                }
+                return true
             },
-            push: { target, _ in
-                guard let pushURL = target.pushURL else { throw CommitPublishWorkflowError.missingPushDestination }
+            push: { target, sha in
+                let urls = target.capturedPushURLs
+                guard !urls.isEmpty else { throw CommitPublishWorkflowError.missingPushDestination }
                 let remote = target.pushRemoteName ?? target.remoteName
-                let destination = try await run(["remote", "get-url", "--push", remote])
+                let destination = try await run(["remote", "get-url", "--push", "--all", remote])
                 try GitService.assertSuccess(destination, op: "Resolve push destination")
-                guard destination.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == pushURL else {
+                let currentURLs = destination.stdout.split(whereSeparator: \.isNewline).map(String.init)
+                guard currentURLs.sorted() == urls.sorted() else {
                     throw CommitPublishWorkflowError.pushDestinationChanged
                 }
-                let ref = target.upstreamBranch.map { "HEAD:\($0)" } ?? target.branch
+                let branch = target.upstreamBranch ?? target.branch
+                let ref = "\(sha):refs/heads/\(branch)"
                 let result = try await run(["push", "-u", remote, ref])
                 guard result.exitCode == 0 else {
                     throw NSError(domain: "CommitPublish", code: Int(result.exitCode),
                         userInfo: [NSLocalizedDescriptionKey: RightPaneState.reviewLoopPushFailureMessage(result)])
+                }
+                if target.upstreamBranch == nil {
+                    // An explicit SHA source gives `push -u` no local branch to configure.
+                    for (key, value) in [("remote", remote), ("merge", "refs/heads/\(branch)")] {
+                        let configuration = try await run(["config", "--local", "branch.\(target.branch).\(key)", value])
+                        try GitService.assertSuccess(configuration, op: "Configure branch upstream")
+                    }
                 }
             },
             currentReviewRequestExists: { target in

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -8,6 +8,15 @@ struct CommitPublishCreatedCommit: Equatable, Sendable {
 }
 
 @MainActor
+final class CommitPublishSyncExecutionMarker {
+    private(set) var started = false
+
+    func markStarted() {
+        started = true
+    }
+}
+
+@MainActor
 @Observable
 final class CommitPublishSession {
     private(set) var checkpoint: CommitPublishCheckpoint?
@@ -107,15 +116,15 @@ struct CommitPublishOperations {
     var configureUpstreamTracking: (_ target: CommitPublishReviewTarget) async throws -> Void = { _ in }
     var currentReviewRequestExists: (_ target: CommitPublishReviewTarget) async throws -> Bool
     var createReviewRequest: (_ target: CommitPublishReviewTarget, _ subject: String, _ body: String) async throws -> URL
-    var syncGG: () async throws -> Void
-    var syncGGForTarget: (_ target: GGStackTargetIdentity) async throws -> Void = { _ in }
+    var syncGG: (_ execution: CommitPublishSyncExecutionMarker) async throws -> Void
+    var syncGGForTarget: (_ target: GGStackTargetIdentity, _ execution: CommitPublishSyncExecutionMarker) async throws -> Void = { _, _ in }
     var refreshAfterCompletion: () async -> Void
 
     static func live(
         worktreePath: URL,
         reviewLoop: ReviewLoopState,
         comparisonBase: String?,
-        syncGG: @escaping () async throws -> Void,
+        syncGG: @escaping (_ execution: CommitPublishSyncExecutionMarker) async throws -> Void,
         refreshAfterCompletion: @escaping () async -> Void,
         runGit: (([String]) async throws -> ProcessResult)? = nil,
         commit: ((String, String, Bool) async throws -> String)? = nil,
@@ -422,19 +431,17 @@ final class CommitPublishWorkflow {
 
                 activity = .syncing
                 try Task.checkCancellation()
-                var syncStarted = false
+                let syncExecution = CommitPublishSyncExecutionMarker()
                 do {
                     if let target {
                         try await operations.validateGGTarget(target)
                         try Task.checkCancellation()
-                        syncStarted = true
-                        try await operations.syncGGForTarget(target)
+                        try await operations.syncGGForTarget(target, syncExecution)
                     } else {
-                        syncStarted = true
-                        try await operations.syncGG()
+                        try await operations.syncGG(syncExecution)
                     }
                 } catch {
-                    if syncStarted {
+                    if syncExecution.started {
                         try await persistPostGGSyncHeadIfNeeded(&checkpoint)
                     }
                     throw error

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -47,7 +47,7 @@ final class CommitPublishWorkflow {
 
     private(set) var activity: CommitPublishActivity = .idle
     private(set) var lastError: Error?
-    private var isRunning = false
+    private var activeRunID: UUID?
 
     init(
         operations: CommitPublishOperations,
@@ -63,8 +63,8 @@ final class CommitPublishWorkflow {
         amend: Bool,
         destination: CommitPublishDestination
     ) async {
-        guard beginRun() else { return }
-        defer { isRunning = false }
+        guard let runID = beginRun() else { return }
+        defer { endRun(runID) }
 
         lastError = nil
         activity = .committing
@@ -82,30 +82,30 @@ final class CommitPublishWorkflow {
             )
             onCheckpointChange(checkpoint)
             try Task.checkCancellation()
-            try await continueResuming(checkpoint)
+            try await continueResuming(checkpoint, runID: runID)
         } catch is CancellationError {
-            finishCancellation()
+            finishCancellation(runID)
         } catch {
-            finish(with: error)
+            finish(with: error, runID: runID)
         }
     }
 
     func resume(_ checkpoint: CommitPublishCheckpoint) async {
-        guard beginRun() else { return }
-        defer { isRunning = false }
+        guard let runID = beginRun() else { return }
+        defer { endRun(runID) }
 
         lastError = nil
 
         do {
-            try await continueResuming(checkpoint)
+            try await continueResuming(checkpoint, runID: runID)
         } catch is CancellationError {
-            finishCancellation()
+            finishCancellation(runID)
         } catch {
-            finish(with: error)
+            finish(with: error, runID: runID)
         }
     }
 
-    private func continueResuming(_ initialCheckpoint: CommitPublishCheckpoint) async throws {
+    private func continueResuming(_ initialCheckpoint: CommitPublishCheckpoint, runID: UUID) async throws {
         try Task.checkCancellation()
         let currentHeadSHA = try await operations.currentHeadSHA()
         try Task.checkCancellation()
@@ -147,7 +147,7 @@ final class CommitPublishWorkflow {
                 if !requestExists {
                     _ = try await operations.createReviewRequest(target, checkpoint.subject, checkpoint.body)
                 }
-                try await complete()
+                try await complete(runID)
                 return
 
             case .sync:
@@ -158,7 +158,7 @@ final class CommitPublishWorkflow {
                 activity = .syncing
                 try Task.checkCancellation()
                 try await operations.syncGG()
-                try await complete()
+                try await complete(runID)
                 return
             }
         }
@@ -173,26 +173,35 @@ final class CommitPublishWorkflow {
         }
     }
 
-    private func complete() async throws {
+    private func complete(_ runID: UUID) async throws {
         onCheckpointChange(nil)
-        try Task.checkCancellation()
         activity = .idle
         lastError = nil
+        endRun(runID)
+        try Task.checkCancellation()
         await operations.refreshAfterCompletion()
     }
 
-    private func beginRun() -> Bool {
-        guard !isRunning else { return false }
-        isRunning = true
-        return true
+    private func beginRun() -> UUID? {
+        guard activeRunID == nil else { return nil }
+        let runID = UUID()
+        activeRunID = runID
+        return runID
     }
 
-    private func finishCancellation() {
+    private func endRun(_ runID: UUID) {
+        guard activeRunID == runID else { return }
+        activeRunID = nil
+    }
+
+    private func finishCancellation(_ runID: UUID) {
+        guard activeRunID == runID else { return }
         activity = .idle
         lastError = nil
     }
 
-    private func finish(with error: Error) {
+    private func finish(with error: Error, runID: UUID) {
+        guard activeRunID == runID else { return }
         activity = .idle
         lastError = error
     }

--- a/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
+++ b/Alas/Sources/Center/Commit/CommitPublishWorkflow.swift
@@ -97,6 +97,16 @@ enum CommitPublishActivity: Equatable {
     case pushing
     case creatingReviewRequest
     case syncing
+
+    func actionLabel(reviewRequestLabel: String) -> String? {
+        switch self {
+        case .idle: nil
+        case .committing: "Committing..."
+        case .pushing: "Pushing..."
+        case .creatingReviewRequest: "Creating \(reviewRequestLabel)..."
+        case .syncing: "Syncing..."
+        }
+    }
 }
 
 enum CommitPublishWorkflowError: LocalizedError, Equatable {
@@ -151,6 +161,8 @@ final class CommitPublishWorkflow {
 
         lastError = nil
         activity = .committing
+        let subject = subject.trimmingCharacters(in: .whitespacesAndNewlines)
+        let body = body.trimmingCharacters(in: .whitespacesAndNewlines)
 
         do {
             let createdCommit = try await operations.createCommit(subject, body, amend)

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -49,7 +49,7 @@ struct DraftCommitTabView: View {
         guard let rps = appState.rightPaneStore.activeState(worktreeId: worktreeId) else { return false }
         return rps.changes.contains { $0.stage == .staged }
     }
-    private var canCommit: Bool { hasStaged && !trimmedSubject.isEmpty && !busy && publishCheckpoint == nil }
+    private var canCommit: Bool { presentation.commit.isEnabled }
     private var busy: Bool { localBusy || publishSession?.isRunning == true }
     private var publishSession: CommitPublishSession? { appState.tabs.commitPublishSession(tabId: tabState.id) }
     private var publishError: String? { publishSession?.lastError?.localizedDescription }
@@ -57,7 +57,7 @@ struct DraftCommitTabView: View {
         if let publishSession { return publishSession.checkpoint }
         return tabState.publishCheckpoint
     }
-    private var mutationsDisabled: Bool { busy || publishCheckpoint != nil }
+    private var mutationsDisabled: Bool { presentation.mutationsDisabled }
     private var rightPane: RightPaneState? { appState.rightPaneStore.activeState(worktreeId: worktreeId) }
 
     private var publicationProbeKey: String {
@@ -79,7 +79,7 @@ struct DraftCommitTabView: View {
                 contextIsActive: true, stackLoadState: rps.ggStackLoadState,
                 stack: rps.ggStack, currentHeadSHA: rps.currentHeadSHA
             ) ?? (amend ? publicationProbe.result(for: publicationProbeKey).disabledReason : nil)
-            return .init(label: "Commit & sync", detail: "Sync stack", disabledReason: reason, showsDraftToggle: false)
+            return .gg(disabledReason: reason)
         }
         let mutationReason: String?
         if rps.mergeOp.current != nil {
@@ -99,38 +99,23 @@ struct DraftCommitTabView: View {
     }
 
     private var publishAction: CommitPrimaryAction? {
-        guard publishCheckpoint != nil || publishAvailability != nil else { return nil }
-        let label: String
-        if let activityLabel = publishActivityText {
-            label = activityLabel
-        } else if let checkpoint = publishCheckpoint {
-            label = checkpoint.nextPhase.retryLabel(reviewRequestLabel: reviewRequestLabel)
-        } else {
-            label = publishAvailability?.label ?? "Publish"
-        }
-        return .init(label: label, savedLabel: nil,
-            isEnabled: !busy && (publishCheckpoint != nil || (canCommit && publishAvailability?.isEnabled == true)),
-            showSavedState: false, keyboardShortcut: nil, handler: runPublish)
+        guard let action = presentation.publish else { return nil }
+        return .init(label: action.label, isEnabled: action.isEnabled,
+            help: action.help, accessibilityIdentifier: "commit-composer-publish", handler: runPublish)
     }
 
     private var publishActivityText: String? {
-        activity.actionLabel(reviewRequestLabel: reviewRequestLabel)
+        presentation.activityText
     }
 
     private var activity: CommitPublishActivity {
         committingLocally ? .committing : publishSession?.activity ?? .idle
     }
 
-    private var commitActionLabel: String {
-        if activity == .committing, let label = publishActivityText { return label }
-        return amend ? "Amend" : "Commit"
-    }
-
-    private var reviewRequestLabel: String {
-        if let checkpoint = publishCheckpoint, case .review(let target) = checkpoint.destination {
-            return target.provider.reviewRequestLabel
-        }
-        return rightPane?.reviewLoop.snapshot?.remote?.kind.reviewRequestLabel ?? "PR"
+    private var presentation: CommitPublishPresentation {
+        CommitPublishPresentation(subject: subject, hasStaged: hasStaged, amend: amend,
+            busy: busy, activity: activity, checkpoint: publishCheckpoint,
+            preferredAction: tabState.preferredAction, availability: publishAvailability)
     }
 
     /// A key that changes whenever the staged set changes in the sidebar.
@@ -217,16 +202,18 @@ struct DraftCommitTabView: View {
                 availableAgents: appState.agentRegistry.enabled(),
                 onGenerate: handleGenerate,
                 primaryAction: CommitPrimaryAction(
-                    label: commitActionLabel,
+                    label: presentation.commit.label,
                     savedLabel: nil,
                     isEnabled: canCommit,
                     showSavedState: false,
                     keyboardShortcut: appState.shortcut(for: .commitInComposer),
+                    help: presentation.commit.help,
+                    accessibilityIdentifier: "commit-composer-commit",
                     handler: runCommit
                 ),
                 alternateAction: publishAction,
-                preferredActionPosition: publishCheckpoint != nil || tabState.preferredAction == .publish ? .trailing : .leading,
-                editorDisabled: publishCheckpoint != nil,
+                preferredActionPosition: presentation.preferredActionPosition,
+                editorDisabled: presentation.editorDisabled,
                 onDismissError: {
                     publishSession?.clearError()
                     error = nil
@@ -239,11 +226,13 @@ struct DraftCommitTabView: View {
                         .toggleStyle(.checkbox)
                         .disabled(mutationsDisabled || !canAmend)
                         .help(canAmend ? "" : "No previous commit to amend")
-                        if publishAvailability?.showsDraftToggle == true {
-                            Toggle("Draft \(rightPane?.reviewLoop.snapshot?.remote?.kind.reviewRequestLabel ?? "PR")", isOn: $createReviewRequestAsDraft)
+                        if let label = presentation.draftToggleLabel {
+                            Toggle(label, isOn: $createReviewRequestAsDraft)
                                 .font(.system(size: 11))
                                 .toggleStyle(.checkbox)
-                                .disabled(mutationsDisabled)
+                                .disabled(!presentation.draftToggleEnabled)
+                                .help(presentation.draftToggleHelp)
+                                .accessibilityIdentifier("commit-composer-draft-review-request")
                         }
                     }
                 )
@@ -545,7 +534,7 @@ struct DraftCommitTabView: View {
     }
 
     private func runCommit() {
-        guard !mutationsDisabled else { return }
+        guard canCommit else { return }
         let subjectSnapshot = trimmedSubject
         let bodySnapshot = bodyText
         let amendSnapshot = amend
@@ -599,8 +588,7 @@ struct DraftCommitTabView: View {
     }
 
     private func runPublish() {
-        guard !busy, let rps = rightPane,
-              publishCheckpoint != nil || (canCommit && publishAvailability?.isEnabled == true)
+        guard presentation.publish?.isEnabled == true, let rps = rightPane
         else { return }
         let subjectSnapshot = subject
         let bodySnapshot = bodyText

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -234,6 +234,14 @@ struct DraftCommitTabView: View {
                                 .help(presentation.draftToggleHelp)
                                 .accessibilityIdentifier("commit-composer-draft-review-request")
                         }
+                        if publishCheckpoint != nil {
+                            AlasButton(title: "Abandon retry", style: .subtle) {
+                                abandonPublishCheckpoint()
+                            }
+                            .disabled(busy)
+                            .help("Clear the paused publish retry.")
+                            .accessibilityIdentifier("commit-composer-abandon-publish")
+                        }
                     }
                 )
             )
@@ -627,5 +635,13 @@ struct DraftCommitTabView: View {
                     runGit: { try await Process.git($0, cwd: worktreePath) }
                 ))
             })
+    }
+
+    private func abandonPublishCheckpoint() {
+        guard !busy else { return }
+        if appState.tabs.abandonCommitPublishCheckpoint(worktreeId: worktreeId, tabId: tabState.id) {
+            error = nil
+            refreshActionsOverlay()
+        }
     }
 }

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -18,6 +18,11 @@ struct DraftCommitTabView: View {
     @State private var amendWarning: Bool = false
     @State private var canAmend: Bool = true
     @State private var generation: Task<Void, Never>? = nil
+    @State private var createReviewRequestAsDraft = false
+    @State private var publishCheckpoint: CommitPublishCheckpoint?
+    @State private var publishWorkflow: CommitPublishWorkflow?
+    @State private var publishError: String?
+    @State private var publicationProbe = CommitPublishAmendProbeLoader()
 
     @State private var stagedSession: DiffReviewLoadedSession?
     @State private var sessionWithActions: DiffReviewLoadedSession?
@@ -46,7 +51,77 @@ struct DraftCommitTabView: View {
         guard let rps = appState.rightPaneStore.activeState(worktreeId: worktreeId) else { return false }
         return rps.changes.contains { $0.stage == .staged }
     }
-    private var canCommit: Bool { hasStaged && !trimmedSubject.isEmpty && !busy }
+    private var canCommit: Bool { hasStaged && !trimmedSubject.isEmpty && !busy && publishCheckpoint == nil }
+    private var mutationsDisabled: Bool { busy || publishCheckpoint != nil }
+    private var rightPane: RightPaneState? { appState.rightPaneStore.activeState(worktreeId: worktreeId) }
+
+    private var publicationProbeKey: String {
+        guard let rps = rightPane else { return "" }
+        return ChangesTabView.amendPublicationProbeKey(
+            worktreeID: worktreeId, branch: rps.currentBranch, headSHA: rps.currentHeadSHA,
+            amend: amend, ggModeActive: rps.ggContext.isActive, reviewLoop: rps.reviewLoop
+        )
+    }
+
+    private var publishAvailability: CommitPublishAvailability? {
+        guard let rps = rightPane else { return nil }
+        if rps.ggContext.isActive {
+            let reason = ChangesTabView.ggPreparationMutationDisabledReason(
+                contextIsActive: true, stackLoadState: rps.ggStackLoadState,
+                pausedOperation: rps.ggActionState.pausedOperation,
+                inFlightAction: rps.ggActionState.inFlightAction, mergeOperation: rps.mergeOp.current
+            ) ?? ChangesTabView.ggNewStackCommitDisabledReason(
+                contextIsActive: true, stackLoadState: rps.ggStackLoadState,
+                stack: rps.ggStack, currentHeadSHA: rps.currentHeadSHA
+            ) ?? (amend ? publicationProbe.result(for: publicationProbeKey).disabledReason : nil)
+            return .init(label: "Commit & sync", detail: "Sync stack", disabledReason: reason, showsDraftToggle: false)
+        }
+        let mutationReason: String?
+        if rps.mergeOp.current != nil {
+            mutationReason = "Finish the current Git operation first."
+        } else if rps.reviewLoop.inFlightAction != nil || rps.pullInFlight || rps.stashOperationInFlight {
+            mutationReason = "Another Git operation is running."
+        } else {
+            mutationReason = nil
+        }
+        return .review(
+            snapshot: rps.reviewLoop.snapshot, supportedRemote: rps.commitRemote ?? rps.primaryCommitRemote,
+            isRefreshing: rps.reviewLoop.isRefreshing, currentBranch: rps.currentBranch,
+            currentBaseBranch: rps.baseBranch, lastError: rps.reviewLoop.lastError,
+            mutationDisabledReason: mutationReason, amend: amend,
+            amendProbe: publicationProbe.result(for: publicationProbeKey)
+        )
+    }
+
+    private var publishAction: CommitPrimaryAction? {
+        guard publishCheckpoint != nil || publishAvailability != nil else { return nil }
+        let label: String
+        if let checkpoint = publishCheckpoint {
+            switch checkpoint.nextPhase {
+            case .push: label = "Retry push"
+            case .createReviewRequest:
+                if case .review(let target) = checkpoint.destination {
+                    label = "Retry \(target.provider.reviewRequestLabel)"
+                } else { label = "Retry publish" }
+            case .sync: label = "Retry sync"
+            }
+        } else {
+            label = publishAvailability?.label ?? "Publish"
+        }
+        return .init(label: label, savedLabel: nil,
+            isEnabled: !busy && (publishCheckpoint != nil || (canCommit && publishAvailability?.isEnabled == true)),
+            showSavedState: false, keyboardShortcut: nil, handler: runPublish)
+    }
+
+    private var publishActivityText: String? {
+        switch publishWorkflow?.activity ?? .idle {
+        case .idle: return nil
+        case .committing: return "Committing..."
+        case .pushing: return "Pushing..."
+        case .creatingReviewRequest: return "Publishing review request..."
+        case .syncing: return "Syncing stack..."
+        }
+    }
 
     /// A key that changes whenever the staged set changes in the sidebar.
     /// SwiftUI tracks reads of `@Observable` properties, so this recomputes
@@ -80,7 +155,7 @@ struct DraftCommitTabView: View {
     // DiffReviewFileSection can detect a `busy` flip even when the session's
     // content is otherwise unchanged — see `refreshActionsOverlay`.
     private func overlayingActions(on session: DiffReviewLoadedSession) -> DiffReviewLoadedSession {
-        let unstageEnabledBase = !busy
+        let unstageEnabledBase = !mutationsDisabled
         let filesWithActions = session.files.map { model in
             var m = model
             m.stagedMutationActions = DiffReviewStagedMutationActions(
@@ -128,7 +203,7 @@ struct DraftCommitTabView: View {
                 aiToolId: appState.bind(\.changes.aiToolId),
                 title: amend ? "Amend HEAD" : "Draft commit",
                 busy: busy,
-                error: error,
+                error: publishError ?? error,
                 availableAgents: appState.agentRegistry.enabled(),
                 onGenerate: handleGenerate,
                 primaryAction: CommitPrimaryAction(
@@ -139,15 +214,40 @@ struct DraftCommitTabView: View {
                     keyboardShortcut: appState.shortcut(for: .commitInComposer),
                     handler: runCommit
                 ),
+                alternateAction: publishAction,
+                preferredActionPosition: publishCheckpoint != nil || tabState.preferredAction == .publish ? .trailing : .leading,
+                editorDisabled: publishCheckpoint != nil,
+                onDismissError: {
+                    publishError = nil
+                    error = nil
+                },
                 accessory: AnyView(
-                    Toggle(isOn: $amend) {
-                        Text("Amend").font(.system(size: 11)).foregroundColor(theme.color("fg-dim"))
+                    HStack(spacing: 8) {
+                        Toggle(isOn: $amend) {
+                            Text("Amend").font(.system(size: 11)).foregroundColor(theme.color("fg-dim"))
+                        }
+                        .toggleStyle(.checkbox)
+                        .disabled(mutationsDisabled || !canAmend)
+                        .help(canAmend ? "" : "No previous commit to amend")
+                        if publishAvailability?.showsDraftToggle == true {
+                            Toggle("Draft \(rightPane?.reviewLoop.snapshot?.remote?.kind.reviewRequestLabel ?? "PR")", isOn: $createReviewRequestAsDraft)
+                                .font(.system(size: 11))
+                                .toggleStyle(.checkbox)
+                                .disabled(mutationsDisabled)
+                        }
                     }
-                    .toggleStyle(.checkbox)
-                    .disabled(busy || !canAmend)
-                    .help(canAmend ? "" : "No previous commit to amend")
                 )
             )
+            if let activity = publishActivityText {
+                HStack(spacing: 6) {
+                    ProgressView().controlSize(.small)
+                    Text(activity).font(.system(size: 11))
+                    Spacer()
+                }.padding(.horizontal, 12).padding(.vertical, 6)
+            } else if publishCheckpoint == nil, let reason = publishAvailability?.disabledReason {
+                Text(reason).font(.system(size: 11)).foregroundColor(theme.color("fg-dim"))
+                    .frame(maxWidth: .infinity, alignment: .leading).padding(.horizontal, 12).padding(.vertical, 6)
+            }
             if amend && amendWarning {
                 Text("Amending a pushed commit will rewrite history.")
                     .font(.system(size: 10.5))
@@ -163,6 +263,17 @@ struct DraftCommitTabView: View {
         // HEAD-changing event (external commit, rebase, reset, etc.). On
         // mount the key is "" → "<sha>" so the task fires once.
         .task(id: amendProbeKey) { await refreshCanAmend() }
+        .task(id: publicationProbeKey) {
+            guard amend else { return }
+            await publicationProbe.load(key: publicationProbeKey) {
+                try await git.headPublicationState(worktreePath: worktreePath)
+            }
+        }
+        .onChange(of: createReviewRequestAsDraft) { _, new in
+            appState.tabs.updateDraftCommit(worktreeId: worktreeId, tabId: tabState.id) {
+                $0.createReviewRequestAsDraft = new
+            }
+        }
         .onChange(of: subject) { _, new in persist(subject: new) }
         .onChange(of: bodyText) { _, new in persist(body: new) }
         .onChange(of: amend) { _, new in
@@ -175,6 +286,7 @@ struct DraftCommitTabView: View {
         }
         .onChange(of: selectedFileID) { _, new in persist(selectedPath: new?.path) }
         .onChange(of: busy) { _, _ in refreshActionsOverlay() }
+        .onChange(of: publishCheckpoint) { _, _ in refreshActionsOverlay() }
         .task(id: stagedKey) {
             if await loadStagedSession() {
                 onStartupRecoveryReady()
@@ -219,6 +331,8 @@ struct DraftCommitTabView: View {
         subject = tabState.subject
         bodyText = tabState.bodyText
         amend = tabState.amend
+        createReviewRequestAsDraft = tabState.createReviewRequestAsDraft
+        publishCheckpoint = tabState.publishCheckpoint
         selectedFileID = tabState.selectedPath.map { DiffReviewFileID(namespace: "staged", path: $0) }
     }
 
@@ -232,8 +346,9 @@ struct DraftCommitTabView: View {
     }
 
     private func applyAmendPrefill() async {
+        guard publishCheckpoint == nil else { return }
         let head = (try? await git.headMessage(worktreePath: worktreePath)) ?? nil
-        guard amend else { return }
+        guard amend, publishCheckpoint == nil else { return }
         if let head,
            let prefill = DraftAmendPrefill.apply(
                priorSubject: head.subject,
@@ -274,6 +389,7 @@ struct DraftCommitTabView: View {
     }
 
     private func handleGenerate() {
+        guard publishCheckpoint == nil else { return }
         if busy {
             generation?.cancel()
             // Do not clear generation or busy here — runGenerate's defer handles both.
@@ -381,7 +497,7 @@ struct DraftCommitTabView: View {
     }
 
     private func unstageFileByPaths(path: String, originalPath: String?) {
-        guard !busy else { return }
+        guard !mutationsDisabled else { return }
         busy = true
         error = nil
         Task { @MainActor in
@@ -401,7 +517,7 @@ struct DraftCommitTabView: View {
     }
 
     private func unstageHunk(path: String, hunk: ParsedDiff.Hunk) {
-        guard !busy else { return }
+        guard !mutationsDisabled else { return }
         busy = true
         error = nil
         Task { @MainActor in
@@ -417,7 +533,7 @@ struct DraftCommitTabView: View {
     }
 
     private func runCommit() {
-        guard !busy else { return }
+        guard !mutationsDisabled else { return }
         let subjectSnapshot = trimmedSubject
         let bodySnapshot = bodyText
         let amendSnapshot = amend
@@ -461,6 +577,67 @@ struct DraftCommitTabView: View {
                 await refreshCanAmend()
             } catch {
                 self.error = (error as NSError).localizedDescription
+            }
+        }
+    }
+
+    private func runPublish() {
+        guard !busy, let rps = rightPane,
+              publishCheckpoint != nil || (canCommit && publishAvailability?.isEnabled == true)
+        else { return }
+        let subjectSnapshot = trimmedSubject
+        let bodySnapshot = bodyText
+        let amendSnapshot = amend
+        let draftSnapshot = createReviewRequestAsDraft
+        let reviewSnapshot = rps.reviewLoop.snapshot
+        let ggMode = rps.ggContext.isActive
+        let comparisonBase = appState.rightPaneStore.commitEditorComparisonRef(worktreeId: worktreeId)
+        busy = true
+        error = nil
+        publishError = nil
+
+        Task { @MainActor in
+            defer { busy = false }
+            do {
+                let operations = CommitPublishOperations.live(
+                    worktreePath: worktreePath, reviewLoop: rps.reviewLoop, comparisonBase: comparisonBase,
+                    syncGG: { try await rps.syncGGForCommitPublish() },
+                    refreshAfterCompletion: { _ = await rps.refresh(forceReviewLoopRemote: true) }
+                )
+                let workflow = CommitPublishWorkflow(operations: operations) { checkpoint in
+                    let completed = publishCheckpoint
+                    publishCheckpoint = checkpoint
+                    appState.tabs.updateDraftCommit(worktreeId: worktreeId, tabId: tabState.id) {
+                        $0.publishCheckpoint = checkpoint
+                    }
+                    if checkpoint == nil, let completed {
+                        _ = appState.tabs.replaceDraftWithCommitEditor(
+                            worktreeId: worktreeId, draftTabId: tabState.id,
+                            baseRef: completed.baseRef, newSha: completed.commitSHA, title: completed.commitTitle
+                        )
+                    }
+                }
+                publishWorkflow = workflow
+                if let checkpoint = publishCheckpoint {
+                    await workflow.resume(checkpoint)
+                } else {
+                    let destination: CommitPublishDestination
+                    if ggMode {
+                        destination = .gg
+                    } else if let reviewSnapshot {
+                        destination = .review(try await CommitPublishReviewTarget.capture(
+                            snapshot: reviewSnapshot, createAsDraft: draftSnapshot,
+                            runGit: { try await Process.git($0, cwd: worktreePath) }
+                        ))
+                    } else {
+                        throw CommitPublishWorkflowError.invalidDestination(phase: .push)
+                    }
+                    await workflow.start(subject: subjectSnapshot, body: bodySnapshot,
+                        amend: amendSnapshot, destination: destination)
+                }
+                publishError = workflow.lastError?.localizedDescription
+            } catch {
+                publishError = error.localizedDescription
             }
         }
     }

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -596,17 +596,31 @@ struct DraftCommitTabView: View {
         let draftSnapshot = createReviewRequestAsDraft
         let reviewSnapshot = rps.reviewLoop.snapshot
         let ggMode = rps.ggContext.isActive
+        let ggTarget: GGStackTargetIdentity?
+        if ggMode {
+            guard let target = rps.ggTargetForCommitPublish() else {
+                error = GGMutationError.staleConfirmation.localizedDescription
+                return
+            }
+            ggTarget = target
+        } else {
+            ggTarget = nil
+        }
         let comparisonBase = appState.rightPaneStore.commitEditorComparisonRef(worktreeId: worktreeId)
         error = nil
-        let operations = CommitPublishOperations.live(
+        var operations = CommitPublishOperations.live(
             worktreePath: worktreePath, reviewLoop: rps.reviewLoop, comparisonBase: comparisonBase,
             syncGG: { try await rps.syncGGForCommitPublish() },
             refreshAfterCompletion: { _ = await rps.refresh(forceReviewLoopRemote: true) }
         )
+        operations.validateGGTarget = { try await rps.validateGGTargetForCommitPublish($0) }
+        operations.syncGGForTarget = { try await rps.syncGGForCommitPublish(target: $0) }
         appState.tabs.runCommitPublish(worktreeId: worktreeId, tabId: tabState.id,
             subject: subjectSnapshot, body: bodySnapshot, amend: amendSnapshot,
             operations: operations, prepareDestination: { [worktreePath] in
-                if ggMode { return .gg }
+                if let ggTarget {
+                    return .gg(ggTarget)
+                }
                 guard let reviewSnapshot else { throw CommitPublishWorkflowError.invalidDestination(phase: .push) }
                 return .review(try await CommitPublishReviewTarget.capture(
                     snapshot: reviewSnapshot, createAsDraft: draftSnapshot,

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -618,11 +618,11 @@ struct DraftCommitTabView: View {
         error = nil
         var operations = CommitPublishOperations.live(
             worktreePath: worktreePath, reviewLoop: rps.reviewLoop, comparisonBase: comparisonBase,
-            syncGG: { try await rps.syncGGForCommitPublish() },
+            syncGG: { execution in try await rps.syncGGForCommitPublish(markExecutionStarted: execution.markStarted) },
             refreshAfterCompletion: { _ = await rps.refresh(forceReviewLoopRemote: true) }
         )
         operations.validateGGTarget = { try await rps.validateGGTargetForCommitPublish($0) }
-        operations.syncGGForTarget = { try await rps.syncGGForCommitPublish(target: $0) }
+        operations.syncGGForTarget = { try await rps.syncGGForCommitPublish(target: $0, markExecutionStarted: $1.markStarted) }
         appState.tabs.runCommitPublish(worktreeId: worktreeId, tabId: tabState.id,
             subject: subjectSnapshot, body: bodySnapshot, amend: amendSnapshot,
             operations: operations, prepareDestination: { [worktreePath] in

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -10,7 +10,7 @@ struct DraftCommitTabView: View {
     @State private var subject: String = ""
     @State private var bodyText: String = ""
     @State private var amend: Bool = false
-    @State private var busy = false
+    @State private var localBusy = false
     @State private var committingLocally = false
     @State private var error: String?
     @State private var amendPrefilled: Bool = false
@@ -20,9 +20,6 @@ struct DraftCommitTabView: View {
     @State private var canAmend: Bool = true
     @State private var generation: Task<Void, Never>? = nil
     @State private var createReviewRequestAsDraft = false
-    @State private var publishCheckpoint: CommitPublishCheckpoint?
-    @State private var publishWorkflow: CommitPublishWorkflow?
-    @State private var publishError: String?
     @State private var publicationProbe = CommitPublishAmendProbeLoader()
 
     @State private var stagedSession: DiffReviewLoadedSession?
@@ -53,6 +50,13 @@ struct DraftCommitTabView: View {
         return rps.changes.contains { $0.stage == .staged }
     }
     private var canCommit: Bool { hasStaged && !trimmedSubject.isEmpty && !busy && publishCheckpoint == nil }
+    private var busy: Bool { localBusy || publishSession?.isRunning == true }
+    private var publishSession: CommitPublishSession? { appState.tabs.commitPublishSession(tabId: tabState.id) }
+    private var publishError: String? { publishSession?.lastError?.localizedDescription }
+    private var publishCheckpoint: CommitPublishCheckpoint? {
+        if let publishSession { return publishSession.checkpoint }
+        return tabState.publishCheckpoint
+    }
     private var mutationsDisabled: Bool { busy || publishCheckpoint != nil }
     private var rightPane: RightPaneState? { appState.rightPaneStore.activeState(worktreeId: worktreeId) }
 
@@ -114,7 +118,7 @@ struct DraftCommitTabView: View {
     }
 
     private var activity: CommitPublishActivity {
-        committingLocally ? .committing : publishWorkflow?.activity ?? .idle
+        committingLocally ? .committing : publishSession?.activity ?? .idle
     }
 
     private var commitActionLabel: String {
@@ -224,7 +228,7 @@ struct DraftCommitTabView: View {
                 preferredActionPosition: publishCheckpoint != nil || tabState.preferredAction == .publish ? .trailing : .leading,
                 editorDisabled: publishCheckpoint != nil,
                 onDismissError: {
-                    publishError = nil
+                    publishSession?.clearError()
                     error = nil
                 },
                 accessory: AnyView(
@@ -338,7 +342,6 @@ struct DraftCommitTabView: View {
         bodyText = tabState.bodyText
         amend = tabState.amend
         createReviewRequestAsDraft = tabState.createReviewRequestAsDraft
-        publishCheckpoint = tabState.publishCheckpoint
         selectedFileID = tabState.selectedPath.map { DiffReviewFileID(namespace: "staged", path: $0) }
     }
 
@@ -405,7 +408,7 @@ struct DraftCommitTabView: View {
     }
 
     private func runGenerate() {
-        publishError = nil
+        publishSession?.clearError()
         guard let agent = appState.agent(id: appState.config.changes.aiToolId) else {
             error = "Select an AI tool to generate a commit message."
             return
@@ -415,12 +418,12 @@ struct DraftCommitTabView: View {
         let prompt = appState.config.changes.prompt
         let baseBranch = appState.rightPaneStore.commitEditorComparisonRef(worktreeId: worktreeId) ?? "HEAD"
 
-        busy = true
+        localBusy = true
         error = nil
 
         generation = Task { @MainActor in
             defer {
-                busy = false
+                localBusy = false
                 generation = nil
             }
             do {
@@ -505,11 +508,11 @@ struct DraftCommitTabView: View {
 
     private func unstageFileByPaths(path: String, originalPath: String?) {
         guard !mutationsDisabled else { return }
-        busy = true
+        localBusy = true
         error = nil
-        publishError = nil
+        publishSession?.clearError()
         Task { @MainActor in
-            defer { busy = false }
+            defer { localBusy = false }
             do {
                 var paths = [path]
                 if let original = originalPath, !original.isEmpty {
@@ -526,11 +529,11 @@ struct DraftCommitTabView: View {
 
     private func unstageHunk(path: String, hunk: ParsedDiff.Hunk) {
         guard !mutationsDisabled else { return }
-        busy = true
+        localBusy = true
         error = nil
-        publishError = nil
+        publishSession?.clearError()
         Task { @MainActor in
-            defer { busy = false }
+            defer { localBusy = false }
             do {
                 try await git.unstageHunk(worktreePath: worktreePath, path: path, hunk: hunk)
                 await loadStagedSession()
@@ -547,14 +550,14 @@ struct DraftCommitTabView: View {
         let bodySnapshot = bodyText
         let amendSnapshot = amend
 
-        busy = true
+        localBusy = true
         committingLocally = true
         error = nil
-        publishError = nil
+        publishSession?.clearError()
 
         Task { @MainActor in
             defer {
-                busy = false
+                localBusy = false
                 committingLocally = false
             }
             do {
@@ -606,53 +609,21 @@ struct DraftCommitTabView: View {
         let reviewSnapshot = rps.reviewLoop.snapshot
         let ggMode = rps.ggContext.isActive
         let comparisonBase = appState.rightPaneStore.commitEditorComparisonRef(worktreeId: worktreeId)
-        busy = true
         error = nil
-        publishError = nil
-
-        Task { @MainActor in
-            defer { busy = false }
-            do {
-                let operations = CommitPublishOperations.live(
-                    worktreePath: worktreePath, reviewLoop: rps.reviewLoop, comparisonBase: comparisonBase,
-                    syncGG: { try await rps.syncGGForCommitPublish() },
-                    refreshAfterCompletion: { _ = await rps.refresh(forceReviewLoopRemote: true) }
-                )
-                let workflow = CommitPublishWorkflow(operations: operations) { checkpoint in
-                    let completed = publishCheckpoint
-                    publishCheckpoint = checkpoint
-                    appState.tabs.updateDraftCommit(worktreeId: worktreeId, tabId: tabState.id) {
-                        $0.publishCheckpoint = checkpoint
-                    }
-                    if checkpoint == nil, let completed {
-                        _ = appState.tabs.replaceDraftWithCommitEditor(
-                            worktreeId: worktreeId, draftTabId: tabState.id,
-                            baseRef: completed.baseRef, newSha: completed.commitSHA, title: completed.commitTitle
-                        )
-                    }
-                }
-                publishWorkflow = workflow
-                if let checkpoint = publishCheckpoint {
-                    await workflow.resume(checkpoint)
-                } else {
-                    let destination: CommitPublishDestination
-                    if ggMode {
-                        destination = .gg
-                    } else if let reviewSnapshot {
-                        destination = .review(try await CommitPublishReviewTarget.capture(
-                            snapshot: reviewSnapshot, createAsDraft: draftSnapshot,
-                            runGit: { try await Process.git($0, cwd: worktreePath) }
-                        ))
-                    } else {
-                        throw CommitPublishWorkflowError.invalidDestination(phase: .push)
-                    }
-                    await workflow.start(subject: subjectSnapshot, body: bodySnapshot,
-                        amend: amendSnapshot, destination: destination)
-                }
-                publishError = workflow.lastError?.localizedDescription
-            } catch {
-                publishError = error.localizedDescription
-            }
-        }
+        let operations = CommitPublishOperations.live(
+            worktreePath: worktreePath, reviewLoop: rps.reviewLoop, comparisonBase: comparisonBase,
+            syncGG: { try await rps.syncGGForCommitPublish() },
+            refreshAfterCompletion: { _ = await rps.refresh(forceReviewLoopRemote: true) }
+        )
+        appState.tabs.runCommitPublish(worktreeId: worktreeId, tabId: tabState.id,
+            subject: subjectSnapshot, body: bodySnapshot, amend: amendSnapshot,
+            operations: operations, prepareDestination: { [worktreePath] in
+                if ggMode { return .gg }
+                guard let reviewSnapshot else { throw CommitPublishWorkflowError.invalidDestination(phase: .push) }
+                return .review(try await CommitPublishReviewTarget.capture(
+                    snapshot: reviewSnapshot, createAsDraft: draftSnapshot,
+                    runGit: { try await Process.git($0, cwd: worktreePath) }
+                ))
+            })
     }
 }

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -11,6 +11,7 @@ struct DraftCommitTabView: View {
     @State private var bodyText: String = ""
     @State private var amend: Bool = false
     @State private var busy = false
+    @State private var committingLocally = false
     @State private var error: String?
     @State private var amendPrefilled: Bool = false
     @State private var amendPrefilledSubject: String = ""
@@ -96,15 +97,10 @@ struct DraftCommitTabView: View {
     private var publishAction: CommitPrimaryAction? {
         guard publishCheckpoint != nil || publishAvailability != nil else { return nil }
         let label: String
-        if let checkpoint = publishCheckpoint {
-            switch checkpoint.nextPhase {
-            case .push: label = "Retry push"
-            case .createReviewRequest:
-                if case .review(let target) = checkpoint.destination {
-                    label = "Retry \(target.provider.reviewRequestLabel)"
-                } else { label = "Retry publish" }
-            case .sync: label = "Retry sync"
-            }
+        if let activityLabel = publishActivityText {
+            label = activityLabel
+        } else if let checkpoint = publishCheckpoint {
+            label = checkpoint.nextPhase.retryLabel(reviewRequestLabel: reviewRequestLabel)
         } else {
             label = publishAvailability?.label ?? "Publish"
         }
@@ -114,13 +110,23 @@ struct DraftCommitTabView: View {
     }
 
     private var publishActivityText: String? {
-        switch publishWorkflow?.activity ?? .idle {
-        case .idle: return nil
-        case .committing: return "Committing..."
-        case .pushing: return "Pushing..."
-        case .creatingReviewRequest: return "Publishing review request..."
-        case .syncing: return "Syncing stack..."
+        activity.actionLabel(reviewRequestLabel: reviewRequestLabel)
+    }
+
+    private var activity: CommitPublishActivity {
+        committingLocally ? .committing : publishWorkflow?.activity ?? .idle
+    }
+
+    private var commitActionLabel: String {
+        if activity == .committing, let label = publishActivityText { return label }
+        return amend ? "Amend" : "Commit"
+    }
+
+    private var reviewRequestLabel: String {
+        if let checkpoint = publishCheckpoint, case .review(let target) = checkpoint.destination {
+            return target.provider.reviewRequestLabel
         }
+        return rightPane?.reviewLoop.snapshot?.remote?.kind.reviewRequestLabel ?? "PR"
     }
 
     /// A key that changes whenever the staged set changes in the sidebar.
@@ -207,7 +213,7 @@ struct DraftCommitTabView: View {
                 availableAgents: appState.agentRegistry.enabled(),
                 onGenerate: handleGenerate,
                 primaryAction: CommitPrimaryAction(
-                    label: amend ? "Amend" : "Commit",
+                    label: commitActionLabel,
                     savedLabel: nil,
                     isEnabled: canCommit,
                     showSavedState: false,
@@ -399,6 +405,7 @@ struct DraftCommitTabView: View {
     }
 
     private func runGenerate() {
+        publishError = nil
         guard let agent = appState.agent(id: appState.config.changes.aiToolId) else {
             error = "Select an AI tool to generate a commit message."
             return
@@ -500,6 +507,7 @@ struct DraftCommitTabView: View {
         guard !mutationsDisabled else { return }
         busy = true
         error = nil
+        publishError = nil
         Task { @MainActor in
             defer { busy = false }
             do {
@@ -520,6 +528,7 @@ struct DraftCommitTabView: View {
         guard !mutationsDisabled else { return }
         busy = true
         error = nil
+        publishError = nil
         Task { @MainActor in
             defer { busy = false }
             do {
@@ -539,10 +548,15 @@ struct DraftCommitTabView: View {
         let amendSnapshot = amend
 
         busy = true
+        committingLocally = true
         error = nil
+        publishError = nil
 
         Task { @MainActor in
-            defer { busy = false }
+            defer {
+                busy = false
+                committingLocally = false
+            }
             do {
                 let newSha = try await git.commit(
                     worktreePath: worktreePath,
@@ -585,7 +599,7 @@ struct DraftCommitTabView: View {
         guard !busy, let rps = rightPane,
               publishCheckpoint != nil || (canCommit && publishAvailability?.isEnabled == true)
         else { return }
-        let subjectSnapshot = trimmedSubject
+        let subjectSnapshot = subject
         let bodySnapshot = bodyText
         let amendSnapshot = amend
         let draftSnapshot = createReviewRequestAsDraft

--- a/Alas/Sources/Center/Commit/DraftCommitTabView.swift
+++ b/Alas/Sources/Center/Commit/DraftCommitTabView.swift
@@ -605,7 +605,7 @@ struct DraftCommitTabView: View {
         let reviewSnapshot = rps.reviewLoop.snapshot
         let ggMode = rps.ggContext.isActive
         let ggTarget: GGStackTargetIdentity?
-        if ggMode {
+        if publishCheckpoint == nil, ggMode {
             guard let target = rps.ggTargetForCommitPublish() else {
                 error = GGMutationError.staleConfirmation.localizedDescription
                 return
@@ -623,6 +623,8 @@ struct DraftCommitTabView: View {
         )
         operations.validateGGTarget = { try await rps.validateGGTargetForCommitPublish($0) }
         operations.syncGGForTarget = { try await rps.syncGGForCommitPublish(target: $0, markExecutionStarted: $1.markStarted) }
+        operations.currentGGRecoveryOperationID = { try await rps.currentGGRecoveryOperationIDForCommitPublish() }
+        operations.validateGGRecoveryHead = { try rps.validateGGRecoveryHeadForCommitPublish(operationID: $0, headSHA: $1) }
         appState.tabs.runCommitPublish(worktreeId: worktreeId, tabId: tabState.id,
             subject: subjectSnapshot, body: bodySnapshot, amend: amendSnapshot,
             operations: operations, prepareDestination: { [worktreePath] in

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -484,7 +484,23 @@ struct DraftCommitTabState: Codable, Equatable, Identifiable {
     var bodyText: String
     var amend: Bool
     var selectedPath: String?
+    var preferredAction: DraftCommitPreferredAction
+    var createReviewRequestAsDraft: Bool
+    var publishCheckpoint: CommitPublishCheckpoint?
     private var presentationRevision: Int?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case worktreeId
+        case subject
+        case bodyText
+        case amend
+        case selectedPath
+        case preferredAction
+        case createReviewRequestAsDraft
+        case publishCheckpoint
+        case presentationRevision
+    }
 
     var presentationID: String {
         "\(id):presentation:\(presentationRevision ?? 0)"
@@ -495,7 +511,10 @@ struct DraftCommitTabState: Codable, Equatable, Identifiable {
         subject: String = "",
         bodyText: String = "",
         amend: Bool = false,
-        selectedPath: String? = nil
+        selectedPath: String? = nil,
+        preferredAction: DraftCommitPreferredAction = .commit,
+        createReviewRequestAsDraft: Bool = false,
+        publishCheckpoint: CommitPublishCheckpoint? = nil
     ) {
         self.id = "draft-commit:\(worktreeId)"
         self.worktreeId = worktreeId
@@ -503,7 +522,38 @@ struct DraftCommitTabState: Codable, Equatable, Identifiable {
         self.bodyText = bodyText
         self.amend = amend
         self.selectedPath = selectedPath
+        self.preferredAction = preferredAction
+        self.createReviewRequestAsDraft = createReviewRequestAsDraft
+        self.publishCheckpoint = publishCheckpoint
         self.presentationRevision = nil
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(TabID.self, forKey: .id)
+        worktreeId = try container.decode(String.self, forKey: .worktreeId)
+        subject = try container.decode(String.self, forKey: .subject)
+        bodyText = try container.decode(String.self, forKey: .bodyText)
+        amend = try container.decode(Bool.self, forKey: .amend)
+        selectedPath = try container.decodeIfPresent(String.self, forKey: .selectedPath)
+        preferredAction = try container.decodeIfPresent(DraftCommitPreferredAction.self, forKey: .preferredAction) ?? .commit
+        createReviewRequestAsDraft = try container.decodeIfPresent(Bool.self, forKey: .createReviewRequestAsDraft) ?? false
+        publishCheckpoint = try container.decodeIfPresent(CommitPublishCheckpoint.self, forKey: .publishCheckpoint)
+        presentationRevision = try container.decodeIfPresent(Int.self, forKey: .presentationRevision)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(worktreeId, forKey: .worktreeId)
+        try container.encode(subject, forKey: .subject)
+        try container.encode(bodyText, forKey: .bodyText)
+        try container.encode(amend, forKey: .amend)
+        try container.encodeIfPresent(selectedPath, forKey: .selectedPath)
+        try container.encode(preferredAction, forKey: .preferredAction)
+        try container.encode(createReviewRequestAsDraft, forKey: .createReviewRequestAsDraft)
+        try container.encodeIfPresent(publishCheckpoint, forKey: .publishCheckpoint)
+        try container.encodeIfPresent(presentationRevision, forKey: .presentationRevision)
     }
 
     mutating func prepareForNewCommit() {

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -64,6 +64,7 @@ final class TabsManager {
     /// Session-only split drafts survive view recreation when the user switches
     /// tabs, but are deliberately not persisted as part of the tab identity.
     private var ggSplitCommitDrafts: [TabID: GGSplitCommitDraft] = [:]
+    private var commitPublishSessions: [TabID: CommitPublishSession] = [:]
     /// Tracks which tab IDs have already had `openExternalDocument` fired so
     /// that cache-hit calls to `externalBuffer` don't double-count the ref.
     private var openedExternalDocs: Set<TabID> = []
@@ -1027,6 +1028,52 @@ final class TabsManager {
         return tab
     }
 
+    func commitPublishSession(tabId: TabID) -> CommitPublishSession? {
+        commitPublishSessions[tabId]
+    }
+
+    @discardableResult
+    func runCommitPublish(
+        worktreeId: String,
+        tabId: TabID,
+        subject: String,
+        body: String,
+        amend: Bool,
+        operations: CommitPublishOperations,
+        prepareDestination: @escaping () async throws -> CommitPublishDestination
+    ) -> Task<Void, Never>? {
+        guard case .draftCommit(let draft) = tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }) else {
+            return nil
+        }
+        let session: CommitPublishSession
+        if let existing = commitPublishSessions[tabId] {
+            session = existing
+        } else {
+            session = CommitPublishSession(checkpoint: draft.publishCheckpoint, onCheckpointChange: { [weak self] checkpoint in
+                self?.persistCommitPublishCheckpoint(checkpoint, worktreeId: worktreeId, tabId: tabId)
+            }, onCompletion: { [weak self] checkpoint in
+                guard let self else { return }
+                if replaceDraftWithCommitEditor(worktreeId: worktreeId, draftTabId: tabId,
+                    baseRef: checkpoint.baseRef, newSha: checkpoint.commitSHA, title: checkpoint.commitTitle) == nil {
+                    discardStashedDraft(worktreeId: worktreeId)
+                }
+            })
+            commitPublishSessions[tabId] = session
+        }
+        return session.run(subject: subject, body: body, amend: amend,
+            operations: operations, prepareDestination: prepareDestination)
+    }
+
+    private func persistCommitPublishCheckpoint(_ checkpoint: CommitPublishCheckpoint?, worktreeId: String, tabId: TabID) {
+        if updateDraftCommit(worktreeId: worktreeId, tabId: tabId, mutate: { $0.publishCheckpoint = checkpoint }) != nil {
+            return
+        }
+        guard var file = byWorktree[worktreeId], file.stashedDraft?.id == tabId else { return }
+        file.stashedDraft?.publishCheckpoint = checkpoint
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+    }
+
     @discardableResult
     func openOrFocusDraftReviewRequest(worktreeId: String, snapshot: ReviewLoopSnapshot) -> Tab {
         let baseState = DraftReviewRequestTabState(worktreeId: worktreeId, snapshot: snapshot)
@@ -1068,6 +1115,8 @@ final class TabsManager {
     /// Used when the user explicitly discards the draft (via tab context
     /// menu) or after a successful commit consumes the draft.
     func discardStashedDraft(worktreeId: String) {
+        let tabId = DraftCommitTabState(worktreeId: worktreeId).id
+        if commitPublishSessions[tabId]?.isRunning == false { commitPublishSessions[tabId] = nil }
         guard var file = byWorktree[worktreeId], file.stashedDraft != nil else { return }
         file.stashedDraft = nil
         byWorktree[worktreeId] = file

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -1050,7 +1050,8 @@ final class TabsManager {
             session = existing
         } else {
             session = CommitPublishSession(checkpoint: draft.publishCheckpoint, onCheckpointChange: { [weak self] checkpoint in
-                self?.persistCommitPublishCheckpoint(checkpoint, worktreeId: worktreeId, tabId: tabId)
+                guard let self else { return }
+                try persistCommitPublishCheckpoint(checkpoint, worktreeId: worktreeId, tabId: tabId)
             }, onCompletion: { [weak self] checkpoint in
                 guard let self else { return }
                 if replaceDraftWithCommitEditor(worktreeId: worktreeId, draftTabId: tabId,
@@ -1064,14 +1065,35 @@ final class TabsManager {
             operations: operations, prepareDestination: prepareDestination)
     }
 
-    private func persistCommitPublishCheckpoint(_ checkpoint: CommitPublishCheckpoint?, worktreeId: String, tabId: TabID) {
-        if updateDraftCommit(worktreeId: worktreeId, tabId: tabId, mutate: { $0.publishCheckpoint = checkpoint }) != nil {
-            return
+    @discardableResult
+    func abandonCommitPublishCheckpoint(worktreeId: String, tabId: TabID) -> Bool {
+        guard commitPublishSessions[tabId]?.isRunning != true else { return false }
+        do {
+            try persistCommitPublishCheckpoint(nil, worktreeId: worktreeId, tabId: tabId)
+            _ = commitPublishSessions[tabId]?.abandonCheckpoint()
+            commitPublishSessions[tabId] = nil
+            return true
+        } catch {
+            return false
         }
-        guard var file = byWorktree[worktreeId], file.stashedDraft?.id == tabId else { return }
+    }
+
+    @discardableResult
+    private func persistCommitPublishCheckpoint(_ checkpoint: CommitPublishCheckpoint?, worktreeId: String, tabId: TabID) throws -> Bool {
+        guard var file = byWorktree[worktreeId] else { return false }
+        if let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+           case .draftCommit(var state) = file.tabs[idx] {
+            state.publishCheckpoint = checkpoint
+            file.tabs[idx] = .draftCommit(state)
+            byWorktree[worktreeId] = file
+            try persistThrowing(worktreeId)
+            return true
+        }
+        guard file.stashedDraft?.id == tabId else { return false }
         file.stashedDraft?.publishCheckpoint = checkpoint
         byWorktree[worktreeId] = file
-        persist(worktreeId)
+        try persistThrowing(worktreeId)
+        return true
     }
 
     @discardableResult
@@ -1135,6 +1157,19 @@ final class TabsManager {
               let idx = file.tabs.firstIndex(where: { $0.id == draftTabId }),
               case .draftCommit = file.tabs[idx]
         else { return nil }
+        for existingIdx in file.tabs.indices {
+            guard case .commitEditor(var existing) = file.tabs[existingIdx],
+                  existing.currentSha == newSha else { continue }
+            existing.title = title
+            let tab = Tab.commitEditor(existing)
+            file.tabs[existingIdx] = tab
+            file.tabs.remove(at: idx)
+            file.activeTabId = tab.id
+            file.stashedDraft = nil
+            byWorktree[worktreeId] = file
+            persist(worktreeId)
+            return tab
+        }
         let editor = CommitEditorTabState(
             worktreeId: worktreeId,
             baseRef: baseRef,
@@ -1493,8 +1528,12 @@ final class TabsManager {
     }
 
     private func persist(_ worktreeId: String) {
+        try? persistThrowing(worktreeId)
+    }
+
+    private func persistThrowing(_ worktreeId: String) throws {
         guard let file = byWorktree[worktreeId] else { return }
-        try? store.write(file, to: tabsFile(forWorktreeId: worktreeId))
+        try store.write(file, to: tabsFile(forWorktreeId: worktreeId))
     }
 
     private func tabsFile(forWorktreeId worktreeId: String) -> URL {

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -1055,11 +1055,8 @@ final class TabsManager {
                 try persistCommitPublishCheckpoint(checkpoint, worktreeId: worktreeId, tabId: tabId)
             }, onCompletion: { [weak self] checkpoint in
                 guard let self else { return }
+                try completeCommitPublish(worktreeId: worktreeId, tabId: tabId, checkpoint: checkpoint)
                 onCommitPublishCompletion?(worktreeId, tabId)
-                if replaceDraftWithCommitEditor(worktreeId: worktreeId, draftTabId: tabId,
-                    baseRef: checkpoint.baseRef, newSha: checkpoint.commitSHA, title: checkpoint.commitTitle) == nil {
-                    discardStashedDraft(worktreeId: worktreeId)
-                }
             })
             commitPublishSessions[tabId] = session
         }
@@ -1156,7 +1153,55 @@ final class TabsManager {
         title: String
     ) -> Tab? {
         guard var file = byWorktree[worktreeId],
-              let idx = file.tabs.firstIndex(where: { $0.id == draftTabId }),
+              let tab = replaceDraftWithCommitEditor(
+                  in: &file,
+                  worktreeId: worktreeId,
+                  draftTabId: draftTabId,
+                  baseRef: baseRef,
+                  newSha: newSha,
+                  title: title
+              )
+        else { return nil }
+        do {
+            try persistThrowing(file, worktreeId: worktreeId)
+            byWorktree[worktreeId] = file
+            return tab
+        } catch {
+            return nil
+        }
+    }
+
+    @discardableResult
+    private func completeCommitPublish(worktreeId: String, tabId: TabID, checkpoint: CommitPublishCheckpoint) throws -> Tab? {
+        guard var file = byWorktree[worktreeId] else { return nil }
+        if let tab = replaceDraftWithCommitEditor(
+            in: &file,
+            worktreeId: worktreeId,
+            draftTabId: tabId,
+            baseRef: checkpoint.baseRef,
+            newSha: checkpoint.commitSHA,
+            title: checkpoint.commitTitle
+        ) {
+            try persistThrowing(file, worktreeId: worktreeId)
+            byWorktree[worktreeId] = file
+            return tab
+        }
+        guard file.stashedDraft != nil else { return nil }
+        file.stashedDraft = nil
+        try persistThrowing(file, worktreeId: worktreeId)
+        byWorktree[worktreeId] = file
+        return nil
+    }
+
+    private func replaceDraftWithCommitEditor(
+        in file: inout TabsFile,
+        worktreeId: String,
+        draftTabId: TabID,
+        baseRef: String,
+        newSha: String,
+        title: String
+    ) -> Tab? {
+        guard let idx = file.tabs.firstIndex(where: { $0.id == draftTabId }),
               case .draftCommit = file.tabs[idx]
         else { return nil }
         for existingIdx in file.tabs.indices {
@@ -1168,8 +1213,6 @@ final class TabsManager {
             file.tabs.remove(at: idx)
             file.activeTabId = tab.id
             file.stashedDraft = nil
-            byWorktree[worktreeId] = file
-            persist(worktreeId)
             return tab
         }
         let editor = CommitEditorTabState(
@@ -1185,8 +1228,6 @@ final class TabsManager {
             file.activeTabId = tab.id
         }
         file.stashedDraft = nil
-        byWorktree[worktreeId] = file
-        persist(worktreeId)
         return tab
     }
 

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -967,29 +967,42 @@ final class TabsManager {
     }
 
     @discardableResult
-    func openOrFocusDraftCommit(worktreeId: String, resetAmend: Bool = false) -> Tab {
+    func openOrFocusDraftCommit(
+        worktreeId: String,
+        resetAmend: Bool = false,
+        preferredAction: DraftCommitPreferredAction? = nil
+    ) -> Tab {
         let baseState = DraftCommitTabState(worktreeId: worktreeId)
         if var file = byWorktree[worktreeId],
            let idx = file.tabs.firstIndex(where: { $0.id == baseState.id }),
            case .draftCommit(var existing) = file.tabs[idx] {
             if resetAmend {
                 existing.prepareForNewCommit()
-                file.tabs[idx] = .draftCommit(existing)
             }
-            file.activeTabId = existing.id
+            if let preferredAction {
+                existing.preferredAction = preferredAction
+            }
+            let tab = Tab.draftCommit(existing)
+            file.tabs[idx] = tab
+            file.activeTabId = tab.id
             byWorktree[worktreeId] = file
             persist(worktreeId)
-            return file.tabs[idx]
+            return tab
         }
         // No live tab — restore from the stash if present, otherwise start fresh.
         var state = byWorktree[worktreeId]?.stashedDraft ?? baseState
         if resetAmend {
             state.prepareForNewCommit()
-            if var file = byWorktree[worktreeId], file.stashedDraft != nil {
-                file.stashedDraft = state
-                byWorktree[worktreeId] = file
-                persist(worktreeId)
-            }
+        }
+        if let preferredAction {
+            state.preferredAction = preferredAction
+        }
+        if var file = byWorktree[worktreeId],
+           file.stashedDraft != nil,
+           resetAmend || preferredAction != nil {
+            file.stashedDraft = state
+            byWorktree[worktreeId] = file
+            persist(worktreeId)
         }
         let tab = Tab.draftCommit(state)
         append(tab, to: worktreeId)
@@ -1304,16 +1317,17 @@ final class TabsManager {
     }
 
     /// Capture a draft commit tab's state into `file.stashedDraft` before
-    /// removal. Non-empty drafts stash so they survive close/reopen. Empty
-    /// drafts CLEAR the stash so a user who opens an old stashed draft,
-    /// wipes the text, and closes the tab actually gets rid of it.
+    /// removal. Non-empty drafts and recovery checkpoints stash so they survive
+    /// close/reopen. Empty drafts without recovery state CLEAR the stash so a
+    /// user who opens an old stashed draft, wipes the text, and closes the tab
+    /// actually gets rid of it.
     /// Silently does nothing if `removingTabId` is not a draftCommit tab.
     private func captureDraftIfNeeded(_ file: inout TabsFile, removingTabId: TabID) {
         guard let tab = file.tabs.first(where: { $0.id == removingTabId }),
               case .draftCommit(let state) = tab else { return }
         let hasSubject = !state.subject.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let hasBody = !state.bodyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        file.stashedDraft = (hasSubject || hasBody) ? state : nil
+        file.stashedDraft = (hasSubject || hasBody || state.publishCheckpoint != nil) ? state : nil
     }
 
     func close(worktreeId: String, tabId: TabID) {

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -1087,14 +1087,14 @@ final class TabsManager {
            case .draftCommit(var state) = file.tabs[idx] {
             state.publishCheckpoint = checkpoint
             file.tabs[idx] = .draftCommit(state)
+            try persistThrowing(file, worktreeId: worktreeId)
             byWorktree[worktreeId] = file
-            try persistThrowing(worktreeId)
             return true
         }
         guard file.stashedDraft?.id == tabId else { return false }
         file.stashedDraft?.publishCheckpoint = checkpoint
+        try persistThrowing(file, worktreeId: worktreeId)
         byWorktree[worktreeId] = file
-        try persistThrowing(worktreeId)
         return true
     }
 
@@ -1535,6 +1535,10 @@ final class TabsManager {
 
     private func persistThrowing(_ worktreeId: String) throws {
         guard let file = byWorktree[worktreeId] else { return }
+        try persistThrowing(file, worktreeId: worktreeId)
+    }
+
+    private func persistThrowing(_ file: TabsFile, worktreeId: String) throws {
         try store.write(file, to: tabsFile(forWorktreeId: worktreeId))
     }
 

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -65,6 +65,7 @@ final class TabsManager {
     /// tabs, but are deliberately not persisted as part of the tab identity.
     private var ggSplitCommitDrafts: [TabID: GGSplitCommitDraft] = [:]
     private var commitPublishSessions: [TabID: CommitPublishSession] = [:]
+    @ObservationIgnored var onCommitPublishCompletion: ((String, TabID) -> Void)?
     /// Tracks which tab IDs have already had `openExternalDocument` fired so
     /// that cache-hit calls to `externalBuffer` don't double-count the ref.
     private var openedExternalDocs: Set<TabID> = []
@@ -1054,6 +1055,7 @@ final class TabsManager {
                 try persistCommitPublishCheckpoint(checkpoint, worktreeId: worktreeId, tabId: tabId)
             }, onCompletion: { [weak self] checkpoint in
                 guard let self else { return }
+                onCommitPublishCompletion?(worktreeId, tabId)
                 if replaceDraftWithCommitEditor(worktreeId: worktreeId, draftTabId: tabId,
                     baseRef: checkpoint.baseRef, newSha: checkpoint.commitSHA, title: checkpoint.commitTitle) == nil {
                     discardStashedDraft(worktreeId: worktreeId)

--- a/Alas/Sources/Git/GitService+ReviewLoop.swift
+++ b/Alas/Sources/Git/GitService+ReviewLoop.swift
@@ -30,6 +30,8 @@ extension GitService {
         return .published
     }
 
+    /// Publication callers must pass the captured push URL as `remote`.
+    /// A configured remote name resolves its fetch URL, which may differ.
     func remoteBranchContainsCommit(
         worktreePath: URL,
         remote: String,
@@ -50,7 +52,7 @@ extension GitService {
         }) else { return false }
 
         let temporaryRef = "refs/alas/publish-check/\(UUID().uuidString)"
-        // Await cleanup on both paths so callers never race a detached ref deletion.
+        let containsCommit: Bool
         do {
             let fetch = try await Process.git(
                 ["fetch", "--no-tags", "--no-write-fetch-head", "--no-recurse-submodules", "--refmap=",
@@ -61,12 +63,21 @@ extension GitService {
                 ["merge-base", "--is-ancestor", commitSHA, temporaryRef], cwd: worktreePath
             )
             if result.exitCode != 1 { try Self.assertSuccess(result, op: "Check remote commit") }
-            _ = try? await Process.git(["update-ref", "-d", temporaryRef], cwd: worktreePath)
-            return result.exitCode == 0
+            containsCommit = result.exitCode == 0
         } catch {
-            _ = try? await Process.git(["update-ref", "-d", temporaryRef], cwd: worktreePath)
+            try? await removePublicationProbeRef(temporaryRef, worktreePath: worktreePath)
             throw error
         }
+        try await removePublicationProbeRef(temporaryRef, worktreePath: worktreePath)
+        return containsCommit
+    }
+
+    private func removePublicationProbeRef(_ ref: String, worktreePath: URL) async throws {
+        // Cleanup must survive caller cancellation, but still finish before the probe returns.
+        try await Task.detached {
+            let result = try await Process.git(["update-ref", "-d", ref], cwd: worktreePath)
+            try Self.assertSuccess(result, op: "Delete publication probe ref")
+        }.value
     }
 
     func remotes(worktreePath: URL) async throws -> [GitRemote] {

--- a/Alas/Sources/Git/GitService+ReviewLoop.swift
+++ b/Alas/Sources/Git/GitService+ReviewLoop.swift
@@ -1,6 +1,74 @@
 import Foundation
 
+enum HeadPublicationState: Equatable, Sendable {
+    case noUpstream
+    case unpublished
+    case published
+}
+
 extension GitService {
+    func headPublicationState(worktreePath: URL) async throws -> HeadPublicationState {
+        let head = try await Process.git(["rev-parse", "--verify", "HEAD^{commit}"], cwd: worktreePath)
+        try Self.assertSuccess(head, op: "Resolve HEAD")
+        let branch = try await Process.git(["symbolic-ref", "--quiet", "--short", "HEAD"], cwd: worktreePath)
+        if branch.exitCode == 1 { return .noUpstream }
+        try Self.assertSuccess(branch, op: "Resolve branch")
+        let branchName = branch.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        for key in ["remote", "merge"] {
+            let config = try await Process.git(["config", "--get", "branch.\(branchName).\(key)"], cwd: worktreePath)
+            if config.exitCode == 1 { return .noUpstream }
+            try Self.assertSuccess(config, op: "Read upstream configuration")
+        }
+        let upstream = try await Process.git(["rev-parse", "--verify", "@{u}^{commit}"], cwd: worktreePath)
+        try Self.assertSuccess(upstream, op: "Resolve upstream")
+        let result = try await Process.git(
+            ["merge-base", "--is-ancestor", head.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
+             upstream.stdout.trimmingCharacters(in: .whitespacesAndNewlines)], cwd: worktreePath
+        )
+        if result.exitCode == 1 { return .unpublished }
+        try Self.assertSuccess(result, op: "Check HEAD publication")
+        return .published
+    }
+
+    func remoteBranchContainsCommit(
+        worktreePath: URL,
+        remote: String,
+        branch: String,
+        commitSHA: String
+    ) async throws -> Bool {
+        let branchRef = "refs/heads/\(branch)"
+        let validation = try await Process.git(["check-ref-format", branchRef], cwd: worktreePath)
+        try Self.assertSuccess(validation, op: "Validate remote branch")
+        let advertisement = try await Process.git(
+            ["ls-remote", "--exit-code", "--heads", "--", remote, branchRef], cwd: worktreePath
+        )
+        if advertisement.exitCode == 2 { return false }
+        try Self.assertSuccess(advertisement, op: "Read remote branch")
+        guard advertisement.stdout.split(separator: "\n").contains(where: {
+            let fields = $0.split(whereSeparator: \.isWhitespace)
+            return fields.count == 2 && fields[1] == branchRef
+        }) else { return false }
+
+        let temporaryRef = "refs/alas/publish-check/\(UUID().uuidString)"
+        // Await cleanup on both paths so callers never race a detached ref deletion.
+        do {
+            let fetch = try await Process.git(
+                ["fetch", "--no-tags", "--no-write-fetch-head", "--no-recurse-submodules", "--refmap=",
+                 "--", remote, "+\(branchRef):\(temporaryRef)"], cwd: worktreePath
+            )
+            try Self.assertSuccess(fetch, op: "Fetch remote branch")
+            let result = try await Process.git(
+                ["merge-base", "--is-ancestor", commitSHA, temporaryRef], cwd: worktreePath
+            )
+            if result.exitCode != 1 { try Self.assertSuccess(result, op: "Check remote commit") }
+            _ = try? await Process.git(["update-ref", "-d", temporaryRef], cwd: worktreePath)
+            return result.exitCode == 0
+        } catch {
+            _ = try? await Process.git(["update-ref", "-d", temporaryRef], cwd: worktreePath)
+            throw error
+        }
+    }
+
     func remotes(worktreePath: URL) async throws -> [GitRemote] {
         let result = try await Process.git(["remote", "-v"], cwd: worktreePath)
         guard result.exitCode == 0 else {

--- a/Alas/Sources/Git/GitService+Staging.swift
+++ b/Alas/Sources/Git/GitService+Staging.swift
@@ -114,37 +114,7 @@ extension GitService {
     /// on the Amend checkbox. False when no upstream is configured (nothing
     /// to compare against) or on detached HEAD.
     func isHeadAtOrBehindUpstream(worktreePath: URL) async throws -> Bool {
-        // Same resolution shape as `commitsAhead`: read @{u} via rev-parse.
-        let up = try await Process.git(
-            ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
-            cwd: worktreePath
-        )
-        guard up.exitCode == 0 else { return false }
-        let upstream = up.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !upstream.isEmpty, upstream != "@{u}" else { return false }
-
-        // rev-list --count HEAD..@{u} = how many commits we'd need to PULL.
-        let ahead = try await Process.git(
-            ["rev-list", "--count", "HEAD..@{u}"],
-            cwd: worktreePath
-        )
-        guard ahead.exitCode == 0 else { return false }
-        let count = Int(ahead.stdout.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
-        // count > 0 → upstream is ahead of us (we're behind).
-        // count == 0 → at upstream OR diverged. We treat both as "publish risk".
-        // A separate check for HEAD..@{u}.count == 0 AND @{u}..HEAD.count == 0
-        // would distinguish "equal" from "diverged"; equal is the common case
-        // and either way the warning is appropriate.
-        if count > 0 { return true }
-
-        let behindUs = try await Process.git(
-            ["rev-list", "--count", "@{u}..HEAD"],
-            cwd: worktreePath
-        )
-        guard behindUs.exitCode == 0 else { return false }
-        let ours = Int(behindUs.stdout.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
-        // We are ahead → no warning. Otherwise (equal) → warn.
-        return ours == 0
+        try await headPublicationState(worktreePath: worktreePath) == .published
     }
 
     static func assertSuccess(_ result: ProcessResult, op: String) throws {

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
@@ -17,7 +17,7 @@ final class ReviewLoopState {
     private let worktreePath: URL
     private var baseBranch: String
     private let providerRegistry: CodeHostProviderRegistry
-    private var refreshGeneration: Int = 0
+    private(set) var refreshGeneration: Int = 0
 
     private(set) var snapshot: ReviewLoopSnapshot?
     private(set) var isRefreshing: Bool = false

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
@@ -345,10 +345,41 @@ final class ReviewLoopState {
         body: String,
         isDraft: Bool
     ) async throws -> URL {
-        guard let remote = snapshot.remote,
-              let provider = providerRegistry.provider(for: remote.kind)
-        else {
+        guard let remote = snapshot.remote else {
             throw CodeHostProviderError.unsupportedProvider(snapshot.remote?.kind ?? .github)
+        }
+        return try await createReviewRequest(
+            remote: remote, branch: branch, headOwner: headOwner, baseBranch: baseBranch,
+            title: title, body: body, draft: isDraft
+        )
+    }
+
+    func currentReviewRequest(
+        remote: CodeHostRemote,
+        branch: String,
+        headOwner: String?,
+        baseBranch: String
+    ) async throws -> ReviewRequest? {
+        guard let provider = providerRegistry.provider(for: remote.kind) else {
+            throw CodeHostProviderError.unsupportedProvider(remote.kind)
+        }
+        return try await provider.currentReviewRequest(
+            remote: remote, branch: branch, headOwner: headOwner,
+            baseBranch: baseBranch, cwd: worktreePath
+        )
+    }
+
+    func createReviewRequest(
+        remote: CodeHostRemote,
+        branch: String,
+        headOwner: String?,
+        baseBranch: String,
+        title: String,
+        body: String,
+        draft: Bool
+    ) async throws -> URL {
+        guard let provider = providerRegistry.provider(for: remote.kind) else {
+            throw CodeHostProviderError.unsupportedProvider(remote.kind)
         }
         return try await provider.createReviewRequest(
             remote: remote,
@@ -357,7 +388,7 @@ final class ReviewLoopState {
             baseBranch: baseBranch,
             title: title,
             body: body,
-            isDraft: isDraft,
+            isDraft: draft,
             cwd: worktreePath
         )
     }

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -4,6 +4,8 @@ import Observation
 @MainActor
 struct GGMutationContext {
     var loadFreshStack: () async throws -> GGStackSnapshot
+    var loadCurrentBranch: () async throws -> String
+    var loadCurrentHead: () async throws -> String
     var refreshStack: () async -> Void
     var refreshGitChanges: () async -> Void
     var refreshProviderReviews: () async -> Void
@@ -191,10 +193,18 @@ final class GGMutationCoordinator {
 
     func startApplying(
         _ request: GGMutationRequest,
-        confirmedAgainst identity: GGStackIdentity?
+        confirmedAgainst identity: GGStackIdentity?,
+        expectedTarget: GGStackTargetIdentity? = nil
     ) -> Task<Void, Error>? {
         guard reserve(request) else { return nil }
-        return Task { try await self.applyReserved(request, confirmedAgainst: identity, confirmedWith: nil) }
+        return Task {
+            try await self.applyReserved(
+                request,
+                confirmedAgainst: identity,
+                confirmedWith: nil,
+                expectedTarget: expectedTarget
+            )
+        }
     }
 
     func startApplying(_ prepared: GGPreparedMutation) -> Task<Void, Error>? {
@@ -219,7 +229,8 @@ final class GGMutationCoordinator {
     private func applyReserved(
         _ request: GGMutationRequest,
         confirmedAgainst identity: GGStackIdentity?,
-        confirmedWith confirmation: GGMutationConfirmation?
+        confirmedWith confirmation: GGMutationConfirmation?,
+        expectedTarget: GGStackTargetIdentity? = nil
     ) async throws {
         var didReleaseAction = false
         func releaseAction() {
@@ -247,6 +258,26 @@ final class GGMutationCoordinator {
         } catch {
             guard isRecoveryRequest else { throw error }
             snapshot = nil
+        }
+        if let expectedTarget {
+            let branch = try await context.loadCurrentBranch()
+            let headSHA = try await context.loadCurrentHead()
+            guard let identity = snapshot?.identity,
+                  expectedTarget.matches(
+                      branch: branch,
+                      stackName: identity.stackName,
+                      base: identity.base,
+                      headSHA: identity.headSHA
+                  ),
+                  expectedTarget.matches(
+                      branch: branch,
+                      stackName: identity.stackName,
+                      base: identity.base,
+                      headSHA: headSHA
+                  )
+            else {
+                throw GGMutationError.staleConfirmation
+            }
         }
         let continuedOperationID: String?
         switch request {

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -194,7 +194,8 @@ final class GGMutationCoordinator {
     func startApplying(
         _ request: GGMutationRequest,
         confirmedAgainst identity: GGStackIdentity?,
-        expectedTarget: GGStackTargetIdentity? = nil
+        expectedTarget: GGStackTargetIdentity? = nil,
+        onExecutionStarted: @escaping @MainActor () -> Void = {}
     ) -> Task<Void, Error>? {
         guard reserve(request) else { return nil }
         return Task {
@@ -202,7 +203,8 @@ final class GGMutationCoordinator {
                 request,
                 confirmedAgainst: identity,
                 confirmedWith: nil,
-                expectedTarget: expectedTarget
+                expectedTarget: expectedTarget,
+                onExecutionStarted: onExecutionStarted
             )
         }
     }
@@ -230,7 +232,8 @@ final class GGMutationCoordinator {
         _ request: GGMutationRequest,
         confirmedAgainst identity: GGStackIdentity?,
         confirmedWith confirmation: GGMutationConfirmation?,
-        expectedTarget: GGStackTargetIdentity? = nil
+        expectedTarget: GGStackTargetIdentity? = nil,
+        onExecutionStarted: @escaping @MainActor () -> Void = {}
     ) async throws {
         var didReleaseAction = false
         func releaseAction() {
@@ -314,6 +317,7 @@ final class GGMutationCoordinator {
         GGStackGate.markAlasGGOperationInProgress(repoPath: worktreePath)
 
         do {
+            onExecutionStarted()
             let result = try await service.execute(
                 request,
                 worktreePath: worktreePath,

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -342,6 +342,10 @@ final class GGMutationCoordinator {
                 clientOperationID: clientOperationID,
                 continuedOperationID: continuedOperationID
             )
+            await recordCompletedRecoveryOperation(
+                after: request,
+                continuedOperationID: continuedOperationID
+            )
             recordSummary(for: request, result: result)
             reconcilePausedState(after: request, error: nil)
             if request == .sync {
@@ -697,6 +701,17 @@ final class GGMutationCoordinator {
             worktreeId: worktreeId
         )
         undoCandidate = GGUndoCandidate(operation: newest)
+    }
+
+    private func recordCompletedRecoveryOperation(
+        after request: GGMutationRequest,
+        continuedOperationID: String?
+    ) async {
+        guard request == .continueOperation || request == .abortOperation,
+              let continuedOperationID,
+              let headSHA = try? await context.loadCurrentHead()
+        else { return }
+        actionState.setCompletedRecoveryOperation(.init(operationID: continuedOperationID, headSHA: headSHA))
     }
 
     private func clearUndoCandidate(forOperationID operationID: String) {

--- a/Alas/Sources/Integrations/GG/GGMutationModels.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationModels.swift
@@ -82,6 +82,26 @@ struct GGStackIdentity: Equatable, Sendable {
     var operationID: String?
 }
 
+/// The stable portion of a stack identity used to protect a commit-and-sync
+/// workflow across the local commit that intentionally changes the stack head.
+struct GGStackTargetIdentity: Codable, Equatable, Sendable {
+    var branch: String
+    var stackName: String
+    var base: String
+    var expectedHeadSHA: String
+
+    func matches(branch: String, stackName: String, base: String, headSHA: String) -> Bool {
+        branch == self.branch
+            && stackName == self.stackName
+            && base == self.base
+            && Self.matchesSHA(headSHA, expectedHeadSHA)
+    }
+
+    private static func matchesSHA(_ lhs: String, _ rhs: String) -> Bool {
+        lhs == rhs || lhs.hasPrefix(rhs) || rhs.hasPrefix(lhs)
+    }
+}
+
 struct GGPreparedMutation: Equatable, Sendable {
     var request: GGMutationRequest
     var snapshot: GGStackIdentity

--- a/Alas/Sources/Integrations/GG/GGMutationModels.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationModels.swift
@@ -153,6 +153,7 @@ enum GGMutationError: Error, Equatable {
     case pausedOperation
     case blockingGitOperation
     case stagingFailed
+    case syncTerminalFailure(message: String)
 }
 
 extension GGMutationError: LocalizedError {
@@ -164,6 +165,7 @@ extension GGMutationError: LocalizedError {
         case .pausedOperation: "Continue or abort the paused gg operation first."
         case .blockingGitOperation: "Finish the current Git operation first."
         case .stagingFailed: "Staging failed. Fix the staging error and try again."
+        case .syncTerminalFailure(let message): message
         }
     }
 }

--- a/Alas/Sources/Integrations/GG/GGStackActionState.swift
+++ b/Alas/Sources/Integrations/GG/GGStackActionState.swift
@@ -16,8 +16,13 @@ enum GGLandRequest: Equatable {
 
 /// A gg operation left paused on a conflict (rebase-in-progress), awaiting
 /// `gg continue` / `gg abort`.
-struct GGPausedOperation: Equatable {
+struct GGPausedOperation: Equatable, Sendable {
     let pausedBy: GGStackActionKind
+}
+
+struct GGCompletedRecoveryOperation: Equatable, Sendable {
+    let operationID: String
+    let headSHA: String
 }
 
 /// Per-worktree observable backing the stack-mode drawer's actions. The
@@ -31,6 +36,7 @@ final class GGStackActionState {
     private(set) var lastError: String?
     private(set) var lastErrorAction: GGStackActionKind?
     private(set) var pausedOperation: GGPausedOperation?
+    private(set) var completedRecoveryOperation: GGCompletedRecoveryOperation?
     private(set) var lastActionSummary: String?
     @ObservationIgnored private(set) var actionGeneration: UInt = 0
 
@@ -79,8 +85,14 @@ final class GGStackActionState {
         if lastError != nil { lastError = nil }
         if lastErrorAction != nil { lastErrorAction = nil }
     }
-    func setPaused(_ paused: GGPausedOperation) { if pausedOperation != paused { pausedOperation = paused } }
+    func setPaused(_ paused: GGPausedOperation) {
+        if pausedOperation != paused { pausedOperation = paused }
+        if completedRecoveryOperation != nil { completedRecoveryOperation = nil }
+    }
     func clearPaused() { if pausedOperation != nil { pausedOperation = nil } }
+    func setCompletedRecoveryOperation(_ operation: GGCompletedRecoveryOperation) {
+        if completedRecoveryOperation != operation { completedRecoveryOperation = operation }
+    }
     func setActionSummary(_ message: String) { lastActionSummary = message }
 
     /// One-line result for a completed sync, from the accumulated stream

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -41,6 +41,7 @@ struct ChangesPreparationCard: View {
     let model: ChangesPreparationModel
     let onReviewChanges: () -> Void
     let onDraftCommit: () -> Void
+    let onPublishCommit: () -> Void
     let onGGAction: (GGChangesPreparationAction) -> Void
     let onGGStackAction: (GGStackActionKind) -> Void
     let onReviewRequestAction: (ReviewReadinessActionKind) -> Void
@@ -61,7 +62,7 @@ struct ChangesPreparationCard: View {
                     ggReconciliationButton(reconciliationAction)
                 }
                 if !model.ggActions.isEmpty {
-                    HStack(spacing: 6) {
+                    LazyVGrid(columns: [GridItem(.flexible(minimum: 0)), GridItem(.flexible(minimum: 0))], spacing: 6) {
                         ForEach(model.ggActions, id: \.kind) { action in
                             ggDestinationButton(action)
                         }
@@ -202,6 +203,9 @@ struct ChangesPreparationCard: View {
             if let draftAction = model.draftAction {
                 secondaryDraftButton(draftAction)
             }
+            if let publishAction = model.publishAction {
+                secondaryPublishButton(publishAction)
+            }
             ForEach(model.reviewRequestActions, id: \.kind) { action in
                 secondaryReviewRequestButton(action)
             }
@@ -212,6 +216,9 @@ struct ChangesPreparationCard: View {
         VStack(alignment: .leading, spacing: 6) {
             if let draftAction = model.draftAction {
                 secondaryDraftButton(draftAction)
+            }
+            if let publishAction = model.publishAction {
+                secondaryPublishButton(publishAction)
             }
             ForEach(model.reviewRequestActions, id: \.kind) { action in
                 secondaryReviewRequestButton(action)
@@ -233,6 +240,19 @@ struct ChangesPreparationCard: View {
             action: onDraftCommit
         )
         .accessibilityIdentifier("changes-preparation-draft")
+    }
+
+    private func secondaryPublishButton(_ action: CommitPublishAvailability) -> some View {
+        secondaryButton(
+            title: action.label,
+            subtitle: action.detail,
+            iconName: "arrow.up",
+            showsDot: false,
+            isEnabled: action.isEnabled,
+            action: onPublishCommit
+        )
+        .help(action.disabledReason ?? action.detail)
+        .accessibilityIdentifier("changes-preparation-publish")
     }
 
     private func secondaryReviewRequestButton(
@@ -370,13 +390,13 @@ struct ChangesPreparationCard: View {
             return switch action.kind {
             case .amendCurrent: "Amending…"
             case .absorbIntoStack: "Absorbing…"
-            case .newStackCommit: action.title
+            case .newStackCommit, .commitAndSync: action.title
             }
         }
         if let disabledReason = action.disabledReason {
             return disabledReason
         }
-        if action.kind == .newStackCommit, action.hasNonEmptyDraft, !action.stats.hasChanges {
+        if action.hasNonEmptyDraft, !action.stats.hasChanges {
             return "Draft ready"
         }
         return ChangesPreparationCardText.draftStats(
@@ -389,6 +409,7 @@ struct ChangesPreparationCard: View {
     private func ggIconName(for action: GGChangesPreparationAction) -> String {
         switch action {
         case .newStackCommit: "commit"
+        case .commitAndSync: "arrow.clockwise"
         case .amendCurrent: "arrow.uturn.backward.circle"
         case .absorbIntoStack: "arrow.down.to.line.compact"
         }
@@ -397,6 +418,7 @@ struct ChangesPreparationCard: View {
     private func ggIdentifier(for action: GGChangesPreparationAction) -> String {
         switch action {
         case .newStackCommit: "new"
+        case .commitAndSync: "sync"
         case .amendCurrent: "amend"
         case .absorbIntoStack: "absorb"
         }

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -67,7 +67,7 @@ struct ChangesPreparationCard: View {
                             ggDestinationButton(action)
                         }
                     }
-                } else if model.draftAction != nil || !model.reviewRequestActions.isEmpty {
+                } else if model.draftAction != nil || model.publishAction != nil || !model.reviewRequestActions.isEmpty {
                     ViewThatFits(in: .horizontal) {
                         secondaryActionsHorizontal
                         secondaryActionsVertical
@@ -249,9 +249,9 @@ struct ChangesPreparationCard: View {
             iconName: "arrow.up",
             showsDot: false,
             isEnabled: action.isEnabled,
+            help: action.disabledReason ?? action.detail,
             action: onPublishCommit
         )
-        .help(action.disabledReason ?? action.detail)
         .accessibilityIdentifier("changes-preparation-publish")
     }
 
@@ -439,6 +439,7 @@ struct ChangesPreparationCard: View {
         showsDot: Bool,
         isEnabled: Bool,
         isInFlight: Bool = false,
+        help: String? = nil,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
@@ -484,6 +485,6 @@ struct ChangesPreparationCard: View {
             RoundedRectangle(cornerRadius: 6)
                 .strokeBorder(theme.color("line").opacity(0.65), lineWidth: 0.75)
         )
-        .help(title)
+        .help(help ?? title)
     }
 }

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum GGChangesPreparationAction: Equatable, Sendable {
     case newStackCommit
+    case commitAndSync
     case amendCurrent
     case absorbIntoStack
 }
@@ -54,6 +55,7 @@ struct ChangesPreparationModel: Equatable {
 
     let reviewAction: ReviewAction?
     let draftAction: DraftAction?
+    let publishAction: CommitPublishAvailability?
     let reviewRequestActions: [ReviewRequestAction]
     let reconciliationAction: GGStackReadinessModel.Action?
     let syncProgress: GGSyncProgressPresentation?
@@ -81,7 +83,8 @@ struct ChangesPreparationModel: Equatable {
         draftNonEmpty: Bool,
         aheadCommitCount: Int = 0,
         local: ReviewLoopLocalState? = nil,
-        readinessActions: [ReviewReadinessModel.Action]
+        readinessActions: [ReviewReadinessModel.Action],
+        publishAvailability: CommitPublishAvailability? = nil
     ) {
         let builtReviewAction: ReviewAction?
         if let summary = ReviewChangesTriggerSummary.summary(for: changes) {
@@ -111,12 +114,16 @@ struct ChangesPreparationModel: Equatable {
 
         reviewAction = builtReviewAction
         draftAction = builtDraftAction
+        publishAction = builtDraftAction == nil ? nil : publishAvailability
         reconciliationAction = nil
         syncProgress = nil
         canDismissSyncFailure = false
         ggActions = []
         mutationError = nil
-        let builtActions = Self.compactReviewRequestActions(from: readinessActions)
+        let availableActions = publishAction == nil ? readinessActions : readinessActions.filter {
+            $0.kind != .pushBranch && $0.kind != .createReviewRequest
+        }
+        let builtActions = Self.compactReviewRequestActions(from: availableActions)
         let effectiveAheadCommitCount = local?.aheadCommitCount ?? aheadCommitCount
         reviewRequestActions = Self.applyingHideRules(
             builtActions,
@@ -252,6 +259,14 @@ struct ChangesPreparationModel: Equatable {
                     isInFlight: false
                 ),
                 GGAction(
+                    kind: .commitAndSync,
+                    title: "Commit & sync",
+                    stats: staged,
+                    hasNonEmptyDraft: hasDraft,
+                    disabledReason: effectiveNewCommitDisabledReason,
+                    isInFlight: false
+                ),
+                GGAction(
                     kind: .amendCurrent,
                     title: "Amend current",
                     stats: staged,
@@ -281,6 +296,7 @@ struct ChangesPreparationModel: Equatable {
     ) {
         self.reviewAction = reviewAction
         draftAction = nil
+        publishAction = nil
         reviewRequestActions = []
         self.reconciliationAction = reconciliationAction
         self.syncProgress = syncProgress

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -10,6 +10,8 @@ struct ChangesTabView: View {
 
     @State private var collapsedChangePaths: Set<String> = []
     @State private var appKitActionRelay = ChangesAppKitActionRelay()
+    @State private var amendProbe: CommitPublishAmendProbe = .loading
+    @State private var resolvedAmendProbeKey: String?
     @Environment(\.theme) private var theme
 
     private var conflicts: [ChangedFile] {
@@ -64,7 +66,18 @@ struct ChangesTabView: View {
             draftNonEmpty: draftNonEmpty,
             aheadCommitCount: rps.commits.count,
             local: rps.reviewLoop.snapshot?.local,
-            readinessActions: readiness.actions
+            readinessActions: readiness.actions,
+            publishAvailability: CommitPublishAvailability.review(
+                snapshot: rps.reviewLoop.snapshot,
+                supportedRemote: rps.commitRemote ?? rps.primaryCommitRemote,
+                isRefreshing: rps.reviewLoop.isRefreshing,
+                currentBranch: rps.currentBranch,
+                currentBaseBranch: rps.baseBranch,
+                lastError: rps.reviewLoop.lastError,
+                mutationDisabledReason: publishMutationDisabledReason,
+                amend: currentDraft?.amend == true,
+                amendProbe: resolvedAmendProbeKey == amendProbeKey ? amendProbe : .loading
+            )
         )
     }
 
@@ -92,6 +105,35 @@ struct ChangesTabView: View {
                 )
             }
         }
+        .task(id: amendProbeKey) {
+            let key = amendProbeKey
+            resolvedAmendProbeKey = nil
+            amendProbe = .loading
+            guard currentDraft?.amend == true, !isGGDrawerActive else { return }
+            let result: CommitPublishAmendProbe
+            do {
+                result = .init(try await GitService().headPublicationState(worktreePath: rps.worktree.path))
+            } catch {
+                result = .failed(error.localizedDescription)
+            }
+            guard !Task.isCancelled, key == amendProbeKey else { return }
+            amendProbe = result
+            resolvedAmendProbeKey = key
+        }
+    }
+
+    private var publishMutationDisabledReason: String? {
+        if rps.mergeOp.current != nil { return "Finish the current Git operation first." }
+        if rps.reviewLoop.inFlightAction != nil || rps.pullInFlight || rps.stashOperationInFlight {
+            return "Another Git operation is running."
+        }
+        return nil
+    }
+
+    private var amendProbeKey: String {
+        [rps.worktree.id, rps.currentBranch, rps.currentHeadSHA,
+         String(currentDraft?.amend == true), String(isGGDrawerActive),
+         String(reflecting: rps.reviewLoop.snapshot?.local)].joined(separator: "\u{0}")
     }
 
     private var isGGDrawerActive: Bool {
@@ -273,6 +315,7 @@ struct ChangesTabView: View {
                     model: preparation,
                     onReviewChanges: openReviewChangesTab,
                     onDraftCommit: openDraftTab,
+                    onPublishCommit: openPublishTab,
                     onGGAction: handleGGPreparationAction,
                     onGGStackAction: { rps.onGGStackAction($0, appState: appState) },
                     onReviewRequestAction: { rps.handleReviewReadinessAction($0, appState: appState) },
@@ -666,10 +709,25 @@ struct ChangesTabView: View {
 
     static func stackAction(for action: GGChangesPreparationAction) -> GGStackActionKind? {
         switch action {
-        case .newStackCommit: nil
+        case .newStackCommit, .commitAndSync: nil
         case .amendCurrent: .amendCurrent
         case .absorbIntoStack: .absorbStaged
         }
+    }
+
+    static func draftPreferredAction(for action: GGChangesPreparationAction) -> DraftCommitPreferredAction? {
+        switch action {
+        case .newStackCommit: .commit
+        case .commitAndSync: .publish
+        case .amendCurrent, .absorbIntoStack: nil
+        }
+    }
+
+    private var currentDraft: DraftCommitTabState? {
+        for tab in appState.tabs.tabs(forWorktree: rps.worktree.id) {
+            if case .draftCommit(let state) = tab { return state }
+        }
+        return appState.tabs.stashedDraft(worktreeId: rps.worktree.id)
     }
 
     private var hasDraftTab: Bool {
@@ -694,14 +752,19 @@ struct ChangesTabView: View {
     }
 
     private func openDraftTab() {
-        _ = appState.tabs.openOrFocusDraftCommit(worktreeId: rps.worktree.id)
+        _ = appState.tabs.openOrFocusDraftCommit(worktreeId: rps.worktree.id, preferredAction: .commit)
+    }
+
+    private func openPublishTab() {
+        _ = appState.tabs.openOrFocusDraftCommit(worktreeId: rps.worktree.id, preferredAction: .publish)
     }
 
     private func handleGGPreparationAction(_ action: GGChangesPreparationAction) {
-        if action == .newStackCommit {
+        if let preferredAction = Self.draftPreferredAction(for: action) {
             _ = appState.tabs.openOrFocusDraftCommit(
                 worktreeId: rps.worktree.id,
-                resetAmend: true
+                resetAmend: true,
+                preferredAction: preferredAction
             )
             return
         }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -10,8 +10,7 @@ struct ChangesTabView: View {
 
     @State private var collapsedChangePaths: Set<String> = []
     @State private var appKitActionRelay = ChangesAppKitActionRelay()
-    @State private var amendProbe: CommitPublishAmendProbe = .loading
-    @State private var resolvedAmendProbeKey: String?
+    @State private var amendProbe = CommitPublishAmendProbeLoader()
     @Environment(\.theme) private var theme
 
     private var conflicts: [ChangedFile] {
@@ -76,7 +75,7 @@ struct ChangesTabView: View {
                 lastError: rps.reviewLoop.lastError,
                 mutationDisabledReason: publishMutationDisabledReason,
                 amend: currentDraft?.amend == true,
-                amendProbe: resolvedAmendProbeKey == amendProbeKey ? amendProbe : .loading
+                amendProbe: amendProbe.result(for: amendProbeKey)
             )
         )
     }
@@ -107,18 +106,10 @@ struct ChangesTabView: View {
         }
         .task(id: amendProbeKey) {
             let key = amendProbeKey
-            resolvedAmendProbeKey = nil
-            amendProbe = .loading
             guard currentDraft?.amend == true, !isGGDrawerActive else { return }
-            let result: CommitPublishAmendProbe
-            do {
-                result = .init(try await GitService().headPublicationState(worktreePath: rps.worktree.path))
-            } catch {
-                result = .failed(error.localizedDescription)
+            await amendProbe.load(key: key) {
+                try await GitService().headPublicationState(worktreePath: rps.worktree.path)
             }
-            guard !Task.isCancelled, key == amendProbeKey else { return }
-            amendProbe = result
-            resolvedAmendProbeKey = key
         }
     }
 
@@ -131,9 +122,20 @@ struct ChangesTabView: View {
     }
 
     private var amendProbeKey: String {
-        [rps.worktree.id, rps.currentBranch, rps.currentHeadSHA,
-         String(currentDraft?.amend == true), String(isGGDrawerActive),
-         String(reflecting: rps.reviewLoop.snapshot?.local)].joined(separator: "\u{0}")
+        Self.amendPublicationProbeKey(
+            worktreeID: rps.worktree.id, branch: rps.currentBranch, headSHA: rps.currentHeadSHA,
+            amend: currentDraft?.amend == true, ggModeActive: isGGDrawerActive,
+            reviewLoop: rps.reviewLoop
+        )
+    }
+
+    static func amendPublicationProbeKey(
+        worktreeID: String, branch: String, headSHA: String, amend: Bool,
+        ggModeActive: Bool, reviewLoop: ReviewLoopState
+    ) -> String {
+        [worktreeID, branch, headSHA, String(amend), String(ggModeActive),
+         String(reviewLoop.refreshGeneration),
+         String(reflecting: reviewLoop.snapshot?.local)].joined(separator: "\u{0}")
     }
 
     private var isGGDrawerActive: Bool {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1907,11 +1907,15 @@ final class RightPaneState: GGSplitCommitServicing {
         }
     }
 
-    func syncGGForCommitPublish(target: GGStackTargetIdentity? = nil) async throws {
+    func syncGGForCommitPublish(
+        target: GGStackTargetIdentity? = nil,
+        markExecutionStarted: @escaping @MainActor () -> Void = {}
+    ) async throws {
         guard let operation = ggMutationCoordinator.startApplying(
             .sync,
             confirmedAgainst: nil,
-            expectedTarget: target
+            expectedTarget: target,
+            onExecutionStarted: markExecutionStarted
         ) else {
             throw GGMutationError.operationInFlight
         }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1907,6 +1907,16 @@ final class RightPaneState: GGSplitCommitServicing {
         }
     }
 
+    func currentGGRecoveryOperationIDForCommitPublish() async throws -> String? {
+        try await ggService.currentStackSnapshot(worktreePath: worktree.path.path).operationID
+    }
+
+    func validateGGRecoveryHeadForCommitPublish(operationID: String, headSHA: String) throws {
+        guard ggActionState.completedRecoveryOperation == .init(operationID: operationID, headSHA: headSHA) else {
+            throw GGMutationError.staleConfirmation
+        }
+    }
+
     func syncGGForCommitPublish(
         target: GGStackTargetIdentity? = nil,
         markExecutionStarted: @escaping @MainActor () -> Void = {}

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -465,6 +465,14 @@ final class RightPaneState: GGSplitCommitServicing {
                         worktreePath: self.worktree.path.path
                     )
                 },
+                loadCurrentBranch: { [weak self] in
+                    guard let self else { throw GGServiceError.commandFailed(stderr: "Worktree is no longer available.") }
+                    return try await self.git.currentBranch(worktreePath: self.worktree.path)
+                },
+                loadCurrentHead: { [weak self] in
+                    guard let self else { throw GGServiceError.commandFailed(stderr: "Worktree is no longer available.") }
+                    return try await self.git.revParseHEAD(worktreePath: self.worktree.path)
+                },
                 refreshStack: { [weak self] in
                     guard let self else { return }
                     await self.reevaluateGGGate().value
@@ -1864,8 +1872,47 @@ final class RightPaneState: GGSplitCommitServicing {
         return Task { _ = try? await completion.value }
     }
 
-    func syncGGForCommitPublish() async throws {
-        guard let operation = ggMutationCoordinator.startApplying(.sync, confirmedAgainst: nil) else {
+    func ggTargetForCommitPublish() -> GGStackTargetIdentity? {
+        guard let stack = ggStack, !currentHeadSHA.isEmpty else { return nil }
+        return .init(
+            branch: currentBranch,
+            stackName: stack.name,
+            base: stack.base,
+            expectedHeadSHA: currentHeadSHA
+        )
+    }
+
+    private func readCurrentGGTargetForCommitPublish() async throws -> GGStackTargetIdentity {
+        let branch = try await git.currentBranch(worktreePath: worktree.path)
+        let headSHA = try await git.revParseHEAD(worktreePath: worktree.path)
+        let snapshot = try await ggService.currentStackSnapshot(worktreePath: worktree.path.path)
+        guard let identity = snapshot.identity else { throw GGMutationError.staleConfirmation }
+        return .init(
+            branch: branch,
+            stackName: identity.stackName,
+            base: identity.base,
+            expectedHeadSHA: headSHA
+        )
+    }
+
+    func validateGGTargetForCommitPublish(_ target: GGStackTargetIdentity) async throws {
+        let current = try await readCurrentGGTargetForCommitPublish()
+        guard target.matches(
+            branch: current.branch,
+            stackName: current.stackName,
+            base: current.base,
+            headSHA: current.expectedHeadSHA
+        ) else {
+            throw GGMutationError.staleConfirmation
+        }
+    }
+
+    func syncGGForCommitPublish(target: GGStackTargetIdentity? = nil) async throws {
+        guard let operation = ggMutationCoordinator.startApplying(
+            .sync,
+            confirmedAgainst: nil,
+            expectedTarget: target
+        ) else {
             throw GGMutationError.operationInFlight
         }
         try await completeGGMutation(operation, request: .sync).value

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1916,6 +1916,9 @@ final class RightPaneState: GGSplitCommitServicing {
             throw GGMutationError.operationInFlight
         }
         try await completeGGMutation(operation, request: .sync).value
+        if ggActionState.syncHasTerminalFailure {
+            throw GGMutationError.syncTerminalFailure(message: ggActionState.lastError ?? "GG sync failed.")
+        }
     }
 
     private func completeGGMutation(

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1084,7 +1084,8 @@ final class RightPaneState: GGSplitCommitServicing {
             if Task.isCancelled,
                snapshotGeneration == snapshotInvalidationGeneration,
                refreshGeneration == ggStackRefreshGeneration,
-               !((ggStackLoadState == .loaded || ggStackLoadState == .empty) && ggStackCommitsKey == key) {
+               !((ggStackLoadState == .loaded || ggStackLoadState == .empty)
+                 && ggStackCommitsKey == key && key == currentGGStackCommitsKey) {
                 let canRestorePreviousSnapshot = previousKey == key
                     && key == currentGGStackCommitsKey
                     && (previousLoadState == .loaded || previousLoadState == .empty)
@@ -1162,7 +1163,7 @@ final class RightPaneState: GGSplitCommitServicing {
             if deferralGeneration == ggStackRefreshDeferralGeneration {
                 ggStackRefreshDeferredUntilSyncEnds = false
             }
-            ggStackCommitsKey = key
+            ggStackCommitsKey = currentGGStackCommitsKey
             if ggStack != stack { ggStack = stack }
             ggStackDisplayCommits = displayCommits
             let stackIsEmpty = stack.map { $0.totalCommits == 0 || $0.entries.isEmpty } ?? true
@@ -1849,6 +1850,28 @@ final class RightPaneState: GGSplitCommitServicing {
             request,
             confirmedAgainst: identity
         ) else { return nil }
+        let completion = completeGGMutation(operation, request: request)
+        return Task { _ = try? await completion.value }
+    }
+
+    @discardableResult
+    func runGGMutation(_ prepared: GGPreparedMutation) -> Task<Void, Never>? {
+        guard let operation = ggMutationCoordinator.startApplying(prepared) else { return nil }
+        let completion = completeGGMutation(operation, request: prepared.request)
+        return Task { _ = try? await completion.value }
+    }
+
+    func syncGGForCommitPublish() async throws {
+        guard let operation = ggMutationCoordinator.startApplying(.sync, confirmedAgainst: nil) else {
+            throw GGMutationError.operationInFlight
+        }
+        try await completeGGMutation(operation, request: .sync).value
+    }
+
+    private func completeGGMutation(
+        _ operation: Task<Void, Error>,
+        request: GGMutationRequest
+    ) -> Task<Void, Error> {
         if request == .sync { supersedeGGStackRefreshForSync() }
         let actionGeneration = ggActionState.actionGeneration
         return Task { @MainActor in
@@ -1861,25 +1884,7 @@ final class RightPaneState: GGSplitCommitServicing {
                     for: request.actionKind,
                     actionGeneration: actionGeneration
                 )
-            }
-        }
-    }
-
-    @discardableResult
-    func runGGMutation(_ prepared: GGPreparedMutation) -> Task<Void, Never>? {
-        guard let operation = ggMutationCoordinator.startApplying(prepared) else { return nil }
-        if prepared.request == .sync { supersedeGGStackRefreshForSync() }
-        let actionGeneration = ggActionState.actionGeneration
-        return Task { @MainActor in
-            defer { scheduleDeferredGGStackRefreshIfNeeded() }
-            do {
-                try await operation.value
-            } catch {
-                publishGGMutationPresentationError(
-                    error,
-                    for: prepared.request.actionKind,
-                    actionGeneration: actionGeneration
-                )
+                throw error
             }
         }
     }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1080,12 +1080,14 @@ final class RightPaneState: GGSplitCommitServicing {
         let previousSummary = GGStackSummaryStore.shared.summaries[worktree.path.path]
         let keepsPreviousPresentation = previousKey == key
             && previousLoadState == .loaded
+        var publishedKey: String?
         defer {
+            let retainedKey = publishedKey ?? key
             if Task.isCancelled,
                snapshotGeneration == snapshotInvalidationGeneration,
                refreshGeneration == ggStackRefreshGeneration,
                !((ggStackLoadState == .loaded || ggStackLoadState == .empty)
-                 && ggStackCommitsKey == key && key == currentGGStackCommitsKey) {
+                 && ggStackCommitsKey == retainedKey && retainedKey == currentGGStackCommitsKey) {
                 let canRestorePreviousSnapshot = previousKey == key
                     && key == currentGGStackCommitsKey
                     && (previousLoadState == .loaded || previousLoadState == .empty)
@@ -1176,6 +1178,7 @@ final class RightPaneState: GGSplitCommitServicing {
                 GGStackSummaryStore.shared.summaries[worktree.path.path] = summary
             }
             ggStackRemoteMetadataCache = nil
+            publishedKey = ggStackCommitsKey
             await reconcileGGUndoCandidateIfNeeded()
             guard usesLocalSnapshot else { return }
 

--- a/Alas/Sources/Shortcuts/ShortcutBinding.swift
+++ b/Alas/Sources/Shortcuts/ShortcutBinding.swift
@@ -106,7 +106,7 @@ extension ShortcutBinding {
         case .tab:        key = "tab"
         case .space:      key = "space"
         default:
-            let literalKey = keyboardShortcut.key.character.lowercased()
+            let literalKey = String(keyboardShortcut.key.character)
             guard Self.isSupportedLiteralKey(literalKey) else { return nil }
             key = literalKey
         }

--- a/Alas/Sources/Shortcuts/ShortcutBinding.swift
+++ b/Alas/Sources/Shortcuts/ShortcutBinding.swift
@@ -91,3 +91,32 @@ struct ShortcutBinding: Codable, Equatable, Hashable, Sendable {
         return m
     }
 }
+
+extension ShortcutBinding {
+    init?(keyboardShortcut: KeyboardShortcut) {
+        let key: String
+        switch keyboardShortcut.key {
+        case .return:     key = "return"
+        case .leftArrow:  key = "leftArrow"
+        case .rightArrow: key = "rightArrow"
+        case .upArrow:    key = "upArrow"
+        case .downArrow:  key = "downArrow"
+        case .delete:     key = "delete"
+        case .escape:     key = "escape"
+        case .tab:        key = "tab"
+        case .space:      key = "space"
+        default:
+            let literalKey = keyboardShortcut.key.character.lowercased()
+            guard Self.isSupportedLiteralKey(literalKey) else { return nil }
+            key = literalKey
+        }
+
+        let eventModifiers = keyboardShortcut.modifiers
+        var modifiers: [Modifier] = []
+        if eventModifiers.contains(.control) { modifiers.append(.control) }
+        if eventModifiers.contains(.option) { modifiers.append(.option) }
+        if eventModifiers.contains(.shift) { modifiers.append(.shift) }
+        if eventModifiers.contains(.command) { modifiers.append(.command) }
+        self.init(key: key, modifiers: modifiers)
+    }
+}

--- a/Alas/Sources/Shortcuts/ShortcutBinding.swift
+++ b/Alas/Sources/Shortcuts/ShortcutBinding.swift
@@ -45,6 +45,16 @@ struct ShortcutBinding: Codable, Equatable, Hashable, Sendable {
         keyEquivalent != nil
     }
 
+    func togglingShift() -> Self {
+        var toggledModifiers = modifiers
+        if let shiftIndex = toggledModifiers.firstIndex(of: .shift) {
+            toggledModifiers.remove(at: shiftIndex)
+        } else {
+            toggledModifiers.append(.shift)
+        }
+        return Self(key: key, modifiers: toggledModifiers)
+    }
+
     func asKeyboardShortcut() -> KeyboardShortcut? {
         guard let keyEquivalent else { return nil }
         return KeyboardShortcut(keyEquivalent, modifiers: eventModifiers)

--- a/AlasTests/Center/CommitPublishLiveOperationsTests.swift
+++ b/AlasTests/Center/CommitPublishLiveOperationsTests.swift
@@ -4,6 +4,63 @@ import Testing
 
 @MainActor
 struct CommitPublishLiveOperationsTests {
+    @Test func captureRejectsIncompatibleUpstreamRemoteBeforeReadingGit() async {
+        let snapshot = ReviewLoopSnapshot(
+            local: ReviewLoopLocalState(branchName: "feature", headSHA: "old", baseBranch: "main",
+                hasWorkingTreeChanges: true, hasStagedChanges: true, aheadCommitCount: 1,
+                hasUpstream: true, upstreamRemoteName: "fork", upstreamBranchName: "feature",
+                upstreamAheadCommitCount: 0, needsPush: true),
+            remote: .init(kind: .github, host: "github.com", owner: "team", repository: "repo",
+                remoteName: "origin", webURL: URL(string: "https://github.com/team/repo")!),
+            reviewRequest: nil, providerAvailable: true, providerAuthenticated: true,
+            providerCapabilities: .githubCLI, errorMessage: nil
+        )
+        var commands: [[String]] = []
+
+        await #expect(throws: CommitPublishWorkflowError.incompatiblePushRemote) {
+            try await CommitPublishReviewTarget.capture(
+                snapshot: snapshot, createAsDraft: false, runGit: { args in
+                    commands.append(args)
+                    return .init(exitCode: 0, stdout: "", stderr: "")
+                }
+            )
+        }
+
+        #expect(commands.isEmpty)
+    }
+
+    @Test func captureUsesCompatibleTrackedUpstreamRemote() async throws {
+        let snapshot = ReviewLoopSnapshot(
+            local: ReviewLoopLocalState(branchName: "feature", headSHA: "old", baseBranch: "main",
+                hasWorkingTreeChanges: true, hasStagedChanges: true, aheadCommitCount: 1,
+                hasUpstream: true, upstreamRemoteName: "fork", upstreamBranchName: "review/feature",
+                headRemoteName: "fork", headRemoteOwner: "contributor",
+                upstreamAheadCommitCount: 0, needsPush: true),
+            remote: .init(kind: .github, host: "github.com", owner: "team", repository: "repo",
+                remoteName: "origin", webURL: URL(string: "https://github.com/team/repo")!),
+            reviewRequest: nil, providerAvailable: true, providerAuthenticated: true,
+            providerCapabilities: .githubCLI, errorMessage: nil
+        )
+        let target = try await CommitPublishReviewTarget.capture(
+            snapshot: snapshot, createAsDraft: false, runGit: { args in
+                switch args {
+                case ["symbolic-ref", "--short", "HEAD"]:
+                    return .init(exitCode: 0, stdout: "feature\n", stderr: "")
+                case ["rev-parse", "--verify", "HEAD"]:
+                    return .init(exitCode: 0, stdout: "captured-head\n", stderr: "")
+                case ["remote", "get-url", "--push", "--all", "fork"]:
+                    return .init(exitCode: 0, stdout: "ssh://git@github.com/contributor/repo.git\n", stderr: "")
+                default:
+                    Issue.record("Unexpected Git command: \(args)")
+                    return .init(exitCode: 1, stdout: "", stderr: "")
+                }
+            }
+        )
+
+        #expect(target.pushRemoteName == "fork")
+        #expect(target.upstreamBranch == "review/feature")
+    }
+
     @Test func captureSeparatesReviewRepositoryFromPushDestination() async throws {
         let snapshot = ReviewLoopSnapshot(
             local: ReviewLoopLocalState(branchName: "feature", headSHA: "old", baseBranch: "upstream/main",

--- a/AlasTests/Center/CommitPublishLiveOperationsTests.swift
+++ b/AlasTests/Center/CommitPublishLiveOperationsTests.swift
@@ -17,8 +17,17 @@ struct CommitPublishLiveOperationsTests {
         )
         let target = try await CommitPublishReviewTarget.capture(
             snapshot: snapshot, createAsDraft: true, runGit: { args in
-                #expect(args == ["remote", "get-url", "--push", "--all", "fork"])
-                return ProcessResult(exitCode: 0, stdout: "ssh://git@github.com/contributor/repo.git\nssh://mirror.example/repo.git\n", stderr: "")
+                switch args {
+                case ["symbolic-ref", "--short", "HEAD"]:
+                    return .init(exitCode: 0, stdout: "feature\n", stderr: "")
+                case ["rev-parse", "--verify", "HEAD"]:
+                    return .init(exitCode: 0, stdout: "captured-head\n", stderr: "")
+                case ["remote", "get-url", "--push", "--all", "fork"]:
+                    return .init(exitCode: 0, stdout: "ssh://git@github.com/contributor/repo.git\nssh://mirror.example/repo.git\n", stderr: "")
+                default:
+                    Issue.record("Unexpected Git command: \\(args)")
+                    return .init(exitCode: 1, stdout: "", stderr: "")
+                }
             }
         )
         #expect(target.remote.remoteName == "upstream")
@@ -29,6 +38,7 @@ struct CommitPublishLiveOperationsTests {
         #expect(target.createAsDraft)
         #expect(target.headOwner == "contributor")
         #expect(target.upstreamBranch == nil)
+        #expect(target.expectedHeadSHA == "captured-head")
         #expect(try JSONDecoder().decode(CommitPublishReviewTarget.self, from: JSONEncoder().encode(target)) == target)
     }
 
@@ -63,6 +73,35 @@ struct CommitPublishLiveOperationsTests {
             Issue.record("Expected push failure")
         } catch {
             #expect(error.localizedDescription.contains("remote rejected branch"))
+        }
+    }
+
+    @Test func liveTargetValidationRejectsChangedBranchAndHead() async throws {
+        let path = URL(fileURLWithPath: "/tmp/captured-worktree")
+        let review = ReviewLoopState(worktreePath: path, baseBranch: "main")
+        let branchOperations = CommitPublishOperations.live(worktreePath: path, reviewLoop: review,
+            comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {}, runGit: { args in
+                #expect(args == ["symbolic-ref", "--short", "HEAD"])
+                return .init(exitCode: 0, stdout: "other-feature\n", stderr: "")
+            })
+        await #expect(throws: CommitPublishWorkflowError.branchMismatch(expected: "feature", actual: "other-feature")) {
+            try await branchOperations.validateReviewTarget(makeTarget())
+        }
+
+        let headOperations = CommitPublishOperations.live(worktreePath: path, reviewLoop: review,
+            comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {}, runGit: { args in
+                switch args {
+                case ["symbolic-ref", "--short", "HEAD"]:
+                    return .init(exitCode: 0, stdout: "feature\n", stderr: "")
+                case ["rev-parse", "--verify", "HEAD"]:
+                    return .init(exitCode: 0, stdout: "changed-head\n", stderr: "")
+                default:
+                    Issue.record("Unexpected Git command: \\(args)")
+                    return .init(exitCode: 1, stdout: "", stderr: "")
+                }
+            })
+        await #expect(throws: CommitPublishWorkflowError.headMismatch(expected: "captured-head", actual: "changed-head")) {
+            try await headOperations.validateReviewTarget(makeTarget(expectedHeadSHA: "captured-head"))
         }
     }
 
@@ -208,7 +247,12 @@ struct CommitPublishLiveOperationsTests {
             providerRegistry: .init(providers: [.github: provider]))
         let operations = CommitPublishOperations.live(worktreePath: path, reviewLoop: review,
             comparisonBase: "main", syncGG: {}, refreshAfterCompletion: {},
-            runGit: { _ in .init(exitCode: 0, stdout: "committed", stderr: "") },
+            runGit: { args in
+                if args == ["symbolic-ref", "--short", "HEAD"] {
+                    return .init(exitCode: 0, stdout: "feature", stderr: "")
+                }
+                return .init(exitCode: 0, stdout: "committed", stderr: "")
+            },
             commit: { subject, body, _ in
                 #expect(subject == "Subject")
                 #expect(body == "Body")
@@ -265,10 +309,13 @@ struct CommitPublishLiveOperationsTests {
     }
 
     @Test func oldTargetDecodesWithoutCapturedPushFields() throws {
-        let data = try JSONEncoder().encode(makeTarget())
-        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let encoded = try JSONEncoder().encode(makeTarget())
+        var object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
         #expect(object["pushURL"] == nil)
+        object.removeValue(forKey: "expectedHeadSHA")
+        let data = try JSONSerialization.data(withJSONObject: object)
         let target = try JSONDecoder().decode(CommitPublishReviewTarget.self, from: data)
+        #expect(target.expectedHeadSHA == nil)
         #expect(target.pushURL == nil)
         #expect(target.pushRemoteName == nil)
     }
@@ -283,11 +330,11 @@ struct CommitPublishLiveOperationsTests {
     }
 
     @Test func liveLookupAndCreationUseCapturedTargetThenRefreshAfterCheckpointClears() async throws {
-        let provider = CapturedPublishProvider()
+        let provider = CapturedPublishProvider(expectedBranch: "pushed-feature")
         let path = URL(fileURLWithPath: "/tmp/captured-worktree")
         let review = ReviewLoopState(worktreePath: path, baseBranch: "changed-base",
             providerRegistry: .init(providers: [.github: provider]))
-        let target = makeTarget()
+        let target = makeTarget(upstreamBranch: "pushed-feature")
         var checkpoint: CommitPublishCheckpoint? = .init(commitSHA: "committed", baseRef: "old-base",
             commitTitle: "Title", subject: "Subject", body: "Body", destination: .review(target), nextPhase: .createReviewRequest)
         var refreshed = false
@@ -321,19 +368,28 @@ struct CommitPublishLiveOperationsTests {
         }
     }
 
-    private func makeTarget(upstreamBranch: String? = nil) -> CommitPublishReviewTarget {
+    private func makeTarget(
+        upstreamBranch: String? = nil,
+        expectedHeadSHA: String? = nil
+    ) -> CommitPublishReviewTarget {
         .init(provider: .github, host: "github.com", owner: "team", repository: "repo",
               repositorySlug: "team/repo", remoteName: "upstream",
               webURL: URL(string: "https://github.com/team/repo")!, branch: "feature",
-              upstreamBranch: upstreamBranch, headOwner: "contributor", baseBranch: "main",
+              expectedHeadSHA: expectedHeadSHA, upstreamBranch: upstreamBranch,
+              headOwner: "contributor", baseBranch: "main",
               reviewRequestExisted: false, createAsDraft: true)
     }
 }
 
 private actor CapturedPublishProvider: CodeHostProvider {
     nonisolated let kind = CodeHostKind.github
+    private let expectedBranch: String
     var lookupCount = 0
     var creationCount = 0
+
+    init(expectedBranch: String = "feature") {
+        self.expectedBranch = expectedBranch
+    }
     func isAvailable(cwd: URL) async -> Bool { true }
     func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
     func currentReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, cwd: URL) async throws -> ReviewRequest? {
@@ -353,7 +409,7 @@ private actor CapturedPublishProvider: CodeHostProvider {
     private func checkTarget(_ remote: CodeHostRemote, _ branch: String, _ owner: String?, _ base: String, _ cwd: URL) {
         #expect(remote.repositorySlug == "team/repo")
         #expect(remote.remoteName == "upstream")
-        #expect(branch == "feature")
+        #expect(branch == expectedBranch)
         #expect(owner == "contributor")
         #expect(base == "main")
         #expect(cwd.path == "/tmp/captured-worktree")

--- a/AlasTests/Center/CommitPublishLiveOperationsTests.swift
+++ b/AlasTests/Center/CommitPublishLiveOperationsTests.swift
@@ -198,6 +198,46 @@ struct CommitPublishLiveOperationsTests {
         ])
     }
 
+    @Test func captureRejectsUndetectablePushDestinationsBeforeCommit() async {
+        let snapshot = ReviewLoopSnapshot(
+            local: ReviewLoopLocalState(branchName: "feature", headSHA: "captured-head", baseBranch: "main",
+                hasWorkingTreeChanges: true, hasStagedChanges: true, aheadCommitCount: 1,
+                hasUpstream: true, upstreamRemoteName: "fork", upstreamBranchName: "review/feature",
+                headRemoteName: "fork", headRemoteOwner: "contributor",
+                upstreamAheadCommitCount: 0, needsPush: true),
+            remote: .init(kind: .github, host: "github.com", owner: "team", repository: "repo",
+                remoteName: "origin", webURL: URL(string: "https://github.com/team/repo")!),
+            reviewRequest: nil, providerAvailable: true, providerAuthenticated: true,
+            providerCapabilities: .githubCLI, errorMessage: nil
+        )
+        var commands: [[String]] = []
+
+        await #expect(throws: CommitPublishWorkflowError.pushDestinationChanged) {
+            try await CommitPublishReviewTarget.capture(
+                snapshot: snapshot, createAsDraft: false, runGit: { args in
+                    commands.append(args)
+                    switch args {
+                    case ["symbolic-ref", "--short", "HEAD"]:
+                        return .init(exitCode: 0, stdout: "feature\n", stderr: "")
+                    case ["rev-parse", "--verify", "HEAD"]:
+                        return .init(exitCode: 0, stdout: "captured-head\n", stderr: "")
+                    case ["remote", "get-url", "--push", "--all", "fork"]:
+                        return .init(exitCode: 0, stdout: "../repo.git\nssh://mirror.example/repo.git\n", stderr: "")
+                    default:
+                        Issue.record("Unexpected Git command: \(args)")
+                        return .init(exitCode: 1, stdout: "", stderr: "")
+                    }
+                }
+            )
+        }
+
+        #expect(commands == [
+            ["symbolic-ref", "--short", "HEAD"],
+            ["rev-parse", "--verify", "HEAD"],
+            ["remote", "get-url", "--push", "--all", "fork"],
+        ])
+    }
+
     @Test func livePushUsesCapturedTargetWithoutUpstreamAndReportsOutput() async throws {
         var target = makeTarget()
         target.pushURL = "ssh://git@github.com/contributor/repo.git"

--- a/AlasTests/Center/CommitPublishLiveOperationsTests.swift
+++ b/AlasTests/Center/CommitPublishLiveOperationsTests.swift
@@ -17,13 +17,14 @@ struct CommitPublishLiveOperationsTests {
         )
         let target = try await CommitPublishReviewTarget.capture(
             snapshot: snapshot, createAsDraft: true, runGit: { args in
-                #expect(args == ["remote", "get-url", "--push", "fork"])
-                return ProcessResult(exitCode: 0, stdout: "ssh://git@github.com/contributor/repo.git\n", stderr: "")
+                #expect(args == ["remote", "get-url", "--push", "--all", "fork"])
+                return ProcessResult(exitCode: 0, stdout: "ssh://git@github.com/contributor/repo.git\nssh://mirror.example/repo.git\n", stderr: "")
             }
         )
         #expect(target.remote.remoteName == "upstream")
         #expect(target.pushRemoteName == "fork")
         #expect(target.pushURL == "ssh://git@github.com/contributor/repo.git")
+        #expect(target.pushURLs == ["ssh://git@github.com/contributor/repo.git", "ssh://mirror.example/repo.git"])
         #expect(target.baseBranch == "upstream/main")
         #expect(target.createAsDraft)
         #expect(target.headOwner == "contributor")
@@ -41,10 +42,10 @@ struct CommitPublishLiveOperationsTests {
             reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "changed"),
             comparisonBase: "captured-base", syncGG: {}, refreshAfterCompletion: {},
             runGit: { args in
-                if args == ["remote", "get-url", "--push", "fork"] {
+                if args == ["remote", "get-url", "--push", "--all", "fork"] {
                     return .init(exitCode: 0, stdout: "ssh://git@github.com/contributor/repo.git\n", stderr: "")
                 }
-                #expect(args == ["push", "-u", "fork", "feature"])
+                #expect(args == ["push", "-u", "fork", "created-sha:refs/heads/feature"])
                 return ProcessResult(exitCode: 1, stdout: "remote rejected branch\n", stderr: "")
             },
             containsCommit: { remote, branch, sha in
@@ -109,7 +110,94 @@ struct CommitPublishLiveOperationsTests {
             })
         #expect(try await !operations.remoteBranchContainsCommit(target, "committed"))
         try await operations.push(target, "committed")
-        #expect(calls == [["remote", "get-url", "--push", "fork"], ["push", "-u", "fork", "HEAD:remote-feature"]])
+        #expect(calls == [["remote", "get-url", "--push", "--all", "fork"], ["push", "-u", "fork", "committed:refs/heads/remote-feature"]])
+    }
+
+    @Test func addingPushURLAfterCaptureDoesNotPublishToEitherDestination() async throws {
+        var target = makeTarget()
+        target.pushURL = "ssh://git@github.com/contributor/repo.git"
+        target.pushURLs = [target.pushURL!]
+        target.pushRemoteName = "fork"
+        var pushed = false
+        let operations = CommitPublishOperations.live(worktreePath: URL(fileURLWithPath: "/tmp"),
+            reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
+            comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {}, runGit: { args in
+                if args.first == "remote" {
+                    #expect(args == ["remote", "get-url", "--push", "--all", "fork"])
+                    let urls = args.contains("--all") ? target.pushURL! + "\nssh://unexpected.example/repo.git\n" : target.pushURL!
+                    return .init(exitCode: 0, stdout: urls, stderr: "")
+                }
+                pushed = true
+                return .init(exitCode: 0, stdout: "", stderr: "")
+            })
+        await #expect(throws: CommitPublishWorkflowError.pushDestinationChanged) {
+            try await operations.push(target, "committed")
+        }
+        #expect(!pushed)
+    }
+
+    @Test func headChangeDuringContainmentStillPushesCheckpointCommit() async throws {
+        var target = makeTarget(upstreamBranch: "remote-feature")
+        target.pushURL = "ssh://git@github.com/contributor/repo.git"
+        target.pushRemoteName = "fork"
+        var head = "committed"
+        var pushArguments: [String]?
+        var operations = CommitPublishOperations.live(worktreePath: URL(fileURLWithPath: "/tmp"),
+            reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
+            comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {}, runGit: { args in
+                if args.first == "rev-parse" { return .init(exitCode: 0, stdout: head, stderr: "") }
+                if args.first == "remote" { return .init(exitCode: 0, stdout: target.pushURL!, stderr: "") }
+                pushArguments = args
+                return .init(exitCode: 0, stdout: "", stderr: "")
+            }, containsCommit: { _, _, _ in head = "new-head"; return false })
+        operations.currentReviewRequestExists = { _ in true }
+        let workflow = CommitPublishWorkflow(operations: operations) { _ in }
+        await workflow.resume(.init(commitSHA: "committed", baseRef: "main", commitTitle: "Title",
+            subject: "Subject", body: "", destination: .review(target), nextPhase: .push))
+        #expect(workflow.lastError == nil)
+        #expect(head == "new-head")
+        #expect(pushArguments == ["push", "-u", "fork", "committed:refs/heads/remote-feature"])
+    }
+
+    @Test func containmentChecksEveryCapturedPushURL() async throws {
+        var target = makeTarget()
+        target.pushURL = "ssh://primary.example/repo.git"
+        target.pushURLs = [target.pushURL!, "ssh://mirror.example/repo.git"]
+        var checked: [String] = []
+        let operations = CommitPublishOperations.live(worktreePath: URL(fileURLWithPath: "/tmp"),
+            reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
+            comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {}, containsCommit: { remote, _, _ in
+                checked.append(remote)
+                return remote == target.pushURL
+            })
+        #expect(try await !operations.remoteBranchContainsCommit(target, "committed"))
+        #expect(checked == target.pushURLs)
+    }
+
+    @Test func explicitCommitPushStillSetsUpstreamForUntrackedBranch() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let repo = directory.appendingPathComponent("worktree")
+        let remote = directory.appendingPathComponent("remote.git")
+        for args in [["init", "--bare", remote.path], ["init", "-b", "feature", repo.path]] {
+            try GitService.assertSuccess(try await Process.git(args, cwd: directory), op: "Initialize test repository")
+        }
+        try GitService.assertSuccess(try await Process.git(
+            ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "Initial"], cwd: repo), op: "Create test commit")
+        try GitService.assertSuccess(try await Process.git(["remote", "add", "fork", remote.path], cwd: repo), op: "Add test remote")
+        let head = try await Process.git(["rev-parse", "HEAD"], cwd: repo)
+        let sha = head.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        var target = makeTarget()
+        target.pushURL = remote.path
+        target.pushRemoteName = "fork"
+        let operations = CommitPublishOperations.live(worktreePath: repo,
+            reviewLoop: ReviewLoopState(worktreePath: repo, baseBranch: "main"), comparisonBase: nil,
+            syncGG: {}, refreshAfterCompletion: {})
+        try await operations.push(target, sha)
+        let upstream = try await Process.git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], cwd: repo)
+        #expect(upstream.exitCode == 0)
+        #expect(upstream.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "fork/feature")
     }
 
     @Test func workflowNormalizesMessageBeforeCommitCheckpointAndProviderCreation() async throws {
@@ -180,6 +268,15 @@ struct CommitPublishLiveOperationsTests {
         let target = try JSONDecoder().decode(CommitPublishReviewTarget.self, from: data)
         #expect(target.pushURL == nil)
         #expect(target.pushRemoteName == nil)
+    }
+
+    @Test func legacySinglePushURLDecodesAsOneCapturedDestination() throws {
+        var original = makeTarget()
+        original.pushURL = "ssh://legacy.example/repo.git"
+        let data = try JSONEncoder().encode(original)
+        let restored = try JSONDecoder().decode(CommitPublishReviewTarget.self, from: data)
+        #expect(restored.pushURLs == nil)
+        #expect(restored.capturedPushURLs == ["ssh://legacy.example/repo.git"])
     }
 
     @Test func liveLookupAndCreationUseCapturedTargetThenRefreshAfterCheckpointClears() async throws {

--- a/AlasTests/Center/CommitPublishLiveOperationsTests.swift
+++ b/AlasTests/Center/CommitPublishLiveOperationsTests.swift
@@ -158,6 +158,46 @@ struct CommitPublishLiveOperationsTests {
         #expect(try JSONDecoder().decode(CommitPublishReviewTarget.self, from: JSONEncoder().encode(target)) == target)
     }
 
+    @Test func captureRejectsChangedPushRepositoryBeforeCommit() async {
+        let snapshot = ReviewLoopSnapshot(
+            local: ReviewLoopLocalState(branchName: "feature", headSHA: "captured-head", baseBranch: "main",
+                hasWorkingTreeChanges: true, hasStagedChanges: true, aheadCommitCount: 1,
+                hasUpstream: true, upstreamRemoteName: "fork", upstreamBranchName: "review/feature",
+                headRemoteName: "fork", headRemoteOwner: "contributor",
+                upstreamAheadCommitCount: 0, needsPush: true),
+            remote: .init(kind: .github, host: "github.com", owner: "team", repository: "repo",
+                remoteName: "origin", webURL: URL(string: "https://github.com/team/repo")!),
+            reviewRequest: nil, providerAvailable: true, providerAuthenticated: true,
+            providerCapabilities: .githubCLI, errorMessage: nil
+        )
+        var commands: [[String]] = []
+
+        await #expect(throws: CommitPublishWorkflowError.pushDestinationChanged) {
+            try await CommitPublishReviewTarget.capture(
+                snapshot: snapshot, createAsDraft: false, runGit: { args in
+                    commands.append(args)
+                    switch args {
+                    case ["symbolic-ref", "--short", "HEAD"]:
+                        return .init(exitCode: 0, stdout: "feature\n", stderr: "")
+                    case ["rev-parse", "--verify", "HEAD"]:
+                        return .init(exitCode: 0, stdout: "captured-head\n", stderr: "")
+                    case ["remote", "get-url", "--push", "--all", "fork"]:
+                        return .init(exitCode: 0, stdout: "ssh://git@github.com/attacker/repo.git\n", stderr: "")
+                    default:
+                        Issue.record("Unexpected Git command: \(args)")
+                        return .init(exitCode: 1, stdout: "", stderr: "")
+                    }
+                }
+            )
+        }
+
+        #expect(commands == [
+            ["symbolic-ref", "--short", "HEAD"],
+            ["rev-parse", "--verify", "HEAD"],
+            ["remote", "get-url", "--push", "--all", "fork"],
+        ])
+    }
+
     @Test func livePushUsesCapturedTargetWithoutUpstreamAndReportsOutput() async throws {
         var target = makeTarget()
         target.pushURL = "ssh://git@github.com/contributor/repo.git"
@@ -166,7 +206,7 @@ struct CommitPublishLiveOperationsTests {
         let operations = CommitPublishOperations.live(
             worktreePath: URL(fileURLWithPath: "/tmp"),
             reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "changed"),
-            comparisonBase: "captured-base", syncGG: {}, refreshAfterCompletion: {},
+            comparisonBase: "captured-base", syncGG: { _ in }, refreshAfterCompletion: {},
             runGit: { args in
                 if args == ["remote", "get-url", "--push", "--all", "fork"] {
                     return .init(exitCode: 0, stdout: "ssh://git@github.com/contributor/repo.git\n", stderr: "")
@@ -196,7 +236,7 @@ struct CommitPublishLiveOperationsTests {
         let path = URL(fileURLWithPath: "/tmp/captured-worktree")
         let review = ReviewLoopState(worktreePath: path, baseBranch: "main")
         let branchOperations = CommitPublishOperations.live(worktreePath: path, reviewLoop: review,
-            comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {}, runGit: { args in
+            comparisonBase: nil, syncGG: { _ in }, refreshAfterCompletion: {}, runGit: { args in
                 #expect(args == ["symbolic-ref", "--short", "HEAD"])
                 return .init(exitCode: 0, stdout: "other-feature\n", stderr: "")
             })
@@ -205,7 +245,7 @@ struct CommitPublishLiveOperationsTests {
         }
 
         let headOperations = CommitPublishOperations.live(worktreePath: path, reviewLoop: review,
-            comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {}, runGit: { args in
+            comparisonBase: nil, syncGG: { _ in }, refreshAfterCompletion: {}, runGit: { args in
                 switch args {
                 case ["symbolic-ref", "--short", "HEAD"]:
                     return .init(exitCode: 0, stdout: "feature\n", stderr: "")
@@ -231,7 +271,7 @@ struct CommitPublishLiveOperationsTests {
         var pushed = false
         let operations = CommitPublishOperations.live(worktreePath: URL(fileURLWithPath: "/tmp"),
             reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
-            comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {}, runGit: { args in
+            comparisonBase: nil, syncGG: { _ in }, refreshAfterCompletion: {}, runGit: { args in
                 switch args.first {
                 case "rev-parse": return .init(exitCode: 0, stdout: "committed", stderr: "")
                 case "remote": return .init(exitCode: 0, stdout: "ssh://git@github.com/other/repo.git", stderr: "")
@@ -254,7 +294,7 @@ struct CommitPublishLiveOperationsTests {
         var calls: [[String]] = []
         let operations = CommitPublishOperations.live(worktreePath: URL(fileURLWithPath: "/tmp"),
             reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
-            comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {}, runGit: { args in
+            comparisonBase: nil, syncGG: { _ in }, refreshAfterCompletion: {}, runGit: { args in
                 calls.append(args)
                 return .init(exitCode: 0, stdout: target.pushURL!, stderr: "")
             }, containsCommit: { remote, branch, sha in
@@ -276,7 +316,7 @@ struct CommitPublishLiveOperationsTests {
         var pushed = false
         let operations = CommitPublishOperations.live(worktreePath: URL(fileURLWithPath: "/tmp"),
             reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
-            comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {}, runGit: { args in
+            comparisonBase: nil, syncGG: { _ in }, refreshAfterCompletion: {}, runGit: { args in
                 if args.first == "remote" {
                     #expect(args == ["remote", "get-url", "--push", "--all", "fork"])
                     let urls = args.contains("--all") ? target.pushURL! + "\nssh://unexpected.example/repo.git\n" : target.pushURL!
@@ -299,7 +339,7 @@ struct CommitPublishLiveOperationsTests {
         var pushArguments: [String]?
         var operations = CommitPublishOperations.live(worktreePath: URL(fileURLWithPath: "/tmp"),
             reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
-            comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {}, runGit: { args in
+            comparisonBase: nil, syncGG: { _ in }, refreshAfterCompletion: {}, runGit: { args in
                 if args.first == "rev-parse" { return .init(exitCode: 0, stdout: head, stderr: "") }
                 if args.first == "remote" { return .init(exitCode: 0, stdout: target.pushURL!, stderr: "") }
                 pushArguments = args
@@ -322,7 +362,7 @@ struct CommitPublishLiveOperationsTests {
         var checked: [String] = []
         let operations = CommitPublishOperations.live(worktreePath: URL(fileURLWithPath: "/tmp"),
             reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
-            comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {}, containsCommit: { remote, _, _ in
+            comparisonBase: nil, syncGG: { _ in }, refreshAfterCompletion: {}, containsCommit: { remote, _, _ in
                 checked.append(remote)
                 return remote == target.pushURL
             })
@@ -349,7 +389,7 @@ struct CommitPublishLiveOperationsTests {
         target.pushRemoteName = "fork"
         let operations = CommitPublishOperations.live(worktreePath: repo,
             reviewLoop: ReviewLoopState(worktreePath: repo, baseBranch: "main"), comparisonBase: nil,
-            syncGG: {}, refreshAfterCompletion: {})
+            syncGG: { _ in }, refreshAfterCompletion: {})
         try await operations.push(target, sha)
         try await operations.configureUpstreamTracking(target)
         let upstream = try await Process.git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], cwd: repo)
@@ -380,7 +420,7 @@ struct CommitPublishLiveOperationsTests {
         target.pushRemoteName = "fork"
         let operations = CommitPublishOperations.live(worktreePath: repo,
             reviewLoop: ReviewLoopState(worktreePath: repo, baseBranch: "main"), comparisonBase: nil,
-            syncGG: {}, refreshAfterCompletion: {})
+            syncGG: { _ in }, refreshAfterCompletion: {})
 
         #expect(try await operations.remoteBranchContainsCommit(target, sha))
         let stillMissingTracking = try await Process.git(["rev-parse", "--verify", "refs/remotes/fork/feature"], cwd: repo)
@@ -401,7 +441,7 @@ struct CommitPublishLiveOperationsTests {
         let review = ReviewLoopState(worktreePath: path, baseBranch: "main",
             providerRegistry: .init(providers: [.github: provider]))
         let operations = CommitPublishOperations.live(worktreePath: path, reviewLoop: review,
-            comparisonBase: "main", syncGG: {}, refreshAfterCompletion: {},
+            comparisonBase: "main", syncGG: { _ in }, refreshAfterCompletion: {},
             runGit: { args in
                 if args == ["symbolic-ref", "--short", "HEAD"] {
                     return .init(exitCode: 0, stdout: "feature", stderr: "")
@@ -431,7 +471,7 @@ struct CommitPublishLiveOperationsTests {
         let operations = CommitPublishOperations.live(
             worktreePath: URL(fileURLWithPath: "/tmp"),
             reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
-            comparisonBase: "captured-base", syncGG: {}, refreshAfterCompletion: {},
+            comparisonBase: "captured-base", syncGG: { _ in }, refreshAfterCompletion: {},
             commit: { subject, body, amend in
                 calls.append("commit")
                 #expect(subject == "Subject")
@@ -453,7 +493,7 @@ struct CommitPublishLiveOperationsTests {
         let operations = CommitPublishOperations.live(
             worktreePath: URL(fileURLWithPath: "/tmp"),
             reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
-            comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {},
+            comparisonBase: nil, syncGG: { _ in }, refreshAfterCompletion: {},
             commit: { _, _, _ in committed = true
             return "new" }, publicationState: { .published }
         )
@@ -512,7 +552,7 @@ struct CommitPublishLiveOperationsTests {
             commitTitle: "Title", subject: "Subject", body: "Body", destination: .review(target), nextPhase: .createReviewRequest)
         var refreshed = false
         let operations = CommitPublishOperations.live(worktreePath: path, reviewLoop: review,
-            comparisonBase: "changed-base", syncGG: {}, refreshAfterCompletion: {
+            comparisonBase: "changed-base", syncGG: { _ in }, refreshAfterCompletion: {
                 #expect(checkpoint == nil)
                 #expect(await provider.creationCount == 1)
                 refreshed = true
@@ -531,7 +571,7 @@ struct CommitPublishLiveOperationsTests {
         for parentExists in [true, false] {
             let operations = CommitPublishOperations.live(worktreePath: URL(fileURLWithPath: "/tmp"),
                 reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
-                comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {},
+                comparisonBase: nil, syncGG: { _ in }, refreshAfterCompletion: {},
                 runGit: { args in
                     #expect(args == ["rev-parse", "--verify", "new-sha^"])
                     return .init(exitCode: parentExists ? 0 : 1, stdout: "parent-sha\n", stderr: "")

--- a/AlasTests/Center/CommitPublishLiveOperationsTests.swift
+++ b/AlasTests/Center/CommitPublishLiveOperationsTests.swift
@@ -91,6 +91,53 @@ struct CommitPublishLiveOperationsTests {
         #expect(workflow.lastError?.localizedDescription == "The push destination changed. Restore the captured remote URL before retrying.")
     }
 
+    @Test func livePushUsesCapturedUpstreamBranch() async throws {
+        var target = makeTarget(upstreamBranch: "remote-feature")
+        target.pushURL = "ssh://git@github.com/contributor/repo.git"
+        target.pushRemoteName = "fork"
+        var calls: [[String]] = []
+        let operations = CommitPublishOperations.live(worktreePath: URL(fileURLWithPath: "/tmp"),
+            reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
+            comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {}, runGit: { args in
+                calls.append(args)
+                return .init(exitCode: 0, stdout: target.pushURL!, stderr: "")
+            }, containsCommit: { remote, branch, sha in
+                #expect(remote == target.pushURL)
+                #expect(branch == "remote-feature")
+                #expect(sha == "committed")
+                return false
+            })
+        #expect(try await !operations.remoteBranchContainsCommit(target, "committed"))
+        try await operations.push(target, "committed")
+        #expect(calls == [["remote", "get-url", "--push", "fork"], ["push", "-u", "fork", "HEAD:remote-feature"]])
+    }
+
+    @Test func workflowNormalizesMessageBeforeCommitCheckpointAndProviderCreation() async throws {
+        let provider = CapturedPublishProvider()
+        let path = URL(fileURLWithPath: "/tmp/captured-worktree")
+        let review = ReviewLoopState(worktreePath: path, baseBranch: "main",
+            providerRegistry: .init(providers: [.github: provider]))
+        let operations = CommitPublishOperations.live(worktreePath: path, reviewLoop: review,
+            comparisonBase: "main", syncGG: {}, refreshAfterCompletion: {},
+            runGit: { _ in .init(exitCode: 0, stdout: "committed", stderr: "") },
+            commit: { subject, body, _ in
+                #expect(subject == "Subject")
+                #expect(body == "Body")
+                return "committed"
+            }, containsCommit: { _, _, _ in true })
+        var checkpoints: [CommitPublishCheckpoint] = []
+        let workflow = CommitPublishWorkflow(operations: operations) {
+            if let checkpoint = $0 { checkpoints.append(checkpoint) }
+        }
+        var target = makeTarget()
+        target.pushURL = "ssh://git@github.com/contributor/repo.git"
+        await workflow.start(subject: " \nSubject\t ", body: "\n Body \n", amend: false, destination: .review(target))
+        #expect(workflow.lastError == nil)
+        #expect(await provider.creationCount == 1)
+        #expect(checkpoints.count == 2)
+        #expect(checkpoints.allSatisfy { $0.subject == "Subject" && $0.body == "Body" })
+    }
+
     @Test func liveCommitProbesAmendBeforeCommittingAndKeepsComparisonBase() async throws {
         var calls: [String] = []
         let operations = CommitPublishOperations.live(
@@ -174,11 +221,11 @@ struct CommitPublishLiveOperationsTests {
         }
     }
 
-    private func makeTarget() -> CommitPublishReviewTarget {
+    private func makeTarget(upstreamBranch: String? = nil) -> CommitPublishReviewTarget {
         .init(provider: .github, host: "github.com", owner: "team", repository: "repo",
               repositorySlug: "team/repo", remoteName: "upstream",
               webURL: URL(string: "https://github.com/team/repo")!, branch: "feature",
-              upstreamBranch: nil, headOwner: "contributor", baseBranch: "main",
+              upstreamBranch: upstreamBranch, headOwner: "contributor", baseBranch: "main",
               reviewRequestExisted: false, createAsDraft: true)
     }
 }

--- a/AlasTests/Center/CommitPublishLiveOperationsTests.swift
+++ b/AlasTests/Center/CommitPublishLiveOperationsTests.swift
@@ -6,7 +6,7 @@ import Testing
 struct CommitPublishLiveOperationsTests {
     @Test func captureRejectsIncompatibleUpstreamRemoteBeforeReadingGit() async {
         let snapshot = ReviewLoopSnapshot(
-            local: ReviewLoopLocalState(branchName: "feature", headSHA: "old", baseBranch: "main",
+            local: ReviewLoopLocalState(branchName: "feature", headSHA: "captured-head", baseBranch: "main",
                 hasWorkingTreeChanges: true, hasStagedChanges: true, aheadCommitCount: 1,
                 hasUpstream: true, upstreamRemoteName: "fork", upstreamBranchName: "feature",
                 upstreamAheadCommitCount: 0, needsPush: true),
@@ -31,7 +31,7 @@ struct CommitPublishLiveOperationsTests {
 
     @Test func captureUsesCompatibleTrackedUpstreamRemote() async throws {
         let snapshot = ReviewLoopSnapshot(
-            local: ReviewLoopLocalState(branchName: "feature", headSHA: "old", baseBranch: "main",
+            local: ReviewLoopLocalState(branchName: "feature", headSHA: "captured-head", baseBranch: "main",
                 hasWorkingTreeChanges: true, hasStagedChanges: true, aheadCommitCount: 1,
                 hasUpstream: true, upstreamRemoteName: "fork", upstreamBranchName: "review/feature",
                 headRemoteName: "fork", headRemoteOwner: "contributor",
@@ -61,9 +61,68 @@ struct CommitPublishLiveOperationsTests {
         #expect(target.upstreamBranch == "review/feature")
     }
 
+    @Test func captureRejectsBranchChangedSinceReviewSnapshotBeforeReadingRemote() async {
+        let snapshot = ReviewLoopSnapshot(
+            local: ReviewLoopLocalState(branchName: "feature", headSHA: "captured-head", baseBranch: "main",
+                hasWorkingTreeChanges: true, hasStagedChanges: true, aheadCommitCount: 1,
+                hasUpstream: false, headRemoteName: "fork", headRemoteOwner: "contributor",
+                upstreamAheadCommitCount: 0, needsPush: true),
+            remote: .init(kind: .github, host: "github.com", owner: "team", repository: "repo",
+                remoteName: "origin", webURL: URL(string: "https://github.com/team/repo")!),
+            reviewRequest: nil, providerAvailable: true, providerAuthenticated: true,
+            providerCapabilities: .githubCLI, errorMessage: nil
+        )
+        var commands: [[String]] = []
+
+        await #expect(throws: CommitPublishWorkflowError.branchMismatch(expected: "feature", actual: "other-feature")) {
+            try await CommitPublishReviewTarget.capture(
+                snapshot: snapshot, createAsDraft: false, runGit: { args in
+                    commands.append(args)
+                    #expect(args == ["symbolic-ref", "--short", "HEAD"])
+                    return .init(exitCode: 0, stdout: "other-feature\n", stderr: "")
+                }
+            )
+        }
+
+        #expect(commands == [["symbolic-ref", "--short", "HEAD"]])
+    }
+
+    @Test func captureRejectsHeadChangedSinceReviewSnapshotBeforeReadingRemote() async {
+        let snapshot = ReviewLoopSnapshot(
+            local: ReviewLoopLocalState(branchName: "feature", headSHA: "captured-head", baseBranch: "main",
+                hasWorkingTreeChanges: true, hasStagedChanges: true, aheadCommitCount: 1,
+                hasUpstream: false, headRemoteName: "fork", headRemoteOwner: "contributor",
+                upstreamAheadCommitCount: 0, needsPush: true),
+            remote: .init(kind: .github, host: "github.com", owner: "team", repository: "repo",
+                remoteName: "origin", webURL: URL(string: "https://github.com/team/repo")!),
+            reviewRequest: nil, providerAvailable: true, providerAuthenticated: true,
+            providerCapabilities: .githubCLI, errorMessage: nil
+        )
+        var commands: [[String]] = []
+
+        await #expect(throws: CommitPublishWorkflowError.headMismatch(expected: "captured-head", actual: "changed-head")) {
+            try await CommitPublishReviewTarget.capture(
+                snapshot: snapshot, createAsDraft: false, runGit: { args in
+                    commands.append(args)
+                    switch args {
+                    case ["symbolic-ref", "--short", "HEAD"]:
+                        return .init(exitCode: 0, stdout: "feature\n", stderr: "")
+                    case ["rev-parse", "--verify", "HEAD"]:
+                        return .init(exitCode: 0, stdout: "changed-head\n", stderr: "")
+                    default:
+                        Issue.record("Unexpected Git command: \(args)")
+                        return .init(exitCode: 1, stdout: "", stderr: "")
+                    }
+                }
+            )
+        }
+
+        #expect(commands == [["symbolic-ref", "--short", "HEAD"], ["rev-parse", "--verify", "HEAD"]])
+    }
+
     @Test func captureSeparatesReviewRepositoryFromPushDestination() async throws {
         let snapshot = ReviewLoopSnapshot(
-            local: ReviewLoopLocalState(branchName: "feature", headSHA: "old", baseBranch: "upstream/main",
+            local: ReviewLoopLocalState(branchName: "feature", headSHA: "captured-head", baseBranch: "upstream/main",
                 hasWorkingTreeChanges: true, hasStagedChanges: true, aheadCommitCount: 1,
                 hasUpstream: false, headRemoteName: "fork", headRemoteOwner: "contributor",
                 upstreamAheadCommitCount: 0, needsPush: true),
@@ -292,6 +351,7 @@ struct CommitPublishLiveOperationsTests {
             reviewLoop: ReviewLoopState(worktreePath: repo, baseBranch: "main"), comparisonBase: nil,
             syncGG: {}, refreshAfterCompletion: {})
         try await operations.push(target, sha)
+        try await operations.configureUpstreamTracking(target)
         let upstream = try await Process.git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], cwd: repo)
         #expect(upstream.exitCode == 0)
         #expect(upstream.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "fork/feature")

--- a/AlasTests/Center/CommitPublishLiveOperationsTests.swift
+++ b/AlasTests/Center/CommitPublishLiveOperationsTests.swift
@@ -149,7 +149,8 @@ struct CommitPublishLiveOperationsTests {
                 if args.first == "remote" { return .init(exitCode: 0, stdout: target.pushURL!, stderr: "") }
                 pushArguments = args
                 return .init(exitCode: 0, stdout: "", stderr: "")
-            }, containsCommit: { _, _, _ in head = "new-head"; return false })
+            }, containsCommit: { _, _, _ in head = "new-head"
+            return false })
         operations.currentReviewRequestExists = { _ in true }
         let workflow = CommitPublishWorkflow(operations: operations) { _ in }
         await workflow.resume(.init(commitSHA: "committed", baseRef: "main", commitTitle: "Title",
@@ -239,7 +240,8 @@ struct CommitPublishLiveOperationsTests {
                 #expect(amend)
                 return "abcdef123"
             },
-            publicationState: { calls.append("probe"); return .unpublished }
+            publicationState: { calls.append("probe")
+            return .unpublished }
         )
         let created = try await operations.createCommit("Subject", "Body", true)
         #expect(calls == ["probe", "commit"])
@@ -253,7 +255,8 @@ struct CommitPublishLiveOperationsTests {
             worktreePath: URL(fileURLWithPath: "/tmp"),
             reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
             comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {},
-            commit: { _, _, _ in committed = true; return "new" }, publicationState: { .published }
+            commit: { _, _, _ in committed = true
+            return "new" }, publicationState: { .published }
         )
         await #expect(throws: (any Error).self) {
             try await operations.createCommit("Subject", "", true)

--- a/AlasTests/Center/CommitPublishLiveOperationsTests.swift
+++ b/AlasTests/Center/CommitPublishLiveOperationsTests.swift
@@ -357,6 +357,44 @@ struct CommitPublishLiveOperationsTests {
         #expect(upstream.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "fork/feature")
     }
 
+    @Test func skippedPushMaterializesRemoteTrackingRefForUntrackedBranch() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let repo = directory.appendingPathComponent("worktree")
+        let remote = directory.appendingPathComponent("remote.git")
+        for args in [["init", "--bare", remote.path], ["init", "-b", "feature", repo.path]] {
+            try GitService.assertSuccess(try await Process.git(args, cwd: directory), op: "Initialize test repository")
+        }
+        try GitService.assertSuccess(try await Process.git(
+            ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "Initial"], cwd: repo), op: "Create test commit")
+        try GitService.assertSuccess(try await Process.git(["remote", "add", "fork", remote.path], cwd: repo), op: "Add test remote")
+        let head = try await Process.git(["rev-parse", "HEAD"], cwd: repo)
+        let sha = head.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        try GitService.assertSuccess(try await Process.git(["push", remote.path, "\(sha):refs/heads/feature"], cwd: repo),
+            op: "Seed remote branch")
+        let missingTracking = try await Process.git(["rev-parse", "--verify", "refs/remotes/fork/feature"], cwd: repo)
+        #expect(missingTracking.exitCode != 0)
+        var target = makeTarget()
+        target.pushURL = remote.path
+        target.pushRemoteName = "fork"
+        let operations = CommitPublishOperations.live(worktreePath: repo,
+            reviewLoop: ReviewLoopState(worktreePath: repo, baseBranch: "main"), comparisonBase: nil,
+            syncGG: {}, refreshAfterCompletion: {})
+
+        #expect(try await operations.remoteBranchContainsCommit(target, sha))
+        let stillMissingTracking = try await Process.git(["rev-parse", "--verify", "refs/remotes/fork/feature"], cwd: repo)
+        #expect(stillMissingTracking.exitCode != 0)
+        try await operations.configureUpstreamTracking(target)
+
+        let tracking = try await Process.git(["rev-parse", "--verify", "refs/remotes/fork/feature"], cwd: repo)
+        #expect(tracking.exitCode == 0)
+        #expect(tracking.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == sha)
+        let upstream = try await Process.git(["rev-parse", "--verify", "@{u}"], cwd: repo)
+        #expect(upstream.exitCode == 0)
+        #expect(upstream.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == sha)
+    }
+
     @Test func workflowNormalizesMessageBeforeCommitCheckpointAndProviderCreation() async throws {
         let provider = CapturedPublishProvider()
         let path = URL(fileURLWithPath: "/tmp/captured-worktree")
@@ -379,7 +417,7 @@ struct CommitPublishLiveOperationsTests {
         let workflow = CommitPublishWorkflow(operations: operations) {
             if let checkpoint = $0 { checkpoints.append(checkpoint) }
         }
-        var target = makeTarget()
+        var target = makeTarget(upstreamBranch: "feature")
         target.pushURL = "ssh://git@github.com/contributor/repo.git"
         await workflow.start(subject: " \nSubject\t ", body: "\n Body \n", amend: false, destination: .review(target))
         #expect(workflow.lastError == nil)

--- a/AlasTests/Center/CommitPublishLiveOperationsTests.swift
+++ b/AlasTests/Center/CommitPublishLiveOperationsTests.swift
@@ -1,0 +1,216 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct CommitPublishLiveOperationsTests {
+    @Test func captureSeparatesReviewRepositoryFromPushDestination() async throws {
+        let snapshot = ReviewLoopSnapshot(
+            local: ReviewLoopLocalState(branchName: "feature", headSHA: "old", baseBranch: "upstream/main",
+                hasWorkingTreeChanges: true, hasStagedChanges: true, aheadCommitCount: 1,
+                hasUpstream: false, headRemoteName: "fork", headRemoteOwner: "contributor",
+                upstreamAheadCommitCount: 0, needsPush: true),
+            remote: .init(kind: .github, host: "github.com", owner: "team", repository: "repo",
+                remoteName: "upstream", webURL: URL(string: "https://github.com/team/repo")!),
+            reviewRequest: nil, providerAvailable: true, providerAuthenticated: true,
+            providerCapabilities: .githubCLI, errorMessage: nil
+        )
+        let target = try await CommitPublishReviewTarget.capture(
+            snapshot: snapshot, createAsDraft: true, runGit: { args in
+                #expect(args == ["remote", "get-url", "--push", "fork"])
+                return ProcessResult(exitCode: 0, stdout: "ssh://git@github.com/contributor/repo.git\n", stderr: "")
+            }
+        )
+        #expect(target.remote.remoteName == "upstream")
+        #expect(target.pushRemoteName == "fork")
+        #expect(target.pushURL == "ssh://git@github.com/contributor/repo.git")
+        #expect(target.baseBranch == "upstream/main")
+        #expect(target.createAsDraft)
+        #expect(target.headOwner == "contributor")
+        #expect(target.upstreamBranch == nil)
+        #expect(try JSONDecoder().decode(CommitPublishReviewTarget.self, from: JSONEncoder().encode(target)) == target)
+    }
+
+    @Test func livePushUsesCapturedTargetWithoutUpstreamAndReportsOutput() async throws {
+        var target = makeTarget()
+        target.pushURL = "ssh://git@github.com/contributor/repo.git"
+        target.pushRemoteName = "fork"
+        var containmentCalls = 0
+        let operations = CommitPublishOperations.live(
+            worktreePath: URL(fileURLWithPath: "/tmp"),
+            reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "changed"),
+            comparisonBase: "captured-base", syncGG: {}, refreshAfterCompletion: {},
+            runGit: { args in
+                if args == ["remote", "get-url", "--push", "fork"] {
+                    return .init(exitCode: 0, stdout: "ssh://git@github.com/contributor/repo.git\n", stderr: "")
+                }
+                #expect(args == ["push", "-u", "fork", "feature"])
+                return ProcessResult(exitCode: 1, stdout: "remote rejected branch\n", stderr: "")
+            },
+            containsCommit: { remote, branch, sha in
+                containmentCalls += 1
+                #expect(remote == "ssh://git@github.com/contributor/repo.git")
+                #expect(branch == "feature")
+                #expect(sha == "created-sha")
+                return false
+            }
+        )
+        #expect(try await !operations.remoteBranchContainsCommit(target, "created-sha"))
+        #expect(containmentCalls == 1)
+        do {
+            try await operations.push(target, "created-sha")
+            Issue.record("Expected push failure")
+        } catch {
+            #expect(error.localizedDescription.contains("remote rejected branch"))
+        }
+    }
+
+    @Test func changedPushURLPreservesCheckpointAndDoesNotPush() async throws {
+        var target = makeTarget()
+        target.pushURL = "ssh://git@github.com/contributor/repo.git"
+        target.pushRemoteName = "fork"
+        var checkpoint: CommitPublishCheckpoint? = .init(commitSHA: "committed", baseRef: "base",
+            commitTitle: "Title", subject: "Subject", body: "Body", destination: .review(target), nextPhase: .push)
+        let original = checkpoint
+        var pushed = false
+        let operations = CommitPublishOperations.live(worktreePath: URL(fileURLWithPath: "/tmp"),
+            reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
+            comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {}, runGit: { args in
+                switch args.first {
+                case "rev-parse": return .init(exitCode: 0, stdout: "committed", stderr: "")
+                case "remote": return .init(exitCode: 0, stdout: "ssh://git@github.com/other/repo.git", stderr: "")
+                default:
+                    pushed = true
+                    throw NSError(domain: "Unexpected push", code: 1)
+                }
+            }, containsCommit: { _, _, _ in false })
+        let workflow = CommitPublishWorkflow(operations: operations) { checkpoint = $0 }
+        await workflow.resume(try #require(checkpoint))
+        #expect(!pushed)
+        #expect(checkpoint == original)
+        #expect(workflow.lastError?.localizedDescription == "The push destination changed. Restore the captured remote URL before retrying.")
+    }
+
+    @Test func liveCommitProbesAmendBeforeCommittingAndKeepsComparisonBase() async throws {
+        var calls: [String] = []
+        let operations = CommitPublishOperations.live(
+            worktreePath: URL(fileURLWithPath: "/tmp"),
+            reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
+            comparisonBase: "captured-base", syncGG: {}, refreshAfterCompletion: {},
+            commit: { subject, body, amend in
+                calls.append("commit")
+                #expect(subject == "Subject")
+                #expect(body == "Body")
+                #expect(amend)
+                return "abcdef123"
+            },
+            publicationState: { calls.append("probe"); return .unpublished }
+        )
+        let created = try await operations.createCommit("Subject", "Body", true)
+        #expect(calls == ["probe", "commit"])
+        #expect(created.comparisonBase == "captured-base")
+        #expect(created.editorTitle == "abcdef1 Subject")
+    }
+
+    @Test func publishedAmendNeverCommits() async throws {
+        var committed = false
+        let operations = CommitPublishOperations.live(
+            worktreePath: URL(fileURLWithPath: "/tmp"),
+            reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
+            comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {},
+            commit: { _, _, _ in committed = true; return "new" }, publicationState: { .published }
+        )
+        await #expect(throws: (any Error).self) {
+            try await operations.createCommit("Subject", "", true)
+        }
+        #expect(!committed)
+    }
+
+    @Test func oldTargetDecodesWithoutCapturedPushFields() throws {
+        let data = try JSONEncoder().encode(makeTarget())
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["pushURL"] == nil)
+        let target = try JSONDecoder().decode(CommitPublishReviewTarget.self, from: data)
+        #expect(target.pushURL == nil)
+        #expect(target.pushRemoteName == nil)
+    }
+
+    @Test func liveLookupAndCreationUseCapturedTargetThenRefreshAfterCheckpointClears() async throws {
+        let provider = CapturedPublishProvider()
+        let path = URL(fileURLWithPath: "/tmp/captured-worktree")
+        let review = ReviewLoopState(worktreePath: path, baseBranch: "changed-base",
+            providerRegistry: .init(providers: [.github: provider]))
+        let target = makeTarget()
+        var checkpoint: CommitPublishCheckpoint? = .init(commitSHA: "committed", baseRef: "old-base",
+            commitTitle: "Title", subject: "Subject", body: "Body", destination: .review(target), nextPhase: .createReviewRequest)
+        var refreshed = false
+        let operations = CommitPublishOperations.live(worktreePath: path, reviewLoop: review,
+            comparisonBase: "changed-base", syncGG: {}, refreshAfterCompletion: {
+                #expect(checkpoint == nil)
+                #expect(await provider.creationCount == 1)
+                refreshed = true
+            }, runGit: { args in
+                #expect(args == ["rev-parse", "--verify", "HEAD"])
+                return .init(exitCode: 0, stdout: "committed", stderr: "")
+            })
+        let workflow = CommitPublishWorkflow(operations: operations) { checkpoint = $0 }
+        await workflow.resume(try #require(checkpoint))
+        #expect(workflow.lastError == nil)
+        #expect(refreshed)
+        #expect(await provider.lookupCount == 1)
+    }
+
+    @Test func liveCommitWithoutComparisonUsesFirstParentOrEmptyTree() async throws {
+        for parentExists in [true, false] {
+            let operations = CommitPublishOperations.live(worktreePath: URL(fileURLWithPath: "/tmp"),
+                reviewLoop: ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main"),
+                comparisonBase: nil, syncGG: {}, refreshAfterCompletion: {},
+                runGit: { args in
+                    #expect(args == ["rev-parse", "--verify", "new-sha^"])
+                    return .init(exitCode: parentExists ? 0 : 1, stdout: "parent-sha\n", stderr: "")
+                }, commit: { _, _, _ in "new-sha" })
+            let created = try await operations.createCommit("Subject", "", false)
+            #expect(created.comparisonBase == (parentExists ? "parent-sha" : "4b825dc642cb6eb9a060e54bf8d69288fbee4904"))
+        }
+    }
+
+    private func makeTarget() -> CommitPublishReviewTarget {
+        .init(provider: .github, host: "github.com", owner: "team", repository: "repo",
+              repositorySlug: "team/repo", remoteName: "upstream",
+              webURL: URL(string: "https://github.com/team/repo")!, branch: "feature",
+              upstreamBranch: nil, headOwner: "contributor", baseBranch: "main",
+              reviewRequestExisted: false, createAsDraft: true)
+    }
+}
+
+private actor CapturedPublishProvider: CodeHostProvider {
+    nonisolated let kind = CodeHostKind.github
+    var lookupCount = 0
+    var creationCount = 0
+    func isAvailable(cwd: URL) async -> Bool { true }
+    func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool { true }
+    func currentReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String, cwd: URL) async throws -> ReviewRequest? {
+        lookupCount += 1
+        checkTarget(remote, branch, headOwner, baseBranch, cwd)
+        return nil
+    }
+    func createReviewRequest(remote: CodeHostRemote, branch: String, headOwner: String?, baseBranch: String,
+        title: String, body: String, isDraft: Bool, cwd: URL) async throws -> URL {
+        creationCount += 1
+        checkTarget(remote, branch, headOwner, baseBranch, cwd)
+        #expect(title == "Subject")
+        #expect(body == "Body")
+        #expect(isDraft)
+        return remote.webURL
+    }
+    private func checkTarget(_ remote: CodeHostRemote, _ branch: String, _ owner: String?, _ base: String, _ cwd: URL) {
+        #expect(remote.repositorySlug == "team/repo")
+        #expect(remote.remoteName == "upstream")
+        #expect(branch == "feature")
+        #expect(owner == "contributor")
+        #expect(base == "main")
+        #expect(cwd.path == "/tmp/captured-worktree")
+    }
+    func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] { [] }
+    func rerunFailedChecks(remote: CodeHostRemote, branch: String, headSHA: String, request: ReviewRequest?, cwd: URL) async throws {}
+}

--- a/AlasTests/Center/CommitPublishLiveOperationsTests.swift
+++ b/AlasTests/Center/CommitPublishLiveOperationsTests.swift
@@ -320,6 +320,24 @@ struct CommitPublishLiveOperationsTests {
         #expect(target.pushRemoteName == nil)
     }
 
+    @Test func legacyGGCheckpointDecodesWithoutCapturedTarget() throws {
+        let data = Data(#"""
+        {
+          "commitSHA": "committed",
+          "baseRef": "main",
+          "commitTitle": "Title",
+          "subject": "Subject",
+          "body": "",
+          "destination": { "gg": {} },
+          "nextPhase": "sync"
+        }
+        """#.utf8)
+
+        let checkpoint = try JSONDecoder().decode(CommitPublishCheckpoint.self, from: data)
+
+        #expect(checkpoint.destination == .gg(nil))
+    }
+
     @Test func legacySinglePushURLDecodesAsOneCapturedDestination() throws {
         var original = makeTarget()
         original.pushURL = "ssh://legacy.example/repo.git"

--- a/AlasTests/Center/CommitPublishModelsTests.swift
+++ b/AlasTests/Center/CommitPublishModelsTests.swift
@@ -86,4 +86,24 @@ struct CommitPublishModelsTests {
             webURL: URL(string: "https://gitlab.example.com/team/project")!
         ))
     }
+
+    @Test func preferredTrailingActionReceivesBaseShortcut() {
+        let pair = CommitComposerActionPair.shortcuts(
+            preferred: .trailing,
+            base: .init(key: "return", modifiers: [.command])
+        )
+
+        #expect(pair.leading == .init(key: "return", modifiers: [.command, .shift]))
+        #expect(pair.trailing == .init(key: "return", modifiers: [.command]))
+    }
+
+    @Test func preferredLeadingActionReceivesBaseShortcut() {
+        let pair = CommitComposerActionPair.shortcuts(
+            preferred: .leading,
+            base: .init(key: "j", modifiers: [.command, .shift])
+        )
+
+        #expect(pair.leading == .init(key: "j", modifiers: [.command, .shift]))
+        #expect(pair.trailing == .init(key: "j", modifiers: [.command]))
+    }
 }

--- a/AlasTests/Center/CommitPublishModelsTests.swift
+++ b/AlasTests/Center/CommitPublishModelsTests.swift
@@ -3,6 +3,122 @@ import Testing
 @testable import Alas
 
 struct CommitPublishModelsTests {
+    @Test func composerOffersCommitAndCreateWithEitherPreferredAction() {
+        for preferred in [DraftCommitPreferredAction.commit, .publish] {
+            let presentation = CommitPublishPresentation(
+                subject: "Subject", hasStaged: true, preferredAction: preferred,
+                availability: .review(snapshot: publishSnapshot())
+            )
+            #expect(presentation.commit.label == "Commit")
+            #expect(presentation.commit.isEnabled)
+            #expect(presentation.publish?.label == "Commit & PR")
+            #expect(presentation.publish?.isEnabled == true)
+            #expect(presentation.preferredActionPosition == (preferred == .commit ? .leading : .trailing))
+            #expect(presentation.draftToggleLabel == "Draft PR")
+            #expect(presentation.draftToggleEnabled)
+        }
+    }
+
+    @Test func composerUsesExistingRequestAndGGLabels() {
+        let push = CommitPublishPresentation(subject: "Subject", hasStaged: true,
+            availability: .review(snapshot: publishSnapshot(hasRequest: true)))
+        #expect(push.publish?.label == "Commit & push")
+        #expect(push.draftToggleLabel == nil)
+        let sync = CommitPublishPresentation(subject: "Subject", hasStaged: true, availability: .gg())
+        #expect(sync.publish?.label == "Commit & sync")
+        #expect(sync.publish?.isEnabled == true)
+        #expect(sync.draftToggleLabel == nil)
+    }
+
+    @Test func initialActionsRequireSubjectAndStagedChanges() {
+        for (subject, hasStaged) in [(" \n", true), ("Subject", false), ("", false)] {
+            let presentation = CommitPublishPresentation(subject: subject, hasStaged: hasStaged,
+                availability: .review(snapshot: publishSnapshot()))
+            #expect(!presentation.commit.isEnabled)
+            #expect(presentation.publish?.isEnabled == false)
+            #expect(!presentation.commit.help.isEmpty)
+        }
+    }
+
+    @Test func loadingProviderRetainsItsReviewRequestTerminology() {
+        let remote = CodeHostRemote(kind: .gitlab, host: "gitlab.com", owner: "owner", repository: "repo",
+            remoteName: "origin", webURL: URL(string: "https://gitlab.com/owner/repo")!)
+        let presentation = CommitPublishPresentation(subject: "Subject", hasStaged: true,
+            availability: .review(snapshot: nil, supportedRemote: remote))
+        #expect(presentation.publish?.label == "Commit & MR")
+        #expect(presentation.publish?.isEnabled == false)
+        #expect(presentation.draftToggleLabel == "Draft MR")
+    }
+
+    @Test func retryDoesNotRequireStagedChangesOrCurrentProviderAvailability() {
+        for (phase, label) in [(CommitPublishPhase.push, "Retry push"), (.createReviewRequest, "Retry create MR"), (.sync, "Retry sync")] {
+            let checkpoint = presentationCheckpoint(phase: phase)
+            let presentation = CommitPublishPresentation(subject: "", hasStaged: false, checkpoint: checkpoint)
+            #expect(presentation.publish?.label == label)
+            #expect(presentation.publish?.isEnabled == true)
+            #expect(!presentation.commit.isEnabled)
+            #expect(presentation.preferredActionPosition == .trailing)
+            #expect(presentation.editorDisabled)
+            #expect(presentation.mutationsDisabled)
+            #expect(!presentation.draftToggleEnabled)
+        }
+    }
+
+    @Test func busyDisablesBothActionsIncludingRetry() {
+        for activity in [CommitPublishActivity.idle, .committing, .pushing, .creatingReviewRequest, .syncing] {
+            for checkpoint in [nil, presentationCheckpoint(phase: .push)] {
+                let presentation = CommitPublishPresentation(subject: "Subject", hasStaged: true,
+                    busy: true, activity: activity, checkpoint: checkpoint,
+                    availability: .review(snapshot: publishSnapshot()))
+                #expect(!presentation.commit.isEnabled)
+                #expect(presentation.publish?.isEnabled == false)
+                #expect(!presentation.draftToggleEnabled)
+                #expect(presentation.mutationsDisabled)
+            }
+        }
+    }
+
+    @Test func activityLabelsFollowCapturedProvider() {
+        let presentation = CommitPublishPresentation(subject: "Subject", hasStaged: false,
+            busy: true, activity: .creatingReviewRequest, checkpoint: presentationCheckpoint(phase: .createReviewRequest))
+        #expect(presentation.publish?.label == "Creating MR...")
+        #expect(presentation.activityText == "Creating MR...")
+        let committing = CommitPublishPresentation(subject: "Subject", hasStaged: true,
+            busy: true, activity: .committing, availability: .gg())
+        #expect(committing.commit.label == "Committing...")
+        #expect(committing.publish?.label == "Committing...")
+    }
+
+    @Test func publishedAmendOnlyBlocksPublish() {
+        let presentation = CommitPublishPresentation(subject: "Subject", hasStaged: true, amend: true,
+            availability: .review(snapshot: publishSnapshot(), amend: true, amendProbe: .published))
+        #expect(presentation.commit.label == "Amend")
+        #expect(presentation.commit.isEnabled)
+        #expect(presentation.publish?.isEnabled == false)
+        #expect(presentation.publish?.help == "This commit is already published. Commit locally or turn off Amend before publishing.")
+    }
+
+    @Test func unsupportedHostHidesPublishButSupportedBlockerKeepsItVisible() {
+        let unsupported = CommitPublishPresentation(subject: "Subject", hasStaged: true,
+            preferredAction: .publish, availability: .review(snapshot: publishSnapshot(supported: false)))
+        #expect(unsupported.publish == nil)
+        #expect(unsupported.preferredActionPosition == .leading)
+        let blocked = CommitPublishPresentation(subject: "Subject", hasStaged: true,
+            availability: .review(snapshot: publishSnapshot(authenticated: false)))
+        #expect(blocked.publish?.label == "Commit & PR")
+        #expect(blocked.publish?.isEnabled == false)
+        #expect(blocked.commit.isEnabled)
+    }
+
+    private func presentationCheckpoint(phase: CommitPublishPhase) -> CommitPublishCheckpoint {
+        CommitPublishCheckpoint(commitSHA: "abc", baseRef: "main", commitTitle: "abc Subject",
+            subject: "Subject", body: "", destination: phase == .sync ? .gg : .review(.init(
+                provider: .gitlab, host: "gitlab.com", owner: "owner", repository: "repo",
+                repositorySlug: "owner/repo", remoteName: "origin", webURL: URL(string: "https://gitlab.com/owner/repo")!,
+                branch: "feature", upstreamBranch: nil, headOwner: nil, baseBranch: "main",
+                reviewRequestExisted: false, createAsDraft: true)), nextPhase: phase)
+    }
+
     @Test func actionLabelsDescribeActivityAndCreationRetry() {
         #expect(CommitPublishActivity.idle.actionLabel(reviewRequestLabel: "PR") == nil)
         #expect(CommitPublishActivity.committing.actionLabel(reviewRequestLabel: "PR") == "Committing...")

--- a/AlasTests/Center/CommitPublishModelsTests.swift
+++ b/AlasTests/Center/CommitPublishModelsTests.swift
@@ -3,6 +3,70 @@ import Testing
 @testable import Alas
 
 struct CommitPublishModelsTests {
+    @Test func supportedHostOffersCreateOrPush() {
+        let create = CommitPublishAvailability.review(snapshot: publishSnapshot())
+        #expect(create?.label == "Commit & PR")
+        #expect(create?.disabledReason == nil)
+        #expect(create?.showsDraftToggle == true)
+        let push = CommitPublishAvailability.review(snapshot: publishSnapshot(hasRequest: true, capabilities: .readOnly))
+        #expect(push?.label == "Commit & push")
+        #expect(push?.disabledReason == nil)
+        #expect(push?.showsDraftToggle == false)
+        #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(supported: false)) == nil)
+    }
+
+    @Test func publicationRequiresLoadedAuthenticatedCapableProvider() {
+        #expect(CommitPublishAvailability.review(snapshot: nil, supportedRemote: publishRemote)?.disabledReason != nil)
+        #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(), isRefreshing: true)?.disabledReason != nil)
+        #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(available: false))?.disabledReason != nil)
+        #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(authenticated: false))?.disabledReason != nil)
+        #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(capabilities: .readOnly))?.disabledReason != nil)
+        #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(), lastError: "Refresh failed")?.disabledReason == "Refresh failed")
+        #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(), mutationDisabledReason: "Busy")?.disabledReason == "Busy")
+    }
+
+    @Test func publicationBlocksBaseBranchAndOutdatedLocalState() {
+        #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(branch: "main"))?.disabledReason != nil)
+        #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(branch: "main", base: "origin/main"))?.disabledReason != nil)
+        #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(), currentBranch: "other")?.disabledReason != nil)
+        #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(), currentBaseBranch: "other")?.disabledReason != nil)
+        #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(upstreamAhead: 1, needsPush: false))?.disabledReason != nil)
+        #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(upstreamAhead: 1, needsPush: true))?.disabledReason != nil)
+    }
+
+    @Test func amendPublicationRequiresExplicitUnpublishedResult() {
+        for probe in [CommitPublishAmendProbe.loading, .published, .failed("Probe failed")] {
+            #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(), amend: true, amendProbe: probe)?.disabledReason != nil)
+        }
+        for result in [HeadPublicationState.noUpstream, .unpublished] {
+            #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(), amend: true, amendProbe: .init(result))?.disabledReason == nil)
+        }
+        #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(), amendProbe: .published)?.disabledReason == nil)
+        #expect(CommitPublishAvailability.review(snapshot: publishSnapshot(), amend: true, amendProbe: .failed("Probe failed"))?.disabledReason == "Probe failed")
+    }
+
+    private var publishRemote: CodeHostRemote {
+        CodeHostRemote(kind: .github, host: "github.com", owner: "owner", repository: "repo", remoteName: "origin", webURL: URL(string: "https://github.com/owner/repo")!)
+    }
+
+    private func publishSnapshot(
+        hasRequest: Bool = false, supported: Bool = true,
+        available: Bool = true, authenticated: Bool = true,
+        capabilities: CodeHostProviderCapabilities = .githubCLI,
+        branch: String = "feature", base: String = "main",
+        upstreamAhead: Int = 0, needsPush: Bool = false
+    ) -> ReviewLoopSnapshot {
+        ReviewLoopSnapshot(
+            local: ReviewLoopLocalState(branchName: branch, headSHA: "abc", baseBranch: base,
+                hasWorkingTreeChanges: true, hasStagedChanges: true, aheadCommitCount: 0,
+                hasUpstream: true, upstreamAheadCommitCount: upstreamAhead, needsPush: needsPush),
+            remote: supported ? publishRemote : nil,
+            reviewRequest: hasRequest ? .placeholder(remote: publishRemote, number: 1) : nil,
+            providerAvailable: available, providerAuthenticated: authenticated,
+            providerCapabilities: capabilities, errorMessage: nil
+        )
+    }
+
     @Test func reviewCheckpointRoundTripsEveryCapturedField() throws {
         let checkpoint = CommitPublishCheckpoint(
             commitSHA: "abc123",

--- a/AlasTests/Center/CommitPublishModelsTests.swift
+++ b/AlasTests/Center/CommitPublishModelsTests.swift
@@ -3,6 +3,18 @@ import Testing
 @testable import Alas
 
 struct CommitPublishModelsTests {
+    @Test func actionLabelsDescribeActivityAndCreationRetry() {
+        #expect(CommitPublishActivity.idle.actionLabel(reviewRequestLabel: "PR") == nil)
+        #expect(CommitPublishActivity.committing.actionLabel(reviewRequestLabel: "PR") == "Committing...")
+        #expect(CommitPublishActivity.pushing.actionLabel(reviewRequestLabel: "PR") == "Pushing...")
+        #expect(CommitPublishActivity.creatingReviewRequest.actionLabel(reviewRequestLabel: "PR") == "Creating PR...")
+        #expect(CommitPublishActivity.creatingReviewRequest.actionLabel(reviewRequestLabel: "MR") == "Creating MR...")
+        #expect(CommitPublishActivity.syncing.actionLabel(reviewRequestLabel: "PR") == "Syncing...")
+        #expect(CommitPublishPhase.createReviewRequest.retryLabel(reviewRequestLabel: "PR") == "Retry create PR")
+        #expect(CommitPublishPhase.push.retryLabel(reviewRequestLabel: "PR") == "Retry push")
+        #expect(CommitPublishPhase.sync.retryLabel(reviewRequestLabel: "PR") == "Retry sync")
+    }
+
     @Test func supportedHostOffersCreateOrPush() {
         let create = CommitPublishAvailability.review(snapshot: publishSnapshot())
         #expect(create?.label == "Commit & PR")

--- a/AlasTests/Center/CommitPublishModelsTests.swift
+++ b/AlasTests/Center/CommitPublishModelsTests.swift
@@ -112,7 +112,7 @@ struct CommitPublishModelsTests {
 
     private func presentationCheckpoint(phase: CommitPublishPhase) -> CommitPublishCheckpoint {
         CommitPublishCheckpoint(commitSHA: "abc", baseRef: "main", commitTitle: "abc Subject",
-            subject: "Subject", body: "", destination: phase == .sync ? .gg : .review(.init(
+            subject: "Subject", body: "", destination: phase == .sync ? .gg() : .review(.init(
                 provider: .gitlab, host: "gitlab.com", owner: "owner", repository: "repo",
                 repositorySlug: "owner/repo", remoteName: "origin", webURL: URL(string: "https://gitlab.com/owner/repo")!,
                 branch: "feature", upstreamBranch: nil, headOwner: nil, baseBranch: "main",
@@ -232,7 +232,7 @@ struct CommitPublishModelsTests {
             commitTitle: "def456 Subject",
             subject: "Subject",
             body: "Body",
-            destination: .gg,
+            destination: .gg(),
             nextPhase: .sync
         )
 

--- a/AlasTests/Center/CommitPublishModelsTests.swift
+++ b/AlasTests/Center/CommitPublishModelsTests.swift
@@ -241,7 +241,7 @@ struct CommitPublishModelsTests {
         #expect(try JSONDecoder().decode(CommitPublishCheckpoint.self, from: data) == checkpoint)
     }
 
-    @Test func checkpointDefaultsMissingGGRecoveryFlagToFalse() throws {
+    @Test func checkpointDefaultsMissingGGRecoveryOperationIDToNil() throws {
         let data = """
         {
           "baseRef": "main",
@@ -258,7 +258,7 @@ struct CommitPublishModelsTests {
 
         #expect(checkpoint.commitSHA == "def456")
         #expect(checkpoint.destination == .gg())
-        #expect(!checkpoint.allowsGGRecoveryHeadReconciliation)
+        #expect(checkpoint.ggRecoveryOperationID == nil)
     }
 
     @Test func everyPublishPhaseRoundTrips() throws {

--- a/AlasTests/Center/CommitPublishModelsTests.swift
+++ b/AlasTests/Center/CommitPublishModelsTests.swift
@@ -241,6 +241,26 @@ struct CommitPublishModelsTests {
         #expect(try JSONDecoder().decode(CommitPublishCheckpoint.self, from: data) == checkpoint)
     }
 
+    @Test func checkpointDefaultsMissingGGRecoveryFlagToFalse() throws {
+        let data = """
+        {
+          "baseRef": "main",
+          "body": "Body",
+          "commitSHA": "def456",
+          "commitTitle": "def456 Subject",
+          "destination": { "gg": {} },
+          "nextPhase": "sync",
+          "subject": "Subject"
+        }
+        """.data(using: .utf8)!
+
+        let checkpoint = try JSONDecoder().decode(CommitPublishCheckpoint.self, from: data)
+
+        #expect(checkpoint.commitSHA == "def456")
+        #expect(checkpoint.destination == .gg())
+        #expect(!checkpoint.allowsGGRecoveryHeadReconciliation)
+    }
+
     @Test func everyPublishPhaseRoundTrips() throws {
         for phase in [
             CommitPublishPhase.push,

--- a/AlasTests/Center/CommitPublishModelsTests.swift
+++ b/AlasTests/Center/CommitPublishModelsTests.swift
@@ -106,4 +106,23 @@ struct CommitPublishModelsTests {
         #expect(pair.leading == .init(key: "j", modifiers: [.command, .shift]))
         #expect(pair.trailing == .init(key: "j", modifiers: [.command]))
     }
+
+    @Test func subtleActionBadgeUsesThemeForegroundColors() {
+        #expect(CommitComposerActionEmphasis.subtle.badgeStyle == .init(
+            foreground: .theme("fg"),
+            foregroundOpacity: 1,
+            background: .theme("fg"),
+            backgroundOpacity: 0.12
+        ))
+    }
+
+    @Test func actionPairResolvesShortcutAtEachPosition() {
+        let pair = CommitComposerActionPair.shortcuts(
+            preferred: .trailing,
+            base: .init(key: "return", modifiers: [.command])
+        )
+
+        #expect(pair.shortcut(at: .leading) == .init(key: "return", modifiers: [.command, .shift]))
+        #expect(pair.shortcut(at: .trailing) == .init(key: "return", modifiers: [.command]))
+    }
 }

--- a/AlasTests/Center/CommitPublishModelsTests.swift
+++ b/AlasTests/Center/CommitPublishModelsTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct CommitPublishModelsTests {
+    @Test func reviewCheckpointRoundTripsEveryCapturedField() throws {
+        let checkpoint = CommitPublishCheckpoint(
+            commitSHA: "abc123",
+            baseRef: "main",
+            commitTitle: "abc123 Subject",
+            subject: "Subject",
+            body: "Body",
+            destination: .review(.init(
+                provider: .github,
+                host: "github.com",
+                owner: "owner",
+                repository: "repo",
+                repositorySlug: "owner/repo",
+                remoteName: "origin",
+                webURL: URL(string: "https://github.com/owner/repo")!,
+                branch: "feature",
+                upstreamBranch: nil,
+                headOwner: nil,
+                baseBranch: "main",
+                reviewRequestExisted: false,
+                createAsDraft: true
+            )),
+            nextPhase: .push
+        )
+
+        let data = try JSONEncoder().encode(checkpoint)
+
+        #expect(try JSONDecoder().decode(CommitPublishCheckpoint.self, from: data) == checkpoint)
+    }
+
+    @Test func ggCheckpointRoundTrips() throws {
+        let checkpoint = CommitPublishCheckpoint(
+            commitSHA: "def456",
+            baseRef: "main",
+            commitTitle: "def456 Subject",
+            subject: "Subject",
+            body: "Body",
+            destination: .gg,
+            nextPhase: .sync
+        )
+
+        let data = try JSONEncoder().encode(checkpoint)
+
+        #expect(try JSONDecoder().decode(CommitPublishCheckpoint.self, from: data) == checkpoint)
+    }
+
+    @Test func everyPublishPhaseRoundTrips() throws {
+        for phase in [
+            CommitPublishPhase.push,
+            .createReviewRequest,
+            .sync,
+        ] {
+            let data = try JSONEncoder().encode(phase)
+            #expect(try JSONDecoder().decode(CommitPublishPhase.self, from: data) == phase)
+        }
+    }
+
+    @Test func reviewTargetRestoresCapturedSelfHostedRemote() {
+        let target = CommitPublishReviewTarget(
+            provider: .gitlab,
+            host: "gitlab.example.com",
+            owner: "team",
+            repository: "project",
+            repositorySlug: "team/project",
+            remoteName: "gitlab",
+            webURL: URL(string: "https://gitlab.example.com/team/project")!,
+            branch: "feature",
+            upstreamBranch: "gitlab/feature",
+            headOwner: "fork-owner",
+            baseBranch: "main",
+            reviewRequestExisted: true,
+            createAsDraft: false
+        )
+
+        #expect(target.remote == CodeHostRemote(
+            kind: .gitlab,
+            host: "gitlab.example.com",
+            owner: "team",
+            repository: "project",
+            remoteName: "gitlab",
+            webURL: URL(string: "https://gitlab.example.com/team/project")!
+        ))
+    }
+}

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -522,6 +522,68 @@ struct CommitPublishWorkflowTests {
         #expect(retryWorkflow.lastError == nil)
     }
 
+    @Test func ggPausedRecoveryReconcilesRewrittenHeadForRetry() async throws {
+        let harness = WorkflowHarness()
+        var headSHA = "commit-sha"
+        var persistedCheckpoints: [CommitPublishCheckpoint?] = []
+        var syncedTargets: [GGStackTargetIdentity] = []
+        let checkpoint = harness.ggCheckpoint
+        let operations = CommitPublishOperations(
+            createCommit: { _, _, _ in .init(commitSHA: "unused", comparisonBase: "main", editorTitle: "Unused") },
+            currentHeadSHA: { headSHA },
+            remoteBranchContainsCommit: { _, _ in false },
+            push: { _, _ in },
+            currentReviewRequestExists: { _ in true },
+            createReviewRequest: { target, _, _ in target.webURL },
+            syncGG: { _ in Issue.record("Unexpected untargeted sync") },
+            syncGGForTarget: { target, execution in
+                execution.markStarted()
+                syncedTargets.append(target)
+                headSHA = "paused-sha"
+                throw GGServiceError.pausedConflict(message: "Resolve conflicts and run gg continue.")
+            },
+            refreshAfterCompletion: {}
+        )
+        let workflow = CommitPublishWorkflow(operations: operations) {
+            persistedCheckpoints.append($0)
+        }
+
+        await workflow.resume(checkpoint)
+
+        let retryCheckpoint = try #require(persistedCheckpoints.compactMap(\.self).last)
+        #expect(retryCheckpoint.commitSHA == "paused-sha")
+        #expect(retryCheckpoint.allowsGGRecoveryHeadReconciliation)
+        #expect(workflow.lastError as? GGServiceError == .pausedConflict(message: "Resolve conflicts and run gg continue."))
+
+        headSHA = "recovered-sha"
+        syncedTargets = []
+        var retryPersistedCheckpoints: [CommitPublishCheckpoint?] = []
+        let retryOperations = CommitPublishOperations(
+            createCommit: { _, _, _ in .init(commitSHA: "unused", comparisonBase: "main", editorTitle: "Unused") },
+            currentHeadSHA: { headSHA },
+            remoteBranchContainsCommit: { _, _ in false },
+            push: { _, _ in },
+            currentReviewRequestExists: { _ in true },
+            createReviewRequest: { target, _, _ in target.webURL },
+            syncGG: { _ in Issue.record("Unexpected untargeted sync") },
+            syncGGForTarget: { target, _ in syncedTargets.append(target) },
+            refreshAfterCompletion: {}
+        )
+        let retryWorkflow = CommitPublishWorkflow(operations: retryOperations) {
+            retryPersistedCheckpoints.append($0)
+        }
+
+        await retryWorkflow.resume(retryCheckpoint)
+
+        #expect(retryPersistedCheckpoints.compactMap(\.self).map(\.commitSHA) == ["paused-sha", "recovered-sha"])
+        #expect(retryPersistedCheckpoints.compactMap(\.self).last?.allowsGGRecoveryHeadReconciliation == false)
+        #expect(syncedTargets == [
+            .init(branch: "feature", stackName: "feature", base: "main", expectedHeadSHA: "recovered-sha"),
+        ])
+        #expect(retryPersistedCheckpoints.last! == nil)
+        #expect(retryWorkflow.lastError == nil)
+    }
+
     @Test func pushFailureRetainsPushCheckpoint() async {
         let harness = WorkflowHarness()
         harness.pushError = WorkflowHarness.Failure.push

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -12,7 +12,7 @@ struct CommitPublishWorkflowTests {
             currentHeadSHA: { "committed" }, remoteBranchContainsCommit: { _, _ in false }, push: { _, _ in },
             currentReviewRequestExists: { _ in true },
             createReviewRequest: { target, _, _ in target.webURL },
-            syncGG: {
+            syncGG: { _ in
                 if failSync { throw NSError(domain: "Publish", code: 1, userInfo: [NSLocalizedDescriptionKey: "Second failed"]) }
             }, refreshAfterCompletion: { await refreshGate.waitForFirstCall() }
         )
@@ -53,7 +53,7 @@ struct CommitPublishWorkflowTests {
             currentReviewRequestExists: { _ in true },
             createReviewRequest: { _, _, _ in Issue.record("Unexpected creation")
             return target.webURL },
-            syncGG: {}, refreshAfterCompletion: {}
+            syncGG: { _ in }, refreshAfterCompletion: {}
         )
         let task = try #require(manager.runCommitPublish(worktreeId: "remount-publish", tabId: draft.id,
             subject: "Subject", body: "Body", amend: false, operations: operations,
@@ -101,7 +101,7 @@ struct CommitPublishWorkflowTests {
             push: { _, _ in calls.append("push") },
             currentReviewRequestExists: { _ in true },
             createReviewRequest: { target, _, _ in target.webURL },
-            syncGG: {},
+            syncGG: { _ in },
             refreshAfterCompletion: {}
         )
 
@@ -130,7 +130,7 @@ struct CommitPublishWorkflowTests {
             push: { _, _ in },
             currentReviewRequestExists: { _ in true },
             createReviewRequest: { target, _, _ in target.webURL },
-            syncGG: {},
+            syncGG: { _ in },
             refreshAfterCompletion: {}
         )
         let task = try #require(manager.runCommitPublish(worktreeId: "abandon-publish", tabId: draft.id,
@@ -160,8 +160,11 @@ struct CommitPublishWorkflowTests {
             push: { _, _ in },
             currentReviewRequestExists: { _ in true },
             createReviewRequest: { target, _, _ in target.webURL },
-            syncGG: { Issue.record("Unexpected untargeted sync") },
-            syncGGForTarget: { _ in headSHA = "rebased-sha" },
+            syncGG: { _ in Issue.record("Unexpected untargeted sync") },
+            syncGGForTarget: { _, execution in
+                execution.markStarted()
+                headSHA = "rebased-sha"
+            },
             refreshAfterCompletion: {}
         )
 
@@ -251,7 +254,7 @@ struct CommitPublishWorkflowTests {
             },
             currentHeadSHA: { "committed" }, remoteBranchContainsCommit: { _, _ in false },
             push: { _, _ in calls.append("push") }, currentReviewRequestExists: { _ in true },
-            createReviewRequest: { target, _, _ in target.webURL }, syncGG: {}, refreshAfterCompletion: {}
+            createReviewRequest: { target, _, _ in target.webURL }, syncGG: { _ in }, refreshAfterCompletion: {}
         )
         let workflow = CommitPublishWorkflow(operations: operations) { _ in }
 
@@ -275,7 +278,7 @@ struct CommitPublishWorkflowTests {
             },
             currentHeadSHA: { "committed" }, remoteBranchContainsCommit: { _, _ in false }, push: { _, _ in },
             currentReviewRequestExists: { _ in true },
-            createReviewRequest: { target, _, _ in target.webURL }, syncGG: {}, refreshAfterCompletion: {}
+            createReviewRequest: { target, _, _ in target.webURL }, syncGG: { _ in }, refreshAfterCompletion: {}
         )
         let workflow = CommitPublishWorkflow(operations: operations) { _ in }
 
@@ -295,8 +298,8 @@ struct CommitPublishWorkflowTests {
             return .init(commitSHA: "committed", comparisonBase: "main", editorTitle: "Title") },
             currentHeadSHA: { "commit-sha" }, remoteBranchContainsCommit: { _, _ in false }, push: { _, _ in },
             currentReviewRequestExists: { _ in true },
-            createReviewRequest: { target, _, _ in target.webURL }, syncGG: {},
-            syncGGForTarget: { _ in Issue.record("Unexpected sync") },
+            createReviewRequest: { target, _, _ in target.webURL }, syncGG: { _ in },
+            syncGGForTarget: { _, _ in Issue.record("Unexpected sync") },
             refreshAfterCompletion: {}
         )
         let workflow = CommitPublishWorkflow(operations: operations) { persistedCheckpoint = $0 }
@@ -319,8 +322,8 @@ struct CommitPublishWorkflowTests {
             push: { _, _ in },
             currentReviewRequestExists: { _ in true },
             createReviewRequest: { target, _, _ in target.webURL },
-            syncGG: { Issue.record("Unexpected untargeted sync") },
-            syncGGForTarget: { target in syncedTargets.append(target) },
+            syncGG: { _ in Issue.record("Unexpected untargeted sync") },
+            syncGGForTarget: { target, _ in syncedTargets.append(target) },
             refreshAfterCompletion: {}
         )
         let workflow = CommitPublishWorkflow(operations: operations) {
@@ -351,8 +354,8 @@ struct CommitPublishWorkflowTests {
             push: { _, _ in },
             currentReviewRequestExists: { _ in true },
             createReviewRequest: { target, _, _ in target.webURL },
-            syncGG: { Issue.record("Unexpected untargeted sync") },
-            syncGGForTarget: { target in syncedTargets.append(target) },
+            syncGG: { _ in Issue.record("Unexpected untargeted sync") },
+            syncGGForTarget: { target, _ in syncedTargets.append(target) },
             refreshAfterCompletion: {}
         )
         let workflow = CommitPublishWorkflow(operations: operations) {
@@ -363,6 +366,40 @@ struct CommitPublishWorkflowTests {
 
         #expect(persistedCheckpoints == [checkpoint])
         #expect(syncedTargets.isEmpty)
+        #expect(workflow.lastError as? GGMutationError == .staleConfirmation)
+    }
+
+    @Test func ggSyncPreflightFailureDoesNotPersistRewrittenHeadForRetry() async {
+        let harness = WorkflowHarness()
+        var headSHA = "commit-sha"
+        var persistedCheckpoints: [CommitPublishCheckpoint?] = []
+        var syncedTargets: [GGStackTargetIdentity] = []
+        let checkpoint = harness.ggCheckpoint
+        let operations = CommitPublishOperations(
+            createCommit: { _, _, _ in .init(commitSHA: "unused", comparisonBase: "main", editorTitle: "Unused") },
+            currentHeadSHA: { headSHA },
+            remoteBranchContainsCommit: { _, _ in false },
+            push: { _, _ in },
+            currentReviewRequestExists: { _ in true },
+            createReviewRequest: { target, _, _ in target.webURL },
+            syncGG: { _ in Issue.record("Unexpected untargeted sync") },
+            syncGGForTarget: { target, _ in
+                syncedTargets.append(target)
+                headSHA = "unrelated-sha"
+                throw GGMutationError.staleConfirmation
+            },
+            refreshAfterCompletion: {}
+        )
+        let workflow = CommitPublishWorkflow(operations: operations) {
+            persistedCheckpoints.append($0)
+        }
+
+        await workflow.resume(checkpoint)
+
+        #expect(persistedCheckpoints == [checkpoint])
+        #expect(syncedTargets == [
+            .init(branch: "feature", stackName: "feature", base: "main", expectedHeadSHA: "commit-sha"),
+        ])
         #expect(workflow.lastError as? GGMutationError == .staleConfirmation)
     }
 
@@ -379,8 +416,9 @@ struct CommitPublishWorkflowTests {
             push: { _, _ in },
             currentReviewRequestExists: { _ in true },
             createReviewRequest: { target, _, _ in target.webURL },
-            syncGG: { Issue.record("Unexpected untargeted sync") },
-            syncGGForTarget: { target in
+            syncGG: { _ in Issue.record("Unexpected untargeted sync") },
+            syncGGForTarget: { target, execution in
+                execution.markStarted()
                 syncedTargets.append(target)
                 headSHA = "rebased-sha"
                 throw WorkflowHarness.Failure.sync
@@ -411,8 +449,8 @@ struct CommitPublishWorkflowTests {
             push: { _, _ in },
             currentReviewRequestExists: { _ in true },
             createReviewRequest: { target, _, _ in target.webURL },
-            syncGG: { Issue.record("Unexpected untargeted sync") },
-            syncGGForTarget: { target in syncedTargets.append(target) },
+            syncGG: { _ in Issue.record("Unexpected untargeted sync") },
+            syncGGForTarget: { target, _ in syncedTargets.append(target) },
             refreshAfterCompletion: {}
         )
         let retryWorkflow = CommitPublishWorkflow(operations: retryOperations) {
@@ -469,7 +507,7 @@ struct CommitPublishWorkflowTests {
 
         await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .gg())
 
-        #expect(harness.calls == ["commit", "head", "sync", "head"])
+        #expect(harness.calls == ["commit", "head", "sync"])
         #expect(harness.checkpoint?.nextPhase == .sync)
     }
 
@@ -691,7 +729,7 @@ struct CommitPublishWorkflowTests {
                 calls.append("createPR")
                 return target.webURL
             },
-            syncGG: {},
+            syncGG: { _ in },
             refreshAfterCompletion: {}
         )
         let workflow = CommitPublishWorkflow(operations: operations) { _ in }
@@ -723,7 +761,7 @@ struct CommitPublishWorkflowTests {
                 calls.append("createPR")
                 return target.webURL
             },
-            syncGG: {},
+            syncGG: { _ in },
             refreshAfterCompletion: {}
         )
         let workflow = CommitPublishWorkflow(operations: operations) { next in
@@ -933,12 +971,13 @@ private final class WorkflowHarness {
                     if let createRequestError { throw createRequestError }
                     return URL(string: "https://github.com/owner/repository/pull/1")!
                 },
-                syncGG: { [unowned self] in
+                syncGG: { [unowned self] _ in
                     calls.append("sync")
                     if let syncError { throw syncError }
                 },
-                syncGGForTarget: { [unowned self] target in
+                syncGGForTarget: { [unowned self] target, execution in
                     calls.append("sync")
+                    execution.markStarted()
                     syncedGGTargets.append(target)
                     if let syncError { throw syncError }
                 },

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -144,8 +144,10 @@ struct CommitPublishWorkflowTests {
         let harness = WorkflowHarness()
         harness.refreshChecksCheckpoint = true
         let workflow = harness.makeWorkflow()
+        let checkpoint = harness.checkpoint(nextPhase: .createReviewRequest)
+        harness.checkpoint = checkpoint
 
-        await workflow.resume(harness.checkpoint(nextPhase: .createReviewRequest))
+        await workflow.resume(checkpoint)
 
         #expect(harness.checkpointWasClearedBeforeRefresh)
     }

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -81,6 +81,73 @@ struct CommitPublishWorkflowTests {
         #expect(manager.commitEditorTab(worktreeId: "remount-publish", currentSha: "committed") != nil)
     }
 
+    @Test func tabsManagerStopsBeforeRemoteMutationWhenCheckpointCannotPersist() async throws {
+        let manager = TabsManager(store: FailingTabsStore())
+        let draft = manager.openOrFocusDraftCommit(worktreeId: "checkpoint-persist-failure")
+        var calls: [String] = []
+        let operations = CommitPublishOperations(
+            createCommit: { _, _, _ in
+                calls.append("commit")
+                return .init(commitSHA: "committed", comparisonBase: "main", editorTitle: "Title")
+            },
+            currentHeadSHA: {
+                calls.append("head")
+                return "committed"
+            },
+            remoteBranchContainsCommit: { _, _ in
+                calls.append("remoteContainsCommit")
+                return false
+            },
+            push: { _, _ in calls.append("push") },
+            currentReviewRequestExists: { _ in true },
+            createReviewRequest: { target, _, _ in target.webURL },
+            syncGG: {},
+            refreshAfterCompletion: {}
+        )
+
+        let task = try #require(manager.runCommitPublish(worktreeId: "checkpoint-persist-failure", tabId: draft.id,
+            subject: "Subject", body: "Body", amend: false, operations: operations,
+            prepareDestination: { .review(WorkflowHarness().target) }))
+        await task.value
+
+        let session = try #require(manager.commitPublishSession(tabId: draft.id))
+        #expect(calls == ["commit"])
+        #expect(session.checkpoint?.nextPhase == .push)
+        #expect(session.lastError?.localizedDescription == "write rejected")
+    }
+
+    @Test func tabsManagerCanAbandonPausedPublishCheckpoint() async throws {
+        let manager = TabsManager()
+        let draft = manager.openOrFocusDraftCommit(worktreeId: "abandon-publish")
+        let checkpoint = WorkflowHarness().checkpoint(nextPhase: .push)
+        manager.updateDraftCommit(worktreeId: "abandon-publish", tabId: draft.id) {
+            $0.publishCheckpoint = checkpoint
+        }
+        let operations = CommitPublishOperations(
+            createCommit: { _, _, _ in .init(commitSHA: "unused", comparisonBase: "main", editorTitle: "Unused") },
+            currentHeadSHA: { throw WorkflowHarness.Failure.head },
+            remoteBranchContainsCommit: { _, _ in false },
+            push: { _, _ in },
+            currentReviewRequestExists: { _ in true },
+            createReviewRequest: { target, _, _ in target.webURL },
+            syncGG: {},
+            refreshAfterCompletion: {}
+        )
+        let task = try #require(manager.runCommitPublish(worktreeId: "abandon-publish", tabId: draft.id,
+            subject: "Subject", body: "Body", amend: false, operations: operations,
+            prepareDestination: { .review(WorkflowHarness().target) }))
+        await task.value
+
+        #expect(manager.abandonCommitPublishCheckpoint(worktreeId: "abandon-publish", tabId: draft.id))
+
+        #expect(manager.commitPublishSession(tabId: draft.id) == nil)
+        guard case .draftCommit(let state) = manager.tabs(forWorktree: "abandon-publish").first else {
+            Issue.record("Expected draft commit tab")
+            return
+        }
+        #expect(state.publishCheckpoint == nil)
+    }
+
     @Test func normalNewRequestPublishesInOrder() async {
         let harness = WorkflowHarness()
         let workflow = harness.makeWorkflow()
@@ -453,6 +520,39 @@ struct CommitPublishWorkflowTests {
         #expect(harness.calls == ["head", "remoteContainsCommit", "lookupPR", "createPR"])
     }
 
+    @Test func remoteContainmentStillConfiguresUpstreamForUntrackedBranch() async {
+        var calls: [String] = []
+        let target = WorkflowHarness().targetWithoutUpstream
+        let operations = CommitPublishOperations(
+            createCommit: { _, _, _ in .init(commitSHA: "unused", comparisonBase: "main", editorTitle: "Unused") },
+            currentHeadSHA: {
+                calls.append("head")
+                return "commit-sha"
+            },
+            remoteBranchContainsCommit: { _, _ in
+                calls.append("remoteContainsCommit")
+                return true
+            },
+            push: { _, _ in calls.append("push") },
+            configureUpstreamTracking: { _ in calls.append("configureUpstream") },
+            currentReviewRequestExists: { _ in
+                calls.append("lookupPR")
+                return true
+            },
+            createReviewRequest: { target, _, _ in
+                calls.append("createPR")
+                return target.webURL
+            },
+            syncGG: {},
+            refreshAfterCompletion: {}
+        )
+        let workflow = CommitPublishWorkflow(operations: operations) { _ in }
+
+        await workflow.resume(WorkflowHarness().checkpoint(target: target, nextPhase: .push))
+
+        #expect(calls == ["head", "remoteContainsCommit", "configureUpstream", "lookupPR"])
+    }
+
     @Test func freshLookupSkipsCreateWhenRequestNowExists() async {
         let harness = WorkflowHarness()
         harness.reviewRequestExists = true
@@ -485,6 +585,15 @@ struct CommitPublishWorkflowTests {
 
         #expect(harness.checkpointWasClearedBeforeRefresh)
     }
+}
+
+private struct FailingTabsStore: PersistenceStoreProtocol {
+    func write<T: Encodable>(_: T, to _: URL) throws {
+        throw NSError(domain: "CommitPublishWorkflowTests", code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "write rejected"])
+    }
+
+    func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
 }
 
 @MainActor

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -553,6 +553,44 @@ struct CommitPublishWorkflowTests {
         #expect(calls == ["head", "remoteContainsCommit", "configureUpstream", "lookupPR"])
     }
 
+    @Test func resumeRepersistsCheckpointBeforeRemoteOperations() async {
+        var calls: [String] = []
+        let checkpoint = WorkflowHarness().checkpoint(nextPhase: .push)
+        let operations = CommitPublishOperations(
+            createCommit: { _, _, _ in .init(commitSHA: "unused", comparisonBase: "main", editorTitle: "Unused") },
+            currentHeadSHA: {
+                calls.append("head")
+                return "commit-sha"
+            },
+            remoteBranchContainsCommit: { _, _ in
+                calls.append("remoteContainsCommit")
+                return false
+            },
+            push: { _, _ in calls.append("push") },
+            currentReviewRequestExists: { _ in
+                calls.append("lookupPR")
+                return false
+            },
+            createReviewRequest: { target, _, _ in
+                calls.append("createPR")
+                return target.webURL
+            },
+            syncGG: {},
+            refreshAfterCompletion: {}
+        )
+        let workflow = CommitPublishWorkflow(operations: operations) { next in
+            calls.append("persist")
+            #expect(next == checkpoint)
+            throw NSError(domain: "CommitPublishWorkflowTests", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "write rejected"])
+        }
+
+        await workflow.resume(checkpoint)
+
+        #expect(calls == ["persist"])
+        #expect(workflow.lastError?.localizedDescription == "write rejected")
+    }
+
     @Test func freshLookupSkipsCreateWhenRequestNowExists() async {
         let harness = WorkflowHarness()
         harness.reviewRequestExists = true

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -115,6 +115,122 @@ struct CommitPublishWorkflowTests {
         #expect(harness.checkpoint == nil)
     }
 
+    @Test func currentHeadFailureRetainsCheckpoint() async {
+        let harness = WorkflowHarness()
+        harness.currentHeadError = WorkflowHarness.Failure.head
+        let workflow = harness.makeWorkflow()
+        let checkpoint = harness.checkpoint(nextPhase: .push)
+        harness.checkpoint = checkpoint
+
+        await workflow.resume(checkpoint)
+
+        #expect(harness.calls == ["head"])
+        #expect(harness.checkpoint?.nextPhase == .push)
+        #expect(workflow.lastError != nil)
+    }
+
+    @Test func remoteContainmentFailureRetainsPushCheckpoint() async {
+        let harness = WorkflowHarness()
+        harness.remoteContainsCommitError = WorkflowHarness.Failure.remoteContainment
+        let workflow = harness.makeWorkflow()
+        let checkpoint = harness.checkpoint(nextPhase: .push)
+        harness.checkpoint = checkpoint
+
+        await workflow.resume(checkpoint)
+
+        #expect(harness.calls == ["head", "remoteContainsCommit"])
+        #expect(harness.checkpoint?.nextPhase == .push)
+        #expect(workflow.lastError != nil)
+    }
+
+    @Test func malformedDestinationAndPhaseRetainsCheckpoint() async {
+        let harness = WorkflowHarness()
+        let workflow = harness.makeWorkflow()
+        let checkpoint = CommitPublishCheckpoint(
+            commitSHA: "commit-sha",
+            baseRef: "origin/main",
+            commitTitle: "Subject",
+            subject: "Subject",
+            body: "Body",
+            destination: .gg,
+            nextPhase: .push
+        )
+        harness.checkpoint = checkpoint
+
+        await workflow.resume(checkpoint)
+
+        #expect(harness.calls == ["head"])
+        #expect(harness.checkpoint == checkpoint)
+        #expect((workflow.lastError as? CommitPublishWorkflowError) == .invalidDestination(phase: .push))
+    }
+
+    @Test func cancellationAfterPushAdvancesCheckpointWithoutCreatingRequest() async {
+        let harness = WorkflowHarness()
+        let pushGate = AsyncGate()
+        harness.pushGate = pushGate
+        let workflow = harness.makeWorkflow()
+        let checkpoint = harness.checkpoint(nextPhase: .push)
+        harness.checkpoint = checkpoint
+
+        let task = Task { @MainActor in
+            await workflow.resume(checkpoint)
+        }
+        await pushGate.waitUntilEntered()
+        task.cancel()
+        await pushGate.release()
+        await task.value
+
+        #expect(harness.calls == ["head", "remoteContainsCommit", "push"])
+        #expect(harness.checkpoint?.nextPhase == .createReviewRequest)
+        #expect(workflow.activity == .idle)
+        #expect(workflow.lastError == nil)
+    }
+
+    @Test func overlappingInvocationsDoNotClobberActiveRun() async {
+        let harness = WorkflowHarness()
+        let commitGate = AsyncGate()
+        harness.createCommitGate = commitGate
+        let workflow = harness.makeWorkflow()
+        let checkpoint = harness.checkpoint(nextPhase: .push)
+
+        let first = Task { @MainActor in
+            await workflow.start(subject: "First", body: "Body", amend: false, destination: .review(harness.target))
+        }
+        await commitGate.waitUntilEntered()
+
+        await workflow.start(subject: "Second", body: "Body", amend: false, destination: .review(harness.target))
+        await workflow.resume(checkpoint)
+
+        #expect(harness.calls == ["commit"])
+        #expect(workflow.activity == .committing)
+        #expect(workflow.lastError == nil)
+
+        await commitGate.release()
+        await first.value
+
+        #expect(workflow.activity == .idle)
+        #expect(workflow.lastError == nil)
+    }
+
+    @Test func successfulRetryClearsErrorWithoutRepeatingPush() async {
+        let harness = WorkflowHarness()
+        harness.lookupError = WorkflowHarness.Failure.lookup
+        let workflow = harness.makeWorkflow()
+
+        await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .review(harness.target))
+        let checkpoint = try! #require(harness.checkpoint)
+        #expect(checkpoint.nextPhase == .createReviewRequest)
+        #expect(workflow.lastError != nil)
+
+        harness.lookupError = nil
+        harness.calls.removeAll()
+        await workflow.resume(checkpoint)
+
+        #expect(harness.calls == ["head", "lookupPR", "createPR"])
+        #expect(harness.checkpoint == nil)
+        #expect(workflow.lastError == nil)
+    }
+
     @Test func resumeNeverCreatesAnotherCommit() async {
         let harness = WorkflowHarness()
         let workflow = harness.makeWorkflow()
@@ -177,6 +293,8 @@ struct CommitPublishWorkflowTests {
 private final class WorkflowHarness {
     enum Failure: Error {
         case commit
+        case head
+        case remoteContainment
         case push
         case lookup
         case create
@@ -190,12 +308,16 @@ private final class WorkflowHarness {
     var remoteContainsCommit = false
     var reviewRequestExists = false
     var createCommitError: Error?
+    var currentHeadError: Error?
+    var remoteContainsCommitError: Error?
     var pushError: Error?
     var lookupError: Error?
     var createRequestError: Error?
     var syncError: Error?
     var refreshChecksCheckpoint = false
     var checkpointWasClearedBeforeRefresh = false
+    var createCommitGate: AsyncGate?
+    var pushGate: AsyncGate?
 
     let target = CommitPublishReviewTarget(
         provider: .github,
@@ -234,6 +356,9 @@ private final class WorkflowHarness {
             operations: CommitPublishOperations(
                 createCommit: { [unowned self] _, _, _ in
                     calls.append("commit")
+                    if let createCommitGate {
+                        await createCommitGate.waitForFirstCall()
+                    }
                     if let createCommitError { throw createCommitError }
                     return CommitPublishCreatedCommit(
                         commitSHA: "commit-sha",
@@ -243,14 +368,19 @@ private final class WorkflowHarness {
                 },
                 currentHeadSHA: { [unowned self] in
                     calls.append("head")
+                    if let currentHeadError { throw currentHeadError }
                     return headSHA
                 },
                 remoteBranchContainsCommit: { [unowned self] _, _ in
                     calls.append("remoteContainsCommit")
+                    if let remoteContainsCommitError { throw remoteContainsCommitError }
                     return remoteContainsCommit
                 },
                 push: { [unowned self] _, _ in
                     calls.append("push")
+                    if let pushGate {
+                        await pushGate.waitForFirstCall()
+                    }
                     if let pushError { throw pushError }
                 },
                 currentReviewRequestExists: { [unowned self] _ in
@@ -295,5 +425,35 @@ private final class WorkflowHarness {
             destination: .review(target ?? self.target),
             nextPhase: nextPhase
         )
+    }
+}
+
+private actor AsyncGate {
+    private var hasEntered = false
+    private var hasSuspended = false
+    private var entryContinuation: CheckedContinuation<Void, Never>?
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func waitForFirstCall() async {
+        guard !hasSuspended else { return }
+        hasSuspended = true
+        hasEntered = true
+        entryContinuation?.resume()
+        entryContinuation = nil
+        await withCheckedContinuation { continuation in
+            releaseContinuation = continuation
+        }
+    }
+
+    func waitUntilEntered() async {
+        guard !hasEntered else { return }
+        await withCheckedContinuation { continuation in
+            entryContinuation = continuation
+        }
+    }
+
+    func release() {
+        releaseContinuation?.resume()
+        releaseContinuation = nil
     }
 }

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -148,6 +148,32 @@ struct CommitPublishWorkflowTests {
         #expect(state.publishCheckpoint == nil)
     }
 
+    @Test func tabsManagerOpensPostSyncGGHeadAfterCommitPublish() async throws {
+        let manager = TabsManager()
+        let draft = manager.openOrFocusDraftCommit(worktreeId: "gg-post-sync-head")
+        var headSHA = "commit-sha"
+        let target = WorkflowHarness().ggTarget
+        let operations = CommitPublishOperations(
+            createCommit: { _, _, _ in .init(commitSHA: "commit-sha", comparisonBase: "main", editorTitle: "commit- feat") },
+            currentHeadSHA: { headSHA },
+            remoteBranchContainsCommit: { _, _ in false },
+            push: { _, _ in },
+            currentReviewRequestExists: { _ in true },
+            createReviewRequest: { target, _, _ in target.webURL },
+            syncGG: { Issue.record("Unexpected untargeted sync") },
+            syncGGForTarget: { _ in headSHA = "rebased-sha" },
+            refreshAfterCompletion: {}
+        )
+
+        let task = try #require(manager.runCommitPublish(worktreeId: "gg-post-sync-head", tabId: draft.id,
+            subject: "feat", body: "", amend: false, operations: operations,
+            prepareDestination: { .gg(target) }))
+        await task.value
+
+        #expect(manager.commitEditorTab(worktreeId: "gg-post-sync-head", currentSha: "rebased-sha") != nil)
+        #expect(manager.commitEditorTab(worktreeId: "gg-post-sync-head", currentSha: "commit-sha") == nil)
+    }
+
     @Test func normalNewRequestPublishesInOrder() async {
         let harness = WorkflowHarness()
         let workflow = harness.makeWorkflow()
@@ -178,7 +204,7 @@ struct CommitPublishWorkflowTests {
 
         await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .gg())
 
-        #expect(harness.calls == ["commit", "head", "sync"])
+        #expect(harness.calls == ["commit", "head", "sync", "head"])
         #expect(harness.checkpointPhases == [.sync])
         #expect(harness.checkpoint == nil)
     }
@@ -189,7 +215,7 @@ struct CommitPublishWorkflowTests {
 
         await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .gg(harness.ggTarget))
 
-        #expect(harness.calls == ["validateGGTarget", "commit", "head", "validateGGTarget", "sync"])
+        #expect(harness.calls == ["validateGGTarget", "commit", "head", "validateGGTarget", "sync", "head"])
         #expect(harness.validatedGGTargets == [
             harness.ggTarget,
             .init(branch: "feature", stackName: "feature", base: "main", expectedHeadSHA: "commit-sha"),
@@ -281,6 +307,36 @@ struct CommitPublishWorkflowTests {
         #expect(workflow.lastError as? GGMutationError == .staleConfirmation)
     }
 
+    @Test func ggRetryUpdatesCheckpointForRewrittenHeadBeforeSync() async {
+        let harness = WorkflowHarness()
+        var persistedCheckpoints: [CommitPublishCheckpoint?] = []
+        var syncedTargets: [GGStackTargetIdentity] = []
+        let checkpoint = harness.ggCheckpoint
+        let operations = CommitPublishOperations(
+            createCommit: { _, _, _ in .init(commitSHA: "unused", comparisonBase: "main", editorTitle: "Unused") },
+            currentHeadSHA: { "rebased-sha" },
+            remoteBranchContainsCommit: { _, _ in false },
+            push: { _, _ in },
+            currentReviewRequestExists: { _ in true },
+            createReviewRequest: { target, _, _ in target.webURL },
+            syncGG: { Issue.record("Unexpected untargeted sync") },
+            syncGGForTarget: { target in syncedTargets.append(target) },
+            refreshAfterCompletion: {}
+        )
+        let workflow = CommitPublishWorkflow(operations: operations) {
+            persistedCheckpoints.append($0)
+        }
+
+        await workflow.resume(checkpoint)
+
+        #expect(persistedCheckpoints.compactMap { $0?.commitSHA } == ["commit-sha", "rebased-sha"])
+        #expect(syncedTargets == [
+            .init(branch: "feature", stackName: "feature", base: "main", expectedHeadSHA: "rebased-sha"),
+        ])
+        #expect(persistedCheckpoints.last! == nil)
+        #expect(workflow.lastError == nil)
+    }
+
     @Test func pushFailureRetainsPushCheckpoint() async {
         let harness = WorkflowHarness()
         harness.pushError = WorkflowHarness.Failure.push
@@ -341,7 +397,7 @@ struct CommitPublishWorkflowTests {
 
         await workflow.resume(checkpoint)
 
-        #expect(harness.calls == ["head", "sync"])
+        #expect(harness.calls == ["head", "sync", "head"])
         #expect(harness.checkpoint == nil)
     }
 
@@ -477,7 +533,7 @@ struct CommitPublishWorkflowTests {
 
         await workflow.start(subject: "Second", body: "Body", amend: false, destination: .gg())
 
-        #expect(harness.calls == ["head", "lookupPR", "createPR", "commit", "head", "sync"])
+        #expect(harness.calls == ["head", "lookupPR", "createPR", "commit", "head", "sync", "head"])
         #expect(harness.checkpoint == nil)
         #expect(workflow.lastError == nil)
 

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -231,6 +231,30 @@ struct CommitPublishWorkflowTests {
         #expect(workflow.lastError == nil)
     }
 
+    @Test func refreshDoesNotBlockNextRun() async {
+        let harness = WorkflowHarness()
+        let refreshGate = AsyncGate()
+        harness.refreshGate = refreshGate
+        let workflow = harness.makeWorkflow()
+        let checkpoint = harness.checkpoint(nextPhase: .createReviewRequest)
+        harness.checkpoint = checkpoint
+
+        let completingRun = Task { @MainActor in
+            await workflow.resume(checkpoint)
+        }
+        await refreshGate.waitUntilEntered()
+        #expect(workflow.activity == .idle)
+
+        await workflow.start(subject: "Second", body: "Body", amend: false, destination: .gg)
+
+        #expect(harness.calls == ["head", "lookupPR", "createPR", "commit", "head", "sync"])
+        #expect(harness.checkpoint == nil)
+        #expect(workflow.lastError == nil)
+
+        await refreshGate.release()
+        await completingRun.value
+    }
+
     @Test func resumeNeverCreatesAnotherCommit() async {
         let harness = WorkflowHarness()
         let workflow = harness.makeWorkflow()
@@ -318,6 +342,7 @@ private final class WorkflowHarness {
     var checkpointWasClearedBeforeRefresh = false
     var createCommitGate: AsyncGate?
     var pushGate: AsyncGate?
+    var refreshGate: AsyncGate?
 
     let target = CommitPublishReviewTarget(
         provider: .github,
@@ -398,6 +423,9 @@ private final class WorkflowHarness {
                     if let syncError { throw syncError }
                 },
                 refreshAfterCompletion: { [unowned self] in
+                    if let refreshGate {
+                        await refreshGate.waitForFirstCall()
+                    }
                     if refreshChecksCheckpoint {
                         checkpointWasClearedBeforeRefresh = checkpoint == nil
                     }

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -307,7 +307,7 @@ struct CommitPublishWorkflowTests {
         #expect(workflow.lastError as? GGMutationError == .staleConfirmation)
     }
 
-    @Test func ggRetryUpdatesCheckpointForRewrittenHeadBeforeSync() async {
+    @Test func ggRetryRejectsUnrelatedRewrittenHeadBeforeSync() async {
         let harness = WorkflowHarness()
         var persistedCheckpoints: [CommitPublishCheckpoint?] = []
         var syncedTargets: [GGStackTargetIdentity] = []
@@ -329,12 +329,72 @@ struct CommitPublishWorkflowTests {
 
         await workflow.resume(checkpoint)
 
+        #expect(persistedCheckpoints == [checkpoint])
+        #expect(syncedTargets.isEmpty)
+        #expect(workflow.lastError as? CommitPublishWorkflowError == .headMismatch(expected: "commit-sha", actual: "rebased-sha"))
+    }
+
+    @Test func ggSyncFailurePersistsRewrittenHeadForRetry() async throws {
+        let harness = WorkflowHarness()
+        var headSHA = "commit-sha"
+        var persistedCheckpoints: [CommitPublishCheckpoint?] = []
+        var syncedTargets: [GGStackTargetIdentity] = []
+        let checkpoint = harness.ggCheckpoint
+        let operations = CommitPublishOperations(
+            createCommit: { _, _, _ in .init(commitSHA: "unused", comparisonBase: "main", editorTitle: "Unused") },
+            currentHeadSHA: { headSHA },
+            remoteBranchContainsCommit: { _, _ in false },
+            push: { _, _ in },
+            currentReviewRequestExists: { _ in true },
+            createReviewRequest: { target, _, _ in target.webURL },
+            syncGG: { Issue.record("Unexpected untargeted sync") },
+            syncGGForTarget: { target in
+                syncedTargets.append(target)
+                headSHA = "rebased-sha"
+                throw WorkflowHarness.Failure.sync
+            },
+            refreshAfterCompletion: {}
+        )
+        let workflow = CommitPublishWorkflow(operations: operations) {
+            persistedCheckpoints.append($0)
+        }
+
+        await workflow.resume(checkpoint)
+
         #expect(persistedCheckpoints.compactMap { $0?.commitSHA } == ["commit-sha", "rebased-sha"])
+        #expect(syncedTargets == [
+            .init(branch: "feature", stackName: "feature", base: "main", expectedHeadSHA: "commit-sha"),
+        ])
+        #expect(workflow.lastError as? WorkflowHarness.Failure == .sync)
+
+        let retryCheckpoint = try #require(persistedCheckpoints.compactMap(\.self).last)
+        #expect(retryCheckpoint.commitSHA == "rebased-sha")
+        headSHA = "rebased-sha"
+        syncedTargets = []
+        var retryPersistedCheckpoints: [CommitPublishCheckpoint?] = []
+        let retryOperations = CommitPublishOperations(
+            createCommit: { _, _, _ in .init(commitSHA: "unused", comparisonBase: "main", editorTitle: "Unused") },
+            currentHeadSHA: { headSHA },
+            remoteBranchContainsCommit: { _, _ in false },
+            push: { _, _ in },
+            currentReviewRequestExists: { _ in true },
+            createReviewRequest: { target, _, _ in target.webURL },
+            syncGG: { Issue.record("Unexpected untargeted sync") },
+            syncGGForTarget: { target in syncedTargets.append(target) },
+            refreshAfterCompletion: {}
+        )
+        let retryWorkflow = CommitPublishWorkflow(operations: retryOperations) {
+            retryPersistedCheckpoints.append($0)
+        }
+
+        await retryWorkflow.resume(retryCheckpoint)
+
+        #expect(retryPersistedCheckpoints.first == retryCheckpoint)
         #expect(syncedTargets == [
             .init(branch: "feature", stackName: "feature", base: "main", expectedHeadSHA: "rebased-sha"),
         ])
-        #expect(persistedCheckpoints.last! == nil)
-        #expect(workflow.lastError == nil)
+        #expect(retryPersistedCheckpoints.last! == nil)
+        #expect(retryWorkflow.lastError == nil)
     }
 
     @Test func pushFailureRetainsPushCheckpoint() async {
@@ -377,7 +437,7 @@ struct CommitPublishWorkflowTests {
 
         await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .gg())
 
-        #expect(harness.calls == ["commit", "head", "sync"])
+        #expect(harness.calls == ["commit", "head", "sync", "head"])
         #expect(harness.checkpoint?.nextPhase == .sync)
     }
 

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -1,0 +1,277 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct CommitPublishWorkflowTests {
+    @Test func normalNewRequestPublishesInOrder() async {
+        let harness = WorkflowHarness()
+        let workflow = harness.makeWorkflow()
+
+        await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .review(harness.target))
+
+        #expect(harness.calls == ["commit", "head", "remoteContainsCommit", "push", "lookupPR", "createPR"])
+        #expect(harness.checkpointPhases == [.push, .createReviewRequest])
+        #expect(harness.checkpoint == nil)
+        #expect(workflow.activity == .idle)
+        #expect(workflow.lastError == nil)
+    }
+
+    @Test func existingRequestCompletesWithoutCreatingAnotherRequest() async {
+        let harness = WorkflowHarness()
+        harness.reviewRequestExists = true
+        let workflow = harness.makeWorkflow()
+
+        await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .review(harness.target))
+
+        #expect(harness.calls == ["commit", "head", "remoteContainsCommit", "push", "lookupPR"])
+        #expect(harness.checkpoint == nil)
+    }
+
+    @Test func ggSyncsAfterCommit() async {
+        let harness = WorkflowHarness()
+        let workflow = harness.makeWorkflow()
+
+        await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .gg)
+
+        #expect(harness.calls == ["commit", "head", "sync"])
+        #expect(harness.checkpointPhases == [.sync])
+        #expect(harness.checkpoint == nil)
+    }
+
+    @Test func commitFailureDoesNotCheckpoint() async {
+        let harness = WorkflowHarness()
+        harness.createCommitError = WorkflowHarness.Failure.commit
+        let workflow = harness.makeWorkflow()
+
+        await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .review(harness.target))
+
+        #expect(harness.calls == ["commit"])
+        #expect(harness.checkpoint == nil)
+        #expect(workflow.lastError != nil)
+    }
+
+    @Test func pushFailureRetainsPushCheckpoint() async {
+        let harness = WorkflowHarness()
+        harness.pushError = WorkflowHarness.Failure.push
+        let workflow = harness.makeWorkflow()
+
+        await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .review(harness.target))
+
+        #expect(harness.calls == ["commit", "head", "remoteContainsCommit", "push"])
+        #expect(harness.checkpoint?.nextPhase == .push)
+    }
+
+    @Test func lookupFailureAfterPushRetainsCreateRequestCheckpoint() async {
+        let harness = WorkflowHarness()
+        harness.lookupError = WorkflowHarness.Failure.lookup
+        let workflow = harness.makeWorkflow()
+
+        await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .review(harness.target))
+
+        #expect(harness.calls == ["commit", "head", "remoteContainsCommit", "push", "lookupPR"])
+        #expect(harness.checkpoint?.nextPhase == .createReviewRequest)
+    }
+
+    @Test func createFailureRetainsCreateRequestCheckpoint() async {
+        let harness = WorkflowHarness()
+        harness.createRequestError = WorkflowHarness.Failure.create
+        let workflow = harness.makeWorkflow()
+
+        await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .review(harness.target))
+
+        #expect(harness.calls == ["commit", "head", "remoteContainsCommit", "push", "lookupPR", "createPR"])
+        #expect(harness.checkpoint?.nextPhase == .createReviewRequest)
+    }
+
+    @Test func syncFailureRetainsSyncCheckpoint() async {
+        let harness = WorkflowHarness()
+        harness.syncError = WorkflowHarness.Failure.sync
+        let workflow = harness.makeWorkflow()
+
+        await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .gg)
+
+        #expect(harness.calls == ["commit", "head", "sync"])
+        #expect(harness.checkpoint?.nextPhase == .sync)
+    }
+
+    @Test func resumeNeverCreatesAnotherCommit() async {
+        let harness = WorkflowHarness()
+        let workflow = harness.makeWorkflow()
+
+        await workflow.resume(harness.checkpoint(nextPhase: .push))
+
+        #expect(harness.calls == ["head", "remoteContainsCommit", "push", "lookupPR", "createPR"])
+    }
+
+    @Test func headMismatchStopsBeforeRemoteOperations() async {
+        let harness = WorkflowHarness()
+        harness.headSHA = "different-sha"
+        let workflow = harness.makeWorkflow()
+
+        let checkpoint = harness.checkpoint(nextPhase: .push)
+        harness.checkpoint = checkpoint
+
+        await workflow.resume(checkpoint)
+
+        #expect(harness.calls == ["head"])
+        #expect(harness.checkpoint?.nextPhase == .push)
+        #expect(workflow.lastError != nil)
+    }
+
+    @Test func remoteContainmentSkipsPushEvenWithoutAnUpstreamBranch() async {
+        let harness = WorkflowHarness()
+        harness.remoteContainsCommit = true
+        let noUpstreamTarget = harness.targetWithoutUpstream
+        let workflow = harness.makeWorkflow()
+
+        await workflow.resume(harness.checkpoint(target: noUpstreamTarget, nextPhase: .push))
+
+        #expect(harness.calls == ["head", "remoteContainsCommit", "lookupPR", "createPR"])
+    }
+
+    @Test func freshLookupSkipsCreateWhenRequestNowExists() async {
+        let harness = WorkflowHarness()
+        harness.reviewRequestExists = true
+        let workflow = harness.makeWorkflow()
+
+        await workflow.resume(harness.checkpoint(nextPhase: .createReviewRequest))
+
+        #expect(harness.calls == ["head", "lookupPR"])
+    }
+
+    @Test func completionClearsCheckpointBeforeRefreshing() async {
+        let harness = WorkflowHarness()
+        harness.refreshChecksCheckpoint = true
+        let workflow = harness.makeWorkflow()
+
+        await workflow.resume(harness.checkpoint(nextPhase: .createReviewRequest))
+
+        #expect(harness.checkpointWasClearedBeforeRefresh)
+    }
+}
+
+@MainActor
+private final class WorkflowHarness {
+    enum Failure: Error {
+        case commit
+        case push
+        case lookup
+        case create
+        case sync
+    }
+
+    var calls: [String] = []
+    var checkpoint: CommitPublishCheckpoint?
+    var checkpointPhases: [CommitPublishPhase] = []
+    var headSHA = "commit-sha"
+    var remoteContainsCommit = false
+    var reviewRequestExists = false
+    var createCommitError: Error?
+    var pushError: Error?
+    var lookupError: Error?
+    var createRequestError: Error?
+    var syncError: Error?
+    var refreshChecksCheckpoint = false
+    var checkpointWasClearedBeforeRefresh = false
+
+    let target = CommitPublishReviewTarget(
+        provider: .github,
+        host: "github.com",
+        owner: "owner",
+        repository: "repository",
+        repositorySlug: "owner/repository",
+        remoteName: "origin",
+        webURL: URL(string: "https://github.com/owner/repository")!,
+        branch: "feature",
+        upstreamBranch: "origin/feature",
+        headOwner: "owner",
+        baseBranch: "main",
+        reviewRequestExisted: false,
+        createAsDraft: false
+    )
+
+    let targetWithoutUpstream = CommitPublishReviewTarget(
+        provider: .github,
+        host: "github.com",
+        owner: "owner",
+        repository: "repository",
+        repositorySlug: "owner/repository",
+        remoteName: "origin",
+        webURL: URL(string: "https://github.com/owner/repository")!,
+        branch: "feature",
+        upstreamBranch: nil,
+        headOwner: "owner",
+        baseBranch: "main",
+        reviewRequestExisted: false,
+        createAsDraft: false
+    )
+
+    func makeWorkflow() -> CommitPublishWorkflow {
+        CommitPublishWorkflow(
+            operations: CommitPublishOperations(
+                createCommit: { [unowned self] _, _, _ in
+                    calls.append("commit")
+                    if let createCommitError { throw createCommitError }
+                    return CommitPublishCreatedCommit(
+                        commitSHA: "commit-sha",
+                        comparisonBase: "origin/main",
+                        editorTitle: "Subject"
+                    )
+                },
+                currentHeadSHA: { [unowned self] in
+                    calls.append("head")
+                    return headSHA
+                },
+                remoteBranchContainsCommit: { [unowned self] _, _ in
+                    calls.append("remoteContainsCommit")
+                    return remoteContainsCommit
+                },
+                push: { [unowned self] _, _ in
+                    calls.append("push")
+                    if let pushError { throw pushError }
+                },
+                currentReviewRequestExists: { [unowned self] _ in
+                    calls.append("lookupPR")
+                    if let lookupError { throw lookupError }
+                    return reviewRequestExists
+                },
+                createReviewRequest: { [unowned self] _, _, _ in
+                    calls.append("createPR")
+                    if let createRequestError { throw createRequestError }
+                    return URL(string: "https://github.com/owner/repository/pull/1")!
+                },
+                syncGG: { [unowned self] in
+                    calls.append("sync")
+                    if let syncError { throw syncError }
+                },
+                refreshAfterCompletion: { [unowned self] in
+                    if refreshChecksCheckpoint {
+                        checkpointWasClearedBeforeRefresh = checkpoint == nil
+                    }
+                }
+            ),
+            onCheckpointChange: { [unowned self] checkpoint in
+                self.checkpoint = checkpoint
+                if let checkpoint {
+                    self.checkpointPhases.append(checkpoint.nextPhase)
+                }
+            }
+        )
+    }
+
+    func checkpoint(
+        target: CommitPublishReviewTarget? = nil,
+        nextPhase: CommitPublishPhase
+    ) -> CommitPublishCheckpoint {
+        CommitPublishCheckpoint(
+            commitSHA: "commit-sha",
+            baseRef: "origin/main",
+            commitTitle: "Subject",
+            subject: "Subject",
+            body: "Body",
+            destination: .review(target ?? self.target),
+            nextPhase: nextPhase
+        )
+    }
+}

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -18,12 +18,12 @@ struct CommitPublishWorkflowTests {
         )
         let session = CommitPublishSession(checkpoint: nil, onCheckpointChange: { _ in }, onCompletion: { _ in })
         let first = try #require(session.run(subject: "First", body: "", amend: false, operations: operations,
-            prepareDestination: { .gg }))
+            prepareDestination: { .gg() }))
         await refreshGate.waitUntilEntered()
         #expect(!session.isRunning)
         failSync = true
         let second = session.run(subject: "Second", body: "", amend: false, operations: operations,
-            prepareDestination: { .gg })
+            prepareDestination: { .gg() })
         #expect(second != nil)
         await second?.value
         await refreshGate.release()
@@ -109,7 +109,7 @@ struct CommitPublishWorkflowTests {
         let harness = WorkflowHarness()
         let workflow = harness.makeWorkflow()
 
-        await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .gg)
+        await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .gg())
 
         #expect(harness.calls == ["commit", "head", "sync"])
         #expect(harness.checkpointPhases == [.sync])
@@ -194,21 +194,23 @@ struct CommitPublishWorkflowTests {
 
     @Test func changedGGTargetStopsRetryBeforeSync() async {
         let harness = WorkflowHarness()
-        var checkpoint = harness.ggCheckpoint
+        let checkpoint = harness.ggCheckpoint
+        var persistedCheckpoint: CommitPublishCheckpoint? = checkpoint
         let operations = CommitPublishOperations(
             validateGGTarget: { _ in throw GGMutationError.staleConfirmation },
             createCommit: { _, _, _ in Issue.record("Unexpected commit")
             return .init(commitSHA: "committed", comparisonBase: "main", editorTitle: "Title") },
             currentHeadSHA: { "commit-sha" }, remoteBranchContainsCommit: { _, _ in false }, push: { _, _ in },
             currentReviewRequestExists: { _ in true },
-            createReviewRequest: { target, _, _ in target.webURL }, syncGG: { _ in Issue.record("Unexpected sync") },
+            createReviewRequest: { target, _, _ in target.webURL }, syncGG: {},
+            syncGGForTarget: { _ in Issue.record("Unexpected sync") },
             refreshAfterCompletion: {}
         )
-        let workflow = CommitPublishWorkflow(operations: operations) { checkpoint = $0 }
+        let workflow = CommitPublishWorkflow(operations: operations) { persistedCheckpoint = $0 }
 
         await workflow.resume(checkpoint)
 
-        #expect(checkpoint == harness.ggCheckpoint)
+        #expect(persistedCheckpoint == checkpoint)
         #expect(workflow.lastError as? GGMutationError == .staleConfirmation)
     }
 
@@ -250,7 +252,7 @@ struct CommitPublishWorkflowTests {
         harness.syncError = WorkflowHarness.Failure.sync
         let workflow = harness.makeWorkflow()
 
-        await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .gg)
+        await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .gg())
 
         #expect(harness.calls == ["commit", "head", "sync"])
         #expect(harness.checkpoint?.nextPhase == .sync)
@@ -265,7 +267,7 @@ struct CommitPublishWorkflowTests {
             commitTitle: "Subject",
             subject: "Subject",
             body: "Body",
-            destination: .gg,
+            destination: .gg(),
             nextPhase: .sync
         )
         harness.checkpoint = checkpoint
@@ -313,7 +315,7 @@ struct CommitPublishWorkflowTests {
             commitTitle: "Subject",
             subject: "Subject",
             body: "Body",
-            destination: .gg,
+            destination: .gg(),
             nextPhase: .push
         )
         harness.checkpoint = checkpoint
@@ -406,7 +408,7 @@ struct CommitPublishWorkflowTests {
         await refreshGate.waitUntilEntered()
         #expect(workflow.activity == .idle)
 
-        await workflow.start(subject: "Second", body: "Body", amend: false, destination: .gg)
+        await workflow.start(subject: "Second", body: "Body", amend: false, destination: .gg())
 
         #expect(harness.calls == ["head", "lookupPR", "createPR", "commit", "head", "sync"])
         #expect(harness.checkpoint == nil)

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -334,6 +334,38 @@ struct CommitPublishWorkflowTests {
         #expect(workflow.lastError as? CommitPublishWorkflowError == .headMismatch(expected: "commit-sha", actual: "rebased-sha"))
     }
 
+    @Test func ggValidationFailureDoesNotPersistRewrittenHeadForRetry() async {
+        let harness = WorkflowHarness()
+        var headSHA = "commit-sha"
+        var persistedCheckpoints: [CommitPublishCheckpoint?] = []
+        var syncedTargets: [GGStackTargetIdentity] = []
+        let checkpoint = harness.ggCheckpoint
+        let operations = CommitPublishOperations(
+            validateGGTarget: { _ in
+                headSHA = "unrelated-sha"
+                throw GGMutationError.staleConfirmation
+            },
+            createCommit: { _, _, _ in .init(commitSHA: "unused", comparisonBase: "main", editorTitle: "Unused") },
+            currentHeadSHA: { headSHA },
+            remoteBranchContainsCommit: { _, _ in false },
+            push: { _, _ in },
+            currentReviewRequestExists: { _ in true },
+            createReviewRequest: { target, _, _ in target.webURL },
+            syncGG: { Issue.record("Unexpected untargeted sync") },
+            syncGGForTarget: { target in syncedTargets.append(target) },
+            refreshAfterCompletion: {}
+        )
+        let workflow = CommitPublishWorkflow(operations: operations) {
+            persistedCheckpoints.append($0)
+        }
+
+        await workflow.resume(checkpoint)
+
+        #expect(persistedCheckpoints == [checkpoint])
+        #expect(syncedTargets.isEmpty)
+        #expect(workflow.lastError as? GGMutationError == .staleConfirmation)
+    }
+
     @Test func ggSyncFailurePersistsRewrittenHeadForRetry() async throws {
         let harness = WorkflowHarness()
         var headSHA = "commit-sha"

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -48,9 +48,11 @@ struct CommitPublishWorkflowTests {
                 commits += 1
                 return .init(commitSHA: "committed", comparisonBase: "main", editorTitle: "Title")
             }, currentHeadSHA: { "committed" }, remoteBranchContainsCommit: { _, _ in false },
-            push: { _, _ in pushes += 1; await gate.waitForFirstCall() },
+            push: { _, _ in pushes += 1
+            await gate.waitForFirstCall() },
             currentReviewRequestExists: { _ in true },
-            createReviewRequest: { _, _, _ in Issue.record("Unexpected creation"); return target.webURL },
+            createReviewRequest: { _, _, _ in Issue.record("Unexpected creation")
+            return target.webURL },
             syncGG: {}, refreshAfterCompletion: {}
         )
         let task = try #require(manager.runCommitPublish(worktreeId: "remount-publish", tabId: draft.id,

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -95,6 +95,26 @@ struct CommitPublishWorkflowTests {
         #expect(harness.checkpoint?.nextPhase == .sync)
     }
 
+    @Test func resumeSyncsWithoutCreatingAnotherCommit() async {
+        let harness = WorkflowHarness()
+        let workflow = harness.makeWorkflow()
+        let checkpoint = CommitPublishCheckpoint(
+            commitSHA: "commit-sha",
+            baseRef: "origin/main",
+            commitTitle: "Subject",
+            subject: "Subject",
+            body: "Body",
+            destination: .gg,
+            nextPhase: .sync
+        )
+        harness.checkpoint = checkpoint
+
+        await workflow.resume(checkpoint)
+
+        #expect(harness.calls == ["head", "sync"])
+        #expect(harness.checkpoint == nil)
+    }
+
     @Test func resumeNeverCreatesAnotherCommit() async {
         let harness = WorkflowHarness()
         let workflow = harness.makeWorkflow()

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -116,6 +116,22 @@ struct CommitPublishWorkflowTests {
         #expect(harness.checkpoint == nil)
     }
 
+    @Test func ggCheckpointUpdatesExpectedHeadBeforeSync() async {
+        let harness = WorkflowHarness()
+        let workflow = harness.makeWorkflow()
+
+        await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .gg(harness.ggTarget))
+
+        #expect(harness.calls == ["validateGGTarget", "commit", "head", "validateGGTarget", "sync"])
+        #expect(harness.validatedGGTargets == [
+            harness.ggTarget,
+            .init(branch: "feature", stackName: "feature", base: "main", expectedHeadSHA: "commit-sha"),
+        ])
+        #expect(harness.syncedGGTargets == [
+            .init(branch: "feature", stackName: "feature", base: "main", expectedHeadSHA: "commit-sha"),
+        ])
+    }
+
     @Test func commitFailureDoesNotCheckpoint() async {
         let harness = WorkflowHarness()
         harness.createCommitError = WorkflowHarness.Failure.commit
@@ -150,6 +166,50 @@ struct CommitPublishWorkflowTests {
 
         #expect(calls == ["validateTarget"])
         #expect(workflow.lastError as? CommitPublishWorkflowError == .headMismatch(expected: "captured", actual: "changed"))
+    }
+
+    @Test func changedGGTargetStopsBeforeCreatingLocalCommit() async {
+        var calls: [String] = []
+        let target = WorkflowHarness().ggTarget
+        let operations = CommitPublishOperations(
+            validateGGTarget: { _ in
+                calls.append("validateTarget")
+                throw GGMutationError.staleConfirmation
+            },
+            createCommit: { _, _, _ in
+                calls.append("commit")
+                return .init(commitSHA: "committed", comparisonBase: "main", editorTitle: "Title")
+            },
+            currentHeadSHA: { "committed" }, remoteBranchContainsCommit: { _, _ in false }, push: { _, _ in },
+            currentReviewRequestExists: { _ in true },
+            createReviewRequest: { target, _, _ in target.webURL }, syncGG: {}, refreshAfterCompletion: {}
+        )
+        let workflow = CommitPublishWorkflow(operations: operations) { _ in }
+
+        await workflow.start(subject: "Subject", body: "", amend: false, destination: .gg(target))
+
+        #expect(calls == ["validateTarget"])
+        #expect(workflow.lastError as? GGMutationError == .staleConfirmation)
+    }
+
+    @Test func changedGGTargetStopsRetryBeforeSync() async {
+        let harness = WorkflowHarness()
+        var checkpoint = harness.ggCheckpoint
+        let operations = CommitPublishOperations(
+            validateGGTarget: { _ in throw GGMutationError.staleConfirmation },
+            createCommit: { _, _, _ in Issue.record("Unexpected commit")
+            return .init(commitSHA: "committed", comparisonBase: "main", editorTitle: "Title") },
+            currentHeadSHA: { "commit-sha" }, remoteBranchContainsCommit: { _, _ in false }, push: { _, _ in },
+            currentReviewRequestExists: { _ in true },
+            createReviewRequest: { target, _, _ in target.webURL }, syncGG: { _ in Issue.record("Unexpected sync") },
+            refreshAfterCompletion: {}
+        )
+        let workflow = CommitPublishWorkflow(operations: operations) { checkpoint = $0 }
+
+        await workflow.resume(checkpoint)
+
+        #expect(checkpoint == harness.ggCheckpoint)
+        #expect(workflow.lastError as? GGMutationError == .staleConfirmation)
     }
 
     @Test func pushFailureRetainsPushCheckpoint() async {
@@ -450,6 +510,8 @@ private final class WorkflowHarness {
     var lookupError: Error?
     var createRequestError: Error?
     var syncError: Error?
+    var validatedGGTargets: [GGStackTargetIdentity] = []
+    var syncedGGTargets: [GGStackTargetIdentity] = []
     var refreshChecksCheckpoint = false
     var checkpointWasClearedBeforeRefresh = false
     var createCommitGate: AsyncGate?
@@ -488,6 +550,30 @@ private final class WorkflowHarness {
         createAsDraft: false
     )
 
+    let ggTarget = GGStackTargetIdentity(
+        branch: "feature",
+        stackName: "feature",
+        base: "main",
+        expectedHeadSHA: "before-commit"
+    )
+
+    var ggCheckpoint: CommitPublishCheckpoint {
+        .init(
+            commitSHA: "commit-sha",
+            baseRef: "origin/main",
+            commitTitle: "Subject",
+            subject: "Subject",
+            body: "Body",
+            destination: .gg(.init(
+                branch: "feature",
+                stackName: "feature",
+                base: "main",
+                expectedHeadSHA: "commit-sha"
+            )),
+            nextPhase: .sync
+        )
+    }
+
     let existingRequestTarget = CommitPublishReviewTarget(
         provider: .github,
         host: "github.com",
@@ -507,6 +593,10 @@ private final class WorkflowHarness {
     func makeWorkflow() -> CommitPublishWorkflow {
         CommitPublishWorkflow(
             operations: CommitPublishOperations(
+                validateGGTarget: { [unowned self] target in
+                    calls.append("validateGGTarget")
+                    validatedGGTargets.append(target)
+                },
                 createCommit: { [unowned self] _, _, _ in
                     calls.append("commit")
                     if let createCommitGate {
@@ -548,6 +638,11 @@ private final class WorkflowHarness {
                 },
                 syncGG: { [unowned self] in
                     calls.append("sync")
+                    if let syncError { throw syncError }
+                },
+                syncGGForTarget: { [unowned self] target in
+                    calls.append("sync")
+                    syncedGGTargets.append(target)
                     if let syncError { throw syncError }
                 },
                 refreshAfterCompletion: { [unowned self] in

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -542,6 +542,7 @@ struct CommitPublishWorkflowTests {
                 headSHA = "paused-sha"
                 throw GGServiceError.pausedConflict(message: "Resolve conflicts and run gg continue.")
             },
+            currentGGRecoveryOperationID: { "op_paused" },
             refreshAfterCompletion: {}
         )
         let workflow = CommitPublishWorkflow(operations: operations) {
@@ -552,11 +553,12 @@ struct CommitPublishWorkflowTests {
 
         let retryCheckpoint = try #require(persistedCheckpoints.compactMap(\.self).last)
         #expect(retryCheckpoint.commitSHA == "paused-sha")
-        #expect(retryCheckpoint.allowsGGRecoveryHeadReconciliation)
+        #expect(retryCheckpoint.ggRecoveryOperationID == "op_paused")
         #expect(workflow.lastError as? GGServiceError == .pausedConflict(message: "Resolve conflicts and run gg continue."))
 
         headSHA = "recovered-sha"
         syncedTargets = []
+        var validatedRecovery: [String] = []
         var retryPersistedCheckpoints: [CommitPublishCheckpoint?] = []
         let retryOperations = CommitPublishOperations(
             createCommit: { _, _, _ in .init(commitSHA: "unused", comparisonBase: "main", editorTitle: "Unused") },
@@ -567,6 +569,9 @@ struct CommitPublishWorkflowTests {
             createReviewRequest: { target, _, _ in target.webURL },
             syncGG: { _ in Issue.record("Unexpected untargeted sync") },
             syncGGForTarget: { target, _ in syncedTargets.append(target) },
+            validateGGRecoveryHead: { operationID, headSHA in
+                validatedRecovery.append("\(operationID):\(headSHA)")
+            },
             refreshAfterCompletion: {}
         )
         let retryWorkflow = CommitPublishWorkflow(operations: retryOperations) {
@@ -576,12 +581,59 @@ struct CommitPublishWorkflowTests {
         await retryWorkflow.resume(retryCheckpoint)
 
         #expect(retryPersistedCheckpoints.compactMap(\.self).map(\.commitSHA) == ["paused-sha", "recovered-sha"])
-        #expect(retryPersistedCheckpoints.compactMap(\.self).last?.allowsGGRecoveryHeadReconciliation == false)
+        #expect(retryPersistedCheckpoints.compactMap(\.self).last?.ggRecoveryOperationID == nil)
+        #expect(validatedRecovery == ["op_paused:recovered-sha"])
         #expect(syncedTargets == [
             .init(branch: "feature", stackName: "feature", base: "main", expectedHeadSHA: "recovered-sha"),
         ])
         #expect(retryPersistedCheckpoints.last! == nil)
         #expect(retryWorkflow.lastError == nil)
+    }
+
+    @Test func ggRecoveryCheckpointRejectsUnrecordedHeadBeforeSync() async {
+        var persistedCheckpoints: [CommitPublishCheckpoint?] = []
+        var validatedRecovery: [String] = []
+        var syncedTargets: [GGStackTargetIdentity] = []
+        let checkpoint = CommitPublishCheckpoint(
+            commitSHA: "paused-sha",
+            baseRef: "origin/main",
+            commitTitle: "Subject",
+            subject: "Subject",
+            body: "Body",
+            destination: .gg(.init(
+                branch: "feature",
+                stackName: "feature",
+                base: "main",
+                expectedHeadSHA: "paused-sha"
+            )),
+            nextPhase: .sync,
+            ggRecoveryOperationID: "op_paused"
+        )
+        let operations = CommitPublishOperations(
+            createCommit: { _, _, _ in .init(commitSHA: "unused", comparisonBase: "main", editorTitle: "Unused") },
+            currentHeadSHA: { "manual-sha" },
+            remoteBranchContainsCommit: { _, _ in false },
+            push: { _, _ in },
+            currentReviewRequestExists: { _ in true },
+            createReviewRequest: { target, _, _ in target.webURL },
+            syncGG: { _ in Issue.record("Unexpected untargeted sync") },
+            syncGGForTarget: { target, _ in syncedTargets.append(target) },
+            validateGGRecoveryHead: { operationID, headSHA in
+                validatedRecovery.append("\(operationID):\(headSHA)")
+                throw GGMutationError.staleConfirmation
+            },
+            refreshAfterCompletion: {}
+        )
+        let workflow = CommitPublishWorkflow(operations: operations) {
+            persistedCheckpoints.append($0)
+        }
+
+        await workflow.resume(checkpoint)
+
+        #expect(persistedCheckpoints == [checkpoint])
+        #expect(validatedRecovery == ["op_paused:manual-sha"])
+        #expect(syncedTargets.isEmpty)
+        #expect(workflow.lastError as? GGMutationError == .staleConfirmation)
     }
 
     @Test func pushFailureRetainsPushCheckpoint() async {

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -128,6 +128,30 @@ struct CommitPublishWorkflowTests {
         #expect(workflow.lastError != nil)
     }
 
+    @Test func changedReviewTargetStopsBeforeCreatingLocalCommit() async {
+        var calls: [String] = []
+        let target = WorkflowHarness().target
+        let operations = CommitPublishOperations(
+            validateReviewTarget: { _ in
+                calls.append("validateTarget")
+                throw CommitPublishWorkflowError.headMismatch(expected: "captured", actual: "changed")
+            },
+            createCommit: { _, _, _ in
+                calls.append("commit")
+                return .init(commitSHA: "committed", comparisonBase: "main", editorTitle: "Title")
+            },
+            currentHeadSHA: { "committed" }, remoteBranchContainsCommit: { _, _ in false },
+            push: { _, _ in calls.append("push") }, currentReviewRequestExists: { _ in true },
+            createReviewRequest: { target, _, _ in target.webURL }, syncGG: {}, refreshAfterCompletion: {}
+        )
+        let workflow = CommitPublishWorkflow(operations: operations) { _ in }
+
+        await workflow.start(subject: "Subject", body: "", amend: false, destination: .review(target))
+
+        #expect(calls == ["validateTarget"])
+        #expect(workflow.lastError as? CommitPublishWorkflowError == .headMismatch(expected: "captured", actual: "changed"))
+    }
+
     @Test func pushFailureRetainsPushCheckpoint() async {
         let harness = WorkflowHarness()
         harness.pushError = WorkflowHarness.Failure.push
@@ -377,6 +401,17 @@ struct CommitPublishWorkflowTests {
         #expect(harness.calls == ["head", "lookupPR"])
     }
 
+    @Test func previouslyExistingRequestSkipsLookupAndCreationAfterPush() async {
+        let harness = WorkflowHarness()
+        let target = harness.existingRequestTarget
+        let workflow = harness.makeWorkflow()
+
+        await workflow.start(subject: "Subject", body: "Body", amend: false, destination: .review(target))
+
+        #expect(harness.calls == ["commit", "head", "remoteContainsCommit", "push"])
+        #expect(harness.checkpoint == nil)
+    }
+
     @Test func completionClearsCheckpointBeforeRefreshing() async {
         let harness = WorkflowHarness()
         harness.refreshChecksCheckpoint = true
@@ -450,6 +485,22 @@ private final class WorkflowHarness {
         headOwner: "owner",
         baseBranch: "main",
         reviewRequestExisted: false,
+        createAsDraft: false
+    )
+
+    let existingRequestTarget = CommitPublishReviewTarget(
+        provider: .github,
+        host: "github.com",
+        owner: "owner",
+        repository: "repository",
+        repositorySlug: "owner/repository",
+        remoteName: "origin",
+        webURL: URL(string: "https://github.com/owner/repository")!,
+        branch: "feature",
+        upstreamBranch: "origin/feature",
+        headOwner: "owner",
+        baseBranch: "main",
+        reviewRequestExisted: true,
         createAsDraft: false
     )
 

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -116,6 +116,61 @@ struct CommitPublishWorkflowTests {
         #expect(session.lastError?.localizedDescription == "write rejected")
     }
 
+    @Test func tabsManagerKeepsCheckpointWhenCompletionPersistenceFails() async throws {
+        let store = FlakyCommitPublishTabsStore()
+        let manager = TabsManager(store: store)
+        let worktreeId = "completion-persist-failure"
+        let draft = manager.openOrFocusDraftCommit(worktreeId: worktreeId)
+        let target = WorkflowHarness().target
+        var calls: [String] = []
+        let operations = CommitPublishOperations(
+            createCommit: { _, _, _ in
+                calls.append("commit")
+                return .init(commitSHA: "committed", comparisonBase: "main", editorTitle: "Title")
+            },
+            currentHeadSHA: {
+                calls.append("head")
+                return "committed"
+            },
+            remoteBranchContainsCommit: { _, _ in
+                calls.append("remoteContainsCommit")
+                return false
+            },
+            push: { _, _ in calls.append("push") },
+            currentReviewRequestExists: { _ in
+                calls.append("lookupPR")
+                store.failWrites = true
+                return true
+            },
+            createReviewRequest: { target, _, _ in target.webURL },
+            syncGG: { _ in },
+            refreshAfterCompletion: {}
+        )
+
+        let task = try #require(manager.runCommitPublish(worktreeId: worktreeId, tabId: draft.id,
+            subject: "Subject", body: "Body", amend: false, operations: operations,
+            prepareDestination: { .review(target) }))
+        await task.value
+
+        let session = try #require(manager.commitPublishSession(tabId: draft.id))
+        #expect(calls == ["commit", "head", "remoteContainsCommit", "push", "lookupPR"])
+        #expect(session.checkpoint?.nextPhase == .createReviewRequest)
+        #expect(session.lastError?.localizedDescription == "write rejected")
+        #expect(manager.commitEditorTab(worktreeId: worktreeId, currentSha: "committed") == nil)
+        guard case .draftCommit(let liveState) = manager.tabs(forWorktree: worktreeId).first(where: { $0.id == draft.id }) else {
+            Issue.record("Expected draft commit tab")
+            return
+        }
+        #expect(liveState.publishCheckpoint?.nextPhase == .createReviewRequest)
+
+        let persisted = store.files[Paths.tabsFile(forWorktreeId: worktreeId)]
+        guard case .draftCommit(let persistedState)? = persisted?.tabs.first(where: { $0.id == draft.id }) else {
+            Issue.record("Expected persisted draft commit tab")
+            return
+        }
+        #expect(persistedState.publishCheckpoint?.nextPhase == .createReviewRequest)
+    }
+
     @Test func tabsManagerCanAbandonPausedPublishCheckpoint() async throws {
         let manager = TabsManager()
         let draft = manager.openOrFocusDraftCommit(worktreeId: "abandon-publish")
@@ -818,6 +873,25 @@ private struct FailingTabsStore: PersistenceStoreProtocol {
     }
 
     func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+}
+
+private final class FlakyCommitPublishTabsStore: PersistenceStoreProtocol, @unchecked Sendable {
+    var failWrites = false
+    var files: [URL: TabsFile] = [:]
+
+    func write<T: Encodable>(_ value: T, to url: URL) throws {
+        if failWrites {
+            throw NSError(domain: "CommitPublishWorkflowTests", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "write rejected"])
+        }
+        if let file = value as? TabsFile {
+            files[url] = file
+        }
+    }
+
+    func readIfExists<T: Decodable>(_: T.Type, from url: URL) throws -> T? {
+        files[url] as? T
+    }
 }
 
 @MainActor

--- a/AlasTests/Center/CommitPublishWorkflowTests.swift
+++ b/AlasTests/Center/CommitPublishWorkflowTests.swift
@@ -4,6 +4,81 @@ import Testing
 
 @MainActor
 struct CommitPublishWorkflowTests {
+    @Test func ownerReleasesCompletedRunBeforeRefreshWithoutClearingNewerFailure() async throws {
+        let refreshGate = AsyncGate()
+        var failSync = false
+        let operations = CommitPublishOperations(
+            createCommit: { _, _, _ in .init(commitSHA: "committed", comparisonBase: "main", editorTitle: "Title") },
+            currentHeadSHA: { "committed" }, remoteBranchContainsCommit: { _, _ in false }, push: { _, _ in },
+            currentReviewRequestExists: { _ in true },
+            createReviewRequest: { target, _, _ in target.webURL },
+            syncGG: {
+                if failSync { throw NSError(domain: "Publish", code: 1, userInfo: [NSLocalizedDescriptionKey: "Second failed"]) }
+            }, refreshAfterCompletion: { await refreshGate.waitForFirstCall() }
+        )
+        let session = CommitPublishSession(checkpoint: nil, onCheckpointChange: { _ in }, onCompletion: { _ in })
+        let first = try #require(session.run(subject: "First", body: "", amend: false, operations: operations,
+            prepareDestination: { .gg }))
+        await refreshGate.waitUntilEntered()
+        #expect(!session.isRunning)
+        failSync = true
+        let second = session.run(subject: "Second", body: "", amend: false, operations: operations,
+            prepareDestination: { .gg })
+        #expect(second != nil)
+        await second?.value
+        await refreshGate.release()
+        await first.value
+        #expect(session.lastError?.localizedDescription == "Second failed")
+        #expect(session.checkpoint?.subject == "Second")
+        #expect(!session.isRunning)
+    }
+
+    @Test func tabsManagerKeepsSuspendedPublishOwnedAcrossDraftRemount() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let manager = TabsManager(tabsDirectory: directory)
+        let draft = manager.openOrFocusDraftCommit(worktreeId: "remount-publish")
+        let gate = AsyncGate()
+        let target = WorkflowHarness().target
+        var commits = 0
+        var pushes = 0
+        let operations = CommitPublishOperations(
+            createCommit: { _, _, _ in
+                commits += 1
+                return .init(commitSHA: "committed", comparisonBase: "main", editorTitle: "Title")
+            }, currentHeadSHA: { "committed" }, remoteBranchContainsCommit: { _, _ in false },
+            push: { _, _ in pushes += 1; await gate.waitForFirstCall() },
+            currentReviewRequestExists: { _ in true },
+            createReviewRequest: { _, _, _ in Issue.record("Unexpected creation"); return target.webURL },
+            syncGG: {}, refreshAfterCompletion: {}
+        )
+        let task = try #require(manager.runCommitPublish(worktreeId: "remount-publish", tabId: draft.id,
+            subject: "Subject", body: "Body", amend: false, operations: operations,
+            prepareDestination: { .review(target) }))
+        await gate.waitUntilEntered()
+        let originalSession = try #require(manager.commitPublishSession(tabId: draft.id))
+        #expect(originalSession.isRunning)
+        #expect(originalSession.activity == .pushing)
+
+        manager.close(worktreeId: "remount-publish", tabId: draft.id)
+        let reopened = manager.openOrFocusDraftCommit(worktreeId: "remount-publish")
+        let remountedSession = try #require(manager.commitPublishSession(tabId: reopened.id))
+        #expect(remountedSession === originalSession)
+        #expect(remountedSession.checkpoint?.nextPhase == .push)
+        #expect(manager.runCommitPublish(worktreeId: "remount-publish", tabId: reopened.id,
+            subject: "Another subject", body: "", amend: false, operations: operations,
+            prepareDestination: { .review(target) }) == nil)
+        #expect(commits == 1)
+        #expect(pushes == 1)
+
+        await gate.release()
+        await task.value
+        #expect(!remountedSession.isRunning)
+        #expect(remountedSession.checkpoint == nil)
+        #expect(manager.commitEditorTab(worktreeId: "remount-publish", currentSha: "committed") != nil)
+    }
+
     @Test func normalNewRequestPublishesInOrder() async {
         let harness = WorkflowHarness()
         let workflow = harness.makeWorkflow()

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -4,6 +4,14 @@ import Testing
 
 @MainActor
 struct ChangesTabViewTests {
+    @Test func ggFirstRowRoutesToDraftWithExplicitIntent() {
+        #expect(ChangesTabView.draftPreferredAction(for: .newStackCommit) == .commit)
+        #expect(ChangesTabView.draftPreferredAction(for: .commitAndSync) == .publish)
+        #expect(ChangesTabView.stackAction(for: .commitAndSync) == nil)
+        #expect(ChangesTabView.draftPreferredAction(for: .amendCurrent) == nil)
+        #expect(ChangesTabView.draftPreferredAction(for: .absorbIntoStack) == nil)
+    }
+
     @Test func appKitCommitHeaderTracksCommitCounts() {
         #expect(ChangesTabView.commitHeaderCountsToken(primary: 1, older: 23)
             != ChangesTabView.commitHeaderCountsToken(primary: 12, older: 3))

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -4,6 +4,65 @@ import Testing
 
 @MainActor
 struct ChangesTabViewTests {
+    @Test func unchangedReviewRefreshRetriesFailedAmendProbe() async {
+        let reviewLoop = ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp/probe"), baseBranch: "main")
+        let local = ReviewLoopLocalState(branchName: "feature", headSHA: "abc", baseBranch: "main",
+            hasWorkingTreeChanges: true, hasStagedChanges: true, aheadCommitCount: 1,
+            hasUpstream: false, needsPush: true)
+        let initialRefresh = reviewLoop.beginLocalRefresh(local: local)
+        reviewLoop.finishLocalRefresh(initialRefresh, preservingRemoteWith: local)
+        let initialSnapshot = reviewLoop.snapshot
+        let loader = CommitPublishAmendProbeLoader()
+        let initialKey = amendProbeKey(reviewLoop)
+        await loader.load(key: initialKey) { throw AmendProbeTestError.failed }
+        #expect(loader.result(for: initialKey) == .failed("Probe failed"))
+
+        let refresh = reviewLoop.beginLocalRefresh(local: local)
+        reviewLoop.finishLocalRefresh(refresh, preservingRemoteWith: local)
+        let refreshedKey = amendProbeKey(reviewLoop)
+        #expect(reviewLoop.snapshot == initialSnapshot)
+        #expect(refreshedKey != initialKey)
+        #expect(loader.result(for: refreshedKey) == .loading)
+
+        let gate = AmendProbeTestGate()
+        let retry = Task { await loader.load(key: refreshedKey) { await gate.probe() } }
+        await gate.waitForEntry()
+        #expect(loader.result(for: refreshedKey) == .loading)
+        gate.finish(.noUpstream)
+        await retry.value
+        #expect(loader.result(for: refreshedKey) == .notPublished)
+    }
+
+    @Test func supersededAmendProbeCannotReplaceRetryResult() async {
+        let loader = CommitPublishAmendProbeLoader()
+        let gate = AmendProbeTestGate()
+        let original = Task { await loader.load(key: "original") { await gate.probe() } }
+        await gate.waitForEntry()
+        await loader.load(key: "retry") { .unpublished }
+        gate.finish(.published)
+        await original.value
+        #expect(loader.result(for: "retry") == .notPublished)
+        #expect(loader.result(for: "original") == .loading)
+    }
+
+    @Test func cancelledAmendProbeDiscardsUncooperativeCompletion() async {
+        let loader = CommitPublishAmendProbeLoader()
+        let gate = AmendProbeTestGate()
+        let task = Task { await loader.load(key: "head") { await gate.probe() } }
+        await gate.waitForEntry()
+        task.cancel()
+        gate.finish(.published)
+        await task.value
+        #expect(loader.result(for: "head") == .loading)
+        await loader.load(key: "head") { .unpublished }
+        #expect(loader.result(for: "head") == .notPublished)
+    }
+
+    private func amendProbeKey(_ reviewLoop: ReviewLoopState) -> String {
+        ChangesTabView.amendPublicationProbeKey(worktreeID: "worktree", branch: "feature",
+            headSHA: "abc", amend: true, ggModeActive: false, reviewLoop: reviewLoop)
+    }
+
     @Test func ggFirstRowRoutesToDraftWithExplicitIntent() {
         #expect(ChangesTabView.draftPreferredAction(for: .newStackCommit) == .commit)
         #expect(ChangesTabView.draftPreferredAction(for: .commitAndSync) == .publish)
@@ -392,5 +451,34 @@ struct ChangesTabViewTests {
             behindBase: behindBase,
             entries: [entry]
         )
+    }
+}
+
+private enum AmendProbeTestError: LocalizedError {
+    case failed
+    var errorDescription: String? { "Probe failed" }
+}
+
+@MainActor
+private final class AmendProbeTestGate {
+    private var probeContinuation: CheckedContinuation<HeadPublicationState, Never>?
+    private var entryContinuation: CheckedContinuation<Void, Never>?
+
+    func probe() async -> HeadPublicationState {
+        await withCheckedContinuation { continuation in
+            probeContinuation = continuation
+            entryContinuation?.resume()
+            entryContinuation = nil
+        }
+    }
+
+    func waitForEntry() async {
+        guard probeContinuation == nil else { return }
+        await withCheckedContinuation { entryContinuation = $0 }
+    }
+
+    func finish(_ state: HeadPublicationState) {
+        probeContinuation?.resume(returning: state)
+        probeContinuation = nil
     }
 }

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -150,20 +150,21 @@ struct ClosedTabAppStateTests {
         #expect(!fixture.state.canReopenClosedTab)
     }
 
-    @Test func completedCommitPublishRemovesClosedDraftHistory() async throws {
+    @Test func completedCommitPublishRemovesClosedDraftHistoryCapturedBeforeCheckpoint() async throws {
         let fixture = makeFixture()
         let draft = fixture.state.tabs.openOrFocusDraftCommit(worktreeId: fixture.first.id)
-        let syncGate = AsyncGate()
+        let commitGate = AsyncGate()
         let operations = CommitPublishOperations(
             createCommit: { _, _, _ in
-                .init(commitSHA: "commit-sha", comparisonBase: "origin/main", editorTitle: "commit-sha Subject")
+                await commitGate.enterAndWait()
+                return .init(commitSHA: "commit-sha", comparisonBase: "origin/main", editorTitle: "commit-sha Subject")
             },
             currentHeadSHA: { "commit-sha" },
             remoteBranchContainsCommit: { _, _ in false },
             push: { _, _ in },
             currentReviewRequestExists: { _ in true },
             createReviewRequest: { target, _, _ in target.webURL },
-            syncGG: { await syncGate.enterAndWait() },
+            syncGG: { _ in },
             refreshAfterCompletion: {}
         )
 
@@ -176,11 +177,11 @@ struct ClosedTabAppStateTests {
             operations: operations,
             prepareDestination: { .gg() }
         ))
-        await syncGate.waitUntilEntered()
+        await commitGate.waitUntilEntered()
         fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: draft.id)
         #expect(fixture.state.canReopenClosedTab)
 
-        await syncGate.release()
+        await commitGate.release()
         await task.value
 
         #expect(!fixture.state.canReopenClosedTab)

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -150,6 +150,44 @@ struct ClosedTabAppStateTests {
         #expect(!fixture.state.canReopenClosedTab)
     }
 
+    @Test func completedCommitPublishRemovesClosedDraftHistory() async throws {
+        let fixture = makeFixture()
+        let draft = fixture.state.tabs.openOrFocusDraftCommit(worktreeId: fixture.first.id)
+        let syncGate = AsyncGate()
+        let operations = CommitPublishOperations(
+            createCommit: { _, _, _ in
+                .init(commitSHA: "commit-sha", comparisonBase: "origin/main", editorTitle: "commit-sha Subject")
+            },
+            currentHeadSHA: { "commit-sha" },
+            remoteBranchContainsCommit: { _, _ in false },
+            push: { _, _ in },
+            currentReviewRequestExists: { _ in true },
+            createReviewRequest: { target, _, _ in target.webURL },
+            syncGG: { await syncGate.enterAndWait() },
+            refreshAfterCompletion: {}
+        )
+
+        let task = try #require(fixture.state.tabs.runCommitPublish(
+            worktreeId: fixture.first.id,
+            tabId: draft.id,
+            subject: "Subject",
+            body: "",
+            amend: false,
+            operations: operations,
+            prepareDestination: { .gg() }
+        ))
+        await syncGate.waitUntilEntered()
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: draft.id)
+        #expect(fixture.state.canReopenClosedTab)
+
+        await syncGate.release()
+        await task.value
+
+        #expect(!fixture.state.canReopenClosedTab)
+        await fixture.state.reopenLastClosedTab()
+        #expect(fixture.state.tabs.tabs(forWorktree: fixture.first.id).isEmpty)
+    }
+
     @Test func reopenACPSessionWaitsForCloseDetachBeforeRestoring() async {
         let gate = AsyncGate()
         var detachCalls = 0

--- a/AlasTests/CommitMessageEditorViewTests.swift
+++ b/AlasTests/CommitMessageEditorViewTests.swift
@@ -133,7 +133,10 @@ struct CommitMessageEditorViewTests {
         await drain(controller.view)
         #expect(model.subject == "`subject`")
 
-        let body = try #require(firstSubview(of: PairedDelimiterTextView.self, in: controller.view))
+        let body = try #require(firstSubview(of: PairedDelimiterTextView.self, in: controller.view) {
+            !$0.isFieldEditor
+        })
+        #expect(body.string == "body")
         body.setSelectedRange(NSRange(location: 0, length: 4))
         body.performKeyboardTextInsertion {
             body.insertText("`", replacementRange: NSRange(location: NSNotFound, length: 0))
@@ -199,10 +202,10 @@ struct CommitMessageEditorViewTests {
         view.layoutSubtreeIfNeeded()
     }
 
-    private func firstSubview<T: NSView>(of type: T.Type, in view: NSView) -> T? {
-        if let match = view as? T { return match }
+    private func firstSubview<T: NSView>(of type: T.Type, in view: NSView, matching predicate: (T) -> Bool = { _ in true }) -> T? {
+        if let match = view as? T, predicate(match) { return match }
         for subview in view.subviews {
-            if let match = firstSubview(of: type, in: subview) { return match }
+            if let match = firstSubview(of: type, in: subview, matching: predicate) { return match }
         }
         return nil
     }

--- a/AlasTests/DraftCommitTabStateTests.swift
+++ b/AlasTests/DraftCommitTabStateTests.swift
@@ -43,4 +43,31 @@ struct DraftCommitTabStateTests {
         let decoded = try JSONDecoder().decode(DraftCommitTabState.self, from: data)
         #expect(decoded == s)
     }
+
+    @Test func roundTripsPersistedPublishIntentAndPresentationRevision() throws {
+        var state = DraftCommitTabState(worktreeId: "wt-1")
+        state.preferredAction = .publish
+        state.createReviewRequestAsDraft = true
+        state.publishCheckpoint = CommitPublishCheckpoint(
+            commitSHA: "abc123",
+            baseRef: "main",
+            commitTitle: "abc123 Subject",
+            subject: "Subject",
+            body: "Body",
+            destination: .gg,
+            nextPhase: .sync
+        )
+        state.prepareForNewCommit()
+        state.prepareForNewCommit()
+        let presentationID = state.presentationID
+
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(DraftCommitTabState.self, from: data)
+
+        #expect(decoded == state)
+        #expect(decoded.preferredAction == .publish)
+        #expect(decoded.createReviewRequestAsDraft)
+        #expect(decoded.publishCheckpoint == state.publishCheckpoint)
+        #expect(decoded.presentationID == presentationID)
+    }
 }

--- a/AlasTests/DraftCommitTabStateTests.swift
+++ b/AlasTests/DraftCommitTabStateTests.swift
@@ -16,6 +16,23 @@ struct DraftCommitTabStateTests {
         #expect(s.selectedPath == nil)
     }
 
+    @Test func draftDefaultsToLocalCommitAndRegularReviewRequest() {
+        let state = DraftCommitTabState(worktreeId: "wt-1")
+
+        #expect(state.preferredAction == .commit)
+        #expect(state.createReviewRequestAsDraft == false)
+        #expect(state.publishCheckpoint == nil)
+    }
+
+    @Test func legacyDraftJSONDecodesNewFieldsWithDefaults() throws {
+        let data = Data(#"{"id":"draft-commit:wt-1","worktreeId":"wt-1","subject":"Subject","bodyText":"Body","amend":false}"#.utf8)
+        let state = try JSONDecoder().decode(DraftCommitTabState.self, from: data)
+
+        #expect(state.preferredAction == .commit)
+        #expect(state.createReviewRequestAsDraft == false)
+        #expect(state.publishCheckpoint == nil)
+    }
+
     @Test func roundTripsThroughCodable() throws {
         var s = DraftCommitTabState(worktreeId: "wt-1")
         s.subject = "feat: foo"

--- a/AlasTests/DraftCommitTabStateTests.swift
+++ b/AlasTests/DraftCommitTabStateTests.swift
@@ -67,7 +67,7 @@ struct DraftCommitTabStateTests {
             commitTitle: "abc123 Subject",
             subject: "Subject",
             body: "Body",
-            destination: .gg,
+            destination: .gg(),
             nextPhase: .sync
         )
         state.prepareForNewCommit()

--- a/AlasTests/DraftCommitTabStateTests.swift
+++ b/AlasTests/DraftCommitTabStateTests.swift
@@ -44,6 +44,19 @@ struct DraftCommitTabStateTests {
         #expect(decoded == s)
     }
 
+    @Test func localCommitPreferencePreservesDraftReviewRequestAndEmptyBody() throws {
+        var state = DraftCommitTabState(worktreeId: "wt-1")
+        state.subject = "Subject"
+        state.createReviewRequestAsDraft = true
+        let decoded = try JSONDecoder().decode(DraftCommitTabState.self, from: JSONEncoder().encode(state))
+        #expect(decoded.preferredAction == .commit)
+        #expect(decoded.createReviewRequestAsDraft)
+        #expect(decoded.bodyText.isEmpty)
+        let presentation = CommitPublishPresentation(subject: decoded.subject, hasStaged: true, availability: .gg())
+        #expect(presentation.commit.isEnabled)
+        #expect(presentation.publish?.isEnabled == true)
+    }
+
     @Test func roundTripsPersistedPublishIntentAndPresentationRevision() throws {
         var state = DraftCommitTabState(worktreeId: "wt-1")
         state.preferredAction = .publish

--- a/AlasTests/DraftCommitTabsManagerTests.swift
+++ b/AlasTests/DraftCommitTabsManagerTests.swift
@@ -4,6 +4,111 @@ import Foundation
 
 @MainActor
 struct DraftCommitTabsManagerTests {
+    @Test func openDraftWithPublishIntentCreatesPublishFirstDraft() {
+        let worktreeId = "draft-commit-tabs-mgr-publish-intent-new"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+
+        let tab = manager.openOrFocusDraftCommit(worktreeId: worktreeId, preferredAction: .publish)
+
+        guard case .draftCommit(let state) = tab else {
+            Issue.record("expected draftCommit tab")
+            return
+        }
+        #expect(state.preferredAction == .publish)
+    }
+
+    @Test func changingIntentPreservesLiveDraftContents() {
+        let worktreeId = "draft-commit-tabs-mgr-publish-intent-live"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let draft = manager.openOrFocusDraftCommit(worktreeId: worktreeId)
+        let checkpoint = makePublishCheckpoint()
+        manager.updateDraftCommit(worktreeId: worktreeId, tabId: draft.id) { state in
+            state.subject = "feat: publish this"
+            state.bodyText = "Preserve this body"
+            state.createReviewRequestAsDraft = true
+            state.amend = true
+            state.selectedPath = "Alas/Sources/Center/TabsManager.swift"
+            state.publishCheckpoint = checkpoint
+        }
+        guard case .draftCommit(let original) = manager.tabs(forWorktree: worktreeId).first(where: { $0.id == draft.id }) else {
+            Issue.record("expected live draftCommit tab")
+            return
+        }
+        var expected = original
+        expected.preferredAction = .publish
+
+        let reopened = manager.openOrFocusDraftCommit(
+            worktreeId: worktreeId,
+            resetAmend: false,
+            preferredAction: .publish
+        )
+
+        guard case .draftCommit(let state) = reopened,
+              case .draftCommit(let selectedState) = manager.activeTab(forWorktree: worktreeId) else {
+            Issue.record("expected focused draftCommit tab")
+            return
+        }
+        #expect(state == expected)
+        #expect(selectedState == expected)
+        #expect(reopened.id == draft.id)
+        #expect(manager.tabs(forWorktree: worktreeId).count == 1)
+    }
+
+    @Test func changingIntentPreservesStashedDraftContents() {
+        let worktreeId = "draft-commit-tabs-mgr-publish-intent-stashed"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let draft = manager.openOrFocusDraftCommit(worktreeId: worktreeId)
+        let checkpoint = makePublishCheckpoint()
+        manager.updateDraftCommit(worktreeId: worktreeId, tabId: draft.id) { state in
+            state.subject = "feat: resume publish"
+            state.bodyText = "Preserve this stashed body"
+            state.createReviewRequestAsDraft = true
+            state.amend = true
+            state.selectedPath = "Alas/Sources/Center/TabsManager.swift"
+            state.publishCheckpoint = checkpoint
+        }
+        guard case .draftCommit(let original) = manager.tabs(forWorktree: worktreeId).first(where: { $0.id == draft.id }) else {
+            Issue.record("expected live draftCommit tab")
+            return
+        }
+        manager.close(worktreeId: worktreeId, tabId: draft.id)
+        var expected = original
+        expected.preferredAction = .publish
+
+        let reopened = manager.openOrFocusDraftCommit(
+            worktreeId: worktreeId,
+            resetAmend: false,
+            preferredAction: .publish
+        )
+
+        guard case .draftCommit(let state) = reopened else {
+            Issue.record("expected restored draftCommit tab")
+            return
+        }
+        #expect(state == expected)
+        #expect(manager.stashedDraft(worktreeId: worktreeId) == expected)
+    }
+
+    @Test func closingCheckpointOnlyDraftRetainsCheckpoint() {
+        let worktreeId = "draft-commit-tabs-mgr-checkpoint-stash"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let draft = manager.openOrFocusDraftCommit(worktreeId: worktreeId)
+        let checkpoint = makePublishCheckpoint()
+        manager.updateDraftCommit(worktreeId: worktreeId, tabId: draft.id) { state in
+            state.subject = ""
+            state.bodyText = ""
+            state.publishCheckpoint = checkpoint
+        }
+
+        manager.close(worktreeId: worktreeId, tabId: draft.id)
+
+        #expect(manager.stashedDraft(worktreeId: worktreeId)?.publishCheckpoint == checkpoint)
+    }
+
     @Test func openOrFocusDraftCommit_createsTabFirstTime() {
         let worktreeId = "draft-commit-tabs-mgr-create"
         defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
@@ -306,5 +411,17 @@ struct DraftCommitTabsManagerTests {
         _ = mgr.closeAll(worktreeId: worktreeId)
 
         #expect(mgr.stashedDraft(worktreeId: worktreeId)?.subject == "wip: close-all test")
+    }
+
+    private func makePublishCheckpoint() -> CommitPublishCheckpoint {
+        CommitPublishCheckpoint(
+            commitSHA: "abc1234",
+            baseRef: "main",
+            commitTitle: "abc1234 feat: publish",
+            subject: "feat: publish",
+            body: "Publish body",
+            destination: .gg,
+            nextPhase: .push
+        )
     }
 }

--- a/AlasTests/DraftCommitTabsManagerTests.swift
+++ b/AlasTests/DraftCommitTabsManagerTests.swift
@@ -119,6 +119,33 @@ struct DraftCommitTabsManagerTests {
         #expect(state.publishCheckpoint == checkpoint)
     }
 
+    @Test func failedCheckpointClearPreservesRetryStateForLaterClose() {
+        let worktreeId = "draft-commit-tabs-mgr-checkpoint-clear-fails"
+        let store = FlakyTabsStore()
+        let manager = TabsManager(store: store)
+        let draft = manager.openOrFocusDraftCommit(worktreeId: worktreeId)
+        let checkpoint = makePublishCheckpoint()
+        manager.updateDraftCommit(worktreeId: worktreeId, tabId: draft.id) { state in
+            state.publishCheckpoint = checkpoint
+        }
+
+        store.failWrites = true
+        #expect(!manager.abandonCommitPublishCheckpoint(worktreeId: worktreeId, tabId: draft.id))
+
+        guard case .draftCommit(let liveState) = manager.tabs(forWorktree: worktreeId).first(where: { $0.id == draft.id }) else {
+            Issue.record("expected live draftCommit tab")
+            return
+        }
+        #expect(liveState.publishCheckpoint == checkpoint)
+
+        store.failWrites = false
+        manager.close(worktreeId: worktreeId, tabId: draft.id)
+
+        let persisted = store.files[Paths.tabsFile(forWorktreeId: worktreeId)]
+        #expect(manager.stashedDraft(worktreeId: worktreeId)?.publishCheckpoint == checkpoint)
+        #expect(persisted?.stashedDraft?.publishCheckpoint == checkpoint)
+    }
+
     @Test func openOrFocusDraftCommit_createsTabFirstTime() {
         let worktreeId = "draft-commit-tabs-mgr-create"
         defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
@@ -460,5 +487,24 @@ struct DraftCommitTabsManagerTests {
             destination: .gg(),
             nextPhase: .push
         )
+    }
+}
+
+private final class FlakyTabsStore: PersistenceStoreProtocol, @unchecked Sendable {
+    var failWrites = false
+    var files: [URL: TabsFile] = [:]
+
+    func write<T: Encodable>(_ value: T, to url: URL) throws {
+        if failWrites {
+            throw NSError(domain: "DraftCommitTabsManagerTests", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "write rejected"])
+        }
+        if let file = value as? TabsFile {
+            files[url] = file
+        }
+    }
+
+    func readIfExists<T: Decodable>(_: T.Type, from url: URL) throws -> T? {
+        files[url] as? T
     }
 }

--- a/AlasTests/DraftCommitTabsManagerTests.swift
+++ b/AlasTests/DraftCommitTabsManagerTests.swift
@@ -430,7 +430,7 @@ struct DraftCommitTabsManagerTests {
             commitTitle: "abc1234 feat: publish",
             subject: "feat: publish",
             body: "Publish body",
-            destination: .gg,
+            destination: .gg(),
             nextPhase: .push
         )
     }

--- a/AlasTests/DraftCommitTabsManagerTests.swift
+++ b/AlasTests/DraftCommitTabsManagerTests.swift
@@ -94,8 +94,10 @@ struct DraftCommitTabsManagerTests {
 
     @Test func closingCheckpointOnlyDraftRetainsCheckpoint() {
         let worktreeId = "draft-commit-tabs-mgr-checkpoint-stash"
-        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
-        let manager = TabsManager()
+        let tabsDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-draft-checkpoint-stash-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tabsDirectory) }
+        let manager = TabsManager(store: PersistenceStore(), tabsDirectory: tabsDirectory)
         let draft = manager.openOrFocusDraftCommit(worktreeId: worktreeId)
         let checkpoint = makePublishCheckpoint()
         manager.updateDraftCommit(worktreeId: worktreeId, tabId: draft.id) { state in
@@ -106,7 +108,15 @@ struct DraftCommitTabsManagerTests {
 
         manager.close(worktreeId: worktreeId, tabId: draft.id)
 
-        #expect(manager.stashedDraft(worktreeId: worktreeId)?.publishCheckpoint == checkpoint)
+        let reloaded = TabsManager(store: PersistenceStore(), tabsDirectory: tabsDirectory)
+        reloaded.loadAll(worktreeIds: [worktreeId])
+        let reopened = reloaded.openOrFocusDraftCommit(worktreeId: worktreeId)
+
+        guard case .draftCommit(let state) = reopened else {
+            Issue.record("expected restored draftCommit tab")
+            return
+        }
+        #expect(state.publishCheckpoint == checkpoint)
     }
 
     @Test func openOrFocusDraftCommit_createsTabFirstTime() {

--- a/AlasTests/DraftCommitTabsManagerTests.swift
+++ b/AlasTests/DraftCommitTabsManagerTests.swift
@@ -272,6 +272,33 @@ struct DraftCommitTabsManagerTests {
         #expect(s.baseRef == "main")
     }
 
+    @Test func replaceDraftWithCommitEditor_reusesExistingEditorForPublishedCommit() {
+        let worktreeId = "draft-commit-tabs-mgr-replace-reuse"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let draft = mgr.openOrFocusDraftCommit(worktreeId: worktreeId)
+        let existing = mgr.openCommitEditor(
+            worktreeId: worktreeId,
+            baseRef: "main",
+            originalSha: "abc1234",
+            currentSha: "abc1234",
+            title: "abc1234 existing"
+        )
+
+        let replaced = mgr.replaceDraftWithCommitEditor(
+            worktreeId: worktreeId,
+            draftTabId: draft.id,
+            baseRef: "main",
+            newSha: "abc1234",
+            title: "abc1234 feat: foo"
+        )
+
+        #expect(replaced?.id == existing.id)
+        #expect(mgr.tabs(forWorktree: worktreeId).count == 1)
+        #expect(!mgr.tabs(forWorktree: worktreeId).contains { $0.id == draft.id })
+        #expect(mgr.activeTabId(forWorktree: worktreeId) == existing.id)
+    }
+
     @Test func closingDraftTab_stashesStateAcrossReopen() {
         let worktreeId = "draft-stash-roundtrip"
         defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }

--- a/AlasTests/GitServiceUpstreamTests.swift
+++ b/AlasTests/GitServiceUpstreamTests.swift
@@ -4,6 +4,111 @@ import Foundation
 
 @Suite(.serialized)
 struct GitServiceUpstreamTests {
+    @Test func strictPublicationDistinguishesStatesAndProbeFailures() async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let git = GitService()
+        #expect(try await git.headPublicationState(worktreePath: repo) == .published)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "local"], cwd: repo)
+        #expect(try await git.headPublicationState(worktreePath: repo) == .unpublished)
+        _ = try await Process.git(["update-ref", "-d", "refs/remotes/origin/main"], cwd: repo)
+        await #expect(throws: (any Error).self) { try await git.headPublicationState(worktreePath: repo) }
+        _ = try await Process.git(["branch", "--unset-upstream"], cwd: repo)
+        #expect(try await git.headPublicationState(worktreePath: repo) == .noUpstream)
+        await #expect(throws: (any Error).self) { try await git.headPublicationState(worktreePath: remote.deletingLastPathComponent()) }
+    }
+
+    @Test func strictPublicationDistinguishesBehindDivergedAndDetachedHead() async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let git = GitService()
+        let initial = try await checkedGit(["rev-parse", "HEAD"], cwd: repo)
+        _ = try await checkedGit(["commit", "-q", "--allow-empty", "-m", "remote update"], cwd: repo)
+        _ = try await checkedGit(["push", "-q", "origin", "main"], cwd: repo)
+        _ = try await checkedGit(["update-ref", "refs/heads/main", initial], cwd: repo)
+        #expect(try await git.headPublicationState(worktreePath: repo) == .published)
+        _ = try await checkedGit(["commit", "-q", "--allow-empty", "-m", "local divergence"], cwd: repo)
+        #expect(try await git.headPublicationState(worktreePath: repo) == .unpublished)
+        #expect(try await git.isHeadAtOrBehindUpstream(worktreePath: repo) == false)
+        _ = try await checkedGit(["checkout", "--detach", "HEAD"], cwd: repo)
+        #expect(try await git.headPublicationState(worktreePath: repo) == .noUpstream)
+    }
+
+    @Test func remoteContainmentUsesExactBranchWithoutUpstreamAndCleansTemporaryRef() async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let git = GitService()
+        let checkpoint = try await checkedGit(["rev-parse", "HEAD"], cwd: repo)
+        let secondRemote = repo.appendingPathComponent("secondary.git")
+        _ = try await checkedGit(["init", "--bare", "-q", secondRemote.path], cwd: repo)
+        _ = try await checkedGit(["remote", "add", "publish", secondRemote.path], cwd: repo)
+        _ = try await checkedGit(["push", "-q", "publish", "HEAD:main"], cwd: repo)
+        _ = try await checkedGit(["branch", "--unset-upstream"], cwd: repo)
+        _ = try await checkedGit(["update-ref", "refs/alas/publish-check/keep", checkpoint], cwd: repo)
+        #expect(try await git.remoteBranchContainsCommit(worktreePath: repo, remote: "origin", branch: "missing", commitSHA: checkpoint) == false)
+        #expect(try await git.remoteBranchContainsCommit(worktreePath: repo, remote: "origin", branch: "main", commitSHA: checkpoint))
+        _ = try await checkedGit(["commit", "-q", "--allow-empty", "-m", "advance"], cwd: repo)
+        _ = try await checkedGit(["push", "-q", "origin", "HEAD:main"], cwd: repo)
+        #expect(try await git.remoteBranchContainsCommit(worktreePath: repo, remote: "origin", branch: "main", commitSHA: checkpoint))
+        _ = try await checkedGit(["checkout", "--orphan", "unrelated"], cwd: repo)
+        _ = try await checkedGit(["commit", "-q", "--allow-empty", "-m", "unrelated"], cwd: repo)
+        _ = try await checkedGit(["push", "-q", "--force", "origin", "HEAD:main"], cwd: repo)
+        _ = try await checkedGit(["update-ref", "refs/remotes/origin/main", checkpoint], cwd: repo)
+        #expect(try await git.remoteBranchContainsCommit(worktreePath: repo, remote: "origin", branch: "main", commitSHA: checkpoint) == false)
+        #expect(try await git.remoteBranchContainsCommit(worktreePath: repo, remote: "publish", branch: "main", commitSHA: checkpoint))
+        #expect(try await checkedGit(["rev-parse", "refs/remotes/origin/main"], cwd: repo) == checkpoint)
+        await #expect(throws: (any Error).self) {
+            try await git.remoteBranchContainsCommit(worktreePath: repo, remote: "origin", branch: "main", commitSHA: "not-a-commit")
+        }
+        #expect(try await checkedGit(["for-each-ref", "--format=%(refname)", "refs/alas/publish-check/"], cwd: repo) == "refs/alas/publish-check/keep")
+        _ = try await checkedGit(["remote", "set-url", "origin", remote.appendingPathComponent("missing").path], cwd: repo)
+        await #expect(throws: (any Error).self) {
+            try await git.remoteBranchContainsCommit(worktreePath: repo, remote: "origin", branch: "main", commitSHA: checkpoint)
+        }
+    }
+
+    @Test func remoteContainmentThrowsWhenFetchFailsAfterAdvertisement() async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let checkpoint = try await checkedGit(["rev-parse", "HEAD"], cwd: repo)
+        let script = repo.appendingPathComponent("upload-pack")
+        let marker = repo.appendingPathComponent("advertised")
+        try """
+        #!/bin/sh
+        if [ -f '\(marker.path)' ]; then
+            echo 'fetch refused' >&2
+            exit 42
+        fi
+        touch '\(marker.path)'
+        exec /usr/bin/git-upload-pack "$@"
+        """.write(to: script, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: script.path)
+        _ = try await checkedGit(["config", "remote.origin.uploadpack", script.path], cwd: repo)
+        await #expect(throws: (any Error).self) {
+            try await GitService().remoteBranchContainsCommit(worktreePath: repo, remote: "origin", branch: "main", commitSHA: checkpoint)
+        }
+        #expect(FileManager.default.fileExists(atPath: marker.path))
+        #expect(try await checkedGit(["for-each-ref", "--format=%(refname)", "refs/alas/publish-check/"], cwd: repo).isEmpty)
+    }
+
+    private func checkedGit(_ args: [String], cwd: URL) async throws -> String {
+        let result = try await Process.git(args, cwd: cwd)
+        guard result.exitCode == 0 else { throw ProcessError.nonZeroExit(result.exitCode, result.stderr) }
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private func makeRepoWithRemote() async throws -> (URL, URL) {
         let repo = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-up-\(UUID().uuidString)")

--- a/AlasTests/GitServiceUpstreamTests.swift
+++ b/AlasTests/GitServiceUpstreamTests.swift
@@ -4,6 +4,104 @@ import Foundation
 
 @Suite(.serialized)
 struct GitServiceUpstreamTests {
+    @Test func cancelledRemoteProbeRemovesFetchedTemporaryRefBeforeReturning() async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let checkpoint = try await checkedGit(["rev-parse", "HEAD"], cwd: repo)
+        let marker = repo.appendingPathComponent("fetched")
+        let release = repo.appendingPathComponent("release-fetch")
+        let hook = repo.appendingPathComponent(".git/hooks/reference-transaction")
+        try """
+        #!/bin/sh
+        while read old new ref; do
+            case "$ref" in
+            refs/alas/publish-check/*)
+                if [ "$new" = '0000000000000000000000000000000000000000' ]; then
+                    sleep 0.1
+                elif [ "$1" = committed ]; then
+                    touch '\(marker.path)'
+                    while [ ! -f '\(release.path)' ]; do sleep 0.01; done
+                fi
+                ;;
+            esac
+        done
+        """.write(to: hook, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hook.path)
+        let probe = Task {
+            try await GitService().remoteBranchContainsCommit(worktreePath: repo, remote: remote.path, branch: "main", commitSHA: checkpoint)
+        }
+        defer {
+            probe.cancel()
+            try? "".write(to: release, atomically: true, encoding: .utf8)
+        }
+        for _ in 0..<500 where !FileManager.default.fileExists(atPath: marker.path) {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        let didFetch = FileManager.default.fileExists(atPath: marker.path)
+        let fetchedRefs = try await checkedGit(["for-each-ref", "--format=%(refname)", "refs/alas/publish-check/"], cwd: repo)
+        probe.cancel()
+        try "".write(to: release, atomically: true, encoding: .utf8)
+        await #expect(throws: (any Error).self) { try await probe.value }
+        #expect(didFetch)
+        #expect(!fetchedRefs.isEmpty)
+        #expect(try await checkedGit(["for-each-ref", "--format=%(refname)", "refs/alas/publish-check/"], cwd: repo).isEmpty)
+    }
+
+    @Test(arguments: [true, false])
+    func remoteProbeReportsCleanupFailureButPreservesOriginalFailure(validCheckpoint: Bool) async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let checkpoint = try await checkedGit(["rev-parse", "HEAD"], cwd: repo)
+        let hook = repo.appendingPathComponent(".git/hooks/reference-transaction")
+        try """
+        #!/bin/sh
+        while read old new ref; do
+            case "$ref" in
+            refs/alas/publish-check/*)
+                if [ "$1" = prepared ] && [ "$new" = '0000000000000000000000000000000000000000' ]; then
+                    echo 'cleanup refused' >&2
+                    exit 1
+                fi
+                ;;
+            esac
+        done
+        """.write(to: hook, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: hook.path)
+        do {
+            _ = try await GitService().remoteBranchContainsCommit(
+                worktreePath: repo, remote: remote.path, branch: "main",
+                commitSHA: validCheckpoint ? checkpoint : "not-a-commit"
+            )
+            Issue.record("Expected the probe or cleanup error to propagate")
+        } catch {
+            #expect((error as NSError).domain == "GitService.\(validCheckpoint ? "Delete publication probe ref" : "Check remote commit")")
+        }
+    }
+
+    @Test func remoteProbeUsesResolvedPushURLForSplitFetchAndPushRemote() async throws {
+        let (repo, fetchRemote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: fetchRemote)
+        }
+        let pushRemote = repo.appendingPathComponent("publish.git")
+        _ = try await checkedGit(["init", "--bare", "-q", pushRemote.path], cwd: repo)
+        _ = try await checkedGit(["remote", "set-url", "--push", "origin", pushRemote.path], cwd: repo)
+        _ = try await checkedGit(["commit", "-q", "--allow-empty", "-m", "publication"], cwd: repo)
+        _ = try await checkedGit(["push", "-q", "origin", "main"], cwd: repo)
+        let checkpoint = try await checkedGit(["rev-parse", "HEAD"], cwd: repo)
+        let publicationURL = try await checkedGit(["remote", "get-url", "--push", "origin"], cwd: repo)
+        let git = GitService()
+        #expect(try await git.remoteBranchContainsCommit(worktreePath: repo, remote: publicationURL, branch: "main", commitSHA: checkpoint))
+        #expect(try await git.remoteBranchContainsCommit(worktreePath: repo, remote: "origin", branch: "main", commitSHA: checkpoint) == false)
+    }
+
     @Test func strictPublicationDistinguishesStatesAndProbeFailures() async throws {
         let (repo, remote) = try await makeRepoWithRemote()
         defer {

--- a/AlasTests/Integrations/GGMutationCoordinatorTests.swift
+++ b/AlasTests/Integrations/GGMutationCoordinatorTests.swift
@@ -1233,6 +1233,7 @@ struct GGMutationCoordinatorTests {
             stacks: [stack(head: "a", operationID: "op_paused")],
             supportsClientOperationID: true
         )
+        harness.currentHeadSHA = "recovered"
         harness.service.newestOperation = completed
 
         try await harness.coordinator.apply(.continueOperation, confirmedAgainst: nil)
@@ -1241,6 +1242,7 @@ struct GGMutationCoordinatorTests {
         #expect(harness.service.operationListCallCount == 1)
         #expect(harness.markers.operationID(worktreeId: "wt") == completed.id)
         #expect(harness.coordinator.undoCandidate == GGUndoCandidate(operation: completed))
+        #expect(harness.actionState.completedRecoveryOperation == .init(operationID: "op_paused", headSHA: "recovered"))
     }
 
     @Test func continueRejectsANewerOperationThanThePausedOperation() async throws {
@@ -1287,6 +1289,7 @@ struct GGMutationCoordinatorTests {
             stacks: [stack(head: "a", operationID: "op_paused")],
             supportsClientOperationID: true
         )
+        harness.currentHeadSHA = "aborted"
         harness.service.newestOperation = GGOperationSummary(
             id: "op_paused", kind: "restack", status: .completed, createdAtMs: 2,
             args: ["--client-operation-id", "alas:original", "restack"],
@@ -1299,6 +1302,7 @@ struct GGMutationCoordinatorTests {
         #expect(harness.service.operationListCallCount == 0)
         #expect(harness.markers.operationID(worktreeId: "wt") == nil)
         #expect(harness.coordinator.undoCandidate == nil)
+        #expect(harness.actionState.completedRecoveryOperation == .init(operationID: "op_paused", headSHA: "aborted"))
     }
 
     @Test func relaunchRestoresOnlyMatchingPersistedLocalUndoableOperation() async {

--- a/AlasTests/Integrations/GGMutationCoordinatorTests.swift
+++ b/AlasTests/Integrations/GGMutationCoordinatorTests.swift
@@ -210,7 +210,8 @@ private final class GGMutationHarness {
     var refreshes: [Refresh] = []
     var selectedPaths: [String] = []
     var worktreeExists = true
-    var currentBranch: String? = "feature"
+    var currentBranch = "feature"
+    var currentHeadSHA = "committed"
     var finishPendingStaging: () async -> Bool = { true }
     var onRefreshStack: (() async -> Void)?
     private(set) var coordinator: GGMutationCoordinator!
@@ -242,6 +243,8 @@ private final class GGMutationHarness {
                     defer { loadCount += 1 }
                     return stacks[min(loadCount, stacks.count - 1)]
                 },
+                loadCurrentBranch: { [unowned self] in currentBranch },
+                loadCurrentHead: { [unowned self] in currentHeadSHA },
                 refreshStack: { [unowned self] in
                     refreshes.append(.stack)
                     await onRefreshStack?()
@@ -675,6 +678,91 @@ struct GGMutationCoordinatorTests {
         #expect(harness.refreshes == [.gitChanges, .stack, .providerReviews, .inbox])
         #expect(harness.actionState.lastActionSummary == "Synced")
         #expect(harness.actionState.syncProgress.isEmpty)
+    }
+
+    @Test func syncExpectedTargetRejectsChangedBranchBeforeProcessLaunch() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "committed")])
+        harness.currentBranch = "other-feature"
+        let target = GGStackTargetIdentity(
+            branch: "feature",
+            stackName: "feature",
+            base: "main",
+            expectedHeadSHA: "committed"
+        )
+        let operation = try #require(harness.coordinator.startApplying(
+            .sync,
+            confirmedAgainst: nil,
+            expectedTarget: target
+        ))
+
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            try await operation.value
+        }
+
+        #expect(harness.service.requests.isEmpty)
+    }
+
+    @Test func syncExpectedTargetAllowsDetachedStackContext() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "committed")])
+        harness.currentBranch = ""
+        let target = GGStackTargetIdentity(
+            branch: "",
+            stackName: "feature",
+            base: "main",
+            expectedHeadSHA: "committed"
+        )
+        let operation = try #require(harness.coordinator.startApplying(
+            .sync,
+            confirmedAgainst: nil,
+            expectedTarget: target
+        ))
+
+        try await operation.value
+
+        #expect(harness.service.requests == [.sync])
+    }
+
+    @Test func syncExpectedTargetRejectsChangedHeadBeforeProcessLaunch() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "committed")])
+        harness.currentHeadSHA = "changed"
+        let target = GGStackTargetIdentity(
+            branch: "feature",
+            stackName: "feature",
+            base: "main",
+            expectedHeadSHA: "committed"
+        )
+        let operation = try #require(harness.coordinator.startApplying(
+            .sync,
+            confirmedAgainst: nil,
+            expectedTarget: target
+        ))
+
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            try await operation.value
+        }
+
+        #expect(harness.service.requests.isEmpty)
+    }
+
+    @Test func syncExpectedTargetRejectsChangedStackHeadBeforeProcessLaunch() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "changed")])
+        let target = GGStackTargetIdentity(
+            branch: "feature",
+            stackName: "feature",
+            base: "main",
+            expectedHeadSHA: "committed"
+        )
+        let operation = try #require(harness.coordinator.startApplying(
+            .sync,
+            confirmedAgainst: nil,
+            expectedTarget: target
+        ))
+
+        await #expect(throws: GGMutationError.staleConfirmation) {
+            try await operation.value
+        }
+
+        #expect(harness.service.requests.isEmpty)
     }
 
     @Test func terminalSyncSummaryKeepsRefreshProgressVisibleUntilRefreshCompletes() async throws {

--- a/AlasTests/Integrations/ReviewLoopStateTests.swift
+++ b/AlasTests/Integrations/ReviewLoopStateTests.swift
@@ -5,6 +5,43 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct ReviewLoopStateTests {
+    @Test func explicitTargetLookupAndCreationUseCapturedProviderAndArguments() async throws {
+        let remote = CodeHostRemote(
+            kind: .gitlab, host: "gitlab.com", owner: "captured", repository: "project",
+            remoteName: "publish", webURL: URL(string: "https://gitlab.com/captured/project")!
+        )
+        let provider = FakeCodeHostProvider(kind: .gitlab)
+        let state = ReviewLoopState(
+            worktreePath: URL(fileURLWithPath: "/tmp/alas-review-loop"), baseBranch: "main",
+            providerRegistry: CodeHostProviderRegistry(providers: [.github: FakeCodeHostProvider(kind: .github), .gitlab: provider])
+        )
+        await state.refresh(local: Self.makeLocal(branchName: "current"), remotes: [Self.makeGitHubRemote()])
+        provider.request = Self.makeReviewRequest(remote: remote, checks: [])
+        let request = try await state.currentReviewRequest(remote: remote, branch: "captured", headOwner: "fork", baseBranch: "release")
+        #expect(request?.number == 42)
+        #expect(provider.lookupTargets.last == .init(remote: remote, branch: "captured", headOwner: "fork", baseBranch: "release"))
+        let url = try await state.createReviewRequest(remote: remote, branch: "captured", headOwner: "fork", baseBranch: "release", title: "Title", body: "Body", draft: true)
+        #expect(url == remote.webURL)
+        #expect(provider.creationRemotes == [remote])
+        #expect(provider.createdReviewRequests == [.init(branch: "captured", headOwner: "fork", baseBranch: "release", title: "Title", body: "Body", isDraft: true)])
+        let error = CodeHostProviderError.commandFailed(command: "lookup", stderr: "offline")
+        provider.requestError = error
+        await #expect(throws: error) {
+            try await state.currentReviewRequest(remote: remote, branch: "captured", headOwner: "fork", baseBranch: "release")
+        }
+        provider.createError = error
+        await #expect(throws: error) {
+            try await state.createReviewRequest(remote: remote, branch: "captured", headOwner: "fork", baseBranch: "release", title: "Title", body: "Body", draft: true)
+        }
+        let unsupported = ReviewLoopState(worktreePath: URL(fileURLWithPath: "/tmp"), baseBranch: "main", providerRegistry: CodeHostProviderRegistry(providers: [:]))
+        await #expect(throws: CodeHostProviderError.unsupportedProvider(.gitlab)) {
+            try await unsupported.currentReviewRequest(remote: remote, branch: "captured", headOwner: nil, baseBranch: "main")
+        }
+        await #expect(throws: CodeHostProviderError.unsupportedProvider(.gitlab)) {
+            try await unsupported.createReviewRequest(remote: remote, branch: "captured", headOwner: nil, baseBranch: "main", title: "Title", body: "Body", draft: false)
+        }
+    }
+
     @Test func rightPaneStoreForwardsCompletedRemoteReviewSnapshot() {
         let store = RightPaneStore()
         let worktree = Worktree(
@@ -1206,6 +1243,14 @@ private struct StubError: LocalizedError {
 }
 
 private final class FakeCodeHostProvider: CodeHostProvider, @unchecked Sendable {
+    struct LookupTarget: Equatable {
+        let remote: CodeHostRemote
+        let branch: String
+        let headOwner: String?
+        let baseBranch: String
+    }
+    var lookupTargets: [LookupTarget] = []
+    var creationRemotes: [CodeHostRemote] = []
     struct CreatedReviewRequest: Equatable {
         let branch: String
         let headOwner: String?
@@ -1287,6 +1332,7 @@ private final class FakeCodeHostProvider: CodeHostProvider, @unchecked Sendable 
         baseBranch: String,
         cwd: URL
     ) async throws -> ReviewRequest? {
+        lookupTargets.append(.init(remote: remote, branch: branch, headOwner: headOwner, baseBranch: baseBranch))
         if let requestError { throw requestError }
         if let delay = delayForBranch[branch] {
             try? await Task.sleep(nanoseconds: delay)
@@ -1305,6 +1351,7 @@ private final class FakeCodeHostProvider: CodeHostProvider, @unchecked Sendable 
         cwd: URL
     ) async throws -> URL {
         if let createError { throw createError }
+        creationRemotes.append(remote)
         createdReviewRequests.append(CreatedReviewRequest(
             branch: branch,
             headOwner: headOwner,

--- a/AlasTests/Right/ChangesPreparationModelTests.swift
+++ b/AlasTests/Right/ChangesPreparationModelTests.swift
@@ -91,7 +91,7 @@ struct ChangesPreparationModelTests {
         #expect(model.ggActions.isEmpty)
     }
 
-    @Test func ggPreparationShowsReviewAndThreeDestinations() {
+    @Test func ggPreparationShowsReviewAndFourDestinations() {
         let model = ChangesPreparationModel.makeGG(
             staged: .init(files: 2, insertions: 8, deletions: 3),
             hasDraft: false,
@@ -99,8 +99,8 @@ struct ChangesPreparationModelTests {
         )
 
         #expect(model.primaryAction?.title == "Review current changes")
-        #expect(model.ggActions.map(\.kind) == [.newStackCommit, .amendCurrent, .absorbIntoStack])
-        #expect(model.ggActions.map(\.title) == ["New stack commit", "Amend current", "Absorb into stack"])
+        #expect(model.ggActions.map(\.kind) == [.newStackCommit, .commitAndSync, .amendCurrent, .absorbIntoStack])
+        #expect(model.ggActions.map(\.title) == ["New stack commit", "Commit & sync", "Amend current", "Absorb into stack"])
         #expect(model.ggActions.allSatisfy { $0.isEnabled })
     }
 
@@ -112,6 +112,7 @@ struct ChangesPreparationModelTests {
         )
 
         #expect(model.ggAction(.newStackCommit)?.isEnabled == true)
+        #expect(model.ggAction(.commitAndSync)?.isEnabled == true)
         #expect(model.ggAction(.amendCurrent)?.disabledReason == "Stage changes first")
         #expect(model.ggAction(.absorbIntoStack)?.disabledReason == "Stage changes first")
     }
@@ -162,7 +163,7 @@ struct ChangesPreparationModelTests {
             capabilities: stagedOnlyCapabilities
         )
 
-        #expect(model.ggActions.map(\.kind) == [.newStackCommit, .amendCurrent, .absorbIntoStack])
+        #expect(model.ggActions.map(\.kind) == [.newStackCommit, .commitAndSync, .amendCurrent, .absorbIntoStack])
         #expect(!model.ggActions.contains { $0.isEnabled })
         #expect(!model.isVisible)
     }
@@ -299,6 +300,8 @@ struct ChangesPreparationModelTests {
 
         #expect(model.ggAction(.newStackCommit)?.disabledReason ==
             "Checkout the stack head to create a new stack commit.")
+        #expect(model.ggAction(.commitAndSync)?.disabledReason ==
+            "Checkout the stack head to create a new stack commit.")
         #expect(model.ggAction(.amendCurrent)?.isEnabled == true)
         #expect(model.ggAction(.absorbIntoStack)?.isEnabled == true)
     }
@@ -315,6 +318,41 @@ struct ChangesPreparationModelTests {
         #expect(model.ggActions.allSatisfy {
             $0.disabledReason == "Another GG operation is running."
         })
+    }
+
+    @Test func publishDestinationSuppressesOnlyRedundantCompactActions() {
+        let publish = CommitPublishAvailability(label: "Commit & PR", detail: "Publish branch", disabledReason: nil, showsDraftToggle: true)
+        for kind in [ReviewReadinessActionKind.pushBranch, .createReviewRequest, .inspectReviewEvidence] {
+            let model = ChangesPreparationModel(
+                changes: [changedFile("App.swift", stage: .staged, add: 1, del: 0)],
+                hasDraft: false, draftNonEmpty: false,
+                readinessActions: [Action(kind: kind, title: "Action", isEnabled: true)],
+                publishAvailability: publish
+            )
+            #expect(model.draftAction != nil)
+            #expect(model.publishAction == publish)
+            #expect(model.reviewRequestActions.map(\.kind) == (kind == .inspectReviewEvidence ? [kind] : []))
+        }
+    }
+
+    @Test func publishDestinationNeedsStagedChangesOrDraft() {
+        let model = ChangesPreparationModel(changes: [], hasDraft: false, draftNonEmpty: false,
+            readinessActions: [], publishAvailability: .init(label: "Commit & PR", detail: "Publish branch", disabledReason: nil, showsDraftToggle: true))
+        #expect(model.publishAction == nil)
+    }
+
+    @Test func publishDestinationKeepsUnrelatedActionBesideRedundantPush() {
+        let model = ChangesPreparationModel(
+            changes: [], hasDraft: true, draftNonEmpty: true,
+            readinessActions: [
+                Action(kind: .pushBranch, title: "Push", isEnabled: true),
+                Action(kind: .inspectReviewEvidence, title: "Inspect", isEnabled: true),
+            ],
+            publishAvailability: .init(label: "Commit & push", detail: "Publish branch", disabledReason: "Published Amend", showsDraftToggle: false)
+        )
+        #expect(model.draftAction != nil)
+        #expect(model.publishAction?.isEnabled == false)
+        #expect(model.reviewRequestActions.map(\.kind) == [.inspectReviewEvidence])
     }
 }
 

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -698,6 +698,45 @@ struct RightPaneGGRefreshSchedulingTests {
 
 @MainActor
 struct RightPaneGGStackTests {
+    @Test func commitPublishSyncAwaitsCoordinatorAndPreservesSummary() async throws {
+        let state = makeState()
+        let runner = ReentrantSyncFakeGGRunner()
+        state.ggService = GGService(runner: runner)
+        state.ggContextProvider = { _ in .active(stackName: "stack") }
+        try await state.syncGGForCommitPublish()
+        #expect(runner.syncCallCount == 1)
+        #expect(state.ggActionState.inFlightAction == nil)
+        #expect(state.ggActionState.lastActionSummary == "Synced · 1 pushed")
+        #expect(state.ggActionState.lastError == nil)
+    }
+
+    @Test func commitPublishSyncThrowsAndPublishesFailureOnce() async throws {
+        let state = makeState()
+        let runner = ThrowingFakeGGRunner()
+        state.ggService = GGService(runner: runner)
+        let generation = state.ggActionState.actionGeneration
+        await #expect(throws: (any Error).self) { try await state.syncGGForCommitPublish() }
+        #expect(runner.callCount == 1)
+        #expect(state.ggActionState.actionGeneration == generation + 1)
+        #expect(state.ggActionState.lastError?.contains("boom") == true)
+        #expect(state.ggActionState.syncHasTerminalFailure)
+        #expect(state.ggActionState.inFlightAction == nil)
+        #expect(state.ggActionState.lastActionSummary == nil)
+    }
+
+    @Test func commitPublishSyncRefusesConcurrentMutation() async throws {
+        let state = makeState()
+        let runner = ReentrantSyncFakeGGRunner()
+        state.ggService = GGService(runner: runner)
+        let first = try #require(state.runGGMutation(.sync))
+        let generation = state.ggActionState.actionGeneration
+        await #expect(throws: GGMutationError.operationInFlight) { try await state.syncGGForCommitPublish() }
+        #expect(state.ggActionState.actionGeneration == generation)
+        #expect(state.ggActionState.lastError == nil)
+        await first.value
+        #expect(runner.syncCallCount == 1)
+    }
+
     private struct MemoryStore: PersistenceStoreProtocol {
         var projectsFile: ProjectsFile?
 
@@ -745,6 +784,13 @@ struct RightPaneGGStackTests {
     }
 
     private func installFakeGGStackLoader(on state: RightPaneState) {
+        state.ggCapabilities = {
+            GGCapabilities(
+                structuredSplit: false,
+                keepCurrentUnstack: false,
+                localStackSnapshot: false
+            )
+        }
         state.ggStackCommitLoader = { _, shas in
             Dictionary(uniqueKeysWithValues: shas.map { sha in
                 let fullSHA = sha.count == 40
@@ -1498,6 +1544,7 @@ struct RightPaneGGStackTests {
         let worktree = makeWorktree()
         let state = store.state(for: worktree, baseBranch: "main", comparisonMode: .manual)
         store.deactivate()
+        installFakeGGStackLoader(on: state)
         let runner = CountingFakeGGRunner(
             result: ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
         )
@@ -2561,7 +2608,8 @@ struct RightPaneGGStackTests {
         await state.refreshGGStack()
         #expect(state.ggStack?.name == "agent-inbox")
         #expect(state.ggStackCommitsKey == state.currentGGStackCommitsKey)
-        #expect(runner.callCount == 3)
+        // The legacy snapshot path makes one read per refresh, without remote enrichment.
+        #expect(runner.callCount == 2)
     }
 
     @Test func cancelledFirstStackLoadBecomesRetryableFailure() async {
@@ -3066,6 +3114,13 @@ struct RightPaneGGStackTests {
         let runner = StaleMutationFailureRunner()
         let state = RightPaneState(worktree: worktree, baseBranch: "main")
         state.ggService = GGService(runner: runner)
+        state.ggCapabilities = {
+            GGCapabilities(
+                structuredSplit: false,
+                keepCurrentUnstack: false,
+                localStackSnapshot: false
+            )
+        }
         state.ggContextProvider = { _ in .active(stackName: "agent-inbox") }
         state.ggStackSourceCommits = [
             commit(sha: String(repeating: "s", count: 40), stackShaped: true),

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -698,6 +698,21 @@ struct RightPaneGGRefreshSchedulingTests {
 
 @MainActor
 struct RightPaneGGStackTests {
+    @Test func commitPublishTargetCapturesDetachedStackContext() throws {
+        let state = makeState()
+        state.ggContext = .active(stackName: "agent-inbox")
+        state.ggStack = try GGStackSnapshot.decode(fromJSON: Data(GGStackModelsTests.fixture.utf8)).stack
+        state.currentBranch = ""
+        state.currentHeadSHA = "ccccccc"
+
+        #expect(state.ggTargetForCommitPublish() == .init(
+            branch: "",
+            stackName: "agent-inbox",
+            base: "main",
+            expectedHeadSHA: "ccccccc"
+        ))
+    }
+
     @Test func commitPublishSyncAwaitsCoordinatorAndPreservesSummary() async throws {
         let state = makeState()
         let runner = ReentrantSyncFakeGGRunner()

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -907,6 +907,35 @@ struct RightPaneGGStackTests {
         #expect(!state.ggStackRemoteEnrichmentPending)
     }
 
+    @Test func cancelledEnrichmentKeepsLocalStackAfterDetachedContextPromotion() async throws {
+        let runner = LocalFirstGGRunner()
+        runner.delaysRemote = true
+        let state = makeState()
+        defer { GGStackSummaryStore.shared.summaries[state.worktree.path.path] = nil }
+        state.ggService = GGService(runner: runner)
+        state.ggCapabilities = {
+            GGCapabilities(structuredSplit: false, keepCurrentUnstack: false, localStackSnapshot: true)
+        }
+        state.ggContextProvider = { _ in .inactive(reason: .branchPrefixMismatch(expectedPrefix: "nacho/")) }
+        state.seedGGContext(branch: "")
+        let refresh = Task { @MainActor in await state.refreshGGStack() }
+        for _ in 0..<500 where runner.calls.count < 2 {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        #expect(state.ggContext == .active(stackName: "agent-inbox"))
+        #expect(state.ggStackLoadState == .loaded)
+        let publishedKey = state.ggStackCommitsKey
+        refresh.cancel()
+        await refresh.value
+        #expect(state.ggStackLoadState == .loaded)
+        #expect(state.ggStack?.name == "agent-inbox")
+        #expect(state.ggStackDisplayCommits.count == 3)
+        #expect(state.ggStackCommitsKey == publishedKey)
+        #expect(state.ggStackCommitsKey == state.currentGGStackCommitsKey)
+        #expect(state.ggStackRemoteEnrichmentPending)
+        #expect(GGStackSummaryStore.shared.summaries[state.worktree.path.path] != nil)
+    }
+
     @Test func cancelledRemoteEnrichmentKeepsPublishedEmptyStack() async throws {
         let runner = LocalFirstGGRunner()
         runner.delaysRemote = true

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -251,14 +251,26 @@ private actor ControlledStackGGRunner: GGCommandRunning {
 /// to the non-streaming path.
 private final class NDJSONSyncFakeGGRunner: GGCommandRunning, @unchecked Sendable {
     private let ndjson: String
+    private let json: String?
 
-    init(ndjson: String) {
+    init(ndjson: String, json: String? = nil) {
         self.ndjson = ndjson
+        self.json = json
     }
 
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
         if args == ["sync", "--help"] {
             return ProcessResult(exitCode: 0, stdout: "--jsonl", stderr: "")
+        }
+        if args == ["ls", "--json"] {
+            return ProcessResult(exitCode: 0, stdout: GGStackModelsTests.fixture, stderr: "")
+        }
+        if args == ["sync", "--json"] {
+            return ProcessResult(
+                exitCode: 0,
+                stdout: json ?? ndjson,
+                stderr: ""
+            )
         }
         return ProcessResult(exitCode: 0, stdout: ndjson, stderr: "")
     }
@@ -737,6 +749,23 @@ struct RightPaneGGStackTests {
         #expect(state.ggActionState.syncHasTerminalFailure)
         #expect(state.ggActionState.inFlightAction == nil)
         #expect(state.ggActionState.lastActionSummary == nil)
+    }
+
+    @Test func commitPublishSyncThrowsWhenStreamReportsTerminalEntryFailure() async throws {
+        let state = makeState()
+        let runner = NDJSONSyncFakeGGRunner(ndjson: [
+            #"{"event":"start","total_entries":1}"#,
+            #"{"event":"summary","entries":[{"position":1,"error":{"message":"push failed"}}]}"#,
+        ].joined(separator: "\n"), json: #"{"version":1,"sync":{"entries":[{"position":1,"error":{"message":"push failed"}}]}}"#)
+        state.ggService = GGService(runner: runner)
+
+        await #expect(throws: GGMutationError.syncTerminalFailure(message: "push failed")) {
+            try await state.syncGGForCommitPublish()
+        }
+
+        #expect(state.ggActionState.lastError == "push failed")
+        #expect(state.ggActionState.syncHasTerminalFailure)
+        #expect(state.ggActionState.inFlightAction == nil)
     }
 
     @Test func commitPublishSyncRefusesConcurrentMutation() async throws {

--- a/AlasTests/ShortcutBindingTests.swift
+++ b/AlasTests/ShortcutBindingTests.swift
@@ -71,4 +71,13 @@ struct ShortcutBindingTests {
 
         #expect(base.togglingShift() == .init(key: "j", modifiers: [.command]))
     }
+
+    @Test func keyboardShortcutConvertsToBinding() throws {
+        let shortcut = KeyboardShortcut(.return, modifiers: [.command, .shift])
+
+        #expect(try #require(ShortcutBinding(keyboardShortcut: shortcut)) == .init(
+            key: "return",
+            modifiers: [.shift, .command]
+        ))
+    }
 }

--- a/AlasTests/ShortcutBindingTests.swift
+++ b/AlasTests/ShortcutBindingTests.swift
@@ -80,4 +80,12 @@ struct ShortcutBindingTests {
             modifiers: [.shift, .command]
         ))
     }
+
+    @Test func keyboardShortcutConversionPreservesUppercaseLiteralKey() throws {
+        let shortcut = KeyboardShortcut("P", modifiers: [.command])
+        let binding = try #require(ShortcutBinding(keyboardShortcut: shortcut))
+
+        #expect(binding == .init(key: "P", modifiers: [.command]))
+        #expect(binding.asKeyboardShortcut() == shortcut)
+    }
 }

--- a/AlasTests/ShortcutBindingTests.swift
+++ b/AlasTests/ShortcutBindingTests.swift
@@ -59,4 +59,16 @@ struct ShortcutBindingTests {
         #expect(ShortcutBinding(key: "f13", modifiers: [.command]).asKeyboardShortcut() == nil)
         #expect(ShortcutBinding(key: "🙂", modifiers: [.command]).asKeyboardShortcut() == nil)
     }
+
+    @Test func shiftVariantAddsShift() {
+        let base = ShortcutBinding(key: "return", modifiers: [.command])
+
+        #expect(base.togglingShift() == .init(key: "return", modifiers: [.command, .shift]))
+    }
+
+    @Test func shiftVariantRemovesExistingShift() {
+        let base = ShortcutBinding(key: "j", modifiers: [.command, .shift])
+
+        #expect(base.togglingShift() == .init(key: "j", modifiers: [.command]))
+    }
 }

--- a/docs/superpowers/plans/2026-09-06-commit-and-publish.md
+++ b/docs/superpowers/plans/2026-09-06-commit-and-publish.md
@@ -1,0 +1,952 @@
+# Commit and Publish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a recoverable commit-and-publish action that pushes and creates or updates a review request for normal Git branches and runs `gg sync` for active GG stacks.
+
+**Architecture:** Persist the user's preferred commit action and any post-commit recovery checkpoint in `DraftCommitTabState`. A testable `CommitPublishWorkflow` sequences injected commit, push, provider, and GG operations, while the existing views only select intent, render progress, and persist workflow transitions. Existing `ReviewLoopState` and `GGMutationCoordinator` remain the owners of provider and GG behavior.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Observation, Swift Testing, XcodeGen, existing `GitService`, code-host providers, and GG integration.
+
+---
+
+## File map
+
+**Create:**
+
+- `Alas/Sources/Center/Commit/CommitPublishModels.swift` owns Codable intent,
+  target, checkpoint, phase, availability, and presentation values.
+- `Alas/Sources/Center/Commit/CommitPublishWorkflow.swift` owns the injected
+  operations and resumable phase sequence.
+- `AlasTests/Center/CommitPublishModelsTests.swift` covers model compatibility,
+  labels, enablement, and shortcut-independent presentation rules.
+- `AlasTests/Center/CommitPublishWorkflowTests.swift` covers operation order,
+  checkpoints, deduplication, and retry safety.
+
+**Modify:**
+
+- `Alas/Sources/Center/Tab.swift` persists the new draft fields with tolerant
+  decoding.
+- `Alas/Sources/Center/TabsManager.swift` accepts and updates the preferred
+  action for live and stashed drafts.
+- `Alas/Sources/Shortcuts/ShortcutBinding.swift` adds the pure Shift-variant
+  helper.
+- `Alas/Sources/Center/Commit/CommitPrimaryAction.swift` defines stable
+  leading/trailing composer action placement.
+- `Alas/Sources/Center/Commit/CommitMessageEditorView.swift` renders an optional
+  alternate action and assigns emphasis and shortcuts.
+- `Alas/Sources/Right/ChangesPreparationModel.swift` models normal publish and
+  GG commit-and-sync destinations.
+- `Alas/Sources/Right/ChangesPreparationCard.swift` renders the normal action
+  pair and the GG two-column grid.
+- `Alas/Sources/Right/ChangesTabView.swift` derives publish availability and
+  routes the selected intent into `TabsManager`.
+- `Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift` exposes a fresh,
+  targeted review-request lookup for duplicate prevention.
+- `Alas/Sources/Git/GitService+ReviewLoop.swift` probes the checkpointed remote
+  branch for the exact commit before push and provides a strict HEAD
+  publication probe for Amend safety.
+- `Alas/Sources/Right/RightPaneState.swift` exposes an awaitable GG sync method
+  that preserves existing action state and error reporting.
+- `Alas/Sources/Center/Commit/DraftCommitTabView.swift` wires live operations,
+  progress, persistence, retry, and completion into the composer.
+- `AlasTests/DraftCommitTabStateTests.swift` and
+  `AlasTests/DraftCommitTabsManagerTests.swift` cover persisted compatibility
+  and intent routing.
+- `AlasTests/ShortcutBindingTests.swift` covers Shift toggling.
+- `AlasTests/Right/ChangesPreparationModelTests.swift` and
+  `AlasTests/ChangesTabViewTests.swift` cover action construction and preflight
+  presentation.
+- `AlasTests/Integrations/ReviewLoopStateTests.swift` covers targeted fresh
+  lookup.
+- `AlasTests/GitServiceUpstreamTests.swift` covers strict publication state and
+  exact remote-branch containment.
+- `AlasTests/RightPaneGGStackTests.swift` covers awaited sync success and
+  failure.
+- `Alas.xcodeproj/project.pbxproj` is regenerated after adding source and test
+  files.
+
+## Task 1: Persist intent and recovery models
+
+**Files:**
+
+- Create: `Alas/Sources/Center/Commit/CommitPublishModels.swift`
+- Create: `AlasTests/Center/CommitPublishModelsTests.swift`
+- Modify: `Alas/Sources/Center/Tab.swift:490-530`
+- Modify: `AlasTests/DraftCommitTabStateTests.swift:1-35`
+- Modify: `Alas.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Write failing model and compatibility tests**
+
+Add tests that define the required model behavior before the types exist:
+
+```swift
+@Test func draftDefaultsToLocalCommitAndRegularReviewRequest() {
+    let state = DraftCommitTabState(worktreeId: "wt-1")
+    #expect(state.preferredAction == .commit)
+    #expect(state.createReviewRequestAsDraft == false)
+    #expect(state.publishCheckpoint == nil)
+}
+
+@Test func legacyDraftJSONDecodesNewFieldsWithDefaults() throws {
+    let data = Data(#"{"id":"draft-commit:wt-1","worktreeId":"wt-1","subject":"Subject","bodyText":"Body","amend":false}"#.utf8)
+    let state = try JSONDecoder().decode(DraftCommitTabState.self, from: data)
+    #expect(state.preferredAction == .commit)
+    #expect(state.createReviewRequestAsDraft == false)
+    #expect(state.publishCheckpoint == nil)
+}
+
+@Test func reviewCheckpointRoundTripsEveryCapturedField() throws {
+    let checkpoint = CommitPublishCheckpoint(
+        commitSHA: "abc123",
+        baseRef: "main",
+        commitTitle: "abc123 Subject",
+        subject: "Subject",
+        body: "Body",
+        destination: .review(.init(
+            provider: .github,
+            host: "github.com",
+            owner: "owner",
+            repository: "repo",
+            repositorySlug: "owner/repo",
+            remoteName: "origin",
+            webURL: URL(string: "https://github.com/owner/repo")!,
+            branch: "feature",
+            upstreamBranch: nil,
+            headOwner: nil,
+            baseBranch: "main",
+            reviewRequestExisted: false,
+            createAsDraft: true
+        )),
+        nextPhase: .push
+    )
+    let data = try JSONEncoder().encode(checkpoint)
+    #expect(try JSONDecoder().decode(CommitPublishCheckpoint.self, from: data) == checkpoint)
+}
+```
+
+Also cover the GG destination and every `CommitPublishPhase` value.
+
+- [ ] **Step 2: Regenerate the project and verify the tests fail**
+
+Run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DraftCommitTabStateTests -only-testing:AlasTests/CommitPublishModelsTests test
+```
+
+Expected: compilation fails because the new model types and draft properties do
+not exist.
+
+- [ ] **Step 3: Add the minimal Codable models**
+
+Define the persisted values in `CommitPublishModels.swift`:
+
+```swift
+enum DraftCommitPreferredAction: String, Codable, Equatable, Sendable {
+    case commit
+    case publish
+}
+
+enum CommitPublishPhase: String, Codable, Equatable, Sendable {
+    case push
+    case createReviewRequest
+    case sync
+}
+
+struct CommitPublishReviewTarget: Codable, Equatable, Sendable {
+    let provider: CodeHostKind
+    let host: String
+    let owner: String
+    let repository: String
+    let repositorySlug: String
+    let remoteName: String
+    let webURL: URL
+    let branch: String
+    let upstreamBranch: String?
+    let headOwner: String?
+    let baseBranch: String
+    let reviewRequestExisted: Bool
+    let createAsDraft: Bool
+}
+
+enum CommitPublishDestination: Codable, Equatable, Sendable {
+    case review(CommitPublishReviewTarget)
+    case gg
+}
+
+struct CommitPublishCheckpoint: Codable, Equatable, Sendable {
+    let commitSHA: String
+    let baseRef: String
+    let commitTitle: String
+    let subject: String
+    let body: String
+    let destination: CommitPublishDestination
+    var nextPhase: CommitPublishPhase
+}
+```
+
+Give `CommitPublishReviewTarget` a computed `remote` that reconstructs the exact
+captured `CodeHostRemote`. This makes retry independent of the current review
+snapshot and preserves self-hosted host and web URL identity across relaunch.
+
+Add non-optional `preferredAction`, `createReviewRequestAsDraft`, and optional
+`publishCheckpoint` fields to `DraftCommitTabState`. Implement explicit
+`CodingKeys` and `init(from:)` so missing keys decode to `.commit`, `false`, and
+`nil`. Keep encoded field names stable and keep `presentationRevision`
+backward-compatible.
+
+- [ ] **Step 4: Run the focused tests and confirm they pass**
+
+Run the focused `xcodebuild` command from Step 2.
+
+Expected: both suites pass.
+
+- [ ] **Step 5: Commit the persisted model**
+
+```bash
+rtk git add Alas/Sources/Center/Commit/CommitPublishModels.swift Alas/Sources/Center/Tab.swift AlasTests/Center/CommitPublishModelsTests.swift AlasTests/DraftCommitTabStateTests.swift Alas.xcodeproj/project.pbxproj
+rtk git commit -m "feat(commit): persist publish workflow state"
+```
+
+## Task 2: Route Prepare intent through TabsManager
+
+**Files:**
+
+- Modify: `Alas/Sources/Center/TabsManager.swift:970-1015`
+- Modify: `AlasTests/DraftCommitTabsManagerTests.swift:1-205`
+
+- [ ] **Step 1: Write failing live, new, and stashed intent tests**
+
+Add tests for these cases:
+
+```swift
+@Test func openDraftWithPublishIntentCreatesPublishFirstDraft() {
+    let worktreeID = "publish-intent-new"
+    defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeID)) }
+    let manager = TabsManager()
+    let tab = manager.openOrFocusDraftCommit(
+        worktreeId: worktreeID,
+        preferredAction: .publish
+    )
+    guard case .draftCommit(let state) = tab else {
+        Issue.record("Expected draft commit")
+        return
+    }
+    #expect(state.preferredAction == .publish)
+}
+```
+
+Add `changingIntentPreservesLiveDraftContents` by creating a draft, populating
+subject, body, Draft PR, Amend, selection, and checkpoint through
+`updateDraftCommit`, then reopening with `.publish`. Assert that only
+`preferredAction` changes when `resetAmend` is false. Keep the draft selected
+throughout this case and assert the manager's live tab state changes in place;
+this covers switching intent from Prepare while the composer is already
+visible. Add the same test after closing the populated draft to exercise
+stashed state, then assert the stored stash also contains `.publish`.
+
+Add a checkpoint-only close test by clearing subject and body after installing
+a checkpoint, closing the tab, and asserting `stashedDraft` retains that
+checkpoint. This protects recovery against future model changes.
+
+- [ ] **Step 2: Run the manager suite and verify failure**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DraftCommitTabsManagerTests test
+```
+
+Expected: compilation fails because `preferredAction` is not accepted by
+`openOrFocusDraftCommit`, then the checkpoint-only stash assertion fails.
+
+- [ ] **Step 3: Implement intent updates without clearing draft data**
+
+Change the API to:
+
+```swift
+func openOrFocusDraftCommit(
+    worktreeId: String,
+    resetAmend: Bool = false,
+    preferredAction: DraftCommitPreferredAction? = nil
+) -> Tab
+```
+
+Apply a non-nil preference to new, live, and stashed state before focusing or
+appending the tab. Preserve all other fields. Update `captureDraftIfNeeded` so
+`publishCheckpoint != nil` also qualifies the draft for stashing.
+
+- [ ] **Step 4: Run the manager suite and confirm it passes**
+
+Run the command from Step 2.
+
+Expected: all `DraftCommitTabsManagerTests` pass.
+
+- [ ] **Step 5: Commit intent routing**
+
+```bash
+rtk git add Alas/Sources/Center/TabsManager.swift AlasTests/DraftCommitTabsManagerTests.swift
+rtk git commit -m "feat(commit): route draft publish intent"
+```
+
+## Task 3: Add paired composer actions and Shift shortcuts
+
+**Files:**
+
+- Modify: `Alas/Sources/Shortcuts/ShortcutBinding.swift:1-85`
+- Modify: `Alas/Sources/Center/Commit/CommitPrimaryAction.swift:1-40`
+- Modify: `Alas/Sources/Center/Commit/CommitMessageEditorView.swift:1-125`
+- Modify: `AlasTests/ShortcutBindingTests.swift:1-70`
+- Modify: `AlasTests/Center/CommitPublishModelsTests.swift`
+
+- [ ] **Step 1: Write failing Shift-variant and action-assignment tests**
+
+```swift
+@Test func shiftVariantAddsShift() {
+    let base = ShortcutBinding(key: "return", modifiers: [.command])
+    #expect(base.togglingShift() == .init(key: "return", modifiers: [.command, .shift]))
+}
+
+@Test func shiftVariantRemovesExistingShift() {
+    let base = ShortcutBinding(key: "j", modifiers: [.command, .shift])
+    #expect(base.togglingShift() == .init(key: "j", modifiers: [.command]))
+}
+
+@Test func preferredTrailingActionReceivesBaseShortcut() {
+    let pair = CommitComposerActionPair.shortcuts(
+        preferred: .trailing,
+        base: .init(key: "return", modifiers: [.command])
+    )
+    #expect(pair.leading == .init(key: "return", modifiers: [.command, .shift]))
+    #expect(pair.trailing == .init(key: "return", modifiers: [.command]))
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify failure**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ShortcutBindingTests -only-testing:AlasTests/CommitPublishModelsTests test
+```
+
+Expected: compilation fails on `togglingShift` and the paired-action helper.
+
+- [ ] **Step 3: Implement pure shortcut assignment**
+
+Add `ShortcutBinding.togglingShift()`, preserving modifier order after toggling.
+Add a small `CommitComposerActionPosition` and pure shortcut-assignment helper
+beside `CommitPrimaryAction`. Do not add a new `ShortcutAction` setting.
+
+- [ ] **Step 4: Render the optional alternate action**
+
+Extend `CommitMessageEditorView` with optional `alternateAction` and
+`preferredActionPosition`, defaulting to the current single leading action.
+Render buttons in stable leading/trailing order. The preferred button uses the
+accent fill and base shortcut; the other button uses the Shift variant and a
+subtle fill. Both display their actual shortcut badges. Keep the existing
+saved-state behavior for single-action callers.
+
+Extract one `actionButton` builder so enabled, busy, accessibility, and badge
+behavior cannot drift between the two buttons.
+
+- [ ] **Step 5: Run focused tests and a compile check**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ShortcutBindingTests -only-testing:AlasTests/CommitPublishModelsTests test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: tests and build pass; existing call sites compile unchanged.
+
+- [ ] **Step 6: Commit paired composer actions**
+
+```bash
+rtk git add Alas/Sources/Shortcuts/ShortcutBinding.swift Alas/Sources/Center/Commit/CommitPrimaryAction.swift Alas/Sources/Center/Commit/CommitMessageEditorView.swift AlasTests/ShortcutBindingTests.swift AlasTests/Center/CommitPublishModelsTests.swift
+rtk git commit -m "feat(commit): add paired composer actions"
+```
+
+## Task 4: Add Prepare publish destinations
+
+**Files:**
+
+- Modify: `Alas/Sources/Center/Commit/CommitPublishModels.swift`
+- Modify: `Alas/Sources/Right/ChangesPreparationModel.swift:1-390`
+- Modify: `Alas/Sources/Right/ChangesPreparationCard.swift:35-430`
+- Modify: `Alas/Sources/Right/ChangesTabView.swift:10-210,260-290,660-715`
+- Modify: `AlasTests/Center/CommitPublishModelsTests.swift`
+- Modify: `AlasTests/Right/ChangesPreparationModelTests.swift`
+- Modify: `AlasTests/ChangesTabViewTests.swift`
+
+- [ ] **Step 1: Write failing publish-availability tests**
+
+Define a pure availability resolver and test supported-host states:
+
+```swift
+@Test func noRequestOffersCommitAndPR() {
+    let availability = CommitPublishAvailability.review(snapshot: snapshot(reviewRequest: nil))
+    #expect(availability?.label == "Commit & PR")
+    #expect(availability?.disabledReason == nil)
+    #expect(availability?.showsDraftToggle == true)
+}
+
+@Test func existingRequestOffersCommitAndPush() {
+    let availability = CommitPublishAvailability.review(snapshot: snapshot(reviewRequest: request))
+    #expect(availability?.label == "Commit & push")
+    #expect(availability?.showsDraftToggle == false)
+}
+
+@Test func unsupportedHostHidesPublishDestination() {
+    #expect(CommitPublishAvailability.review(snapshot: unsupportedSnapshot) == nil)
+}
+```
+
+Cover loading, unavailable CLI, authentication, create capability, base branch,
+stale/diverged upstream, and published Amend. Model Amend publication as an
+explicit probe state: loading, not published (including no upstream), published,
+or failed. Publish stays disabled unless the probe resolved to not published.
+The existing warning can render from the same state.
+
+- [ ] **Step 2: Write failing preparation-model tests**
+
+Update the normal model expectation to contain Draft commit plus the supplied
+publish destination. Update GG expectations to:
+
+```swift
+#expect(model.ggActions.map(\.kind) == [
+    .newStackCommit, .commitAndSync, .amendCurrent, .absorbIntoStack,
+])
+```
+
+Test that Commit & sync shares New stack commit's staged/draft and stack-head
+requirements, plus the common GG mutation blocker. Test that a combined
+destination suppresses a redundant compact Push or Create PR action while
+leaving unrelated review actions intact.
+
+- [ ] **Step 3: Run model tests and verify failure**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CommitPublishModelsTests -only-testing:AlasTests/ChangesPreparationModelTests -only-testing:AlasTests/ChangesTabViewTests test
+```
+
+Expected: compilation or assertions fail because publish availability and the
+fourth GG action are missing.
+
+- [ ] **Step 4: Implement availability and model construction**
+
+Add `CommitPublishAvailability` with `label`, `detail`, `disabledReason`, and
+`showsDraftToggle`. Build normal availability from `ReviewLoopSnapshot?`,
+refresh state, current branch/base, conflicting action, Amend, and the supported
+remote. Build GG availability from the existing GG context, stack-head, paused,
+in-flight, and merge-operation values.
+
+When Amend is selected, start a strict asynchronous HEAD publication probe.
+Keep publish disabled while it is loading or failed, and report the failure in
+help text. A published result disables publish but leaves local Commit enabled.
+The eventual workflow preflight repeats the strict probe to close the race
+between rendering and invocation.
+
+Extend `ChangesPreparationModel` with an optional publish draft action and add
+`.commitAndSync` to `GGChangesPreparationAction`. Keep current Draft, Amend, and
+Absorb behavior unchanged.
+
+- [ ] **Step 5: Render the normal pair and GG grid**
+
+Render Draft commit and the normal publish action in the existing
+`ViewThatFits` path. For GG, replace the one-row `HStack` with a two-column
+`LazyVGrid` or `Grid` using stable equal-width tracks and the approved order.
+Use existing `secondaryButton` and `ggDestinationButton` styles. Add distinct
+accessibility identifiers:
+
+```text
+changes-preparation-draft
+changes-preparation-publish
+changes-preparation-gg-new
+changes-preparation-gg-sync
+changes-preparation-gg-amend
+changes-preparation-gg-absorb
+```
+
+- [ ] **Step 6: Route both entry intents**
+
+Change `openDraftTab` and `handleGGPreparationAction` so Draft/New stack commit
+passes `.commit`, while Commit & PR/Push/Sync passes `.publish`. Keep
+`resetAmend: true` for both GG first-row actions.
+
+- [ ] **Step 7: Run focused tests and build**
+
+Run the command from Step 3, then:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: focused tests and build pass.
+
+- [ ] **Step 8: Commit Prepare destinations**
+
+```bash
+rtk git add Alas/Sources/Center/Commit/CommitPublishModels.swift Alas/Sources/Right/ChangesPreparationModel.swift Alas/Sources/Right/ChangesPreparationCard.swift Alas/Sources/Right/ChangesTabView.swift AlasTests/Center/CommitPublishModelsTests.swift AlasTests/Right/ChangesPreparationModelTests.swift AlasTests/ChangesTabViewTests.swift
+rtk git commit -m "feat(changes): add commit publish destinations"
+```
+
+## Task 5: Build the resumable workflow engine
+
+**Files:**
+
+- Create: `Alas/Sources/Center/Commit/CommitPublishWorkflow.swift`
+- Create: `AlasTests/Center/CommitPublishWorkflowTests.swift`
+- Modify: `Alas.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Write failing happy-path sequence tests**
+
+Use a closure-backed spy that records calls. Cover these exact sequences:
+
+```swift
+#expect(spy.calls == ["commit", "head", "remoteContainsCommit", "push", "lookupPR", "createPR"])
+#expect(checkpoints.map(\.nextPhase) == [.push, .createReviewRequest])
+```
+
+For an existing review request, expect commit, HEAD verification, push probe,
+push, and completion with no create call. For GG, expect commit, HEAD
+verification, sync, and completion.
+
+- [ ] **Step 2: Write failing recovery tests**
+
+Cover each boundary:
+
+- commit failure emits no checkpoint;
+- push failure leaves `.push`;
+- successful push followed by lookup failure leaves `.createReviewRequest`;
+- create failure leaves `.createReviewRequest`;
+- sync failure leaves `.sync`;
+- resume never invokes commit;
+- HEAD mismatch invokes no network or GG operation;
+- remote branch containment of the checkpointed SHA skips push, including when
+  the original branch had no upstream;
+- an existing request from fresh lookup skips create;
+- checkpoint completion is cleared before a best-effort refresh callback.
+
+- [ ] **Step 3: Regenerate and run the tests to verify failure**
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CommitPublishWorkflowTests test
+```
+
+Expected: compilation fails because `CommitPublishWorkflow` and its operations
+do not exist.
+
+- [ ] **Step 4: Implement injected operations and activity state**
+
+Use a main-actor closure bundle so tests do not require real repositories or
+providers:
+
+```swift
+@MainActor
+struct CommitPublishOperations {
+    var createCommit: (_ subject: String, _ body: String, _ amend: Bool) async throws -> CommitPublishCreatedCommit
+    var currentHeadSHA: () async throws -> String
+    var remoteBranchContainsCommit: (_ target: CommitPublishReviewTarget, _ commitSHA: String) async throws -> Bool
+    var push: (_ target: CommitPublishReviewTarget, _ commitSHA: String) async throws -> Void
+    var currentReviewRequestExists: (_ target: CommitPublishReviewTarget) async throws -> Bool
+    var createReviewRequest: (_ target: CommitPublishReviewTarget, _ subject: String, _ body: String) async throws -> URL
+    var syncGG: () async throws -> Void
+    var refreshAfterCompletion: () async -> Void
+}
+
+enum CommitPublishActivity: Equatable {
+    case idle, committing, pushing, creatingReviewRequest, syncing
+}
+```
+
+`CommitPublishCreatedCommit` contains SHA, comparison base, and commit-editor
+title. `CommitPublishWorkflow.start` creates and checkpoints the commit, then
+calls `resume`. `resume` validates HEAD and advances one persisted phase at a
+time through a checkpoint callback. Clear the checkpoint before the final
+best-effort refresh callback.
+
+- [ ] **Step 5: Run workflow tests and confirm they pass**
+
+Run the command from Step 3.
+
+Expected: all workflow sequence and recovery tests pass.
+
+- [ ] **Step 6: Commit the workflow engine**
+
+```bash
+rtk git add Alas/Sources/Center/Commit/CommitPublishWorkflow.swift AlasTests/Center/CommitPublishWorkflowTests.swift Alas.xcodeproj/project.pbxproj
+rtk git commit -m "feat(commit): add resumable publish workflow"
+```
+
+## Task 6: Add strict Git, provider, and GG operations
+
+**Files:**
+
+- Modify: `Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift:320-365`
+- Modify: `Alas/Sources/Git/GitService+ReviewLoop.swift:1-80`
+- Modify: `Alas/Sources/Right/RightPaneState.swift:1360-1415,1840-1910`
+- Modify: `AlasTests/Integrations/ReviewLoopStateTests.swift:340-560,1208-1335`
+- Modify: `AlasTests/GitServiceUpstreamTests.swift:1-70`
+- Modify: `AlasTests/RightPaneGGStackTests.swift`
+
+- [ ] **Step 1: Write a failing fresh review-request lookup test**
+
+Add a test where the captured snapshot has no request, the fake provider now
+has one, and the new lookup returns it using the captured branch, head owner,
+base, and remote. Add provider-error propagation coverage.
+
+The intended API is:
+
+```swift
+func currentReviewRequest(
+    remote: CodeHostRemote,
+    branch: String,
+    headOwner: String?,
+    baseBranch: String
+) async throws -> ReviewRequest?
+
+func createReviewRequest(
+    remote: CodeHostRemote,
+    branch: String,
+    headOwner: String?,
+    baseBranch: String,
+    title: String,
+    body: String,
+    draft: Bool
+) async throws -> URL
+```
+
+- [ ] **Step 2: Run the review-loop tests and verify failure**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ReviewLoopStateTests test
+```
+
+Expected: compilation fails because the targeted lookup is missing.
+
+- [ ] **Step 3: Implement provider lookup through the existing registry**
+
+Resolve the provider from the explicit remote, call its existing
+`currentReviewRequest` API with the explicit branch, head owner, and base, and
+return the result. Do not fetch checks; the workflow only needs existence for
+deduplication. Refactor `createReviewRequest` through the same explicit-remote
+path, pass the explicit head owner to the provider, and preserve a
+snapshot-taking overload for existing callers. Reuse the current
+unsupported-provider error behavior and return the created request URL.
+Workflow lookup and creation must reconstruct the remote from
+`CommitPublishReviewTarget`; neither may substitute the current review
+snapshot's remote identity.
+
+- [ ] **Step 4: Write failing exact-remote and strict-Amend Git tests**
+
+Extend `GitServiceUpstreamTests` with local and bare repositories. Cover:
+
+- a missing remote branch does not contain the checkpointed SHA;
+- a newly pushed branch contains it even when no upstream existed before push;
+- a remote branch advanced beyond the SHA still contains its ancestor;
+- an unrelated remote tip does not contain it;
+- transport or fetch failure throws instead of being treated as absent;
+- strict HEAD publication returns no-upstream, unpublished, and published
+  states, and throws on an actual ancestry-probe failure.
+
+Implement `remoteBranchContainsCommit` by first running `ls-remote --exit-code
+--heads <remote> refs/heads/<branch>`. Treat its documented no-match status as
+`false` and propagate every other nonzero result. Fetch the exact advertised
+branch into a UUID-scoped temporary ref under `refs/alas/publish-check/`, check
+`merge-base --is-ancestor <checkpoint-sha> <temporary-ref>`, and delete only
+that temporary ref in `defer`. Propagate transport, fetch, and ancestry-probe
+errors. Never rely only on `@{u}` or `ls-remote` tip equality.
+
+Add a strict `headPublicationState` helper and let the existing
+`isHeadAtOrBehindUpstream` warning helper adapt it to Bool for current callers.
+The strict API must distinguish no upstream from command failure.
+
+- [ ] **Step 5: Run Git and review-loop tests**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitServiceUpstreamTests -only-testing:AlasTests/ReviewLoopStateTests test
+```
+
+Expected: exact remote containment, strict publication state, and provider
+lookup tests pass.
+
+- [ ] **Step 6: Write failing awaited GG sync tests**
+
+Using `RightPaneState.ggService` with existing fake runners, assert that:
+
+- the new async method does not return before sync finishes;
+- success preserves normal progress/summary and refresh behavior;
+- failure throws to the caller and also updates `ggActionState` once;
+- concurrent mutation refusal throws `GGMutationError.operationInFlight`.
+
+- [ ] **Step 7: Implement one shared awaited GG mutation path**
+
+Extract the body currently duplicated by the two `runGGMutation` overloads into
+an async throwing helper that starts the coordinator operation, applies sync
+refresh deferral, awaits `operation.value`, publishes existing presentation
+errors, and schedules deferred refresh in `defer`.
+
+Keep existing fire-and-forget callers by wrapping the helper in `Task`. Add:
+
+```swift
+@MainActor
+func syncGGForCommitPublish() async throws {
+    try await performGGMutation(.sync)
+}
+```
+
+Do not create a second `GGService.sync` call path.
+
+- [ ] **Step 8: Run provider and GG tests**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitServiceUpstreamTests -only-testing:AlasTests/ReviewLoopStateTests -only-testing:AlasTests/RightPaneGGStackTests test
+```
+
+Expected: both suites pass.
+
+- [ ] **Step 9: Commit live operation support**
+
+```bash
+rtk git add Alas/Sources/Git/GitService+ReviewLoop.swift Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift Alas/Sources/Right/RightPaneState.swift AlasTests/GitServiceUpstreamTests.swift AlasTests/Integrations/ReviewLoopStateTests.swift AlasTests/RightPaneGGStackTests.swift
+rtk git commit -m "feat(commit): expose publish operation adapters"
+```
+
+## Task 7: Wire publishing into DraftCommitTabView
+
+**Files:**
+
+- Modify: `Alas/Sources/Center/Commit/DraftCommitTabView.swift:1-465`
+- Modify: `Alas/Sources/Center/Commit/CommitPublishWorkflow.swift`
+- Modify: `AlasTests/Center/CommitPublishWorkflowTests.swift`
+
+- [ ] **Step 1: Add failing live-operation adapter tests**
+
+Extend the workflow tests with a small adapter harness and verify:
+
+- push arguments match `RightPaneState.reviewLoopPushArguments`, including
+  upstream branch and `-u` fallback behavior;
+- the exact-remote containment probe uses the checkpointed remote and branch,
+  including a branch that had no upstream at preflight;
+- push errors use `RightPaneState.reviewLoopPushFailureMessage`;
+- provider lookup and creation use the checkpointed remote, host,
+  branch/base/head-owner values even if the live snapshot changes;
+- commit creation computes the same parent or empty-tree comparison base as the
+  current `runCommit` implementation;
+- completion refresh is best-effort and happens after checkpoint clear.
+
+Keep shell processes behind injected closures in these tests.
+
+- [ ] **Step 2: Run workflow tests and verify failure**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CommitPublishWorkflowTests test
+```
+
+Expected: the new adapter assertions fail until the live closure construction
+is extracted from the view.
+
+- [ ] **Step 3: Hydrate and persist the new draft fields**
+
+Add view state for Draft PR, checkpoint, and current activity, and hydrate those
+values from `tabState`. Do not copy `preferredAction` into one-time view state.
+Derive action emphasis directly from the current `tabState.preferredAction` so
+reopening an already-visible draft from Prepare updates the default action
+immediately. Extend the existing `persist` helper so mutable draft changes write
+through `TabsManager.updateDraftCommit`. When a checkpoint exists, disable
+subject, body, Amend, Draft PR, AI generation, staging mutations, and the
+alternate local-commit action.
+
+- [ ] **Step 4: Build the contextual action pair**
+
+Read normal review state and GG context from the active `RightPaneState`, using
+the same pure availability resolver as Prepare. Build:
+
+- Commit as the stable leading action;
+- Commit & PR, Commit & push, or Commit & sync as the trailing action;
+- Retry push, Retry create PR, or Retry sync when a checkpoint exists;
+- the preferred position directly from the current persisted tab intent, except
+  recovery always makes the retry action preferred;
+- an accessory `HStack` containing Draft PR when applicable and the existing
+  Amend checkbox.
+
+Pass the configured `commitInComposer` shortcut as the base. The shared editor
+assigns its Shift variant.
+
+- [ ] **Step 5: Replace direct publish sequencing with the workflow**
+
+Keep commit-only behavior and its immediate draft-to-editor replacement intact.
+For publish:
+
+1. Build and validate an immutable review or GG destination before commit.
+2. Build `CommitPublishOperations` from the existing `GitService`, active
+   `ReviewLoopState`, and `RightPaneState.syncGGForCommitPublish`.
+3. Call `CommitPublishWorkflow.start` when there is no checkpoint or `resume`
+   when one exists.
+4. Persist every checkpoint callback immediately.
+5. Update the button label from activity and publish inline errors on failure.
+6. On success, replace the draft with the commit editor and refresh Amend state.
+
+The push phase first calls `git.remoteBranchContainsCommit` with the
+checkpointed remote, branch, and SHA. A true result advances without pushing.
+Otherwise run the existing push arguments. The PR phase always calls the new
+fresh lookup against the checkpoint's reconstructed remote before create. Use
+the exact trimmed commit subject and body and the checkpointed Draft PR value.
+
+Before creating or amending the commit for a publish action, repeat the strict
+`headPublicationState` check when Amend is selected. Abort before commit unless
+it resolves to not published (which includes no upstream). Do not trust the
+earlier UI probe.
+
+- [ ] **Step 6: Guard recovery against branch movement**
+
+On resume, let the workflow compare `git rev-parse HEAD` with checkpoint SHA.
+Render a specific inline error when they differ and leave the checkpoint intact.
+Do not move HEAD, recommit, or start a remote operation.
+
+- [ ] **Step 7: Run focused tests and build**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CommitPublishWorkflowTests -only-testing:AlasTests/DraftCommitTabStateTests -only-testing:AlasTests/DraftCommitTabsManagerTests test
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: focused tests and the app build pass.
+
+- [ ] **Step 8: Commit composer integration**
+
+```bash
+rtk git add Alas/Sources/Center/Commit/DraftCommitTabView.swift Alas/Sources/Center/Commit/CommitPublishWorkflow.swift AlasTests/Center/CommitPublishWorkflowTests.swift
+rtk git commit -m "feat(commit): wire commit and publish workflow"
+```
+
+## Task 8: Close presentation and recovery gaps
+
+**Files:**
+
+- Modify: `Alas/Sources/Center/Commit/CommitPublishModels.swift`
+- Modify: `Alas/Sources/Center/Commit/DraftCommitTabView.swift`
+- Modify: `Alas/Sources/Right/ChangesPreparationCard.swift`
+- Modify: `AlasTests/Center/CommitPublishModelsTests.swift`
+- Modify: `AlasTests/Center/CommitPublishWorkflowTests.swift`
+- Modify: `AlasTests/Right/ChangesPreparationModelTests.swift`
+
+- [ ] **Step 1: Add failing edge-case presentation tests**
+
+Cover exact labels and control rules for:
+
+- Commit selected versus publish selected;
+- normal PR, existing PR, GG, and all retry phases;
+- empty body still allowing publication;
+- empty subject and no staged changes disabling initial actions;
+- checkpoint recovery remaining enabled without staged changes;
+- Draft PR persisting when Commit is preferred;
+- published Amend disabling publish but not Commit;
+- busy state disabling both actions;
+- unsupported host hiding publish while a supported blocked host shows it
+  disabled with a reason.
+
+- [ ] **Step 2: Run focused tests and verify failures**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CommitPublishModelsTests -only-testing:AlasTests/CommitPublishWorkflowTests -only-testing:AlasTests/ChangesPreparationModelTests test
+```
+
+Expected: any missing labels or enablement rules fail explicitly.
+
+- [ ] **Step 3: Centralize labels and enablement in pure presentation values**
+
+Move remaining conditional strings and button-enable decisions out of the
+SwiftUI body into `CommitPublishModels.swift`. Views should render the returned
+values rather than independently infer recovery or availability.
+
+Add help text and stable accessibility identifiers to the composer buttons and
+Draft PR toggle. Use provider terminology already exposed by
+`CodeHostKind.reviewRequestLabel` where the existing UI requires PR versus MR
+wording; keep the approved GitHub labels unchanged.
+
+- [ ] **Step 4: Run focused tests and build**
+
+Run the command from Step 2, then:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: focused tests and build pass.
+
+- [ ] **Step 5: Commit presentation hardening**
+
+```bash
+rtk git add Alas/Sources/Center/Commit/CommitPublishModels.swift Alas/Sources/Center/Commit/DraftCommitTabView.swift Alas/Sources/Right/ChangesPreparationCard.swift AlasTests/Center/CommitPublishModelsTests.swift AlasTests/Center/CommitPublishWorkflowTests.swift AlasTests/Right/ChangesPreparationModelTests.swift
+rtk git commit -m "test(commit): cover publish recovery states"
+```
+
+## Task 9: Regenerate and verify the complete change
+
+**Files:**
+
+- Modify: `Alas.xcodeproj/project.pbxproj` if XcodeGen output changed
+
+- [ ] **Step 1: Regenerate the Xcode project**
+
+```bash
+rtk xcodegen
+rtk git diff --exit-code project.yml
+```
+
+Expected: `project.yml` is unchanged; `Alas.xcodeproj/project.pbxproj` contains
+all new source and test files.
+
+- [ ] **Step 2: Run all focused suites together**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' \
+  -only-testing:AlasTests/CommitPublishModelsTests \
+  -only-testing:AlasTests/CommitPublishWorkflowTests \
+  -only-testing:AlasTests/DraftCommitTabStateTests \
+  -only-testing:AlasTests/DraftCommitTabsManagerTests \
+  -only-testing:AlasTests/ShortcutBindingTests \
+  -only-testing:AlasTests/ChangesPreparationModelTests \
+  -only-testing:AlasTests/ChangesTabViewTests \
+  -only-testing:AlasTests/ReviewLoopStateTests \
+  -only-testing:AlasTests/GitServiceUpstreamTests \
+  -only-testing:AlasTests/RightPaneGGStackTests test
+```
+
+Expected: all focused suites pass with zero failures.
+
+- [ ] **Step 3: Run the required clean build**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: all tests pass with zero failures.
+
+- [ ] **Step 5: Inspect final scope and formatting**
+
+```bash
+rtk git diff --check
+rtk git status --short
+rtk git diff --stat e92aafb3..HEAD
+```
+
+Expected: no whitespace errors, no unrelated files, and only the planned source,
+test, generated project, spec, and plan changes.
+
+- [ ] **Step 6: Commit final generated-project changes if needed**
+
+If Step 1 changed the generated project after the last feature commit:
+
+```bash
+rtk git add Alas.xcodeproj/project.pbxproj
+rtk git commit -m "chore: regenerate Xcode project"
+```

--- a/docs/superpowers/specs/2026-09-06-commit-and-publish-design.md
+++ b/docs/superpowers/specs/2026-09-06-commit-and-publish-design.md
@@ -55,12 +55,13 @@ Choosing either destination preserves any existing draft text and changes the
 preferred action on a live or stashed draft. Other ways of opening a draft use
 local commit as the default.
 
-The publish destination is disabled with a concise help reason while review
-state is loading or when preflight detects a blocker. Blockers include a missing
-supported remote, unavailable or unauthenticated provider CLI when a new review
-request is needed, selecting the base branch, a stale or diverged upstream, and
-another active operation. A repository with no supported review host does not
-show a misleading review-request action.
+For a supported review host, the publish destination is disabled with a concise
+help reason while review state is loading or when preflight detects an
+actionable blocker. Blockers include an unavailable or unauthenticated provider
+CLI when a new review request is needed, selecting the base branch, a stale or
+diverged upstream, and another active operation. A repository with no supported
+review host hides the publish destination instead of showing a review-request
+action that cannot succeed.
 
 GG mode adds **Commit & sync** beside **New stack commit**, **Amend current**,
 and **Absorb into stack**. The four GG actions use a two-column, two-row grid:

--- a/docs/superpowers/specs/2026-09-06-commit-and-publish-design.md
+++ b/docs/superpowers/specs/2026-09-06-commit-and-publish-design.md
@@ -1,0 +1,321 @@
+# Commit and Publish
+
+## Summary
+
+Add a second commit path that creates the commit and publishes it in one
+recoverable workflow. For normal Git branches, publishing pushes the branch and
+creates a pull or merge request when one does not already exist. For active GG
+stacks, publishing runs `gg sync` after the commit.
+
+The action appears in both the Changes pane's Prepare card and the draft commit
+composer. The Prepare choice sets the composer's default action. The existing
+configurable commit shortcut runs that default action, while its Shift variant
+runs the alternate action.
+
+## Goals
+
+- Add a one-click commit-and-publish path without removing the existing local
+  commit path.
+- Keep the Prepare entry point and the final composer action consistent.
+- Create a regular review request by default, with a per-draft option to create
+  it as a draft.
+- Update an existing review request by pushing without trying to create a
+  duplicate.
+- Map the same interaction to commit-and-sync in GG mode.
+- Make partial success retryable without creating a second commit, repeating a
+  successful push, or creating a duplicate review request.
+- Preserve existing draft commit state across tab closure and app relaunch.
+
+## Non-goals
+
+- Do not generate a separate review request title or description. The commit
+  subject and body are used directly.
+- Do not open the existing review request draft editor as part of this path.
+- Do not automatically open a browser or review tab after success.
+- Do not add a separate configurable shortcut for publishing.
+- Do not add automatic force-push behavior.
+- Do not change GG's review request policy or add a Draft PR override to
+  `gg sync`.
+- Do not make publish checkpoints a general-purpose background job system.
+
+## User experience
+
+### Prepare card
+
+For a normal Git branch, the Prepare card shows two destinations when a commit
+draft is available:
+
+- **Draft commit** opens or focuses the draft with local commit selected.
+- **Commit & PR** opens or focuses the draft with publishing selected when the
+  branch has no review request.
+- **Commit & push** replaces **Commit & PR** when the current branch already has
+  a review request.
+
+Choosing either destination preserves any existing draft text and changes the
+preferred action on a live or stashed draft. Other ways of opening a draft use
+local commit as the default.
+
+The publish destination is disabled with a concise help reason while review
+state is loading or when preflight detects a blocker. Blockers include a missing
+supported remote, unavailable or unauthenticated provider CLI when a new review
+request is needed, selecting the base branch, a stale or diverged upstream, and
+another active operation. A repository with no supported review host does not
+show a misleading review-request action.
+
+GG mode adds **Commit & sync** beside **New stack commit**, **Amend current**,
+and **Absorb into stack**. The four GG actions use a two-column, two-row grid:
+
+1. New stack commit
+2. Commit & sync
+3. Amend current
+4. Absorb into stack
+
+The existing Review current changes action remains above this grid. Choosing
+either action in the first row opens the same draft composer and selects the
+corresponding default. Amend and Absorb remain immediate GG mutations.
+
+### Draft commit composer
+
+The composer shows **Commit** and one contextual publish action:
+
+- **Commit & PR** when normal Git can create a new review request;
+- **Commit & push** when the branch already has one;
+- **Commit & sync** when the worktree has an active GG stack.
+
+The action selected from Prepare uses the accent treatment and the configured
+commit shortcut. The alternate action uses the Shift variant of that shortcut.
+Button order remains stable, with Commit before the publish action. If the
+configured shortcut already contains Shift, the alternate removes Shift so the
+bindings remain distinct.
+
+For a normal Git branch without an existing review request, a **Draft PR**
+checkbox appears beside the composer actions. Its value is persisted with the
+commit draft and defaults to off. It remains available even when Commit is the
+selected default because the user can invoke the alternate publish action. The
+checkbox is hidden for an existing review request and in GG mode.
+
+While the workflow runs, the selected button reports the active phase, such as
+Committing, Pushing, Creating PR, or Syncing. All mutation controls are disabled
+until that phase finishes or fails.
+
+## Shortcut behavior
+
+`commitInComposer` remains the only configurable shortcut. The composer first
+resolves its effective binding using the existing fallback behavior. The
+preferred action receives that binding. The alternate action receives the same
+key and modifiers with Shift toggled.
+
+For the default binding:
+
+- Entering through Draft commit makes `Command-Return` commit and
+  `Command-Shift-Return` publish.
+- Entering through Commit & PR, Commit & push, or Commit & sync makes
+  `Command-Return` publish and `Command-Shift-Return` commit.
+
+Single-action callers of `CommitMessageEditorView`, including commit-message
+editing and the existing review request composer, keep their current behavior.
+
+## Persisted draft state
+
+`DraftCommitTabState` gains:
+
+- a preferred action, commit or publish;
+- the Draft PR choice;
+- an optional publish checkpoint.
+
+The checkpoint records the created commit SHA, the comparison base needed by
+the eventual commit editor, the publish kind, and the next unfinished phase.
+The publish kind distinguishes normal Git review publication from GG sync. A
+normal Git checkpoint also retains the branch, remote, base branch, provider,
+review request existence, Draft PR choice, and commit message values captured
+by preflight so later UI changes cannot alter an in-progress operation.
+
+Decoding is tolerant of all fields being absent. Existing persisted drafts load
+as commit-first, regular review request, with no checkpoint.
+
+Closing a tab after the commit phase keeps the checkpoint in the stashed draft.
+Reopening the draft presents the appropriate retry action. A successfully
+completed workflow clears the checkpoint through the existing draft-to-commit
+editor replacement.
+
+## Components and ownership
+
+`ChangesPreparationModel` owns the labels, visibility, enablement, and disabled
+reasons for the new destinations. `ChangesPreparationCard` renders the normal
+pair and the GG grid. `ChangesTabView` passes the selected intent to
+`TabsManager.openOrFocusDraftCommit`.
+
+`TabsManager` persists the intent on new, live, and stashed drafts without
+clearing their subject, body, Draft PR choice, or file selection. Its existing
+reset-for-new-stack-commit behavior still clears Amend.
+
+`CommitMessageEditorView` accepts an optional alternate action. It owns only
+button presentation and shortcut assignment. Existing callers can continue to
+provide one primary action.
+
+A focused commit-publish coordinator owns preflight and phase sequencing. It
+uses `GitService` for commit and remote-state probes, the existing review loop
+and code-host provider for review request lookup and creation, and the existing
+GG mutation coordinator for sync and progress events. The SwiftUI view observes
+the coordinator and persists checkpoint changes through `TabsManager`; it does
+not run the multi-step sequence itself.
+
+GG mutation plumbing gains an awaitable result for this workflow while
+preserving the current stack progress, pause, error, undo, refresh, and
+serialization behavior used by `RightPaneState`.
+
+## Preflight
+
+Preflight runs before creating a commit. It captures the message and destination
+metadata and rejects known blockers while the draft is still fully editable.
+
+Normal Git publication requires:
+
+- a non-empty subject and staged changes;
+- a feature branch distinct from the selected base branch;
+- a supported code-host remote;
+- no stale or diverged upstream state;
+- no conflicting review action;
+- an available, authenticated provider with create capability when no review
+  request exists.
+
+GG publication requires an active GG context, a usable stack head, no paused or
+in-flight GG mutation, and no blocking Git operation.
+
+Amend receives an additional safety check. If the current HEAD is already
+reachable from the tracked upstream, the combined publish action is disabled.
+The user may still amend locally, but publishing rewritten history remains an
+explicit follow-up outside this feature. Amending an unpushed HEAD may use the
+combined action because a normal push remains fast-forward.
+
+## Normal Git workflow
+
+The coordinator performs these steps:
+
+1. Run preflight and capture its immutable publication target.
+2. Create or amend the commit with the existing `GitService.commit` operation.
+3. Persist a checkpoint containing the new SHA before starting network work.
+4. Push with upstream tracking using the same remote and branch resolution as
+   the existing review-loop Push action.
+5. Persist that push completed and refresh remote review state.
+6. If a review request now exists, skip creation. Otherwise create one with the
+   captured commit subject and body and the captured Draft PR choice.
+7. Mark publication complete, refresh right-pane review state, and replace the
+   draft with the existing commit editor.
+
+An empty commit body produces an empty review request description. Only the
+subject is required. A successful create returns its URL, but the workflow does
+not navigate away from the commit editor.
+
+When a review request existed at preflight, the sequence ends after push and
+refresh. Its UI label is Commit & push, and Draft PR has no effect.
+
+## GG workflow
+
+The coordinator performs these steps:
+
+1. Run GG preflight.
+2. Create the commit through the existing commit operation.
+3. Persist a checkpoint containing the new SHA and sync as the unfinished
+   phase.
+4. Start `gg sync` through the existing mutation coordinator and await its
+   result.
+5. Keep using the current GG sync progress presentation, conflict pause state,
+   error mapping, and stack refresh behavior.
+6. On success, clear the checkpoint and replace the draft with the existing
+   commit editor.
+
+`gg sync` remains responsible for creating or updating every review request in
+the stack. Alas does not invoke a provider create operation in this path.
+
+## Failure and recovery
+
+Preflight and commit failures leave the draft editable and do not create a
+checkpoint. Existing inline error presentation shows the failure.
+
+After commit succeeds, the commit is never rolled back. The message, Amend,
+Draft PR, and alternate commit action become read-only. The publish action
+changes to the unfinished operation:
+
+- **Retry push**
+- **Retry create PR**
+- **Retry sync**
+
+Before any retry, the coordinator verifies that the worktree's HEAD still
+matches the checkpointed commit. A mismatch stops automatic recovery and
+explains that the branch changed after the commit; the user can finish from the
+Changes pane. Alas does not move HEAD or publish a different commit.
+
+Push retry first refreshes or probes the upstream. If the recorded commit is
+already present remotely, it advances the checkpoint without pushing again.
+This covers a push that reached the remote before the local process reported an
+error.
+
+Review request retry first queries the provider for the current branch and
+base. If a request exists, it advances without creating another one. This
+covers a provider request that succeeded remotely but returned an ambiguous
+local error.
+
+GG sync retries the existing idempotent sync operation. Partial stack progress
+and paused conflicts continue to use GG's existing recovery controls.
+
+Once the last remote mutation succeeds, checkpoint completion is authoritative.
+A later sidebar refresh failure does not expose a retry that could repeat the
+mutation; normal refresh error UI handles that independently.
+
+## Testing
+
+### Presentation and shortcuts
+
+- Normal Git uses Commit & PR without a request and Commit & push with one.
+- GG uses Commit & sync and the four actions render in the intended order.
+- Prepare selection updates the preferred action on new, live, and stashed
+  drafts without changing message contents.
+- Preferred and alternate buttons receive the base and Shift-variant shortcuts
+  for default and customized bindings, including a customized binding that
+  already contains Shift.
+- Single-action composer callers remain unchanged.
+- Draft PR appears only for a creatable normal Git review request.
+
+### Persistence
+
+- Existing encoded drafts decode with default values for every new field.
+- Preferred action, Draft PR, and each checkpoint phase round-trip.
+- Closing and reopening a partially published draft retains its retry phase.
+- Successful replacement clears live and stashed recovery state.
+
+### Preflight and amend safety
+
+- Missing remote, provider availability, authentication, capability, base-branch
+  selection, stale upstream, diverged upstream, and conflicting operation each
+  block publication before commit.
+- Published amended HEAD disables publication without disabling local Amend.
+- An unpushed amended HEAD may publish with a normal push.
+- GG paused, in-flight, inactive, stale-head, and blocking-operation states
+  prevent commit-and-sync.
+
+### Workflow sequencing
+
+- Commit-only behavior remains unchanged.
+- New review publication runs commit, push, lookup, then create with the exact
+  captured subject, body, base, and Draft PR value.
+- Existing review publication runs commit and push but never create.
+- GG publication runs commit then one GG sync through existing mutation state.
+- Each failure persists the correct next phase and exposes the matching retry
+  label.
+- Retrying after commit never calls commit again.
+- A remote-complete push probe skips a duplicate push.
+- A provider lookup that finds a request skips duplicate creation.
+- A HEAD mismatch stops retry without performing a remote mutation.
+- A refresh failure after remote success does not reactivate a completed phase.
+
+## Verification
+
+Run focused draft-state, preparation-model, shortcut, coordinator, review-loop,
+and GG tests first. Then run the repository-required verification serially:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```


### PR DESCRIPTION
## Summary
- add paired commit and publish actions in the prepare pane and composer
- persist resumable publish checkpoints for push, review-request creation, and Graphite sync
- add publish availability, keyboard shortcuts, and recovery state coverage

## Verification
- focused commit/publish suites passed
- xcodegen and macOS build passed
- full suite will run in CI