### PR TITLE
feat(run): notify when run scripts finish

### DIFF
--- a/Alas/Sources/App/AppState+RunScripts.swift
+++ b/Alas/Sources/App/AppState+RunScripts.swift
@@ -392,6 +392,14 @@ extension AppState {
                 defer { runScriptCompletionTasks.removeValue(forKey: runID) }
                 do {
                     let completion = try await runScriptCompletionWaiter(location)
+                    harness.notifications.notifyRunScriptFinished(
+                        scriptName: script.displayName,
+                        exitCode: completion.exitCode,
+                        projectId: worktree.projectId,
+                        worktreeId: worktree.id,
+                        sessionId: sessionID,
+                        runID: runID
+                    )
                     guard completion.exitCode != 0 else { return }
                     let capturedOutput: RunScriptCapturedOutput
                     if let transcript = completion.transcript {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -5279,7 +5279,7 @@ final class AppState {
             return state.root.find(leafId: leafId) != nil
         }?.id
         guard let tabId = owningTabId else { return }
-        scheduleRunScriptCompletionCancellation(sessionID: leafId)
+        cancelRunScriptCompletionTasks(sessionID: leafId, after: .seconds(30))
         guard let outcome = tabs.removeLeaf(
             worktreeId: worktreeId, tabId: tabId, leafId: leafId
         ) else { return }

--- a/Alas/Sources/Harness/NotificationService.swift
+++ b/Alas/Sources/Harness/NotificationService.swift
@@ -95,6 +95,21 @@ final class NotificationService {
         notificationAdder(req)
     }
 
+    func notifyRunScriptFinished(scriptName: String, exitCode: Int32,
+                                 projectId: String, worktreeId: String, sessionId: String,
+                                 runID: String) {
+        let content = UNMutableNotificationContent()
+        content.title = "\(scriptName) finished"
+        content.body = exitCode == 0 ? "Succeeded" : "Failed with exit code \(exitCode)"
+        content.sound = .default
+        content.userInfo = [
+            "projectId": projectId,
+            "worktreeId": worktreeId,
+            "sessionId": sessionId,
+        ]
+        notificationAdder(UNNotificationRequest(identifier: "run-script-\(runID)", content: content, trigger: nil))
+    }
+
     func notifyAlas(body: String, title: String?, agent: AgentKind,
                     projectId: String, worktreeId: String, sessionId: String,
                     owner: SessionOwnerID? = nil) {

--- a/AlasTests/NotificationServiceTests.swift
+++ b/AlasTests/NotificationServiceTests.swift
@@ -4,6 +4,49 @@ import UserNotifications
 @testable import Alas
 
 struct NotificationServiceTests {
+    @Test func successfulRunScriptNotificationIsClickable() {
+        var requests: [UNNotificationRequest] = []
+        let service = NotificationService(notificationAdder: { requests.append($0) })
+
+        service.notifyRunScriptFinished(
+            scriptName: "Dev",
+            exitCode: 0,
+            projectId: "project-1",
+            worktreeId: "worktree-1",
+            sessionId: "session-1",
+            runID: "run-1"
+        )
+
+        #expect(requests.count == 1)
+        #expect(requests[0].identifier == "run-script-run-1")
+        #expect(requests[0].content.title == "Dev finished")
+        #expect(requests[0].content.body == "Succeeded")
+        #expect(requests[0].content.sound != nil)
+        let click = NotificationClickContext(userInfo: requests[0].content.userInfo)
+        #expect(click?.projectId == "project-1")
+        #expect(click?.worktreeId == "worktree-1")
+        #expect(click?.sessionId == "session-1")
+        #expect(click?.owner == .worktree("worktree-1"))
+    }
+
+    @Test func failedRunScriptNotificationIncludesExitCode() {
+        var requests: [UNNotificationRequest] = []
+        let service = NotificationService(notificationAdder: { requests.append($0) })
+
+        service.notifyRunScriptFinished(
+            scriptName: "Test",
+            exitCode: 42,
+            projectId: "project-1",
+            worktreeId: "worktree-1",
+            sessionId: "session-1",
+            runID: "run-1"
+        )
+
+        #expect(requests.count == 1)
+        #expect(requests[0].content.title == "Test finished")
+        #expect(requests[0].content.body == "Failed with exit code 42")
+    }
+
     @Test func awaitingUsesClickableNotificationRequest() {
         var requests: [UNNotificationRequest] = []
         let service = NotificationService(notificationAdder: { request in

--- a/AlasTests/RunScriptLaunchTests.swift
+++ b/AlasTests/RunScriptLaunchTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import UserNotifications
 @testable import Alas
 
 struct RunScriptLaunchTests {
@@ -386,6 +387,8 @@ struct RunScriptLaunchTests {
                 truncated: false
             )
         })
+        var notifications: [UNNotificationRequest] = []
+        fixture.state.harness.notifications.notificationAdder = { notifications.append($0) }
 
         fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
         try await Task.sleep(for: .milliseconds(50))
@@ -397,6 +400,8 @@ struct RunScriptLaunchTests {
         #expect(failures[0].exitCode == 42)
         #expect(failures[0].branch == "main")
         #expect(failures[0].capturedOutput == .available(text: "bad output\n", truncated: false))
+        #expect(notifications.count == 1)
+        #expect(notifications[0].content.body == "Failed with exit code 42")
     }
 
     @MainActor
@@ -404,12 +409,16 @@ struct RunScriptLaunchTests {
         let fixture = try makeAppStateFixture(waiter: { _ in
             RunScriptCompletion(exitCode: 0, transcript: Data("ok\n".utf8), truncated: false)
         })
+        var notifications: [UNNotificationRequest] = []
+        fixture.state.harness.notifications.notificationAdder = { notifications.append($0) }
 
         fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
         try await Task.sleep(for: .milliseconds(50))
         await fixture.state.waitForRunScriptCompletionTasksForTesting()
 
         #expect(fixture.state.runScriptFailures(in: fixture.worktree.id).isEmpty)
+        #expect(notifications.count == 1)
+        #expect(notifications[0].content.body == "Succeeded")
     }
 
     @MainActor
@@ -585,9 +594,13 @@ struct RunScriptLaunchTests {
     @MainActor
     @Test func processExitAllowsCompletedMonitorToReportFailure() async throws {
         let fixture = try makeAppStateFixture(waiter: { _ in
-            try await Task.sleep(for: .milliseconds(20))
+            try await Task.sleep(for: .milliseconds(2_200))
             return RunScriptCompletion(exitCode: 42, transcript: Data("bad\n".utf8), truncated: false)
+        }, terminalSessionOpener: { _, _, _, _, _, _, _, _, _ in
+            .init(id: "session", foregroundPid: { 1 })
         })
+        var notifications: [UNNotificationRequest] = []
+        fixture.state.harness.notifications.notificationAdder = { notifications.append($0) }
 
         fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
         try await Task.sleep(for: .milliseconds(50))
@@ -601,6 +614,7 @@ struct RunScriptLaunchTests {
         await fixture.state.waitForRunScriptCompletionTasksForTesting()
 
         #expect(fixture.state.runScriptFailures(in: fixture.worktree.id).count == 1)
+        #expect(notifications.count == 1)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

Notify after every Cmd+R script completion. The notification reports success or the exit code, and its existing session metadata focuses an open terminal when clicked.

## Tests

- Focused run-script and notification tests
- macOS build
- Full suite run, with unrelated order-dependent failures that pass individually