### PR TITLE
fix(review): cap outdated drawer height so long lists scroll instead of overflowing

### DIFF
--- a/Alas/Sources/Center/Review/OutdatedThreadsDrawer.swift
+++ b/Alas/Sources/Center/Review/OutdatedThreadsDrawer.swift
@@ -10,12 +10,20 @@ enum OutdatedThreadsDrawerPresentation {
 
         return min(defaultMaxExpandedListHeight, max(80, floor(availableHeight * 0.35)))
     }
+
+    /// Height applied to the expanded list's ScrollView: shrink-wraps to the measured
+    /// content when it's shorter than the cap, otherwise clamps to the cap so long lists
+    /// stay within the drawer and scroll instead of overflowing past it.
+    static func cappedListHeight(measuredContentHeight: CGFloat, maxHeight: CGFloat) -> CGFloat {
+        min(max(measuredContentHeight, 1), maxHeight)
+    }
 }
 
 struct OutdatedThreadsDrawer: View {
     let threads: [ReviewThread]  // already filtered: isFileLevel || isOutdated
     let maxExpandedListHeight: CGFloat
     @State private var isExpanded = false
+    @State private var contentHeight: CGFloat = 0
 
     @Environment(\.theme) private var theme
 
@@ -68,9 +76,24 @@ struct OutdatedThreadsDrawer: View {
                             }
                         }
                         .padding(.vertical, 4)
+                        .onGeometryChange(for: CGFloat.self) { proxy in
+                            proxy.size.height
+                        } action: { height in
+                            contentHeight = height
+                        }
                     }
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxHeight: maxExpandedListHeight)
+                    // Shrink-wrap short lists, but never exceed the cap — a plain
+                    // .fixedSize(vertical: true) + .frame(maxHeight:) combo lets the
+                    // ScrollView render at its full (uncapped) content height because
+                    // fixedSize ignores the frame's proposal, so long lists overflowed
+                    // past the drawer instead of clipping and scrolling.
+                    .frame(
+                        height: OutdatedThreadsDrawerPresentation.cappedListHeight(
+                            measuredContentHeight: contentHeight,
+                            maxHeight: maxExpandedListHeight
+                        )
+                    )
+                    .clipped()
                 }
             }
             .background(theme.color("bg-2"))

--- a/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownInlineRendererTests.swift
@@ -362,6 +362,67 @@ struct ACPMarkdownInlineRendererTests {
         #expect(drawerScrollView.frame.height < 200)
     }
 
+    @Test("outdated drawer long thread list stays capped and scrollable")
+    func outdatedDrawerLongThreadListStaysCappedAndScrollable() throws {
+        let threads = (0..<12).map { index in
+            ReviewThread(
+                id: "thread-\(index)",
+                path: "Sources/App\(index).swift",
+                line: nil,
+                startLine: nil,
+                originalLine: nil,
+                diffHunk: "@@ -1,4 +1,8 @@\n func body() {\n     return nil\n }",
+                isResolved: false,
+                isOutdated: true,
+                isFileLevel: false,
+                comments: [
+                    ReviewComment(
+                        id: "comment-\(index)",
+                        author: "chatgpt-codex-connector",
+                        body: """
+                        **Resolve live sessions before declaring them unknown**
+
+                        When a session exists in `liveSession(for:)` but is temporarily absent from
+                        `sessionRows`, all four endpoints incorrectly return `sessionUnknown`.
+                        """,
+                        url: nil,
+                        createdAt: nil,
+                        viewerCanUpdate: false,
+                        viewerCanDelete: false,
+                        isPending: false
+                    )
+                ],
+                viewerCanResolve: false,
+                viewerCanReply: false,
+                url: nil
+            )
+        }
+
+        let host = NSHostingView(
+            rootView: OutdatedThreadsDrawer(
+                threads: threads,
+                maxExpandedListHeight: 280,
+                initiallyExpanded: true
+            )
+            .environment(\.theme, try Theme.loadBundled(id: "cool-slate"))
+            .frame(width: 620, height: 360)
+        )
+        host.frame = NSRect(x: 0, y: 0, width: 620, height: 360)
+        // The capped height is derived from a measured content-height preference, which
+        // needs a follow-up layout pass to settle after the first one discovers it.
+        host.layoutSubtreeIfNeeded()
+        host.layoutSubtreeIfNeeded()
+
+        let drawerScrollView = try #require(
+            allSubviews(of: host)
+                .compactMap { $0 as? NSScrollView }
+                .max { $0.frame.height < $1.frame.height }
+        )
+        // The viewport must honour the cap instead of growing to the full content height,
+        // otherwise the list overflows the drawer and there is nothing left to scroll.
+        #expect(drawerScrollView.frame.height <= 280)
+    }
+
     @Test("inline markdown text invalidates height when resized narrower")
     func inlineMarkdownTextInvalidatesHeightWhenResizedNarrower() throws {
         let theme = try Theme.loadBundled(id: "cool-slate")

--- a/AlasTests/Center/Review/ReviewTabViewTests.swift
+++ b/AlasTests/Center/Review/ReviewTabViewTests.swift
@@ -91,4 +91,31 @@ struct ReviewTabViewTests {
         #expect(OutdatedThreadsDrawerPresentation.expandedListMaxHeight(availableHeight: 200) == 80)
         #expect(OutdatedThreadsDrawerPresentation.expandedListMaxHeight(availableHeight: 0) == 280)
     }
+
+    @Test func outdatedDrawerCappedListHeightShrinksToContentButNeverExceedsCap() {
+        // Short content: shrink-wrap to its measured height.
+        #expect(
+            OutdatedThreadsDrawerPresentation.cappedListHeight(
+                measuredContentHeight: 60,
+                maxHeight: 280
+            ) == 60
+        )
+        // Long content (e.g. many threads): clamp to the cap instead of overflowing
+        // past the drawer, which is what let the expanded section swallow the whole
+        // review pane and made it impossible to scroll.
+        #expect(
+            OutdatedThreadsDrawerPresentation.cappedListHeight(
+                measuredContentHeight: 1_892,
+                maxHeight: 280
+            ) == 280
+        )
+        // Not-yet-measured content (0, before the first layout pass reports a size)
+        // must not collapse the list to zero height.
+        #expect(
+            OutdatedThreadsDrawerPresentation.cappedListHeight(
+                measuredContentHeight: 0,
+                maxHeight: 280
+            ) == 1
+        )
+    }
 }


### PR DESCRIPTION
## Problem
In the PR Review pane, expanding the "Outdated & file-level" drawer with many threads made the list render at its full, uncapped content height and overflow past the drawer into the rest of the review pane — with nothing left to scroll.

## Root cause
`.fixedSize(vertical: true)` forced the list's `ScrollView` to size to its ideal (full content) height, which the surrounding `.frame(maxHeight:)` only clamped for layout accounting purposes, not actual rendering — so long lists ignored the cap entirely.

## Fix
Measure the list's actual content height with `onGeometryChange` and set the `ScrollView`'s frame explicitly to `min(measuredHeight, cap)`, with `.clipped()` as a backstop. Short lists still shrink-wrap; long lists stay capped and scroll properly.

## Testing
- Added a regression test reproducing the overflow (measured 1892pt before the fix vs. the intended 280pt cap).
- Added pure-function coverage for the capping arithmetic.
- `xcodebuild test` passes for the affected suites; full `xcodebuild build` succeeds.