### PR TITLE
fix(worktrees): populate stacked diffs mode submenu

### DIFF
--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -50,6 +50,7 @@ struct WorktreeRowView: View {
     struct GGModeMenuItem: Equatable, Identifiable {
         let mode: GGWorktreeMode
         let title: String
+        let isSelected: Bool
 
         var id: GGWorktreeMode { mode }
     }
@@ -58,15 +59,18 @@ struct WorktreeRowView: View {
         [
             GGModeMenuItem(
                 mode: .inherit,
-                title: selectedMode == .inherit ? "✓ Inherit repository default" : "Inherit repository default"
+                title: "Inherit repository default",
+                isSelected: selectedMode == .inherit
             ),
             GGModeMenuItem(
                 mode: .on,
-                title: selectedMode == .on ? "✓ On" : "On"
+                title: "On",
+                isSelected: selectedMode == .on
             ),
             GGModeMenuItem(
                 mode: .off,
-                title: selectedMode == .off ? "✓ Off" : "Off"
+                title: "Off",
+                isSelected: selectedMode == .off
             )
         ]
     }
@@ -294,12 +298,12 @@ struct WorktreeRowView: View {
                 Divider()
                 if ggMenuModel.isVisible {
                     Menu(Self.ggModeMenuTitle) {
-                        ForEach(Self.ggModeMenuItems(selectedMode: ggMenuModel.selectedMode)) { item in
-                            Button(item.title) {
-                                guard item.mode != ggMenuModel.selectedMode else { return }
-                                onSetGGWorktreeMode(item.mode)
-                            }
-                        }
+                        // Static buttons: a data-driven ForEach inside a hover-revealed
+                        // context-menu submenu renders empty on macOS.
+                        let items = Self.ggModeMenuItems(selectedMode: ggMenuModel.selectedMode)
+                        ggModeMenuButton(items[0])
+                        ggModeMenuButton(items[1])
+                        ggModeMenuButton(items[2])
                     }
                     if let explanation = ggMenuModel.inactiveExplanation {
                         Divider()
@@ -314,6 +318,19 @@ struct WorktreeRowView: View {
                         Button("Delete Worktree, Keep Branch…", role: .destructive, action: onDeleteKeepBranch)
                     }
                 }
+            }
+        }
+    }
+
+    private func ggModeMenuButton(_ item: GGModeMenuItem) -> some View {
+        Button {
+            guard item.mode != ggMenuModel.selectedMode else { return }
+            onSetGGWorktreeMode(item.mode)
+        } label: {
+            if item.isSelected {
+                Label(item.title, systemImage: "checkmark")
+            } else {
+                Text(item.title)
             }
         }
     }

--- a/AlasTests/GGWorktreeMenuModelTests.swift
+++ b/AlasTests/GGWorktreeMenuModelTests.swift
@@ -99,11 +99,12 @@ struct GGWorktreeMenuModelTests {
         #expect(model.showsStatusIndicator)
     }
 
-    @Test func ggModeMenuItemsMarkTheSelectedMode() {
+    @Test func ggModeMenuItemsExposeStableLabelsAndSelectionState() {
         let items = WorktreeRowView.ggModeMenuItems(selectedMode: .on)
 
         #expect(items.map(\.mode) == [.inherit, .on, .off])
-        #expect(items.map(\.title) == ["Inherit repository default", "✓ On", "Off"])
+        #expect(items.map(\.title) == ["Inherit repository default", "On", "Off"])
+        #expect(items.map(\.isSelected) == [false, true, false])
     }
 
     private func menuModel(


### PR DESCRIPTION
## Problem
The worktree row context menu showed **Stacked Diffs Mode ›**, but hovering it revealed an empty submenu — a useless entry. #1099 swapped the menu's Toggles for Buttons but kept the underlying pattern that triggers the bug.

## Root cause
A data-driven `ForEach` inside a hover-revealed `Menu` in a SwiftUI context menu renders empty on macOS. The original `Picker` this replaced (pre-#915) used static items and worked.

## Fix
- Replace the `ForEach` in the submenu with three static `Button`s.
- Restore `isSelected` on `GGModeMenuItem`; the checkmark is rendered as a `Label` / `systemImage: "checkmark"` on the item label instead of a "✓" baked into the title string.

## Tests
- Restored `ggModeMenuItemsExposeStableLabelsAndSelectionState` (watched it fail on the pre-fix model, then pass).
- `GGWorktreeMenuModelTests`, `WorktreeRowHeightTests`, `CommitRowTests` all pass locally; full build clean after `xcodegen`.