### PR TITLE
style(sidebar): refine worktree session badges

### DIFF
--- a/Alas/Sources/Sidebar/HarnessPill.swift
+++ b/Alas/Sources/Sidebar/HarnessPill.swift
@@ -69,27 +69,58 @@ struct HarnessSessionBadge: View {
                 .scaledToFit()
                 .frame(width: 14, height: 14)
                 .frame(width: 21, height: 21)
-                .background(
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(theme.color(isSelected ? "bg-3" : "bg-4").opacity(0.7))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .strokeBorder(borderColor, lineWidth: 0.75)
-                )
+                .modifier(HarnessSessionBadgeChrome(state: session.state, isSelected: isSelected))
         }
         .buttonStyle(.plain)
         .help(tooltip)
         .accessibilityLabel(tooltip)
     }
 
-    private var borderColor: Color {
-        session.state == .running
-            ? theme.color("line")
-            : theme.color("caution").opacity(0.55)
-    }
-
     private var tooltip: String {
         "\(session.agent.displayName) · \(session.state == .running ? "running" : "waiting")"
+    }
+}
+
+struct HarnessSessionBadgeChrome: ViewModifier {
+    let state: HarnessService.AggregatedState
+    var isSelected = false
+
+    @Environment(\.theme) private var theme
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(fillColor)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(borderColor, lineWidth: 0.75)
+            )
+            .overlay {
+                if state == .running {
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(theme.color("add").opacity(0.20), lineWidth: 2)
+                        .blur(radius: 2)
+                }
+            }
+    }
+
+    private var fillColor: Color {
+        switch state {
+        case .running:
+            return theme.color("add").opacity(isSelected ? 0.12 : 0.08)
+        case .awaiting:
+            return theme.color("caution").opacity(isSelected ? 0.14 : 0.10)
+        }
+    }
+
+    private var borderColor: Color {
+        switch state {
+        case .running:
+            return theme.color("add").opacity(0.55)
+        case .awaiting:
+            return theme.color("caution").opacity(0.60)
+        }
     }
 }

--- a/Alas/Sources/Sidebar/HarnessPill.swift
+++ b/Alas/Sources/Sidebar/HarnessPill.swift
@@ -67,25 +67,26 @@ struct HarnessSessionBadge: View {
                 .resizable()
                 .renderingMode(.original)
                 .scaledToFit()
-                .frame(width: 15, height: 15)
+                .frame(width: 14, height: 14)
                 .frame(width: 21, height: 21)
-                .background(theme.color(isSelected ? "bg-3" : "bg-4"))
-                .clipShape(RoundedRectangle(cornerRadius: 5))
-                .overlay(alignment: .bottomTrailing) {
-                    Circle()
-                        .fill(statusColor)
-                        .frame(width: 7, height: 7)
-                        .overlay(Circle().stroke(theme.color(isSelected ? "bg-3" : "bg-4"), lineWidth: 2))
-                        .offset(x: 2, y: 2)
-                }
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(theme.color(isSelected ? "bg-3" : "bg-4").opacity(0.7))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(borderColor, lineWidth: 0.75)
+                )
         }
         .buttonStyle(.plain)
         .help(tooltip)
         .accessibilityLabel(tooltip)
     }
 
-    private var statusColor: Color {
-        theme.color(session.state == .running ? "add" : "mod")
+    private var borderColor: Color {
+        session.state == .running
+            ? theme.color("line")
+            : theme.color("caution").opacity(0.55)
     }
 
     private var tooltip: String {

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -264,8 +264,14 @@ struct WorktreeRowView: View {
                                             .font(.system(size: 10, weight: .medium, design: .monospaced))
                                             .foregroundColor(theme.color("fg-dim"))
                                             .frame(minWidth: 21, minHeight: 21)
-                                            .background(theme.color(isSelected ? "bg-3" : "bg-4"))
-                                            .clipShape(RoundedRectangle(cornerRadius: 5))
+                                            .background(
+                                                RoundedRectangle(cornerRadius: 6)
+                                                    .fill(theme.color(isSelected ? "bg-3" : "bg-4").opacity(0.7))
+                                            )
+                                            .overlay(
+                                                RoundedRectangle(cornerRadius: 6)
+                                                    .strokeBorder(theme.color("line"), lineWidth: 0.75)
+                                            )
                                     }
                                     .menuStyle(.borderlessButton)
                                     .help("\(summary.sessions.count - 2) more active session\(summary.sessions.count == 3 ? "" : "s")")

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -247,8 +247,10 @@ struct WorktreeRowView: View {
                                     )
                                 }
                                 if summary.sessions.count > 2 {
+                                    let hiddenSessions = Array(summary.sessions.dropFirst(2))
+                                    let overflowState: HarnessService.AggregatedState = hiddenSessions.contains { $0.state == .running } ? .running : .awaiting
                                     Menu {
-                                        ForEach(summary.sessions.dropFirst(2)) { session in
+                                        ForEach(hiddenSessions) { session in
                                             Button {
                                                 onActivateHarness(session.id)
                                             } label: {
@@ -264,14 +266,7 @@ struct WorktreeRowView: View {
                                             .font(.system(size: 10, weight: .medium, design: .monospaced))
                                             .foregroundColor(theme.color("fg-dim"))
                                             .frame(minWidth: 21, minHeight: 21)
-                                            .background(
-                                                RoundedRectangle(cornerRadius: 6)
-                                                    .fill(theme.color(isSelected ? "bg-3" : "bg-4").opacity(0.7))
-                                            )
-                                            .overlay(
-                                                RoundedRectangle(cornerRadius: 6)
-                                                    .strokeBorder(theme.color("line"), lineWidth: 0.75)
-                                            )
+                                            .modifier(HarnessSessionBadgeChrome(state: overflowState, isSelected: isSelected))
                                     }
                                     .menuStyle(.borderlessButton)
                                     .help("\(summary.sessions.count - 2) more active session\(summary.sessions.count == 3 ? "" : "s")")


### PR DESCRIPTION
Refines the worktree session badges with state-tinted rounded-square outlines, a subtle running glow, and matching overflow control styling.