### PR TITLE
fix(appstate): prevent duplicate project ID crashes

### DIFF
--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -72,9 +72,10 @@ final class ProjectsManager {
         persistedProjects: [ProjectConfig],
         defaultOrdering: @escaping () -> AppConfig.WorktreeSortMode = { .manual }
     ) {
-        self.projects = persistedProjects
+        var projectIDs = Set<String>()
+        self.projects = persistedProjects.filter { projectIDs.insert($0.id).inserted }
         self.defaultOrderingSource = defaultOrdering
-        for project in persistedProjects {
+        for project in projects {
             if let host = project.host {
                 RemoteHostRegistry.shared.register(root: project.path, host: host)
             }

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -144,6 +144,32 @@ struct AppStateCleanupTests {
         #expect(ids.isEmpty)
     }
 
+    @Test func topologyRefreshHandlesDuplicatePersistedProjectIDs() async throws {
+        let repo = try await makeRepo(name: "duplicate-project-id")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let project = ProjectConfig(
+            id: "duplicate",
+            name: "first",
+            path: repo.path,
+            color: "#5fb7c4",
+            addedAt: .now
+        )
+        let duplicate = ProjectConfig(
+            id: "duplicate",
+            name: "second",
+            path: repo.path,
+            color: "#5fb7c4",
+            addedAt: .now
+        )
+        let state = AppState(store: MemoryStore(projectsFile: ProjectsFile(projects: [project, duplicate])))
+
+        #expect(state.projects.count == 1)
+        await state.refreshProjectTopology(projectId: project.id)
+
+        #expect(state.projectsManager.worktrees(projectId: project.id).count == 1)
+    }
+
     @Test func cleanupMissingWorktreesClosesTabsForDisappearedWorktree() async throws {
         let repo = try await makeRepo(name: "cleanup-tabs")
         defer { try? FileManager.default.removeItem(at: repo) }


### PR DESCRIPTION
## Summary

Persisted project records now keep the first record for a duplicate ID, preventing topology refresh from trapping in Swift dictionary construction.

## Changes

- Normalize duplicate project IDs when loading project state.
- Add a topology-refresh regression test.

## Verification

- `xcodegen`
- Full test target is blocked locally by a pre-existing Ghostty XCFramework metadata error before compilation.