### PR TITLE
feat(workspace): polish UI

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */; };
 		17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */; };
 		17EA736FA0386E75D8D42B2E /* AttachIssueDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098AA369AE6B2740439CD504 /* AttachIssueDialog.swift */; };
+		180B240FCB1AAFA891D01FEE /* WorkspacePresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56F39F3ED50EFE001442585 /* WorkspacePresentationTests.swift */; };
 		188AF4E4D85149D0535251F9 /* GGInboxModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4DA46E3A858D293B9E6C34 /* GGInboxModels.swift */; };
 		188D02B853162BF4533020E2 /* ChevronStabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */; };
 		18CDE0CC16BC53EE02F1D773 /* ACPContextCompactionPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F08BFB7C0F034F695811C85 /* ACPContextCompactionPresentationTests.swift */; };
@@ -3236,6 +3237,7 @@
 		F4A5662DEEA883E342579177 /* RemoteWorktreeFileAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreeFileAccess.swift; sourceTree = "<group>"; };
 		F55C4A7D3820C97CB1CD980D /* IssueResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueResolver.swift; sourceTree = "<group>"; };
 		F56A35888F0783BA6F296CED /* MermaidDiagramViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidDiagramViewer.swift; sourceTree = "<group>"; };
+		F56F39F3ED50EFE001442585 /* WorkspacePresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacePresentationTests.swift; sourceTree = "<group>"; };
 		F59AAA1AFFBA04A837BCBA13 /* ACPBareURLLinkifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBareURLLinkifierTests.swift; sourceTree = "<group>"; };
 		F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessages.swift; sourceTree = "<group>"; };
 		F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeBulkResolvePromptEditorWindow.swift; sourceTree = "<group>"; };
@@ -4547,6 +4549,7 @@
 				2095AC0451AF13ECED80E1F2 /* WorkspaceMemberReviewRollupTests.swift */,
 				D33173D002A6484A1F486C66 /* WorkspaceModelsTests.swift */,
 				8AF872EEC1CAD3B6B84D92F3 /* WorkspaceNavigationStateTests.swift */,
+				F56F39F3ED50EFE001442585 /* WorkspacePresentationTests.swift */,
 				F9C0B9B3E26A743954A8DB13 /* WorkspaceSidebarLayoutTests.swift */,
 				149AB7104993DEC73FD4BC45 /* WorkspaceSpaceMigrationTests.swift */,
 				E92CF7C0175D9E682795CE24 /* WorkspaceStoreTests.swift */,
@@ -7914,6 +7917,7 @@
 				45CD675EC237B954C0BAAE82 /* WorkspaceMemberReviewRollupTests.swift in Sources */,
 				E55241F96E62ACB81DDA73F3 /* WorkspaceModelsTests.swift in Sources */,
 				8876AC7DC1852F059506AF41 /* WorkspaceNavigationStateTests.swift in Sources */,
+				180B240FCB1AAFA891D01FEE /* WorkspacePresentationTests.swift in Sources */,
 				151437414B3DA58FC2103572 /* WorkspaceSidebarLayoutTests.swift in Sources */,
 				ECA019177F789DA97094EE54 /* WorkspaceSpaceMigrationTests.swift in Sources */,
 				8FEA3E8F98A94470463409D3 /* WorkspaceStoreTests.swift in Sources */,

--- a/Alas/Sources/Dialogs/Workspace/WorkspaceDialogs.swift
+++ b/Alas/Sources/Dialogs/Workspace/WorkspaceDialogs.swift
@@ -3,35 +3,212 @@ import SwiftUI
 struct NewWorkspaceDialog: View {
     @Bindable var state: AppState
     @Binding var presented: Bool
+
+    var body: some View {
+        WorkspaceDefinitionEditor(state: state, workspace: nil, presented: $presented)
+    }
+}
+
+struct EditWorkspaceDialog: View {
+    @Bindable var state: AppState
+    let workspace: Workspace
+    @Binding var presented: Bool
+
+    var body: some View {
+        WorkspaceDefinitionEditor(state: state, workspace: workspace, presented: $presented)
+    }
+}
+
+private struct WorkspaceDefinitionEditor: View {
+    @Bindable var state: AppState
+    let workspace: Workspace?
+    @Binding var presented: Bool
     @State private var model: WorkspaceDefinitionDialogModel
     @State private var error: String?
     @State private var isSaving = false
+    @State private var confirmingDeletion = false
+    @State private var locationPickerOpen = false
+    @Environment(\.theme) private var theme
 
-    init(state: AppState, presented: Binding<Bool>) {
+    init(state: AppState, workspace: Workspace?, presented: Binding<Bool>) {
         self.state = state
+        self.workspace = workspace
         self._presented = presented
-        let location = state.projects.first?.host.map(ExecutionLocation.ssh) ?? .local
-        self._model = State(initialValue: .init(executionLocation: location, projects: state.projects))
+        self._model = State(initialValue: workspace.map {
+            WorkspaceDefinitionDialogModel(editing: $0, projects: state.projects)
+        } ?? WorkspaceDefinitionDialogModel(
+            executionLocation: state.projects.first?.host.map(ExecutionLocation.ssh) ?? .local,
+            projects: state.projects
+        ))
     }
-    var body: some View { definitionBody(title: "New Workspace") }
-    @ViewBuilder private func definitionBody(title: String) -> some View {
-        DialogContainer(title: title, subtitle: "A definition for future coordinated checkouts.", content: {
-            TextField("Workspace name", text: $model.name)
-            executionLocationControls
-            Text("Members").font(.headline)
-            ForEach(Array(model.members.enumerated()), id: \.element.id) { index, member in
-                HStack { Text(member.fallbackProjectName)
-                Spacer()
-                Button("Up") { model.moveMember(from: index, to: max(0, index - 1)) }.disabled(index == 0)
-                Button("Down") { model.moveMember(from: index, to: min(model.members.count - 1, index + 1)) }.disabled(index + 1 == model.members.count)
-                Button("Remove", role: .destructive) { model.removeMember(id: member.id) } }
+
+    var body: some View {
+        DialogContainer(
+            title: workspace == nil ? "New workspace" : "Edit workspace",
+            subtitle: workspace == nil ? nil : "Changes apply to future checkouts only.",
+            content: {
+                DialogField(label: "Name") {
+                    AlasField(text: $model.name, placeholder: "Workspace name", focusOnAppear: true, isEnabled: !isSaving)
+                        .accessibilityLabel("Workspace name")
+                }
+                DialogField(label: "Location") {
+                    Button { locationPickerOpen.toggle() } label: {
+                        HStack(spacing: 8) {
+                            Icon(name: model.executionLocation.sshHost == nil ? "desktopcomputer" : "server.rack")
+                            Text(model.executionLocation.sshHost ?? "This Mac")
+                                .lineLimit(1).truncationMode(.middle)
+                            Spacer(minLength: 8)
+                            Icon(name: "chev-down", size: 9)
+                        }
+                        .font(.system(size: 12))
+                        .foregroundColor(theme.color("fg"))
+                        .alasFieldChrome(theme: theme)
+                    }
+                    .buttonStyle(.plain)
+                    .popover(isPresented: $locationPickerOpen, arrowEdge: .bottom) {
+                        ScrollView {
+                            VStack(alignment: .leading, spacing: 0) {
+                                locationOption("This Mac", location: .local)
+                                ForEach(hosts, id: \.self) { host in
+                                    locationOption(host, location: .ssh(host))
+                                }
+                            }
+                            .padding(6)
+                        }
+                        .frame(width: 300, height: CGFloat(min(hosts.count + 1, 8)) * 30 + 12)
+                    }
+                    .accessibilityLabel("Execution location")
+                    .disabled(isSaving)
+                }
+                repositories
+                if let error { WorkspaceNotice(message: error, isError: true) }
+                if workspace != nil {
+                    Button("Delete workspace...", role: .destructive) { confirmingDeletion = true }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 11.5))
+                        .foregroundColor(theme.color("del"))
+                        .disabled(isSaving)
+                }
+            },
+            cancelTitle: "Cancel",
+            confirmTitle: isSaving ? "Saving..." : workspace == nil ? "Create workspace" : "Save changes",
+            confirmStyle: .primary,
+            onCancel: { if !isSaving { presented = false } },
+            onConfirm: save,
+            confirmEnabled: !isSaving && !model.trimmedName.isEmpty && !model.members.isEmpty
+        )
+        .interactiveDismissDisabled(isSaving)
+        .onExitCommand { if !isSaving { presented = false } }
+        .confirmationDialog("Delete workspace?", isPresented: $confirmingDeletion, titleVisibility: .visible) {
+            Button("Delete workspace", role: .destructive, action: deleteWorkspace)
+            Button("Cancel", role: .cancel) { confirmingDeletion = false }
+        } message: {
+            Text("Delete \(workspace?.name ?? "this workspace")? Existing checkouts are retained as Former Workspace checkouts.")
+        }
+    }
+
+    private var hosts: [String] {
+        Array(Set(state.projects.compactMap(\.host) + [model.executionLocation.sshHost].compactMap { $0 })).sorted()
+    }
+
+    private func locationOption(_ title: String, location: ExecutionLocation) -> some View {
+        Button {
+            if model.executionLocation != location { model.executionLocation = location }
+            locationPickerOpen = false
+        } label: {
+            HStack(spacing: 8) {
+                Icon(name: "check", size: 10)
+                    .opacity(model.executionLocation == location ? 1 : 0)
+                Text(title).font(.system(size: 12)).foregroundColor(theme.color("fg"))
+                    .lineLimit(1).truncationMode(.middle)
+                Spacer(minLength: 0)
             }
-            ForEach(model.eligibleProjects) { project in Button("Add \(project.name)") { _ = model.add(project: project) } }
-            if let error { Text(error).foregroundStyle(.red) }
-        }, cancelTitle: "Cancel", confirmTitle: model.saveTitle, confirmStyle: .primary, onCancel: { presented = false }, onConfirm: save, confirmEnabled: !isSaving && !model.trimmedName.isEmpty && !model.members.isEmpty)
+            .padding(8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
+
+    private var repositories: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Repositories")
+                    .font(.system(size: 11.5, weight: .medium))
+                    .foregroundColor(theme.color("fg-muted"))
+                Text("\(model.members.count)")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.color("fg-faint"))
+                Spacer()
+                Menu {
+                    ForEach(model.eligibleProjects) { project in
+                        Button(project.name) { _ = model.add(project: project) }
+                    }
+                } label: {
+                    Icon(name: "plus", size: 12)
+                        .frame(width: 24, height: 22)
+                        .contentShape(Rectangle())
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+                .disabled(model.eligibleProjects.isEmpty)
+                .help("Add repository")
+                .accessibilityLabel("Add repository")
+            }
+            if model.members.isEmpty {
+                Text(model.eligibleProjects.isEmpty ? "No repositories at this location." : "No repositories selected.")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .frame(maxWidth: .infinity, minHeight: 72)
+            } else {
+                ScrollView {
+                    VStack(spacing: 0) {
+                        ForEach(Array(model.members.enumerated()), id: \.element.id) { index, member in
+                            repositoryRow(member, index: index)
+                            if index < model.members.count - 1 { Divider() }
+                        }
+                    }
+                }
+                .frame(height: CGFloat(min(model.members.count, 5)) * 53)
+            }
+        }
+        .disabled(isSaving)
+    }
+
+    private func repositoryRow(_ member: WorkspaceMember, index: Int) -> some View {
+        HStack(spacing: 10) {
+            if let project = state.projects.first(where: { $0.id == member.projectID }) {
+                ProjectIconView(icon: project.icon, fallbackName: project.name, size: .sidebar)
+            } else {
+                Icon(name: "folder", size: 14)
+            }
+            VStack(alignment: .leading, spacing: 3) {
+                Text(member.fallbackProjectName)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(theme.color("fg"))
+                Text(member.fallbackRepositoryRoot)
+                    .font(.system(size: 10.5, design: .monospaced))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .truncationMode(.middle)
+            }
+            .lineLimit(1)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            ToolbarBtn(icon: "arrow.up", tooltip: "Move \(member.fallbackProjectName) up") {
+                model.moveMember(from: index, to: index - 1)
+            }.disabled(index == 0)
+            ToolbarBtn(icon: "arrow.down", tooltip: "Move \(member.fallbackProjectName) down") {
+                model.moveMember(from: index, to: index + 1)
+            }.disabled(index == model.members.count - 1)
+            ToolbarBtn(icon: "x", tooltip: "Remove \(member.fallbackProjectName)") {
+                model.removeMember(id: member.id)
+            }
+        }
+        .frame(height: 52)
+        .help(member.fallbackRepositoryRoot)
+    }
+
     private func save() {
-        guard !isSaving else { return }
+        guard !isSaving, !model.trimmedName.isEmpty, !model.members.isEmpty else { return }
         isSaving = true
         error = nil
         let definition = model.definition()
@@ -41,55 +218,14 @@ struct NewWorkspaceDialog: View {
                 presented = false
             } catch {
                 self.error = error.localizedDescription
-                isSaving = false
             }
+            isSaving = false
         }
     }
-    @ViewBuilder private var executionLocationControls: some View { HStack { Text("Execution location")
-    Button("Local") { model.executionLocation = .local }
-    ForEach(Array(Set(state.projects.compactMap(\.host))).sorted(), id: \.self) { host in Button(host) { model.executionLocation = .ssh(host) } } } }
-}
 
