### PR TITLE
feat(sidebar): update worktree session badges

### DIFF
--- a/Alas/Sources/Agents/AgentLogoView.swift
+++ b/Alas/Sources/Agents/AgentLogoView.swift
@@ -38,6 +38,13 @@ struct AgentLogoView: View {
 }
 
 extension AgentLogoView {
+    static func menuImage(for agent: AgentKind, size: CGFloat = 16) -> NSImage {
+        let source = NSImage(named: agent.logoAssetName) ?? NSImage()
+        let copy = source.copy() as? NSImage ?? source
+        copy.size = NSSize(width: size, height: size)
+        return copy
+    }
+
     /// Returns an `NSImage` copy clamped to `size`.
     /// SwiftUI `Menu` / `Picker` (`.menu` style) renders items as `NSMenuItem`s
     /// and ignores SwiftUI frame sizing on custom icon views, drawing the

--- a/Alas/Sources/Harness/HarnessService.swift
+++ b/Alas/Sources/Harness/HarnessService.swift
@@ -248,7 +248,14 @@ final class HarnessService {
         case running, awaiting
     }
 
+    struct WorktreeHarnessSession: Equatable, Identifiable {
+        let id: String
+        let state: AggregatedState
+        let agent: AgentKind
+    }
+
     struct WorktreeHarnessSummary: Equatable {
+        let sessions: [WorktreeHarnessSession]
         let state: AggregatedState
         let agent: AgentKind
         let primarySessionId: String
@@ -257,34 +264,31 @@ final class HarnessService {
     }
 
     func summary(forSessionIds ids: [String]) -> WorktreeHarnessSummary? {
-        var awaitingIds: [String] = []
-        var runningIds: [String] = []
-        for id in ids {
-            guard let activity = activityBySession[id] else { continue }
+        let sessions = ids.enumerated().compactMap { offset, id -> (session: WorktreeHarnessSession, updatedAt: Date, offset: Int)? in
+            guard let activity = activityBySession[id] else { return nil }
             switch activity.state {
-            case .awaitingInput, .permissionRequest: awaitingIds.append(id)
-            case .busy:          runningIds.append(id)
-            case .idle:          break
+            case .awaitingInput, .permissionRequest:
+                return (WorktreeHarnessSession(id: id, state: .awaiting, agent: activity.agent), activity.updatedAt, offset)
+            case .busy:
+                return (WorktreeHarnessSession(id: id, state: .running, agent: activity.agent), activity.updatedAt, offset)
+            case .idle:
+                return nil
             }
         }
-        if let s = pickSummary(state: .awaiting, ids: awaitingIds,
-                               runningCount: runningIds.count, awaitingCount: awaitingIds.count) { return s }
-        if let s = pickSummary(state: .running, ids: runningIds,
-                               runningCount: runningIds.count, awaitingCount: awaitingIds.count) { return s }
-        return nil
-    }
+        .sorted { lhs, rhs in
+            if lhs.session.state != rhs.session.state { return lhs.session.state == .awaiting }
+            if lhs.updatedAt != rhs.updatedAt { return lhs.updatedAt > rhs.updatedAt }
+            return lhs.offset < rhs.offset
+        }
 
-    private func pickSummary(
-        state: AggregatedState, ids: [String],
-        runningCount: Int, awaitingCount: Int
-    ) -> WorktreeHarnessSummary? {
-        guard let primary = ids.first,
-              let activity = activityBySession[primary] else { return nil }
+        guard let primary = sessions.first else { return nil }
         return WorktreeHarnessSummary(
-            state: state, agent: activity.agent,
-            primarySessionId: primary,
-            runningSessionCount: runningCount,
-            awaitingSessionCount: awaitingCount
+            sessions: sessions.map(\.session),
+            state: primary.session.state,
+            agent: primary.session.agent,
+            primarySessionId: primary.session.id,
+            runningSessionCount: sessions.count { $0.session.state == .running },
+            awaitingSessionCount: sessions.count { $0.session.state == .awaiting }
         )
     }
 

--- a/Alas/Sources/Sidebar/HarnessPill.swift
+++ b/Alas/Sources/Sidebar/HarnessPill.swift
@@ -53,3 +53,42 @@ struct HarnessPill: View {
         }
     }
 }
+
+struct HarnessSessionBadge: View {
+    let session: HarnessService.WorktreeHarnessSession
+    let onActivate: () -> Void
+    var isSelected = false
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Button(action: onActivate) {
+            Image(session.agent.logoAssetName)
+                .resizable()
+                .renderingMode(.original)
+                .scaledToFit()
+                .frame(width: 15, height: 15)
+                .frame(width: 21, height: 21)
+                .background(theme.color(isSelected ? "bg-3" : "bg-4"))
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+                .overlay(alignment: .bottomTrailing) {
+                    Circle()
+                        .fill(statusColor)
+                        .frame(width: 7, height: 7)
+                        .overlay(Circle().stroke(theme.color(isSelected ? "bg-3" : "bg-4"), lineWidth: 2))
+                        .offset(x: 2, y: 2)
+                }
+        }
+        .buttonStyle(.plain)
+        .help(tooltip)
+        .accessibilityLabel(tooltip)
+    }
+
+    private var statusColor: Color {
+        theme.color(session.state == .running ? "add" : "mod")
+    }
+
+    private var tooltip: String {
+        "\(session.agent.displayName) · \(session.state == .running ? "running" : "waiting")"
+    }
+}

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -37,7 +37,7 @@ struct RepoGroupView: View {
     let onDelete: (Worktree) -> Void
     let onDeleteKeepBranch: (Worktree) -> Void
     let showKeepBranchOption: Bool
-    let onActivateHarness: (Worktree) -> Void
+    let onActivateHarness: (Worktree, String) -> Void
     let onCopyError: (String) -> Void
     let onRetryCreate: (Worktree) -> Void
     let onRetryDelete: (Worktree) -> Void
@@ -177,7 +177,7 @@ struct RepoGroupView: View {
                             onDelete: { onDelete(wt) },
                             onDeleteKeepBranch: { onDeleteKeepBranch(wt) },
                             showKeepBranchOption: showKeepBranchOption,
-                            onActivateHarness: { onActivateHarness(wt) },
+                            onActivateHarness: { sessionId in onActivateHarness(wt, sessionId) },
                             onCopyError: onCopyError,
                             onRemoveFailed: { onRemoveFailed(wt) },
                             onRetryCreate: { onRetryCreate(wt) },

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -115,19 +115,11 @@ struct SidebarView: View {
                                 onDelete: { wt in state.deleteWorktree(wt) },
                                 onDeleteKeepBranch: { wt in state.deleteWorktree(wt, keepBranch: true) },
                                 showKeepBranchOption: state.config.worktrees.deleteBranchOnRemove,
-                                onActivateHarness: { wt in
-                                    let ids = state.tabs.tabs(forWorktree: wt.id).flatMap { tab -> [String] in
-                                        switch tab {
-                                        case .terminal(let s):   return s.root.leaves().map(\.sessionId)
-                                        case .acpSession(let s): return [s.sessionId]
-                                        default:                 return []
-                                        }
-                                    }
-                                    guard let summary = state.harness.summary(forSessionIds: ids) else { return }
+                                onActivateHarness: { wt, sessionId in
                                     state.activateHarnessSession(
                                         projectId: project.id,
                                         worktreeId: wt.id,
-                                        sessionId: summary.primarySessionId
+                                        sessionId: sessionId
                                     )
                                 },
                                 onCopyError: { message in

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -111,7 +111,7 @@ struct WorktreeRowView: View {
     let onDelete: () -> Void
     let onDeleteKeepBranch: () -> Void
     let showKeepBranchOption: Bool
-    let onActivateHarness: () -> Void
+    let onActivateHarness: (String) -> Void
     let onCopyError: (String) -> Void
     let onRemoveFailed: () -> Void
     let onRetryCreate: () -> Void
@@ -238,15 +238,42 @@ struct WorktreeRowView: View {
                         }
                         if let summary = harnessSummary {
                             Spacer()
-                            Button(action: onActivateHarness) {
-                                HarnessPill(
-                                    summary: summary,
-                                    variant: .full,
-                                    tooltip: pillTooltip(for: summary),
-                                    isSelected: isSelected
-                                )
+                            HStack(spacing: 4) {
+                                ForEach(summary.sessions.prefix(2)) { session in
+                                    HarnessSessionBadge(
+                                        session: session,
+                                        onActivate: { onActivateHarness(session.id) },
+                                        isSelected: isSelected
+                                    )
+                                }
+                                if summary.sessions.count > 2 {
+                                    Menu {
+                                        ForEach(summary.sessions.dropFirst(2)) { session in
+                                            Button {
+                                                onActivateHarness(session.id)
+                                            } label: {
+                                                Label {
+                                                    Text("\(session.agent.displayName) · \(session.state == .running ? "running" : "waiting")")
+                                                } icon: {
+                                                    Image(nsImage: AgentLogoView.menuImage(for: session.agent, size: 14))
+                                                }
+                                            }
+                                        }
+                                    } label: {
+                                        Text("+\(summary.sessions.count - 2)")
+                                            .font(.system(size: 10, weight: .medium, design: .monospaced))
+                                            .foregroundColor(theme.color("fg-dim"))
+                                            .frame(minWidth: 21, minHeight: 21)
+                                            .background(theme.color(isSelected ? "bg-3" : "bg-4"))
+                                            .clipShape(RoundedRectangle(cornerRadius: 5))
+                                    }
+                                    .menuStyle(.borderlessButton)
+                                    .help("\(summary.sessions.count - 2) more active session\(summary.sessions.count == 3 ? "" : "s")")
+                                    .accessibilityLabel("\(summary.sessions.count - 2) more active sessions")
+                                }
                             }
-                            .buttonStyle(.plain)
+                            .accessibilityElement(children: .contain)
+                            .accessibilityLabel("Active agent sessions")
                         }
                     }
                     .frame(minHeight: 18)
@@ -337,15 +364,6 @@ struct WorktreeRowView: View {
 
     private func relative(_ date: Date) -> String {
         Self.relativeDateFormatter.localizedString(for: date, relativeTo: Date())
-    }
-
-    private func pillTooltip(for summary: HarnessService.WorktreeHarnessSummary) -> String {
-        let stateText: String
-        switch summary.state {
-        case .running:  stateText = "running"
-        case .awaiting: stateText = "awaiting"
-        }
-        return "\(summary.agent.displayName) · \(stateText)"
     }
 
     private static let relativeDateFormatter: RelativeDateTimeFormatter = {

--- a/AlasTests/HarnessServiceTests.swift
+++ b/AlasTests/HarnessServiceTests.swift
@@ -226,6 +226,7 @@ struct HarnessServiceTests {
         #expect(summary?.primarySessionId == "s2")
         #expect(summary?.runningSessionCount == 1)
         #expect(summary?.awaitingSessionCount == 1)
+        #expect(summary?.sessions.map(\.id) == ["s2", "s1"])
     }
 
     @Test func cursorPermissionRequestIsTreatedAsBusyWithoutNotification() {
@@ -301,6 +302,18 @@ struct HarnessServiceTests {
         let summary = service.summary(forSessionIds: ["s1"])
         #expect(summary?.state == .running)
         #expect(summary?.agent == .claude)
+    }
+
+    @Test func summary_prefersMostRecentlyUpdatedSessionWithinTheSameState() {
+        let (service, _) = makeService()
+        service.setStateForTesting(sessionId: "older", agent: .claude, state: .busy)
+        Thread.sleep(forTimeInterval: 0.01)
+        service.setStateForTesting(sessionId: "newer", agent: .codex, state: .busy)
+
+        let summary = service.summary(forSessionIds: ["older", "newer"])
+
+        #expect(summary?.primarySessionId == "newer")
+        #expect(summary?.agent == .codex)
     }
 
     @Test func summary_ignoresIdleSessions() {

--- a/AlasTests/RepoGroupViewLayoutTests.swift
+++ b/AlasTests/RepoGroupViewLayoutTests.swift
@@ -79,7 +79,7 @@ struct RepoGroupViewLayoutTests {
             onDelete: { _ in },
             onDeleteKeepBranch: { _ in },
             showKeepBranchOption: false,
-            onActivateHarness: { _ in },
+            onActivateHarness: { _, _ in },
             onCopyError: { _ in },
             onRetryCreate: { _ in },
             onRetryDelete: { _ in },

--- a/AlasTests/WorktreeRowHeightTests.swift
+++ b/AlasTests/WorktreeRowHeightTests.swift
@@ -48,6 +48,7 @@ struct WorktreeRowHeightTests {
     @Test func rowHeightIsStableWithAndWithoutBadge() throws {
         let withoutBadge = try renderHeight(harnessSummary: nil)
         let withBadge = try renderHeight(harnessSummary: .init(
+            sessions: [.init(id: "s1", state: .running, agent: .claude)],
             state: .running,
             agent: .claude,
             primarySessionId: "s1",
@@ -60,6 +61,7 @@ struct WorktreeRowHeightTests {
 
     @Test func rowHeightIsStableAcrossBadgeStates() throws {
         let running = try renderHeight(harnessSummary: .init(
+            sessions: [.init(id: "s1", state: .running, agent: .claude)],
             state: .running,
             agent: .claude,
             primarySessionId: "s1",
@@ -67,6 +69,7 @@ struct WorktreeRowHeightTests {
             awaitingSessionCount: 0
         ))
         let awaiting = try renderHeight(harnessSummary: .init(
+            sessions: [.init(id: "s1", state: .awaiting, agent: .claude)],
             state: .awaiting,
             agent: .claude,
             primarySessionId: "s1",
@@ -141,7 +144,7 @@ struct WorktreeRowHeightTests {
             onDelete: {},
             onDeleteKeepBranch: {},
             showKeepBranchOption: false,
-            onActivateHarness: {},
+            onActivateHarness: { _ in },
             onCopyError: { _ in },
             onRemoveFailed: {},
             onRetryCreate: {},


### PR DESCRIPTION
## Summary
- show up to two app-logo badges for active harness sessions in each worktree row
- add a +N overflow menu for additional sessions
- route each badge and menu item to the exact harness tab it represents

## Verification
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-badge-icon-launch -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-badge-icon-launch -only-testing:AlasTests/HarnessServiceTests test