-struct EditWorkspaceDialog: View {
-    @Bindable var state: AppState
-    @Binding var presented: Bool
-    let workspace: Workspace
-    @State private var model: WorkspaceDefinitionDialogModel
-    @State private var error: String?
-    @State private var confirmingDeletion = false
-    init(state: AppState, workspace: Workspace, presented: Binding<Bool>) { self.state = state
-    self.workspace = workspace
-    self._presented = presented
-    self._model = State(initialValue: .init(editing: workspace, projects: state.projects)) }
-    var body: some View {
-        DialogContainer(title: "Edit Workspace", subtitle: "Changes apply to future checkouts only.", content: {
-            TextField("Workspace name", text: $model.name)
-            HStack { Text("Execution location")
-            Button("Local") { model.executionLocation = .local }
-            ForEach(Array(Set(state.projects.compactMap(\.host))).sorted(), id: \.self) { host in Button(host) { model.executionLocation = .ssh(host) } } }
-            ForEach(Array(model.members.enumerated()), id: \.element.id) { index, member in HStack { Text(member.fallbackProjectName)
-            Button("Up") { model.moveMember(from: index, to: max(0, index - 1)) }.disabled(index == 0)
-            Button("Down") { model.moveMember(from: index, to: min(model.members.count - 1, index + 1)) }.disabled(index + 1 == model.members.count)
-            Button("Remove", role: .destructive) { model.removeMember(id: member.id) } } }
-            ForEach(model.eligibleProjects) { project in Button("Add \(project.name)") { _ = model.add(project: project) } }
-            if let error { Text(error).foregroundStyle(.red) }
-            Button("Delete Workspace", role: .destructive) { confirmingDeletion = true }
-        }, cancelTitle: "Cancel", confirmTitle: model.saveTitle, confirmStyle: .primary, onCancel: { presented = false }, onConfirm: save, confirmEnabled: !model.trimmedName.isEmpty && !model.members.isEmpty)
-        .confirmationDialog(
-            "Delete Workspace?",
-            isPresented: $confirmingDeletion,
-            titleVisibility: .visible
-        ) {
-            Button("Delete Workspace", role: .destructive) { deleteWorkspace() }
-            Button("Cancel", role: .cancel) { confirmingDeletion = false }
-        } message: {
-            Text("Delete \(workspace.name)? Existing checkouts are retained as Former Workspace checkouts.")
-        }
-    }
-    private func save() { let definition = model.definition()
-    Task { @MainActor in do { try await state.saveWorkspaceDefinition(definition)
-    presented = false } catch { self.error = error.localizedDescription } } }
     private func deleteWorkspace() {
+        guard let workspace, !isSaving else { return }
+        isSaving = true
         Task { @MainActor in
             do {
                 try await state.deleteWorkspaceDefinition(id: workspace.id)
@@ -97,6 +233,7 @@ struct EditWorkspaceDialog: View {
             } catch {
                 self.error = error.localizedDescription
             }
+            isSaving = false
         }
     }
 }
@@ -107,39 +244,245 @@ struct CreateWorkspaceCheckoutDialog: View {
     @Binding var presented: Bool
     @State private var model: WorkspaceCheckoutCreationModel
     @State private var error: String?
-    init(state: AppState, workspace: Workspace, presented: Binding<Bool>) { self.state = state
-    self.workspace = workspace
-    self._presented = presented
-    self._model = State(initialValue: .init(workspace: workspace)) }
-    var body: some View {
-        DialogContainer(title: "Create Workspace Checkout", subtitle: subtitle, content: {
-            if model.step == .details { TextField("Shared branch", text: $model.branch)
-            TextField("Checkout root", text: $model.rootPath)
-            TextField("Base reference", text: $model.baseReference)
-            ForEach(workspace.members) { member in TextField("\(member.fallbackProjectName) base override", text: Binding(get: { model.memberBaseReferences[member.id] ?? "" }, set: { value in if value.isEmpty { model.memberBaseReferences[member.id] = nil } else { model.memberBaseReferences[member.id] = value } })) } }
-            if model.step == .preflight { Text("Preflight never creates files or Git artifacts.").foregroundStyle(.secondary)
-            ForEach(model.preflightMessages, id: \.self) { Text($0).foregroundStyle(.red) }
-            if case .success(let plan) = model.preflightResult { ForEach(plan.warnings, id: \.id) { Text($0.message).foregroundStyle(.orange) }
-            ForEach(plan.members, id: \.checkoutMemberID) { member in Text(verbatim: "✓ \(member.projectID): \(member.baseReference) @ \(member.baseCommit), \(member.branchIntent), \(member.destinationPath)") } } }
-            if model.step == .creating, let id = model.selectedCheckoutID, let checkout = state.workspacesManager.checkout(id: id) { let progress = model.progress(for: checkout)
-            Text("Creating \(progress.completedMembers) of \(progress.totalMembers) members") }
-            if let error { Text(error).foregroundStyle(.red) }
-        }, cancelTitle: "Cancel", confirmTitle: confirmTitle, confirmStyle: .primary, onCancel: { presented = false }, onConfirm: proceed, confirmEnabled: model.step != .creating || model.selectedCheckoutID == nil)
+    @State private var showsBaseOverrides = false
+    @State private var isChecking = false
+    @State private var creationFinished = false
+    @State private var isVisible = true
+    @Environment(\.theme) private var theme
+
+    init(state: AppState, workspace: Workspace, presented: Binding<Bool>) {
+        self.state = state
+        self.workspace = workspace
+        self._presented = presented
+        self._model = State(initialValue: .init(workspace: workspace))
     }
-    private var subtitle: String { "Step \(model.step.rawValue + 1) of 3" }
-    private var confirmTitle: String { model.step == .details ? "Preflight" : model.step == .preflight ? "Create Checkout" : "Creating" }
-    private func proceed() { switch model.step { case .details: let result = model.advance()
-    guard case .success = result else { error = result.failureMessage
-    return }
-    Task { @MainActor in model.receivePreflight(await state.preflightWorkspaceCheckout(model.request())) }
-    case .preflight: guard model.beginCreation(), case .success(let plan) = model.preflightResult else { return }
-    Task { @MainActor in do { let checkout = try await state.createWorkspaceCheckout(workspace: workspace, plan: plan)
-    model.didPersist(checkoutID: checkout.id)
-    while !Task.isCancelled { try? await Task.sleep(for: .milliseconds(250))
-    await state.workspacesManager.refreshCheckoutSnapshots()
-    if let current = state.workspacesManager.checkout(id: checkout.id), current.operation == .idle { if current.members.allSatisfy({ $0.checkpoint == .setupComplete }) { presented = false } else { error = "Creation needs attention. Review the failed member before closing this dialog." }
-    break } } } catch { self.error = error.localizedDescription } }
-    case .creating: break } }
+
+    var body: some View {
+        DialogContainer(
+            title: "New workspace checkout",
+            subtitle: workspace.name,
+            width: 560,
+            content: {
+                steps
+                Group {
+                    switch model.step {
+                    case .details:
+                        ScrollView { details }
+                    case .preflight: preflight
+                    case .creating: creation
+                    }
+                }
+                .frame(height: 280, alignment: .top)
+                if let error { WorkspaceNotice(message: error, isError: true) }
+            },
+            cancelTitle: model.step == .preflight && !isChecking ? "Back" : model.step == .creating ? "Close" : "Cancel",
+            confirmTitle: confirmTitle,
+            confirmStyle: .primary,
+            onCancel: goBackOrClose,
+            onConfirm: proceed,
+            confirmEnabled: canProceed
+        )
+        .onExitCommand(perform: goBackOrClose)
+        .onDisappear { isVisible = false }
+    }
+
+    private var steps: some View {
+        HStack(spacing: 8) {
+            ForEach(Array(["Details", "Review", "Create"].enumerated()), id: \.offset) { index, title in
+                HStack(spacing: 6) {
+                    Image(systemName: index < model.step.rawValue ? "checkmark.circle.fill" : "\(index + 1).circle\(index == model.step.rawValue ? ".fill" : "")")
+                    Text(title)
+                }
+                .font(.system(size: 11.5, weight: index == model.step.rawValue ? .semibold : .regular))
+                .foregroundColor(theme.color(index == model.step.rawValue ? "fg" : "fg-dim"))
+                if index < 2 {
+                    Rectangle().fill(theme.color("line")).frame(height: 1)
+                }
+            }
+        }
+        .padding(.bottom, 4)
+    }
+
+    private var details: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            DialogField(label: "Shared branch") {
+                AlasField(text: $model.branch, placeholder: "feature/my-change", monospaced: true, focusOnAppear: true)
+            }
+            DialogField(label: "Checkout folder") {
+                AlasField(text: $model.rootPath, placeholder: "/path/to/checkouts/my-change", monospaced: true)
+            }
+            DialogField(label: "Base reference") {
+                AlasField(text: $model.baseReference, placeholder: "main", monospaced: true)
+            }
+            DisclosureGroup("Base references by repository", isExpanded: $showsBaseOverrides) {
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(workspace.members) { member in
+                        DialogField(label: member.fallbackProjectName) {
+                            AlasField(text: Binding(
+                                get: { model.memberBaseReferences[member.id] ?? "" },
+                                set: { model.memberBaseReferences[member.id] = $0.isEmpty ? nil : $0 }
+                            ), placeholder: model.baseReference, monospaced: true)
+                        }
+                    }
+                }
+                .padding(.top, 8)
+            }
+            .font(.system(size: 11.5))
+            .foregroundColor(theme.color("fg-muted"))
+        }
+    }
+
+    private var preflight: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if isChecking {
+                HStack(spacing: 10) {
+                    ProgressView().controlSize(.small)
+                    Text("Checking repositories...")
+                        .font(.system(size: 12)).foregroundColor(theme.color("fg-muted"))
+                }
+                .frame(maxWidth: .infinity, minHeight: 80)
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 12) {
+                        ForEach(model.preflightMessages, id: \.self) { WorkspaceNotice(message: $0, isError: true) }
+                        if case .success(let plan) = model.preflightResult {
+                            ForEach(plan.warnings, id: \.id) { WorkspaceNotice(message: $0.message) }
+                            ForEach(plan.members, id: \.checkoutMemberID) { member in
+                                HStack(alignment: .top, spacing: 10) {
+                                    Icon(name: "checkmark.circle.fill", size: 14, color: theme.color("add"))
+                                    VStack(alignment: .leading, spacing: 5) {
+                                        Text(workspace.members.first(where: { $0.projectID == member.projectID })?.fallbackProjectName ?? member.projectID)
+                                            .font(.system(size: 12, weight: .medium))
+                                            .foregroundColor(theme.color("fg"))
+                                        Text("\(member.baseReference) → \(model.branch)")
+                                            .foregroundColor(theme.color("fg-muted"))
+                                        Text(member.branchIntent == .reuse ? "Use existing branch" : "Create branch at \(member.baseCommit.prefix(8))")
+                                            .foregroundColor(theme.color("fg-dim"))
+                                            .help(member.baseCommit)
+                                        Text(member.destinationPath)
+                                            .foregroundColor(theme.color("fg-dim"))
+                                            .textSelection(.enabled)
+                                    }
+                                    .font(.system(size: 11, design: .monospaced))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                }
+                                .padding(.vertical, 4)
+                            }
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(height: 240)
+            }
+        }
+    }
+
+    private var creation: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let id = model.selectedCheckoutID, let checkout = state.workspacesManager.checkout(id: id) {
+                let progress = model.progress(for: checkout)
+                ProgressView(value: Double(progress.completedMembers), total: Double(max(progress.totalMembers, 1)))
+                    .tint(theme.color("accent"))
+                Text("\(progress.completedMembers) of \(progress.totalMembers) repositories ready")
+                    .font(.system(size: 12)).foregroundColor(theme.color("fg-muted"))
+            } else if !creationFinished {
+                ProgressView().controlSize(.small)
+                Text("Preparing checkout...").font(.system(size: 12)).foregroundColor(theme.color("fg-muted"))
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 80, alignment: .leading)
+    }
+
+    private var confirmTitle: String {
+        switch model.step {
+        case .details: "Review checkout"
+        case .preflight: isChecking ? "Checking..." : "Create checkout"
+        case .creating: creationFinished ? "Done" : "Creating..."
+        }
+    }
+
+    private var canProceed: Bool {
+        switch model.step {
+        case .details: return !model.request().branch.isEmpty && !model.request().rootPath.isEmpty
+        case .preflight:
+            if case .success = model.preflightResult { return !isChecking }
+            return false
+        case .creating: return creationFinished
+        }
+    }
+
+    private func goBackOrClose() {
+        if model.step == .preflight && !isChecking {
+            var details = WorkspaceCheckoutCreationModel(
+                workspace: workspace, branch: model.branch, rootPath: model.rootPath, baseReference: model.baseReference
+            )
+            details.memberBaseReferences = model.memberBaseReferences
+            model = details
+            error = nil
+        } else {
+            presented = false
+        }
+    }
+
+    private func proceed() {
+        guard canProceed else { return }
+        error = nil
+        switch model.step {
+        case .details:
+            guard case .success = model.advance() else { return }
+            isChecking = true
+            Task { @MainActor in
+                let result = await state.preflightWorkspaceCheckout(model.request())
+                guard isVisible else { return }
+                model.receivePreflight(result)
+                isChecking = false
+            }
+        case .preflight:
+            guard model.beginCreation(), case .success(let plan) = model.preflightResult else { return }
+            Task { @MainActor in
+                do {
+                    let checkout = try await state.createWorkspaceCheckout(workspace: workspace, plan: plan)
+                    guard isVisible else { return }
+                    model.didPersist(checkoutID: checkout.id)
+                    while isVisible && !Task.isCancelled {
+                        try await Task.sleep(for: .milliseconds(250))
+                        guard isVisible else { return }
+                        await state.workspacesManager.refreshCheckoutSnapshots()
+                        guard isVisible else { return }
+                        if let current = state.workspacesManager.checkout(id: checkout.id), current.operation == .idle {
+                            if current.members.allSatisfy({ $0.checkpoint == .setupComplete }) {
+                                presented = false
+                            } else {
+                                error = "Some repositories need attention. Open checkout details to continue."
+                            }
+                            break
+                        }
+                    }
+                } catch {
+                    self.error = error.localizedDescription
+                }
+                creationFinished = true
+            }
+        case .creating:
+            presented = false
+        }
+    }
 }
 
-private extension WorkspaceCheckoutCreationAdvanceResult { var failureMessage: String? { if case .failure(let message) = self { message } else { nil } } }
+struct WorkspaceNotice: View {
+    let message: String
+    var isError = false
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Icon(name: "alert", size: 12, color: theme.color(isError ? "del" : "fg-muted"))
+            Text(message)
+                .font(.system(size: 11.5))
+                .foregroundColor(theme.color(isError ? "del" : "fg-muted"))
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/Alas/Sources/Sidebar/SidebarHeaderView.swift
+++ b/Alas/Sources/Sidebar/SidebarHeaderView.swift
@@ -7,7 +7,10 @@ struct SidebarHeaderView: View {
     let onAddProject: () -> Void
     let onSearch: () -> Void
     let onHideSidebar: () -> Void
+    var onNewWorkspace: (() -> Void)? = nil
+    @Environment(\.theme) private var theme
     @State private var hovering = false
+    @State private var addMenuHovered = false
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
@@ -20,7 +23,26 @@ struct SidebarHeaderView: View {
                     headerHovered: hovering
                 )
                 ToolbarBtn(icon: "search", tooltip: "Search", action: onSearch)
-                ToolbarBtn(icon: "folder-plus", tooltip: "Add repository", action: onAddProject)
+                if let onNewWorkspace {
+                    Menu {
+                        Button("Add repository...", systemImage: "folder.badge.plus", action: onAddProject)
+                        Button("New workspace...", systemImage: "square.stack.3d.up", action: onNewWorkspace)
+                    } label: {
+                        Icon(name: "folder-plus", size: 13, color: theme.color(addMenuHovered ? "fg" : "fg-muted"))
+                            .frame(width: 26, height: 22)
+                            .contentShape(Rectangle())
+                            .background(addMenuHovered ? theme.color("bg-3") : .clear)
+                            .clipShape(RoundedRectangle(cornerRadius: 5))
+                    }
+                    .menuStyle(.borderlessButton)
+                    .menuIndicator(.hidden)
+                    .fixedSize()
+                    .onHover { addMenuHovered = $0 }
+                    .help("Add repository or workspace")
+                    .accessibilityLabel("Add repository or workspace")
+                } else {
+                    ToolbarBtn(icon: "folder-plus", tooltip: "Add repository", action: onAddProject)
+                }
                 ToolbarBtn(icon: "gear", tooltip: "Settings", action: onSettings)
                 ToolbarBtn(icon: "sidebar.left", tooltip: "Hide sidebar", action: onHideSidebar)
             }
@@ -50,5 +72,6 @@ struct ToolbarBtn: View {
         .buttonStyle(.plain)
         .onHover { hovering = $0 }
         .help(tooltip)
+        .accessibilityLabel(tooltip)
     }
 }

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -13,6 +13,7 @@ struct SidebarView: View {
     @Environment(\.theme) var theme
     @State private var spaceTitleVisible = false
     @State private var hideTitleTask: Task<Void, Never>?
+    @State private var showingNewWorkspace = false
 
     var body: some View {
         let override = state.config.sidebarChromeOverride(forThemeId: state.themeStore.current.id)
@@ -30,7 +31,8 @@ struct SidebarView: View {
                     onSearch: {
                         NotificationCenter.default.post(name: .alasOpenSearch, object: nil)
                     },
-                    onHideSidebar: onHideSidebar
+                    onHideSidebar: onHideSidebar,
+                    onNewWorkspace: state.config.workspacesEnabled ? { showingNewWorkspace = true } : nil
                 )
                 ScrollView(.vertical, showsIndicators: true) {
                     VStack(alignment: .leading, spacing: 8) {
@@ -223,6 +225,9 @@ struct SidebarView: View {
         .onDisappear {
             hideTitleTask?.cancel()
             hideTitleTask = nil
+        }
+        .sheet(isPresented: $showingNewWorkspace) {
+            NewWorkspaceDialog(state: state, presented: $showingNewWorkspace)
         }
     }
 

--- a/Alas/Sources/Sidebar/WorkspaceSidebarTree.swift
+++ b/Alas/Sources/Sidebar/WorkspaceSidebarTree.swift
@@ -6,9 +6,13 @@ import SwiftUI
 struct WorkspaceSidebarTree<ProjectRow: View>: View {
     @Bindable var state: AppState
     let projectRow: (ProjectConfig) -> ProjectRow
-    @State private var showingNewWorkspace = false
     @State private var editingWorkspace: Workspace?
     @State private var creatingCheckout: Workspace?
+    @State private var inspectedCheckout: WorkspaceCheckout?
+    @State private var inspectorGeneration = UUID()
+    @State private var collapsedWorkspaces: Set<UUID> = []
+    @State private var expandedCheckouts: Set<UUID> = []
+    @Environment(\.theme) private var theme
     @State private var lifecycleError: String?
     @State private var deletionConfirmation: PendingDeletionConfirmation?
     @State private var workspaceDeletionConfirmation: PendingWorkspaceDefinitionDeletion?
@@ -27,92 +31,66 @@ struct WorkspaceSidebarTree<ProjectRow: View>: View {
         let checkouts = Dictionary(uniqueKeysWithValues: state.workspacesManager.checkouts.map { ($0.id, $0) })
         let projects = Dictionary(uniqueKeysWithValues: state.projects.map { ($0.id, $0) })
 
-        if state.config.workspacesEnabled {
-            Button("New Workspace", systemImage: "plus") { showingNewWorkspace = true }
-                .buttonStyle(.plain).padding(.horizontal, 12)
-        }
-        ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
-            switch row {
-            case .project(let id):
-                if let project = projects[id] {
-                    projectRow(project)
-                }
-            case .workspace(let id):
-                if let workspace = workspaces[id] {
-                    HStack {
-                        Button { state.selectWorkspace(id: id) } label: { Label(workspace.name, systemImage: "square.stack.3d.up") }
-                            .buttonStyle(.plain)
-                        Spacer()
-                        Button("Create Checkout") { creatingCheckout = workspace }.buttonStyle(.plain)
-                        Button("Edit") { editingWorkspace = workspace }.buttonStyle(.plain)
-                        Button("Delete", role: .destructive) {
-                            workspaceDeletionConfirmation = .init(id: id, name: workspace.name)
-                        }.buttonStyle(.plain)
-                    }.padding(.horizontal, 12)
-                }
-            case .formerWorkspace:
-                Label("Former Workspace", systemImage: "archivebox")
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 12)
-            case .checkout(let id):
-                if let checkout = checkouts[id] {
-                    VStack(alignment: .leading, spacing: 3) {
-                        Button {
-                            state.selectWorkspaceCheckout(id: id)
-                        } label: {
-                            Label(checkout.branch, systemImage: "arrow.triangle.branch")
-                        }
-                        .buttonStyle(.plain)
-                        .padding(.leading, 28)
-                        ForEach(checkout.members) { member in
-                            Button {
-                                state.selectWorkspaceCheckout(id: id)
-                                state.focusWorkspaceCheckoutMember(id: member.id)
-                            } label: {
-                                Text(member.fallbackProjectName)
-                                    .foregroundStyle(member.availability == .available ? .primary : .secondary)
-                            }
-                            .buttonStyle(.plain)
-                            .padding(.leading, 48)
-                        }
-                        if state.workspaceNavigationState.selectedCheckoutID == id {
-                            WorkspaceCheckoutDetailView(
-                                model: Self.detailModel(
-                                    for: checkout,
-                                    rollupBuilder: state.workspaceMemberReviewRollupBuilder(for: checkout)
-                                ),
-                                perform: { action, memberID in
-                                    perform(action, checkoutID: id, memberID: memberID)
-                                },
-                                openReview: { action in
-                                    state.openWorkspaceReview(action)
-                                }
-                            )
-                            .padding(.leading, 28)
-                        }
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                switch row {
+                case .project(let id):
+                    if let project = projects[id] {
+                        projectRow(project).padding(.vertical, 3)
                     }
+                case .workspace(let id):
+                    if let workspace = workspaces[id] {
+                        workspaceHeader(workspace)
+                    }
+                case .formerWorkspace:
+                    Label("Former Workspace", systemImage: "archivebox")
+                        .font(.system(size: 11.5, weight: .semibold))
+                        .foregroundColor(theme.color("fg-muted"))
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 5)
+                case .checkout(let id):
+                    if let checkout = checkouts[id], checkout.workspaceID.map({ !collapsedWorkspaces.contains($0) }) ?? true {
+                        checkoutRows(checkout, projects: projects)
+                    }
+                case .member:
+                    EmptyView()
                 }
-            case .member:
-                EmptyView()
             }
         }
-        .sheet(isPresented: $showingNewWorkspace) { NewWorkspaceDialog(state: state, presented: $showingNewWorkspace) }
         .sheet(item: $editingWorkspace) { workspace in EditWorkspaceDialog(state: state, workspace: workspace, presented: Binding(get: { editingWorkspace != nil }, set: { if !$0 { editingWorkspace = nil } })) }
         .sheet(item: $creatingCheckout) { workspace in CreateWorkspaceCheckoutDialog(state: state, workspace: workspace, presented: Binding(get: { creatingCheckout != nil }, set: { if !$0 { creatingCheckout = nil } })) }
-        .alert("Workspace Checkout", isPresented: Binding(get: { lifecycleError != nil }, set: { if !$0 { lifecycleError = nil } })) {
-            Button("OK", role: .cancel) { lifecycleError = nil }
-        } message: {
-            Text(lifecycleError ?? "")
-        }
-        .sheet(item: $deletionConfirmation) { pending in
-            WorkspaceDeletionConfirmationSheet(model: pending.model) { action in
-                confirmDeletion(action, checkoutID: pending.checkoutID, memberID: pending.memberID)
+        .sheet(item: $inspectedCheckout) { snapshot in
+            let checkout = state.workspacesManager.checkout(id: snapshot.id) ?? snapshot
+            WorkspaceCheckoutDetailView(
+                model: Self.detailModel(for: checkout, rollupBuilder: state.workspaceMemberReviewRollupBuilder(for: checkout)),
+                perform: { action, memberID in perform(action, checkoutID: checkout.id, memberID: memberID) },
+                openReview: { action in
+                    inspectedCheckout = nil
+                    state.openWorkspaceReview(action)
+                }
+            )
+            .sheet(item: $deletionConfirmation) { pending in
+                WorkspaceDeletionConfirmationSheet(model: pending.model) { action in
+                    confirmDeletion(action, checkoutID: pending.checkoutID, memberID: pending.memberID)
+                }
+                .modifier(WorkspaceLifecycleErrorAlert(error: $lifecycleError))
             }
-        }
-        .sheet(item: $repairPlan) { pending in
-            WorkspaceRepairPlanSheet(model: pending.model) { candidate in
-                useRepairCandidate(candidate, checkoutID: pending.checkoutID, memberID: pending.memberID)
+            .sheet(item: $repairPlan) { pending in
+                WorkspaceRepairPlanSheet(model: pending.model) { candidate in
+                    useRepairCandidate(candidate, checkoutID: pending.checkoutID, memberID: pending.memberID)
+                }
+                .modifier(WorkspaceLifecycleErrorAlert(error: $lifecycleError))
             }
+            .modifier(WorkspaceLifecycleErrorAlert(
+                error: $lifecycleError, enabled: deletionConfirmation == nil && repairPlan == nil
+            ))
+        }
+        .modifier(WorkspaceLifecycleErrorAlert(error: $lifecycleError, enabled: inspectedCheckout == nil))
+        .onChange(of: inspectedCheckout?.id) { _, _ in
+            inspectorGeneration = UUID()
+            deletionConfirmation = nil
+            repairPlan = nil
+            lifecycleError = nil
         }
         .confirmationDialog(
             "Delete Workspace?",
@@ -132,10 +110,153 @@ struct WorkspaceSidebarTree<ProjectRow: View>: View {
             let name = workspaceDeletionConfirmation?.name ?? "this Workspace"
             Text("Delete \(name)? Existing checkouts are retained as Former Workspace checkouts.")
         }
+        .onChange(of: state.workspaceNavigationState.selectedCheckoutID, initial: true) { _, id in
+            guard let id, let checkout = state.workspacesManager.checkout(id: id) else { return }
+            expandedCheckouts.insert(id)
+            if let workspaceID = checkout.workspaceID { collapsedWorkspaces.remove(workspaceID) }
+        }
+    }
+
+    private func workspaceHeader(_ workspace: Workspace) -> some View {
+        let collapsed = collapsedWorkspaces.contains(workspace.id)
+        let selected = state.workspaceNavigationState.selectedWorkspaceID == workspace.id
+            && state.workspaceNavigationState.selectedCheckoutID == nil
+        return HStack(spacing: 7) {
+            Button {
+                if collapsed { collapsedWorkspaces.remove(workspace.id) }
+                else { collapsedWorkspaces.insert(workspace.id) }
+            } label: {
+                Icon(name: collapsed ? "chev-right" : "chev-down", size: 10, color: theme.color("fg-faint"))
+                    .frame(width: 14, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help(collapsed ? "Expand workspace" : "Collapse workspace")
+            .accessibilityLabel(collapsed ? "Expand workspace" : "Collapse workspace")
+            Button { state.selectWorkspace(id: workspace.id) } label: {
+                HStack(spacing: 7) {
+                    Icon(name: "square.stack.3d.up", size: 13, color: theme.color(selected ? "accent" : "fg-muted"))
+                    Text(workspace.name)
+                        .font(.system(size: 11.5, weight: .semibold))
+                        .foregroundColor(theme.color(selected ? "fg" : "fg-muted"))
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help(workspace.name)
+            ToolbarBtn(icon: "plus", tooltip: "New checkout in \(workspace.name)") {
+                creatingCheckout = workspace
+            }
+        }
+        .padding(.leading, 12)
+        .padding(.trailing, 8)
+        .padding(.vertical, 3)
+        .background(selected ? theme.color("bg-3") : .clear)
+        .contextMenu {
+            Button("New checkout...", systemImage: "plus") { creatingCheckout = workspace }
+            Button("Edit workspace...", systemImage: "pencil") { editingWorkspace = workspace }
+            Divider()
+            Button("Delete workspace...", role: .destructive) {
+                workspaceDeletionConfirmation = .init(id: workspace.id, name: workspace.name)
+            }
+        }
+    }
+
+    private func checkoutRows(_ checkout: WorkspaceCheckout, projects: [String: ProjectConfig]) -> some View {
+        let selected = state.workspaceNavigationState.selectedCheckoutID == checkout.id
+        let expanded = expandedCheckouts.contains(checkout.id)
+        return VStack(alignment: .leading, spacing: 1) {
+            HStack(spacing: 6) {
+                Button {
+                    if expanded { expandedCheckouts.remove(checkout.id) }
+                    else { expandedCheckouts.insert(checkout.id) }
+                } label: {
+                    Icon(name: expanded ? "chev-down" : "chev-right", size: 9, color: theme.color("fg-faint"))
+                        .frame(width: 14, height: 28)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help(expanded ? "Hide repositories" : "Show repositories")
+                .accessibilityLabel(expanded ? "Hide repositories" : "Show repositories")
+                Button {
+                    state.selectWorkspaceCheckout(id: checkout.id)
+                } label: {
+                    HStack(spacing: 7) {
+                        Icon(name: checkout.archivedAt == nil ? "branch" : "archivebox", size: 12)
+                        Text(checkout.branch)
+                            .font(.system(size: 12, weight: .medium, design: .monospaced))
+                            .foregroundColor(theme.color(checkout.archivedAt == nil ? "fg" : "fg-dim"))
+                            .lineLimit(1).truncationMode(.middle)
+                        Spacer(minLength: 0)
+                        if checkout.operation != .idle {
+                            ProgressView().controlSize(.mini)
+                        } else if checkout.archivedAt == nil && checkout.health != .ready {
+                            Icon(name: "alert", size: 11, color: theme.color("del"))
+                                .help("Checkout needs attention")
+                        }
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                ToolbarBtn(icon: "info.circle", tooltip: "Checkout details") { inspectedCheckout = checkout }
+            }
+            .padding(.leading, 20)
+            .padding(.trailing, 4)
+            .background(selected ? theme.color("bg-4") : .clear, in: RoundedRectangle(cornerRadius: 6))
+            .overlay(alignment: .leading) {
+                if selected {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(theme.color("accent"))
+                        .frame(width: 3, height: 14)
+                        .padding(.leading, 2)
+                }
+            }
+            .contextMenu {
+                Button("Checkout details...", systemImage: "info.circle") { inspectedCheckout = checkout }
+            }
+            .help(checkout.branch)
+            if expanded {
+                ForEach(checkout.members) { member in
+                    let focused = selected && state.workspaceNavigationState.focusedCheckoutMemberID == member.id
+                    Button {
+                        state.selectWorkspaceCheckout(id: checkout.id)
+                        state.focusWorkspaceCheckoutMember(id: member.id)
+                    } label: {
+                        HStack(spacing: 7) {
+                            if let project = projects[member.projectID] {
+                                ProjectIconView(icon: project.icon, fallbackName: project.name, size: .sidebar)
+                            } else {
+                                Icon(name: "folder", size: 12)
+                            }
+                            Text(member.fallbackProjectName)
+                                .font(.system(size: 11.5, weight: focused ? .medium : .regular))
+                                .foregroundColor(theme.color(member.availability == .available ? "fg-muted" : "fg-dim"))
+                                .lineLimit(1)
+                            Spacer(minLength: 0)
+                            if member.checkpoint == .failed || member.availability == .missing || member.availability == .identityConflict {
+                                Icon(name: "alert", size: 10, color: theme.color("del"))
+                            }
+                        }
+                        .padding(.leading, 48).padding(.trailing, 12)
+                        .frame(height: 27)
+                        .contentShape(Rectangle())
+                        .background(focused ? theme.color("bg-3") : .clear, in: RoundedRectangle(cornerRadius: 5))
+                    }
+                    .buttonStyle(.plain)
+                    .help(member.worktreePath)
+                }
+            }
+        }
+        .padding(.horizontal, 6)
     }
 
     private func perform(_ action: WorkspaceCheckoutActionKind, checkoutID: UUID, memberID: UUID?) {
+        let generation = inspectorGeneration
         Task { @MainActor in
+            guard isCurrentInspector(checkoutID, generation: generation) else { return }
             do {
                 switch action {
                 case .archive:
@@ -144,6 +265,7 @@ struct WorkspaceSidebarTree<ProjectRow: View>: View {
                     _ = try await state.unarchiveWorkspaceCheckout(id: checkoutID)
                 case .deleteCheckout:
                     let confirmation = try await state.workspaceCheckoutDeletionConfirmation(checkoutID: checkoutID)
+                    guard isCurrentInspector(checkoutID, generation: generation) else { return }
                     if confirmation.requiresConfirmation {
                         deletionConfirmation = PendingDeletionConfirmation(checkoutID: checkoutID, memberID: nil, model: confirmation)
                     } else {
@@ -155,6 +277,7 @@ struct WorkspaceSidebarTree<ProjectRow: View>: View {
                         deletionConfirmation = PendingDeletionConfirmation(checkoutID: checkoutID, memberID: nil, model: confirmation)
                     } else {
                         try await state.forgetWorkspaceCheckout(id: checkoutID)
+                        if isCurrentInspector(checkoutID, generation: generation) { inspectedCheckout = nil }
                     }
                 case .stopAfterCurrentOperations:
                     try await state.stopWorkspaceCheckoutAfterCurrentOperations(id: checkoutID)
@@ -179,6 +302,7 @@ struct WorkspaceSidebarTree<ProjectRow: View>: View {
                             _ = try await state.deleteWorkspaceCheckoutMemberSnapshot(checkoutID: checkoutID, memberID: memberID)
                         } else {
                             let confirmation = try await state.workspaceMemberDeletionConfirmation(checkoutID: checkoutID, memberID: memberID)
+                            guard isCurrentInspector(checkoutID, generation: generation) else { return }
                             if confirmation.requiresConfirmation {
                                 deletionConfirmation = PendingDeletionConfirmation(checkoutID: checkoutID, memberID: memberID, model: confirmation)
                             } else {
@@ -188,9 +312,13 @@ struct WorkspaceSidebarTree<ProjectRow: View>: View {
                     }
                 }
             } catch {
-                lifecycleError = error.localizedDescription
+                if isCurrentInspector(checkoutID, generation: generation) { lifecycleError = error.localizedDescription }
             }
         }
+    }
+
+    private func isCurrentInspector(_ checkoutID: UUID, generation: UUID) -> Bool {
+        inspectedCheckout?.id == checkoutID && inspectorGeneration == generation
     }
 
     static func detailModel(for checkout: WorkspaceCheckout, rollupBuilder: MemberReviewRollupBuilder = .init()) -> WorkspaceCheckoutDetailModel {
@@ -201,34 +329,39 @@ struct WorkspaceSidebarTree<ProjectRow: View>: View {
     }
 
     private func confirmDeletion(_ action: WorkspaceLifecycleAction, checkoutID: UUID, memberID: UUID?) {
+        let generation = inspectorGeneration
+        let confirmationID = deletionConfirmation?.id
         Task { @MainActor in
+            guard isCurrentInspector(checkoutID, generation: generation) else { return }
             do {
                 switch action {
                 case .deleteCheckout(let confirmingRisks):
                     _ = try await state.deleteWorkspaceCheckout(id: checkoutID, confirmingRisks: confirmingRisks)
-                    deletionConfirmation = nil
                 case .deleteMember(let confirmingRisks):
                     if let memberID {
                         _ = try await state.deleteWorkspaceCheckoutMember(checkoutID: checkoutID, memberID: memberID, confirmingRisks: confirmingRisks)
                     }
-                    deletionConfirmation = nil
                 case .forgetCheckout(let confirmedPreserveArtifacts):
                     try await state.forgetWorkspaceCheckout(id: checkoutID, confirmedPreserveArtifacts: confirmedPreserveArtifacts)
-                    deletionConfirmation = nil
+                    if isCurrentInspector(checkoutID, generation: generation) { inspectedCheckout = nil }
                 }
+                if deletionConfirmation?.id == confirmationID { deletionConfirmation = nil }
             } catch {
-                lifecycleError = error.localizedDescription
+                if isCurrentInspector(checkoutID, generation: generation) { lifecycleError = error.localizedDescription }
             }
         }
     }
 
     private func useRepairCandidate(_ candidate: WorkspaceRepairCandidate, checkoutID: UUID, memberID: UUID) {
+        let generation = inspectorGeneration
+        let repairID = repairPlan?.id
         Task { @MainActor in
+            guard isCurrentInspector(checkoutID, generation: generation) else { return }
             do {
                 _ = try await state.useWorkspaceRepairCandidate(checkoutID: checkoutID, memberID: memberID, candidate: candidate)
-                repairPlan = nil
+                if repairPlan?.id == repairID { repairPlan = nil }
             } catch {
-                lifecycleError = error.localizedDescription
+                if isCurrentInspector(checkoutID, generation: generation) { lifecycleError = error.localizedDescription }
             }
         }
     }
@@ -241,6 +374,22 @@ struct WorkspaceSidebarTree<ProjectRow: View>: View {
             } catch {
                 lifecycleError = error.localizedDescription
             }
+        }
+    }
+}
+
+private struct WorkspaceLifecycleErrorAlert: ViewModifier {
+    @Binding var error: String?
+    var enabled = true
+
+    func body(content: Content) -> some View {
+        content.alert("Workspace checkout", isPresented: Binding(
+            get: { enabled && error != nil },
+            set: { if !$0 && enabled { error = nil } }
+        )) {
+            Button("OK", role: .cancel) { error = nil }
+        } message: {
+            Text(error ?? "")
         }
     }
 }

--- a/Alas/Sources/Workspace/UI/WorkspaceCheckoutDetailView.swift
+++ b/Alas/Sources/Workspace/UI/WorkspaceCheckoutDetailView.swift
@@ -4,61 +4,132 @@ struct WorkspaceCheckoutDetailView: View {
     let model: WorkspaceCheckoutDetailModel
     var perform: (WorkspaceCheckoutActionKind, UUID?) -> Void = { _, _ in }
     var openReview: (WorkspaceReviewAction) -> Void = { _ in }
+    @Environment(\.theme) private var theme
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                VStack(alignment: .leading) {
-                    Text(model.title).font(.title2)
-                    Text(statusText).foregroundStyle(.secondary)
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 10) {
+                Icon(name: "square.stack.3d.up", size: 18, color: theme.color("fg-muted"))
+                    .padding(.top, 2)
+                VStack(alignment: .leading, spacing: 5) {
+                    Text(model.title)
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(theme.color("fg"))
+                        .lineLimit(2)
+                    Label(model.checkout.branch, systemImage: "arrow.triangle.branch")
+                        .font(.system(size: 11.5, design: .monospaced))
+                        .foregroundColor(theme.color("fg-muted"))
+                        .lineLimit(2)
+                        .textSelection(.enabled)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                DialogHeaderIconButton(icon: "x", tooltip: "Close checkout details") { dismiss() }
+            }
+            .padding(22)
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    HStack {
+                        Text(statusText)
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(theme.color("fg-muted"))
+                        Spacer()
+                        ForEach(model.headerBadges.map(\.label), id: \.self) { badge in
+                            Text(badge).font(.system(size: 10.5))
+                                .foregroundColor(theme.color("fg-dim"))
+                        }
+                    }
+                    if let stopMessage = model.stopMessage {
+                        WorkspaceNotice(message: stopMessage)
+                    }
+                    ForEach(model.diagnostics, id: \.self) { diagnostic in
+                        WorkspaceNotice(message: diagnostic, isError: true)
+                    }
+                    if model.checkout.operation == .creating || model.checkout.operation == .repairing {
+                        ProgressView(value: Double(model.progress.completedMembers), total: Double(max(model.progress.totalMembers, 1)))
+                            .tint(theme.color("accent"))
+                    } else if model.checkout.operation != .idle {
+                        ProgressView().controlSize(.small)
+                    }
+                    DialogField(label: "Checkout folder") {
+                        Text(model.checkout.rootPath)
+                            .font(.system(size: 11.5, design: .monospaced))
+                            .foregroundColor(theme.color("fg-muted"))
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Divider()
+                    DialogField(label: "Repositories") {
+                        VStack(spacing: 0) {
+                            ForEach(model.memberRows) { row in
+                                WorkspaceCheckoutMemberRow(row: row) { action in perform(action, row.id) }
+                                if row.id != model.memberRows.last?.id { Divider() }
+                            }
+                        }
+                    }
+                    if !model.checkout.workItems.isEmpty {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Work items").font(.system(size: 11.5, weight: .medium)).foregroundColor(theme.color("fg-muted"))
+                            SwiftUI.ForEach(0..<model.checkout.workItems.count, id: \.self) { index in
+                                let item = model.checkout.workItems[index]
+                                WorkspaceWorkItemDetailRow(item: item)
+                            }
+                        }
+                    }
+                    if let rollup = model.reviewRollup, !rollup.members.isEmpty {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Reviews").font(.system(size: 11.5, weight: .medium)).foregroundColor(theme.color("fg-muted"))
+                            SwiftUI.ForEach(0..<rollup.members.count, id: \.self) { index in
+                                let row = rollup.members[index]
+                                WorkspaceReviewRollupDetailRow(row: row, openReview: openReview)
+                            }
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(22)
+            }
+            .frame(height: 380)
+            HStack {
+                Menu {
+                    ForEach(model.primaryActions) { action in
+                        Button(action.title, role: action.isDestructive ? .destructive : nil) {
+                            perform(action.kind, nil)
+                        }
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Icon(name: "menu", size: 13)
+                        Text("Checkout actions").font(.system(size: 12))
+                    }
+                    .foregroundColor(theme.color("fg-muted"))
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .disabled(model.primaryActions.isEmpty)
                 Spacer()
-                ForEach(model.headerBadges.map(\.label), id: \.self) { badge in
-                    Text(badge).font(.caption).padding(4).background(.quaternary, in: Capsule())
-                }
+                AlasButton(title: "Done", style: .normal) { dismiss() }
             }
-            if let stopMessage = model.stopMessage {
-                Text(stopMessage).foregroundStyle(.secondary)
-            }
-            ForEach(model.diagnostics, id: \.self) { diagnostic in
-                Text(diagnostic).foregroundStyle(.red)
-            }
-            ProgressView(value: Double(model.progress.completedMembers), total: Double(max(model.progress.totalMembers, 1)))
-            HStack {
-                ForEach(model.primaryActions) { action in
-                    Button(action.title) { perform(action.kind, nil) }
-                        .foregroundStyle(action.isDestructive ? .red : .primary)
-                }
-            }
-            if !model.checkout.workItems.isEmpty {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Work Items").font(.headline)
-                    SwiftUI.ForEach(0..<model.checkout.workItems.count, id: \.self) { index in
-                        let item = model.checkout.workItems[index]
-                        WorkspaceWorkItemDetailRow(item: item)
-                    }
-                }
-            }
-            if let rollup = model.reviewRollup, !rollup.members.isEmpty {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Member Reviews").font(.headline)
-                    SwiftUI.ForEach(0..<rollup.members.count, id: \.self) { index in
-                        let row = rollup.members[index]
-                        WorkspaceReviewRollupDetailRow(row: row, openReview: openReview)
-                    }
-                }
-            }
-            ForEach(model.memberRows) { row in
-                WorkspaceCheckoutMemberRow(row: row) { action in perform(action, row.id) }
-            }
+            .padding(.horizontal, 18).padding(.vertical, 12)
+            .background(theme.color("bg-2"))
+            .overlay(Divider(), alignment: .top)
         }
-        .padding()
+        .frame(width: 560)
+        .background(theme.color("bg-1"))
+        .onExitCommand { dismiss() }
     }
 
     private var statusText: String {
+        switch model.checkout.operation {
+        case .deleting: return "Deleting checkout"
+        case .archiving: return "Archiving checkout"
+        case .cleaning: return "Cleaning checkout"
+        default: break
+        }
         switch model.status {
         case .ready(let value), .creating(let value), .partial(let value), .needsAttention(let value), .archived(let value), .formerWorkspace(let value):
-            value
+            return value
         }
     }
 }
@@ -66,29 +137,46 @@ struct WorkspaceCheckoutDetailView: View {
 struct WorkspaceCheckoutMemberRow: View {
     let row: WorkspaceCheckoutMemberRowModel
     var perform: (WorkspaceCheckoutActionKind) -> Void = { _ in }
+    @Environment(\.theme) private var theme
 
     var body: some View {
-        HStack {
-            VStack(alignment: .leading) {
-                Text(row.title)
-                Text(row.detail).font(.caption).foregroundStyle(.secondary)
+        HStack(alignment: .top, spacing: 10) {
+            Icon(name: row.status == .ready ? "checkmark.circle" : "folder", size: 14,
+                 color: theme.color(row.status == .ready ? "add" : "fg-muted"))
+                .padding(.top, 2)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(row.title).font(.system(size: 12, weight: .medium)).foregroundColor(theme.color("fg"))
+                Text(row.detail).font(.system(size: 11)).foregroundColor(theme.color("fg-dim"))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
             }
-            Spacer()
-            Text(row.status.label).font(.caption)
-            ForEach(row.actions) { action in
-                Button(action.title) { perform(action.kind) }
-                    .foregroundStyle(action.isDestructive ? .red : .primary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            Text(row.status.label).font(.system(size: 10.5)).foregroundColor(theme.color("fg-muted"))
+            Menu {
+                ForEach(row.actions) { action in
+                    Button(action.title, role: action.isDestructive ? .destructive : nil) { perform(action.kind) }
+                }
+            } label: {
+                Icon(name: "menu", size: 13).frame(width: 22, height: 20)
             }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .disabled(row.actions.isEmpty)
+            .help("Actions for \(row.title)")
+            .accessibilityLabel("Actions for \(row.title)")
         }
+        .padding(.vertical, 10)
     }
 }
 
 private struct WorkspaceWorkItemDetailRow: View {
     let item: WorkItemSnapshot
+    @Environment(\.theme) private var theme
 
     var body: some View {
         VStack(alignment: .leading) {
-            Text(item.snapshot.title)
+            Text(item.snapshot.title).font(.system(size: 12)).foregroundColor(theme.color("fg"))
             if let refreshError = item.snapshot.refreshError {
                 Text(refreshError)
                     .font(.caption)
@@ -96,7 +184,7 @@ private struct WorkspaceWorkItemDetailRow: View {
             } else {
                 Text(item.snapshot.displayReference ?? item.snapshot.providerLabel)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(theme.color("fg-dim"))
             }
         }
     }
@@ -105,17 +193,18 @@ private struct WorkspaceWorkItemDetailRow: View {
 private struct WorkspaceReviewRollupDetailRow: View {
     let row: WorkspaceMemberReviewRollup.Member
     var openReview: (WorkspaceReviewAction) -> Void
+    @Environment(\.theme) private var theme
 
     var body: some View {
         VStack(alignment: .leading) {
-            Text(row.title)
+            Text(row.title).font(.system(size: 12)).foregroundColor(theme.color("fg"))
             Text("\(row.reviews.count) reviews · \(row.ggStack?.entries.count ?? 0) GG commits · \(row.unpublishedStackEntries.count) unpublished")
                 .font(.caption)
-                .foregroundStyle(.secondary)
-            HStack {
+                .foregroundColor(theme.color("fg-dim"))
+            VStack(alignment: .leading, spacing: 4) {
                 SwiftUI.ForEach(0..<row.reviewActions.count, id: \.self) { index in
                     let action = row.reviewActions[index]
-                    Button("Open Review") { openReview(action) }
+                    AlasButton(title: "Open review", icon: "arrow.up.right", style: .subtle) { openReview(action) }
                 }
             }
         }
@@ -125,32 +214,72 @@ private struct WorkspaceReviewRollupDetailRow: View {
 struct WorkspaceRepairPlanSheet: View {
     let model: WorkspaceRepairPlanModel
     var choose: (WorkspaceRepairCandidate) -> Void = { _ in }
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.theme) private var theme
 
     var body: some View {
-        VStack(alignment: .leading) {
-            Text("Repair \(model.memberName)")
-                .font(.headline)
-            ForEach(model.verifiedCandidates) { candidate in
-                Button(candidate.path) { choose(candidate) }
-            }
-        }
-        .padding()
+        DialogContainer(
+            title: "Repair \(model.memberName)", subtitle: nil,
+            content: {
+                if model.verifiedCandidates.isEmpty {
+                    Text("No matching worktrees found.")
+                        .font(.system(size: 12)).foregroundColor(theme.color("fg-muted"))
+                } else {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 8) {
+                            ForEach(model.verifiedCandidates) { candidate in
+                                Button { choose(candidate) } label: {
+                                    HStack(spacing: 8) {
+                                        Icon(name: "folder", size: 13)
+                                        Text(candidate.path).font(.system(size: 11.5, design: .monospaced))
+                                            .foregroundColor(theme.color("fg"))
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+                                        Icon(name: "arrow.right", size: 12)
+                                    }
+                                    .padding(.vertical, 8)
+                                    .contentShape(Rectangle())
+                                }.buttonStyle(.plain)
+                            }
+                        }
+                    }
+                    .frame(height: 180)
+                }
+            },
+            cancelTitle: "Cancel", confirmTitle: "Done", confirmStyle: .normal,
+            onCancel: { dismiss() }, onConfirm: { dismiss() }, confirmEnabled: true
+        )
+        .onExitCommand { dismiss() }
     }
 }
 
 struct WorkspaceDeletionConfirmationSheet: View {
     let model: WorkspaceLifecycleConfirmationModel
     var confirm: (WorkspaceLifecycleAction) -> Void = { _ in }
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(model.title).font(.headline)
-            ForEach(model.risks, id: \.self) { risk in
-                Text(risk)
-            }
-            Button("Confirm") { confirm(model.confirmAction) }
+        DialogContainer(
+            title: model.title, subtitle: nil,
+            content: {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(model.risks, id: \.self) { WorkspaceNotice(message: $0, isError: true) }
+                    }
+                }
+                .frame(height: min(CGFloat(max(model.risks.count, 1)) * 44, 220))
+            },
+            cancelTitle: "Cancel", confirmTitle: confirmTitle, confirmStyle: .normal,
+            onCancel: { dismiss() }, onConfirm: { confirm(model.confirmAction) }, confirmEnabled: true
+        )
+        .onExitCommand { dismiss() }
+    }
+
+    private var confirmTitle: String {
+        switch model.confirmAction {
+        case .deleteCheckout: "Delete checkout"
+        case .deleteMember: "Delete worktree"
+        case .forgetCheckout: "Forget checkout"
         }
-        .padding()
     }
 }
 

--- a/AlasTests/Workspace/WorkspacePresentationTests.swift
+++ b/AlasTests/Workspace/WorkspacePresentationTests.swift
@@ -1,0 +1,140 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct WorkspacePresentationTests {
+    @Test func workspaceSidebarFitsNarrowAndWideColumns() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = WorkspaceStore(url: directory.appendingPathComponent("workspaces.json"))
+        let workspace = Workspace(name: "Platform release coordination", executionLocation: .local, members: [])
+        var checkout = checkout(memberCount: 2)
+        checkout.workspaceID = workspace.id
+        checkout.branch = "feature/a-long-branch-name-for-coordinated-changes"
+        try await store.checkpoint(.init(workspaces: [workspace], checkouts: [checkout]))
+        let state = AppState(store: MemoryStore(), restoreActiveTabsOnStartup: false, workspaceStore: store)
+        await state.setWorkspacesEnabled(true, persistConfig: false)
+        state.spacesManager.setTypedMembers([.workspace(workspace.id)], forSpace: state.spacesManager.activeSpaceId)
+        state.selectWorkspaceCheckout(id: checkout.id)
+
+        for width in [CGFloat(220), CGFloat(320)] {
+            let size = try render(
+                WorkspaceSidebarTree(state: state) { _ in EmptyView() }.frame(width: width),
+                named: "workspace-sidebar-\(Int(width))"
+            )
+            #expect(size.width == width)
+            #expect(size.height < 220)
+        }
+    }
+
+    @Test func checkoutInspectorKeepsItsSizeWithManyRepositories() throws {
+        let compact = try render(
+            WorkspaceCheckoutDetailView(model: .init(checkout: checkout(memberCount: 2))),
+            named: "workspace-checkout-details"
+        )
+        let large = try render(
+            WorkspaceCheckoutDetailView(model: .init(checkout: checkout(memberCount: 30))),
+            named: "workspace-checkout-many-repositories"
+        )
+
+        #expect(compact.width == 560)
+        #expect(large == compact)
+        #expect(large.height < 640)
+    }
+
+    @Test func definitionDialogsKeepRepositoryListsWithinSheetBounds() throws {
+        let state = AppState(store: MemoryStore(), restoreActiveTabsOnStartup: false)
+        let newSize = try render(
+            NewWorkspaceDialog(state: state, presented: .constant(true)),
+            named: "workspace-new"
+        )
+        let workspace = Workspace(
+            name: "Release coordination",
+            executionLocation: .local,
+            members: (0..<30).map { index in
+                WorkspaceMember(
+                    projectID: "project-\(index)",
+                    fallbackProjectName: "Repository \(index) with a long descriptive name",
+                    fallbackRepositoryRoot: "/Users/developer/Projects/platform/services/repository-\(index)"
+                )
+            }
+        )
+        let editSize = try render(
+            EditWorkspaceDialog(state: state, workspace: workspace, presented: .constant(true)),
+            named: "workspace-edit"
+        )
+        let checkoutSize = try render(
+            CreateWorkspaceCheckoutDialog(state: state, workspace: workspace, presented: .constant(true)),
+            named: "workspace-create-checkout"
+        )
+
+        #expect(newSize.width == 480)
+        #expect(editSize.width == 480)
+        #expect(editSize.height < 640)
+        #expect(checkoutSize.width == 560)
+        #expect(checkoutSize.height < 640)
+    }
+
+    @Test func memberActionsDoNotForceLongNamesBeyondInspectorWidth() throws {
+        let member = WorkspaceCheckoutMemberRowModel(
+            id: UUID(),
+            title: "A repository with a long name that should wrap within the inspector",
+            detail: "/Users/developer/Projects/platform/services/repository-with-a-long-directory-name",
+            status: .identityConflict,
+            actions: [
+                .init(.findExisting, title: "Find Existing"),
+                .init(.deleteMember, title: "Delete Snapshot", isDestructive: true),
+            ]
+        )
+        let size = try render(
+            WorkspaceCheckoutMemberRow(row: member).frame(width: 516),
+            named: "workspace-member-long-name"
+        )
+
+        #expect(size.width == 516)
+        #expect(size.height < 160)
+    }
+
+    private func render<V: View>(_ view: V, named name: String) throws -> CGSize {
+        let theme = try ThemeStore().current
+        let controller = NSHostingController(rootView: view.environment(\.theme, theme).background(theme.color("bg-1")))
+        // Initial selection can expand the sidebar during its first layout.
+        for _ in 0..<3 {
+            controller.view.frame = NSRect(origin: .zero, size: controller.view.fittingSize)
+            controller.view.layoutSubtreeIfNeeded()
+        }
+        let size = controller.view.fittingSize
+        let bitmap = try #require(controller.view.bitmapImageRepForCachingDisplay(in: controller.view.bounds))
+        controller.view.cacheDisplay(in: controller.view.bounds, to: bitmap)
+        let png = try #require(bitmap.representation(using: .png, properties: [:]))
+        Attachment.record(png, named: "\(name).png")
+        return size
+    }
+
+    private func checkout(memberCount: Int) -> WorkspaceCheckout {
+        WorkspaceCheckout(
+            workspaceID: UUID(),
+            fallbackWorkspaceName: "Release coordination",
+            executionLocation: .local,
+            branch: "feature/coordinated-release",
+            rootPath: "/Users/developer/Workspaces/coordinated-release",
+            members: (0..<memberCount).map { index in
+                WorkspaceCheckoutMember(
+                    workspaceMemberID: UUID(), projectID: "project-\(index)",
+                    fallbackProjectName: "Repository \(index)",
+                    fallbackRepositoryRoot: "/Users/developer/Projects/repository-\(index)",
+                    worktreePath: "/Users/developer/Workspaces/coordinated-release/repository-\(index)",
+                    availability: .available, checkpoint: .setupComplete
+                )
+            }
+        )
+    }
+
+    private struct MemoryStore: PersistenceStoreProtocol {
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    }
+}


### PR DESCRIPTION
Refreshes the workspace experience so it matches the surrounding application.

- Move workspace creation into the sidebar add menu and replace bare controls with compact actions and context menus.
- Rework workspace definition and checkout dialogs with themed fields, repository lists, scoped validation, and creation progress.
- Move checkout detail and lifecycle management into a dedicated inspector and guard asynchronous confirmations against stale inspectors.
- Add rendered workspace layout coverage for narrow sidebars, long repository names, and large repository lists.

Validation:
- xcodegen
- macOS build
- Focused workspace test suite: 44 tests across 9 suites