### PR TITLE
feat(remote): improve remote worktree tabs

### DIFF
--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -54,7 +54,7 @@ const worktreeCreation = RemoteWorktreeCreation.createFlow(send);
 worktreeCreation.subscribe(() => renderCreateSheet());
 const changesTree = RemoteFileBrowser.createTree();
 let activeTab = "chat";
-let changesState = { comparisonRef: null, metricsAvailable: true, files: [], truncated: false, loaded: false };
+let changesState = { comparisonRef: null, metricsAvailable: true, files: [], staged: [], unstaged: [], commits: [], truncated: false, loaded: false };
 // Paths (root as "") of directory listings the server reported as truncated
 // (more immediate children than RemoteWorktreeFileAccess.maxFileTreeNodes).
 // `visibleRows()` shows the whole expanded tree at once, so a single notice
@@ -322,6 +322,9 @@ function handle(msg) {
         comparisonRef: msg.comparisonRef || null,
         metricsAvailable: msg.metricsAvailable !== false,
         files: msg.files || [],
+        staged: msg.staged || [],
+        unstaged: msg.unstaged || [],
+        commits: msg.commits || [],
         truncated: !!msg.truncated,
         loaded: true
       };
@@ -518,7 +521,7 @@ function openSession(id) {
   queueItems = []; steerUndoAvailable = false; renderQueue();
   renderDriveBar("idle"); send({ type: "subscribe", sessionId: id });
   changesTree.reset();
-  changesState = { comparisonRef: null, metricsAvailable: true, files: [], truncated: false, loaded: false };
+  changesState = { comparisonRef: null, metricsAvailable: true, files: [], staged: [], unstaged: [], commits: [], truncated: false, loaded: false };
   fileTreeTruncatedPaths = new Set();
   detailStack = [];
   resetChangesAndFilesDOM();
@@ -547,6 +550,7 @@ function showTab(name) {
   showTabListLevel();
   for (const [id, tab] of [["tab-chat", "chat"], ["tab-changes", "changes"], ["tab-files", "files"]]) {
     $(id).classList.toggle("is-active", tab === name);
+    $(id).setAttribute("aria-selected", String(tab === name));
   }
   $("transcript").classList.toggle("hidden", name !== "chat");
   $("changes").classList.toggle("hidden", name !== "changes");
@@ -606,23 +610,37 @@ function renderChanges() {
     return;
   }
 
-  if (changesState.loaded && changesState.files.length === 0) {
+  const sections = RemoteChangesView.changeSections(changesState);
+  if (changesState.loaded && sections.length === 0) {
     list.append(el("p", "placeholder-card", "No changes yet."));
     return;
   }
 
-  for (const file of RemoteChangesView.sortFiles(changesState.files)) {
-    const parts = RemoteChangesView.splitPath(file.path);
-    const row = document.createElement("button");
-    row.type = "button";
-    row.className = "change-row";
-    row.onclick = () => openDiff(file.path);
-
-    row.append(el("span", "change-dir", parts.dir), el("span", "change-name", parts.name));
-    if (file.conflict) row.append(el("span", "change-conflict", "conflict"));
-    row.append(el("span", "change-status", file.status));
-    row.append(el("span", "change-counts", RemoteChangesView.formatFileCounts(file)));
-    list.appendChild(row);
+  for (const section of sections) {
+    list.append(el("h2", "changes-section-title", section.title));
+    for (const file of section.files || []) {
+      const parts = RemoteChangesView.splitPath(file.path);
+      const row = document.createElement("button");
+      row.type = "button";
+      row.className = "change-row";
+      row.onclick = () => openDiff(file.path);
+      row.append(el("span", "change-dir", parts.dir), el("span", "change-name", parts.name));
+      if (file.conflict) row.append(el("span", "change-conflict", "conflict"));
+      row.append(el("span", "change-status", file.status));
+      const counts = el("span", "change-counts");
+      counts.append(el("span", "count-add", "+" + (file.add || 0)), el("span", "count-del", "−" + (file.del || 0)));
+      row.append(counts);
+      list.appendChild(row);
+    }
+    for (const commit of section.commits || []) {
+      const row = document.createElement("div");
+      row.className = "commit-row";
+      row.append(el("code", "commit-sha", commit.shortSha), el("span", "commit-subject", commit.subject), el("span", "commit-author", commit.author));
+      const counts = el("span", "change-counts");
+      counts.append(el("span", "count-add", "+" + (commit.add || 0)), el("span", "count-del", "−" + (commit.del || 0)));
+      row.append(counts);
+      list.appendChild(row);
+    }
   }
 
   const notice = RemoteChangesView.truncationNotice(changesState.truncated, "files");
@@ -733,12 +751,12 @@ function renderFileTree() {
     button.style.paddingLeft = 12 + row.depth * 14 + "px";
 
     const isSubmodule = row.node.kind === "dir" && row.node.isSubmodule === true;
-    const label = row.node.kind === "dir"
-      ? (isSubmodule ? "◇ " : (row.expanded ? "▾ " : "▸ ")) + row.node.name
-      : row.node.name;
-    button.append(el("span", "", label));
-    if (isSubmodule) button.append(el("span", "change-counts", "submodule"));
-    else if (row.node.badge) button.append(el("span", "change-counts", row.node.badge));
+    const iconClass = row.node.kind === "dir"
+      ? "file-icon folder" + (row.expanded ? " expanded" : "")
+      : "file-icon document";
+    button.append(el("span", iconClass), el("span", "file-name", row.node.name));
+    if (isSubmodule) button.append(el("span", "file-badge", "submodule"));
+    else if (row.node.badge) button.append(el("span", "file-badge status-" + row.node.badge, row.node.badge));
 
     button.onclick = () => {
       if (row.node.kind === "dir") {

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -337,11 +337,11 @@ function handle(msg) {
       break;
     case "fileDiffResult":
       if (msg.sessionId !== currentSession) break;
-      renderDiff(msg.path, msg.hunks || [], !!msg.truncated, msg.metadataNote || null);
+      renderDiff(msg.path, msg.stage || null, msg.hunks || [], !!msg.truncated, msg.metadataNote || null);
       break;
     case "fileDiffFailed":
       if (msg.sessionId !== currentSession) break;
-      if ($("diff-path").textContent === msg.path) {
+      if (isActiveDiff(msg.path, msg.stage || null)) {
         $("diff-rows").innerHTML = "";
         $("diff-rows").append(el("p", "placeholder-card", fileAccessMessage(msg.reason, null)));
       }
@@ -713,8 +713,13 @@ function replayActiveListRequest() {
   }
 }
 
-function renderDiff(path, hunks, truncated, metadataNote) {
-  if ($("diff-path").textContent !== path) return;   // a newer file is open
+function isActiveDiff(path, stage) {
+  const top = detailStack[detailStack.length - 1];
+  return top && top.tab === "changes" && top.path === path && top.stage === stage;
+}
+
+function renderDiff(path, stage, hunks, truncated, metadataNote) {
+  if (!isActiveDiff(path, stage)) return;
   const container = $("diff-rows");
   container.innerHTML = "";
   const metadataNotice = RemoteChangesView.metadataOnlyNotice(hunks, metadataNote);

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -324,7 +324,7 @@ function handle(msg) {
         files: msg.files || [],
         staged: msg.staged || [],
         unstaged: msg.unstaged || [],
-        commits: msg.commits || [],
+        commits: msg.commits || [], commitsTruncated: !!msg.commitsTruncated,
         truncated: !!msg.truncated,
         loaded: true
       };
@@ -645,6 +645,7 @@ function renderChanges() {
 
   const notice = RemoteChangesView.truncationNotice(changesState.truncated, "files");
   if (notice) list.append(el("p", "placeholder-card", notice));
+  if (changesState.commitsTruncated) list.append(el("p", "placeholder-card", "Commit list truncated — showing the first 100 commits."));
 }
 
 function openDiff(path, stage = null) {

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -623,7 +623,7 @@ function renderChanges() {
       const row = document.createElement("button");
       row.type = "button";
       row.className = "change-row";
-      row.onclick = () => openDiff(file.path);
+      row.onclick = () => openDiff(file.path, section.stage || null);
       row.append(el("span", "change-dir", parts.dir), el("span", "change-name", parts.name));
       if (file.conflict) row.append(el("span", "change-conflict", "conflict"));
       row.append(el("span", "change-status", file.status));
@@ -647,14 +647,14 @@ function renderChanges() {
   if (notice) list.append(el("p", "placeholder-card", notice));
 }
 
-function openDiff(path) {
-  detailStack.push({ tab: "changes", path });
+function openDiff(path, stage = null) {
+  detailStack.push({ tab: "changes", path, stage });
   $("changes-list").classList.add("hidden");
   $("changes-header").classList.add("hidden");
   $("diff-view").classList.remove("hidden");
   $("diff-path").textContent = path;
   $("diff-rows").innerHTML = "";
-  send({ type: "fileDiff", sessionId: currentSession, path });
+  send({ type: "fileDiff", sessionId: currentSession, path, stage });
 }
 
 function closeDetailLevel() {
@@ -683,7 +683,7 @@ function replayActiveDetailRequest() {
   if (top.tab === "files") {
     send({ type: "readFile", sessionId: currentSession, path: top.path });
   } else if (top.tab === "changes") {
-    send({ type: "fileDiff", sessionId: currentSession, path: top.path });
+    send({ type: "fileDiff", sessionId: currentSession, path: top.path, stage: top.stage || null });
   }
 }
 

--- a/Alas/Resources/RemoteWeb/changes-view.js
+++ b/Alas/Resources/RemoteWeb/changes-view.js
@@ -36,9 +36,10 @@ function changeSections(state) {
 function formatSummary(state) {
   const staged = (state && state.staged) || [];
   const unstaged = (state && state.unstaged) || [];
-  const files = staged.length || unstaged.length
-    ? Array.from(new Map(staged.concat(unstaged).map((file) => [file.path, file])).values())
-    : (state && state.files) || [];
+  const allFiles = (state && state.files) || [];
+  const files = allFiles.length
+    ? allFiles
+    : Array.from(new Map(staged.concat(unstaged).map((file) => [file.path, file])).values());
   let add = 0;
   let del = 0;
   for (const file of files) {

--- a/Alas/Resources/RemoteWeb/changes-view.js
+++ b/Alas/Resources/RemoteWeb/changes-view.js
@@ -19,8 +19,22 @@ function formatFileCounts(file) {
   return "+" + add + " −" + del;
 }
 
+function changeSections(state) {
+  const sections = [];
+  const staged = sortFiles(state && state.staged);
+  const unstaged = sortFiles(state && state.unstaged);
+  const commits = (state && state.commits) || [];
+  if (staged.length || unstaged.length) sections.push({ title: "Working Tree" });
+  if (staged.length) sections.push({ title: "Staged", files: staged });
+  if (unstaged.length) sections.push({ title: "Unstaged", files: unstaged });
+  if (commits.length) sections.push({ title: "Commits", commits });
+  return sections;
+}
+
 function formatSummary(state) {
-  const files = (state && state.files) || [];
+  const staged = (state && state.staged) || [];
+  const unstaged = (state && state.unstaged) || [];
+  const files = staged.length || unstaged.length ? staged.concat(unstaged) : (state && state.files) || [];
   let add = 0;
   let del = 0;
   for (const file of files) {
@@ -30,7 +44,9 @@ function formatSummary(state) {
   const count = files.length + (files.length === 1 ? " file" : " files");
   const totals = count + " · +" + add + " −" + del;
   const ref = state && state.comparisonRef;
-  return ref ? "vs " + ref + " · " + totals : totals;
+  const commitCount = ((state && state.commits) || []).length;
+  const commits = commitCount ? " · " + commitCount + (commitCount === 1 ? " commit" : " commits") : "";
+  return (ref ? "vs " + ref + " · " : "") + totals + commits;
 }
 
 function diffRows(hunks) {
@@ -73,6 +89,7 @@ function metadataOnlyNotice(hunks, metadataNote) {
 globalThis.RemoteChangesView = {
   sortFiles,
   splitPath,
+  changeSections,
   formatSummary,
   formatFileCounts,
   diffRows,

--- a/Alas/Resources/RemoteWeb/changes-view.js
+++ b/Alas/Resources/RemoteWeb/changes-view.js
@@ -21,12 +21,14 @@ function formatFileCounts(file) {
 
 function changeSections(state) {
   const sections = [];
+  const files = sortFiles(state && state.files);
   const staged = sortFiles(state && state.staged);
   const unstaged = sortFiles(state && state.unstaged);
   const commits = (state && state.commits) || [];
+  if (files.length && commits.length) sections.push({ title: "Branch Changes", files });
   if (staged.length || unstaged.length) sections.push({ title: "Working Tree" });
-  if (staged.length) sections.push({ title: "Staged", files: staged });
-  if (unstaged.length) sections.push({ title: "Unstaged", files: unstaged });
+  if (staged.length) sections.push({ title: "Staged", files: staged, stage: "staged" });
+  if (unstaged.length) sections.push({ title: "Unstaged", files: unstaged, stage: "unstaged" });
   if (commits.length) sections.push({ title: "Commits", commits });
   return sections;
 }
@@ -34,7 +36,9 @@ function changeSections(state) {
 function formatSummary(state) {
   const staged = (state && state.staged) || [];
   const unstaged = (state && state.unstaged) || [];
-  const files = staged.length || unstaged.length ? staged.concat(unstaged) : (state && state.files) || [];
+  const files = staged.length || unstaged.length
+    ? Array.from(new Map(staged.concat(unstaged).map((file) => [file.path, file])).values())
+    : (state && state.files) || [];
   let add = 0;
   let del = 0;
   for (const file of files) {

--- a/Alas/Resources/RemoteWeb/changes-view.js
+++ b/Alas/Resources/RemoteWeb/changes-view.js
@@ -49,7 +49,7 @@ function formatSummary(state) {
   const totals = count + " · +" + add + " −" + del;
   const ref = state && state.comparisonRef;
   const commitCount = ((state && state.commits) || []).length;
-  const commits = commitCount ? " · " + commitCount + (commitCount === 1 ? " commit" : " commits") : "";
+  const commits = commitCount ? " · " + commitCount + (state && state.commitsTruncated ? "+" : "") + (commitCount === 1 ? " commit" : " commits") : "";
   return (ref ? "vs " + ref + " · " : "") + totals + commits;
 }
 

--- a/Alas/Resources/RemoteWeb/changes-view.js
+++ b/Alas/Resources/RemoteWeb/changes-view.js
@@ -25,7 +25,7 @@ function changeSections(state) {
   const staged = sortFiles(state && state.staged);
   const unstaged = sortFiles(state && state.unstaged);
   const commits = (state && state.commits) || [];
-  if (files.length && commits.length) sections.push({ title: "Branch Changes", files });
+  if (files.length && (commits.length || (!staged.length && !unstaged.length))) sections.push({ title: "Branch Changes", files });
   if (staged.length || unstaged.length) sections.push({ title: "Working Tree" });
   if (staged.length) sections.push({ title: "Staged", files: staged, stage: "staged" });
   if (unstaged.length) sections.push({ title: "Unstaged", files: unstaged, stage: "unstaged" });

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -196,9 +196,9 @@
   <script src="/purify.min.js?v=28"></script>
   <script src="/session-ordering.js?v=1"></script>
   <script src="/worktree-creation.js?v=1"></script>
-  <script src="/changes-view.js?v=5"></script>
+  <script src="/changes-view.js?v=6"></script>
   <script src="/file-browser.js?v=3"></script>
-  <script src="/app.js?v=75"></script>
+  <script src="/app.js?v=76"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -196,9 +196,9 @@
   <script src="/purify.min.js?v=28"></script>
   <script src="/session-ordering.js?v=1"></script>
   <script src="/worktree-creation.js?v=1"></script>
-  <script src="/changes-view.js?v=4"></script>
+  <script src="/changes-view.js?v=5"></script>
   <script src="/file-browser.js?v=3"></script>
-  <script src="/app.js?v=73"></script>
+  <script src="/app.js?v=74"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/icon.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/icon-180.png" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=43" />
+  <link rel="stylesheet" href="/style.css?v=44" />
 </head>
 <body>
   <header id="bar">

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -198,7 +198,7 @@
   <script src="/worktree-creation.js?v=1"></script>
   <script src="/changes-view.js?v=5"></script>
   <script src="/file-browser.js?v=3"></script>
-  <script src="/app.js?v=74"></script>
+  <script src="/app.js?v=75"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -11,17 +11,17 @@
   <link rel="icon" href="/icon.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/icon-180.png" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=42" />
+  <link rel="stylesheet" href="/style.css?v=43" />
 </head>
 <body>
   <header id="bar">
-    <button id="back" class="hidden">‹ Sessions</button>
+    <button id="back" class="hidden" aria-label="Back to sessions">‹</button>
     <span id="detail-title" class="hidden"></span>
     <button id="detail-rename" class="rename-btn hidden" aria-label="Rename session">✎</button>
     <div id="detail-tabs" class="tabs hidden" role="tablist">
-      <button id="tab-chat" class="tab is-active" role="tab" type="button">Chat</button>
-      <button id="tab-changes" class="tab" role="tab" type="button">Changes</button>
-      <button id="tab-files" class="tab" role="tab" type="button">Files</button>
+      <button id="tab-chat" class="tab is-active" role="tab" type="button" aria-label="Chat" aria-selected="true"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 11.5a7.5 7.5 0 0 1-8 7.5 8.8 8.8 0 0 1-3.3-.7L4 20l1.5-3.6A7 7 0 1 1 20 11.5Z"/></svg></button>
+      <button id="tab-changes" class="tab" role="tab" type="button" aria-label="Changes" aria-selected="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m7 3-4 4 4 4M3 7h12a6 6 0 0 1 6 6v1M17 21l4-4-4-4M21 17H9a6 6 0 0 1-6-6V10"/></svg></button>
+      <button id="tab-files" class="tab" role="tab" type="button" aria-label="Files" aria-selected="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3.5 6.5a2 2 0 0 1 2-2h4l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-13a2 2 0 0 1-2-2Z"/></svg></button>
     </div>
     <span id="nav-title">Alas Remote</span>
     <button id="new-session" aria-label="New session">+ New</button>
@@ -196,9 +196,9 @@
   <script src="/purify.min.js?v=28"></script>
   <script src="/session-ordering.js?v=1"></script>
   <script src="/worktree-creation.js?v=1"></script>
-  <script src="/changes-view.js?v=3"></script>
+  <script src="/changes-view.js?v=4"></script>
   <script src="/file-browser.js?v=3"></script>
-  <script src="/app.js?v=72"></script>
+  <script src="/app.js?v=73"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -357,6 +357,6 @@ button.create-row.is-selected { border-color: var(--accent); background: color-m
   border-radius: 10px; color: var(--fg-muted);
 }
 @media (max-width: 520px) {
-  #detail-title, #detail-rename { display: none; }
+  #detail-title { display: none; }
   #detail-tabs { margin-right: auto; }
 }

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -88,7 +88,7 @@ h1 { font-size: 22px; font-weight: 700; margin: 12px 4px 10px; }
 .session-row-minimal .session-head { flex: 1; }
 .session-row-active.session-row-minimal { background: color-mix(in oklab, var(--accent) 8%, transparent); }
 .session-row-minimal:has(.session-open:active) { background: var(--bg-2); }
-#back { background: none; border: none; color: var(--accent); font-size: 15px; padding: 4px 2px; margin: -4px 0; cursor: pointer; -webkit-tap-highlight-color: transparent; }
+#back { flex: 0 0 auto; width: 28px; height: 28px; background: none; border: none; color: var(--accent); font-size: 27px; line-height: 1; padding: 0; margin: 0; cursor: pointer; -webkit-tap-highlight-color: transparent; }
 .rename-btn { flex: 0 0 auto; width: 30px; height: 30px; border: none; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; background: color-mix(in oklab, var(--bg-3) 64%, transparent); color: var(--fg-muted); font-size: 15px; cursor: pointer; -webkit-tap-highlight-color: transparent; }
 .rename-btn:active { background: var(--bg-4); color: var(--fg); }
 #detail-rename { margin-left: -4px; }
@@ -296,12 +296,13 @@ button.create-row.is-selected { border-color: var(--accent); background: color-m
 .steer-undo { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 7px 12px; border: 0.5px solid var(--line); border-radius: 10px; background: color-mix(in oklab, var(--bg-2) 80%, transparent); color: var(--fg-muted); font-size: 12px; }
 .steer-undo-btn { border: none; background: none; color: var(--accent); font: inherit; font-size: 12px; font-weight: 650; cursor: pointer; -webkit-tap-highlight-color: transparent; }
 
-.tabs { display: flex; gap: 2px; }
+.tabs { display: flex; gap: 2px; padding: 3px; border: 0.5px solid var(--line); border-radius: 9px; background: color-mix(in oklab, var(--bg-2) 84%, transparent); }
 .tab {
-  background: none; border: none; padding: 6px 10px;
-  font: inherit; color: var(--fg-muted); border-radius: 6px;
+  display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 28px;
+  background: none; border: none; padding: 0; color: var(--fg-muted); border-radius: 6px;
 }
-.tab.is-active { color: var(--fg); background: color-mix(in oklab, var(--bg-3) 70%, transparent); }
+.tab svg { width: 15px; height: 15px; fill: none; stroke: currentColor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+.tab.is-active { color: var(--fg); background: var(--bg-1); box-shadow: 0 1px 2px color-mix(in oklab, black 35%, transparent); }
 
 #changes-header {
   display: flex; align-items: center; justify-content: space-between;
@@ -313,11 +314,29 @@ button.create-row.is-selected { border-color: var(--accent); background: color-m
   padding: 10px 12px; background: none; border: none;
   border-bottom: 0.5px solid var(--line-soft); text-align: left; font: inherit; color: var(--fg);
 }
+.changes-section-title { margin: 14px 12px 4px; color: var(--fg-muted); font-size: 11px; font-weight: 700; letter-spacing: 0.45px; text-transform: uppercase; }
+.changes-section-title:first-child { margin-top: 4px; }
 .change-dir { color: var(--fg-faint); }
 .change-name { font-weight: 600; }
-.change-counts { margin-left: auto; font-variant-numeric: tabular-nums; color: var(--fg-muted); }
+.change-counts { margin-left: auto; display: inline-flex; gap: 7px; font-variant-numeric: tabular-nums; }
+.count-add { color: var(--add); }
+.count-del { color: var(--del); }
 .change-conflict { color: var(--del); }
 .change-status { color: var(--fg-faint); font-variant-numeric: tabular-nums; }
+.commit-row { display: flex; align-items: baseline; gap: 8px; padding: 10px 12px; border-bottom: 0.5px solid var(--line-soft); }
+.commit-sha { color: var(--accent); font-size: 11px; }
+.commit-subject { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: 600; }
+.commit-author { color: var(--fg-faint); font-size: 11px; white-space: nowrap; }
+.file-row { align-items: center; }
+.file-icon { width: 16px; height: 16px; flex: 0 0 16px; color: var(--fg-dim); }
+.file-icon::before { display: block; font-size: 15px; line-height: 16px; text-align: center; }
+.file-icon.folder::before { content: "▸"; color: var(--accent); }
+.file-icon.folder.expanded::before { content: "▾"; }
+.file-icon.document::before { content: "•"; }
+.file-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.file-badge { margin-left: auto; font-size: 11px; font-variant-numeric: tabular-nums; color: var(--fg-faint); }
+.file-badge.status-A { color: var(--add); }
+.file-badge.status-D, .file-badge.status-U { color: var(--del); }
 
 #diff-rows, #file-view-body {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -336,4 +355,8 @@ button.create-row.is-selected { border-color: var(--accent); background: color-m
 .placeholder-card {
   margin: 16px 12px; padding: 12px; border: 0.5px solid var(--line);
   border-radius: 10px; color: var(--fg-muted);
+}
+@media (max-width: 520px) {
+  #detail-title, #detail-rename { display: none; }
+  #detail-tabs { margin-right: auto; }
 }

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,13 +1,13 @@
-const CACHE_NAME = "alas-remote-shell-v51";
+const CACHE_NAME = "alas-remote-shell-v52";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
-  "/style.css?v=42",
+  "/style.css?v=43",
   "/session-ordering.js?v=1",
   "/worktree-creation.js?v=1",
-  "/changes-view.js?v=3",
+  "/changes-view.js?v=4",
   "/file-browser.js?v=3",
-  "/app.js?v=72",
+  "/app.js?v=73",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,13 +1,13 @@
-const CACHE_NAME = "alas-remote-shell-v52";
+const CACHE_NAME = "alas-remote-shell-v53";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=43",
   "/session-ordering.js?v=1",
   "/worktree-creation.js?v=1",
-  "/changes-view.js?v=4",
+  "/changes-view.js?v=5",
   "/file-browser.js?v=3",
-  "/app.js?v=73",
+  "/app.js?v=74",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "alas-remote-shell-v53";
+const CACHE_NAME = "alas-remote-shell-v54";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
@@ -7,7 +7,7 @@ const SHELL_ASSETS = [
   "/worktree-creation.js?v=1",
   "/changes-view.js?v=5",
   "/file-browser.js?v=3",
-  "/app.js?v=74",
+  "/app.js?v=75",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,8 +1,8 @@
-const CACHE_NAME = "alas-remote-shell-v55";
+const CACHE_NAME = "alas-remote-shell-v56";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
-  "/style.css?v=43",
+  "/style.css?v=44",
   "/session-ordering.js?v=1",
   "/worktree-creation.js?v=1",
   "/changes-view.js?v=6",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,13 +1,13 @@
-const CACHE_NAME = "alas-remote-shell-v54";
+const CACHE_NAME = "alas-remote-shell-v55";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
   "/style.css?v=43",
   "/session-ordering.js?v=1",
   "/worktree-creation.js?v=1",
-  "/changes-view.js?v=5",
+  "/changes-view.js?v=6",
   "/file-browser.js?v=3",
-  "/app.js?v=75",
+  "/app.js?v=76",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -10507,7 +10507,7 @@ extension AppState: RemoteSessionsProvider {
                 staged: cappedWorkingTree.files.filter { $0.stage == .staged }.map(Self.remoteChangedFile),
                 unstaged: cappedWorkingTree.files.filter { $0.stage == .unstaged }.map(Self.remoteChangedFile),
                 commits: commits.commits.prefix(100).map(Self.remoteCommit),
-                truncated: capped.truncated || cappedWorkingTree.truncated)
+                truncated: capped.truncated || cappedWorkingTree.truncated || commits.commits.count > 100)
         } catch {
             return .failure(reason: .gitFailed, message: error.localizedDescription)
         }
@@ -10558,17 +10558,23 @@ extension AppState: RemoteSessionsProvider {
             if ignored {
                 return .failure(reason: .pathRejected, message: nil)
             }
-            if await isDiffTargetBinary(
+            let changeStage: ChangeStage?
+            if let stage {
+                guard let parsedStage = ChangeStage(rawValue: stage) else {
+                    return .failure(reason: .pathRejected, message: nil)
+                }
+                changeStage = parsedStage
+            } else {
+                changeStage = nil
+            }
+            if changeStage != .staged, await isDiffTargetBinary(
                 worktree: worktree, normalizedPath: normalizedPath, url: url,
                 comparisonRef: commits.comparisonRef, git: git
             ) {
                 return .failure(reason: .binary, message: nil)
             }
             let parsed: ParsedDiff
-            if let stage {
-                guard let changeStage = ChangeStage(rawValue: stage) else {
-                    return .failure(reason: .pathRejected, message: nil)
-                }
+            if let changeStage {
                 parsed = try await git.diff(
                     worktreePath: worktree.path, file: normalizedPath,
                     staged: changeStage == .staged)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -10507,7 +10507,8 @@ extension AppState: RemoteSessionsProvider {
                 staged: cappedWorkingTree.files.filter { $0.stage == .staged }.map(Self.remoteChangedFile),
                 unstaged: cappedWorkingTree.files.filter { $0.stage == .unstaged }.map(Self.remoteChangedFile),
                 commits: commits.commits.prefix(100).map(Self.remoteCommit),
-                truncated: capped.truncated || cappedWorkingTree.truncated || commits.commits.count > 100)
+                truncated: capped.truncated || cappedWorkingTree.truncated,
+                commitsTruncated: commits.commits.count > 100)
         } catch {
             return .failure(reason: .gitFailed, message: error.localizedDescription)
         }
@@ -10578,9 +10579,10 @@ extension AppState: RemoteSessionsProvider {
                 let originalPath = changeStage == .staged
                     ? try await git.status(worktreePath: worktree.path).first { $0.path == normalizedPath }?.renameFrom
                     : nil
-                parsed = try await git.diff(
+                parsed = try await git.remoteDiff(
                     worktreePath: worktree.path, file: normalizedPath,
-                    staged: changeStage == .staged, originalPath: originalPath)
+                    staged: changeStage == .staged, originalPath: originalPath,
+                    maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes)
             } else {
                 parsed = try await git.diff(
                     worktreePath: worktree.path,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -10575,9 +10575,12 @@ extension AppState: RemoteSessionsProvider {
             }
             let parsed: ParsedDiff
             if let changeStage {
+                let originalPath = changeStage == .staged
+                    ? try await git.status(worktreePath: worktree.path).files.first { $0.path == normalizedPath }?.renameFrom
+                    : nil
                 parsed = try await git.diff(
                     worktreePath: worktree.path, file: normalizedPath,
-                    staged: changeStage == .staged)
+                    staged: changeStage == .staged, originalPath: originalPath)
             } else {
                 parsed = try await git.diff(
                     worktreePath: worktree.path,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -10577,10 +10577,9 @@ extension AppState: RemoteSessionsProvider {
             let parsed: ParsedDiff
             if let changeStage {
                 let statusEntry = try await git.status(worktreePath: worktree.path).first { $0.path == normalizedPath }
-                let originalPath = changeStage == .staged ? statusEntry?.renameFrom : nil
                 parsed = try await git.remoteDiff(
                     worktreePath: worktree.path, file: normalizedPath,
-                    staged: changeStage == .staged, originalPath: originalPath,
+                    staged: changeStage == .staged, originalPath: statusEntry?.renameFrom,
                     maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes,
                     conflicted: statusEntry?.conflict != nil)
             } else {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -10499,11 +10499,13 @@ extension AppState: RemoteSessionsProvider {
                 baseBranch: config.worktrees.baseBranch,
                 resolution: GitService.BaseResolution.forCommits(
                     mode: config.changes.comparisonMode, userOverrodeBaseBranch: false))
-            let workingTree = try await git.statusForRemoteChangeList(worktreePath: worktree.path)
+            let statusEntries = try await git.status(worktreePath: worktree.path)
             let changed = try await git.changedFilesAgainstRef(
                 worktreePath: worktree.path, ref: commits.comparisonRef,
-                knownStatusEntries: workingTree)
+                knownStatusEntries: statusEntries)
             let capped = RemoteWorktreeFileAccess.truncateFiles(changed)
+            let workingTree = try await git.statusForRemoteChangeList(
+                worktreePath: worktree.path, knownStatusEntries: statusEntries)
             let cappedWorkingTree = RemoteWorktreeFileAccess.truncateFiles(workingTree)
             return .success(
                 comparisonRef: commits.comparisonRef,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -10420,6 +10420,12 @@ extension AppState: RemoteSessionsProvider {
             renameFrom: file.renameFrom)
     }
 
+    private static func remoteCommit(_ commit: CommitInfo) -> RemoteCommit {
+        RemoteCommit(
+            shortSha: commit.shortSha, subject: commit.rawSubject, author: commit.author,
+            add: commit.insertions, del: commit.deletions)
+    }
+
     private static func remoteDiffHunk(_ hunk: ParsedDiff.Hunk) -> RemoteDiffHunk {
         RemoteDiffHunk(
             header: hunk.header,
@@ -10492,10 +10498,14 @@ extension AppState: RemoteSessionsProvider {
             let changed = try await git.changedFilesAgainstRef(
                 worktreePath: worktree.path, ref: commits.comparisonRef)
             let capped = RemoteWorktreeFileAccess.truncateFiles(changed)
+            let workingTree = try await git.status(worktreePath: worktree.path)
             return .success(
                 comparisonRef: commits.comparisonRef,
                 metricsAvailable: true,
                 files: capped.files.map(Self.remoteChangedFile),
+                staged: workingTree.filter { $0.stage == .staged }.map(Self.remoteChangedFile),
+                unstaged: workingTree.filter { $0.stage == .unstaged }.map(Self.remoteChangedFile),
+                commits: commits.commits.prefix(100).map(Self.remoteCommit),
                 truncated: capped.truncated)
         } catch {
             return .failure(reason: .gitFailed, message: error.localizedDescription)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -10499,20 +10499,21 @@ extension AppState: RemoteSessionsProvider {
                 worktreePath: worktree.path, ref: commits.comparisonRef)
             let capped = RemoteWorktreeFileAccess.truncateFiles(changed)
             let workingTree = try await git.status(worktreePath: worktree.path)
+            let cappedWorkingTree = RemoteWorktreeFileAccess.truncateFiles(workingTree)
             return .success(
                 comparisonRef: commits.comparisonRef,
                 metricsAvailable: true,
                 files: capped.files.map(Self.remoteChangedFile),
-                staged: workingTree.filter { $0.stage == .staged }.map(Self.remoteChangedFile),
-                unstaged: workingTree.filter { $0.stage == .unstaged }.map(Self.remoteChangedFile),
+                staged: cappedWorkingTree.files.filter { $0.stage == .staged }.map(Self.remoteChangedFile),
+                unstaged: cappedWorkingTree.files.filter { $0.stage == .unstaged }.map(Self.remoteChangedFile),
                 commits: commits.commits.prefix(100).map(Self.remoteCommit),
-                truncated: capped.truncated)
+                truncated: capped.truncated || cappedWorkingTree.truncated)
         } catch {
             return .failure(reason: .gitFailed, message: error.localizedDescription)
         }
     }
 
-    func remoteFileDiff(sessionId: String, path: String) async -> RemoteFileDiffResult {
+    func remoteFileDiff(sessionId: String, path: String, stage: String? = nil) async -> RemoteFileDiffResult {
         let worktree: Worktree
         switch remoteWorktreeContext(sessionId: sessionId) {
         case .sessionUnknown:
@@ -10563,10 +10564,20 @@ extension AppState: RemoteSessionsProvider {
             ) {
                 return .failure(reason: .binary, message: nil)
             }
-            let parsed = try await git.diff(
-                worktreePath: worktree.path,
-                againstRef: commits.comparisonRef,
-                file: normalizedPath)
+            let parsed: ParsedDiff
+            if let stage {
+                guard let changeStage = ChangeStage(rawValue: stage) else {
+                    return .failure(reason: .pathRejected, message: nil)
+                }
+                parsed = try await git.diff(
+                    worktreePath: worktree.path, file: normalizedPath,
+                    staged: changeStage == .staged)
+            } else {
+                parsed = try await git.diff(
+                    worktreePath: worktree.path,
+                    againstRef: commits.comparisonRef,
+                    file: normalizedPath)
+            }
             // `isDiffTargetBinary` above only sniffs byte content, which
             // misses a file declared binary purely via `.gitattributes`
             // (e.g. `*.dat binary`) whose bytes happen to still look like

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -10499,10 +10499,11 @@ extension AppState: RemoteSessionsProvider {
                 baseBranch: config.worktrees.baseBranch,
                 resolution: GitService.BaseResolution.forCommits(
                     mode: config.changes.comparisonMode, userOverrodeBaseBranch: false))
-            let changed = try await git.changedFilesAgainstRef(
-                worktreePath: worktree.path, ref: commits.comparisonRef)
-            let capped = RemoteWorktreeFileAccess.truncateFiles(changed)
             let workingTree = try await git.statusForRemoteChangeList(worktreePath: worktree.path)
+            let changed = try await git.changedFilesAgainstRef(
+                worktreePath: worktree.path, ref: commits.comparisonRef,
+                knownStatusEntries: workingTree)
+            let capped = RemoteWorktreeFileAccess.truncateFiles(changed)
             let cappedWorkingTree = RemoteWorktreeFileAccess.truncateFiles(workingTree)
             return .success(
                 comparisonRef: commits.comparisonRef,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -10576,13 +10576,13 @@ extension AppState: RemoteSessionsProvider {
             }
             let parsed: ParsedDiff
             if let changeStage {
-                let originalPath = changeStage == .staged
-                    ? try await git.status(worktreePath: worktree.path).first { $0.path == normalizedPath }?.renameFrom
-                    : nil
+                let statusEntry = try await git.status(worktreePath: worktree.path).first { $0.path == normalizedPath }
+                let originalPath = changeStage == .staged ? statusEntry?.renameFrom : nil
                 parsed = try await git.remoteDiff(
                     worktreePath: worktree.path, file: normalizedPath,
                     staged: changeStage == .staged, originalPath: originalPath,
-                    maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes)
+                    maxOutputBytes: RemoteWorktreeFileAccess.maxDiffSubprocessBytes,
+                    conflicted: statusEntry?.conflict != nil)
             } else {
                 parsed = try await git.diff(
                     worktreePath: worktree.path,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -10498,7 +10498,7 @@ extension AppState: RemoteSessionsProvider {
             let changed = try await git.changedFilesAgainstRef(
                 worktreePath: worktree.path, ref: commits.comparisonRef)
             let capped = RemoteWorktreeFileAccess.truncateFiles(changed)
-            let workingTree = try await git.status(worktreePath: worktree.path)
+            let workingTree = try await git.statusForRemoteChangeList(worktreePath: worktree.path)
             let cappedWorkingTree = RemoteWorktreeFileAccess.truncateFiles(workingTree)
             return .success(
                 comparisonRef: commits.comparisonRef,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -10375,7 +10375,8 @@ extension AppState: RemoteSessionsProvider {
     /// since the file is new) collapsed to "not binary" and produced a
     /// misleading empty "successful" diff.
     private func isDiffTargetBinary(
-        worktree: Worktree, normalizedPath: String, url: URL, comparisonRef: String?, git: GitService
+        worktree: Worktree, normalizedPath: String, url: URL, comparisonRef: String?, git: GitService,
+        missingFileUsesIndex: Bool = false
     ) async -> Bool {
         let existsOnDisk: Bool
         let onDiskLooksBinary: Bool
@@ -10406,6 +10407,9 @@ extension AppState: RemoteSessionsProvider {
         }
         if onDiskLooksBinary { return true }
         if existsOnDisk { return false }
+        if missingFileUsesIndex {
+            return (try? await git.looksBinaryAtIndex(worktreePath: worktree.path, file: normalizedPath)) ?? false
+        }
         guard let comparisonRef, !comparisonRef.isEmpty else { return false }
         return (try? await git.looksBinaryAtRef(worktreePath: worktree.path, ref: comparisonRef, file: normalizedPath)) ?? false
     }
@@ -10570,7 +10574,8 @@ extension AppState: RemoteSessionsProvider {
             }
             if changeStage != .staged, await isDiffTargetBinary(
                 worktree: worktree, normalizedPath: normalizedPath, url: url,
-                comparisonRef: commits.comparisonRef, git: git
+                comparisonRef: commits.comparisonRef, git: git,
+                missingFileUsesIndex: changeStage == .unstaged
             ) {
                 return .failure(reason: .binary, message: nil)
             }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -10581,7 +10581,7 @@ extension AppState: RemoteSessionsProvider {
             }
             let parsed: ParsedDiff
             if let changeStage {
-                let statusEntry = try await git.status(worktreePath: worktree.path).first { $0.path == normalizedPath }
+                let statusEntry = try await git.statusIdentity(worktreePath: worktree.path).first { $0.path == normalizedPath }
                 parsed = try await git.remoteDiff(
                     worktreePath: worktree.path, file: normalizedPath,
                     staged: changeStage == .staged, originalPath: statusEntry?.renameFrom,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -10576,7 +10576,7 @@ extension AppState: RemoteSessionsProvider {
             let parsed: ParsedDiff
             if let changeStage {
                 let originalPath = changeStage == .staged
-                    ? try await git.status(worktreePath: worktree.path).files.first { $0.path == normalizedPath }?.renameFrom
+                    ? try await git.status(worktreePath: worktree.path).first { $0.path == normalizedPath }?.renameFrom
                     : nil
                 parsed = try await git.diff(
                     worktreePath: worktree.path, file: normalizedPath,

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -345,6 +345,15 @@ extension GitService {
         return Self.looksBinary(prefix)
     }
 
+    func looksBinaryAtIndex(worktreePath: URL, file: String) async throws -> Bool? {
+        let existsAtIndex = try await Process.git(
+            ["cat-file", "-e", ":\(file)"], cwd: worktreePath)
+        guard existsAtIndex.exitCode == 0 else { return nil }
+        let prefix = try await Process.gitDataPrefix(
+            ["show", ":\(file)"], cwd: worktreePath, maxBytes: 8192)
+        return Self.looksBinary(prefix)
+    }
+
     /// `git cat-file -e <ref>:<file>` exits with the SAME code (128,
     /// empirically, on git 2.50) both when the object genuinely doesn't
     /// exist at `ref` AND for unrelated fatal errors (an invalid ref name,

--- a/Alas/Sources/Git/GitService+RemoteChanges.swift
+++ b/Alas/Sources/Git/GitService+RemoteChanges.swift
@@ -7,9 +7,19 @@ import Foundation
 extension GitService {
     /// Changed files between `ref` and the working tree, plus untracked files.
     /// A nil `ref` (unborn branch, no resolvable base) falls back to `status`.
-    func changedFilesAgainstRef(worktreePath: URL, ref: String?) async throws -> [ChangedFile] {
+    func changedFilesAgainstRef(
+        worktreePath: URL,
+        ref: String?,
+        knownStatusEntries: [ChangedFile]? = nil
+    ) async throws -> [ChangedFile] {
         guard let ref, !ref.isEmpty else {
-            return Self.collapsingStagedAndUnstagedEntries(try await status(worktreePath: worktreePath))
+            let entries: [ChangedFile]
+            if let knownStatusEntries {
+                entries = knownStatusEntries
+            } else {
+                entries = try await status(worktreePath: worktreePath)
+            }
+            return Self.collapsingStagedAndUnstagedEntries(entries)
         }
 
         // `-c core.quotePath=false` plus `-z` keep non-ASCII (and
@@ -40,7 +50,12 @@ extension GitService {
         guard nameStatus.exitCode == 0 else {
             throw ProcessError.nonZeroExit(nameStatus.exitCode, nameStatus.stderr)
         }
-        let statusEntries = try await status(worktreePath: worktreePath)
+        let statusEntries: [ChangedFile]
+        if let knownStatusEntries {
+            statusEntries = knownStatusEntries
+        } else {
+            statusEntries = try await status(worktreePath: worktreePath)
+        }
         let conflicts = Dictionary(
             statusEntries.compactMap { entry in entry.conflict.map { (entry.path, $0) } },
             uniquingKeysWith: { first, _ in first })

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -200,6 +200,27 @@ extension GitService {
         return entries
     }
 
+    func statusForRemoteChangeList(worktreePath: URL) async throws -> [ChangedFile] {
+        var entries = try await status(worktreePath: worktreePath)
+        let numstat = try await Process.git(
+            ["-c", "core.quotePath=false", "diff", "--numstat", "-M", "-C"],
+            cwd: worktreePath
+        )
+        let counts = NumstatParser.parse(numstat.stdout)
+        for i in entries.indices where entries[i].stage == .unstaged {
+            guard let count = counts[entries[i].path] else { continue }
+            entries[i] = ChangedFile(
+                path: entries[i].path,
+                status: entries[i].status,
+                stage: entries[i].stage,
+                add: count.add,
+                del: count.del,
+                renameFrom: entries[i].renameFrom,
+                conflict: entries[i].conflict)
+        }
+        return entries
+    }
+
     func diff(worktreePath: URL, file: String, staged: Bool = false, originalPath: String? = nil) async throws -> ParsedDiff {
         try await remoteDiff(worktreePath: worktreePath, file: file, staged: staged, originalPath: originalPath, maxOutputBytes: nil)
     }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -204,7 +204,7 @@ extension GitService {
         try await remoteDiff(worktreePath: worktreePath, file: file, staged: staged, originalPath: originalPath, maxOutputBytes: nil)
     }
 
-    func remoteDiff(worktreePath: URL, file: String, staged: Bool, originalPath: String?, maxOutputBytes: Int?) async throws -> ParsedDiff {
+    func remoteDiff(worktreePath: URL, file: String, staged: Bool, originalPath: String?, maxOutputBytes: Int?, conflicted: Bool = false) async throws -> ParsedDiff {
         // Untracked files have no HEAD entry, so `git diff HEAD -- <path>`
         // returns nothing. Detect via `git ls-files --error-unmatch` (exit 0
         // iff tracked) and fall back to comparing against /dev/null so the
@@ -215,12 +215,14 @@ extension GitService {
         )
         if tracked.exitCode != 0 && !staged {
             let result = try await Process.gitCapped(
-                ["diff", "--no-color", "--no-index", "--", "/dev/null", file], cwd: worktreePath,
+                ["--literal-pathspecs", "diff", "--no-color", "--no-index", "--", "/dev/null", file], cwd: worktreePath,
                 maxOutputBytes: maxOutputBytes ?? .max)
             // `git diff --no-index` exits non-zero (1) when there ARE differences
             // — that's the normal case for an untracked file. Only treat exit
             // codes >= 2 as real failures.
-            guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
+            guard result.stdoutTruncated || result.exitCode <= 1 else {
+                throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
+            }
             return await Self.parseOffMain(result.stdout)
         }
 
@@ -235,17 +237,21 @@ extension GitService {
         //     vs empty tree) so initial-commit workflows still render the
         //     staged side.
         let head = try await hasHead(worktreePath: worktreePath)
-        var args = ["diff", "--no-color", "-M", "-C"]
+        var args = ["--literal-pathspecs", "diff", "--no-color", "-M", "-C"]
         if staged {
             args.append("--cached")
             if head { args.append("HEAD") }
         }
+        if conflicted { args.append("--ours") }
         args.append("--")
         args.append(file)
         if let originalPath, !originalPath.isEmpty {
             args.append(originalPath)
         }
         let result = try await Process.gitCapped(args, cwd: worktreePath, maxOutputBytes: maxOutputBytes ?? .max)
+        guard result.stdoutTruncated || result.exitCode <= 1 else {
+            throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
+        }
         let stdout = originalPath?.isEmpty == false
             ? Self.sliceDiffForFile(result.stdout, file: file)
             : result.stdout

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -201,6 +201,10 @@ extension GitService {
     }
 
     func diff(worktreePath: URL, file: String, staged: Bool = false, originalPath: String? = nil) async throws -> ParsedDiff {
+        try await remoteDiff(worktreePath: worktreePath, file: file, staged: staged, originalPath: originalPath, maxOutputBytes: nil)
+    }
+
+    func remoteDiff(worktreePath: URL, file: String, staged: Bool, originalPath: String?, maxOutputBytes: Int?) async throws -> ParsedDiff {
         // Untracked files have no HEAD entry, so `git diff HEAD -- <path>`
         // returns nothing. Detect via `git ls-files --error-unmatch` (exit 0
         // iff tracked) and fall back to comparing against /dev/null so the
@@ -210,10 +214,9 @@ extension GitService {
             cwd: worktreePath
         )
         if tracked.exitCode != 0 && !staged {
-            let result = try await Process.git(
-                ["diff", "--no-color", "--no-index", "--", "/dev/null", file],
-                cwd: worktreePath
-            )
+            let result = try await Process.gitCapped(
+                ["diff", "--no-color", "--no-index", "--", "/dev/null", file], cwd: worktreePath,
+                maxOutputBytes: maxOutputBytes ?? .max)
             // `git diff --no-index` exits non-zero (1) when there ARE differences
             // — that's the normal case for an untracked file. Only treat exit
             // codes >= 2 as real failures.
@@ -242,7 +245,7 @@ extension GitService {
         if let originalPath, !originalPath.isEmpty {
             args.append(originalPath)
         }
-        let result = try await Process.git(args, cwd: worktreePath)
+        let result = try await Process.gitCapped(args, cwd: worktreePath, maxOutputBytes: maxOutputBytes ?? .max)
         let stdout = originalPath?.isEmpty == false
             ? Self.sliceDiffForFile(result.stdout, file: file)
             : result.stdout

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -122,13 +122,13 @@ extension GitService {
         // content of a path regardless of what's staged, matching
         // `diffAgainstHEAD`'s own all-add diff (see the comment there).
         let workingTreeNumstatArgs: [String] = head
-            ? ["diff", "--numstat", "HEAD"]
-            : ["diff", "--numstat", "4b825dc642cb6eb9a060e54bf8d69288fbee4904"]   // canonical empty tree
+            ? ["-c", "core.quotePath=false", "diff", "--numstat", "-z", "HEAD"]
+            : ["-c", "core.quotePath=false", "diff", "--numstat", "-z", "4b825dc642cb6eb9a060e54bf8d69288fbee4904"]   // canonical empty tree
         let workingTreeNumstat = try await Process.git(workingTreeNumstatArgs, cwd: worktreePath)
         guard workingTreeNumstat.exitCode == 0 else {
             throw ProcessError.nonZeroExit(workingTreeNumstat.exitCode, workingTreeNumstat.stderr)
         }
-        let workingTreeCounts = NumstatParser.parse(workingTreeNumstat.stdout)
+        let workingTreeCounts = Self.parseNumstatZOutput(workingTreeNumstat.stdout)
         // Index-only metric — correct for `.staged` entries. Without this,
         // an "AM" path (staged, then further modified in the working tree)
         // got the SAME whole-working-tree count applied to BOTH its staged
@@ -136,13 +136,20 @@ extension GitService {
         // draft-commit summary) reported the unstaged edit's line count as
         // if it were already staged.
         let stagedNumstatArgs: [String] = head
-            ? ["diff", "--cached", "--numstat", "HEAD"]
-            : ["diff", "--cached", "--numstat", "4b825dc642cb6eb9a060e54bf8d69288fbee4904"]
+            ? ["-c", "core.quotePath=false", "diff", "--cached", "--numstat", "-z", "HEAD"]
+            : ["-c", "core.quotePath=false", "diff", "--cached", "--numstat", "-z", "4b825dc642cb6eb9a060e54bf8d69288fbee4904"]
         let stagedNumstat = try await Process.git(stagedNumstatArgs, cwd: worktreePath)
         guard stagedNumstat.exitCode == 0 else {
             throw ProcessError.nonZeroExit(stagedNumstat.exitCode, stagedNumstat.stderr)
         }
-        let stagedCounts = NumstatParser.parse(stagedNumstat.stdout)
+        let stagedCounts = Self.parseNumstatZOutput(stagedNumstat.stdout)
+        func count(
+            in counts: (add: [String: Int], del: [String: Int]),
+            for path: String
+        ) -> (add: Int, del: Int)? {
+            guard let add = counts.add[path], let del = counts.del[path] else { return nil }
+            return (add, del)
+        }
         let untrackedPaths = entries.filter { $0.add == 0 && $0.del == 0 }.map(\.path)
         let remoteCounts: [String: Int]
         if worktreePath.isRemoteAlasPath, let host = RemoteHostRegistry.shared.host(forPath: worktreePath.path) {
@@ -153,7 +160,7 @@ extension GitService {
 
         for i in entries.indices {
             let counts = entries[i].stage == .staged ? stagedCounts : workingTreeCounts
-            if let c = counts[entries[i].path] {
+            if let c = count(in: counts, for: entries[i].path) {
                 entries[i] = ChangedFile(path: entries[i].path,
                                           status: entries[i].status,
                                           stage: entries[i].stage,

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -252,9 +252,18 @@ extension GitService {
         guard result.stdoutTruncated || result.exitCode <= 1 else {
             throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
         }
-        let stdout = originalPath?.isEmpty == false
-            ? Self.sliceDiffForFile(result.stdout, file: file)
-            : result.stdout
+        let stdout: String
+        if originalPath?.isEmpty == false {
+            let sliced = Self.sliceDiffForFile(result.stdout, file: file)
+            guard !(result.stdoutTruncated && sliced.isEmpty) else {
+                throw ProcessError.nonZeroExit(
+                    result.exitCode,
+                    "diff for \(file) exceeded the size cap before its section was captured")
+            }
+            stdout = sliced
+        } else {
+            stdout = result.stdout
+        }
         return await Self.parseOffMain(stdout)
     }
 

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -217,8 +217,16 @@ extension GitService {
         return try StatusParser.parse(s.stdout)
     }
 
-    func statusForRemoteChangeList(worktreePath: URL) async throws -> [ChangedFile] {
-        var entries = try await status(worktreePath: worktreePath)
+    func statusForRemoteChangeList(
+        worktreePath: URL,
+        knownStatusEntries: [ChangedFile]? = nil
+    ) async throws -> [ChangedFile] {
+        var entries: [ChangedFile]
+        if let knownStatusEntries {
+            entries = knownStatusEntries
+        } else {
+            entries = try await status(worktreePath: worktreePath)
+        }
         let numstat = try await Process.git(
             ["-c", "core.quotePath=false", "diff", "--numstat", "-z", "-M", "-C"],
             cwd: worktreePath

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -105,22 +105,7 @@ extension GitService {
     }
 
     func status(worktreePath: URL) async throws -> [ChangedFile] {
-        async let statusResult = Process.git(
-            ["status", "--porcelain=v2", "-z", "--untracked-files=all"],
-            cwd: worktreePath
-        )
-        let s = try await statusResult
-        // Unlike `--no-index diff`/`check-ignore`, plain `git status` has no
-        // legitimate nonzero exit for a healthy repo — ANY failure here (a
-        // dropped SSH connection, an invalid/corrupt repository) is fatal
-        // and must propagate. This is a widely shared method (the desktop
-        // Changes panel, the remote nil-ref fallback, `alas` CLI actions);
-        // silently returning `[]` previously meant a genuine failure looked
-        // identical to "nothing has changed" everywhere it's called.
-        guard s.exitCode == 0 else {
-            throw ProcessError.nonZeroExit(s.exitCode, s.stderr)
-        }
-        var entries = try StatusParser.parse(s.stdout)
+        var entries = try await statusIdentity(worktreePath: worktreePath)
 
         // Numstat needs a base revision. Use HEAD if one exists; on unborn
         // branches diff against git's well-known empty-tree object hash
@@ -204,6 +189,25 @@ extension GitService {
             }
         }
         return entries
+    }
+
+    func statusIdentity(worktreePath: URL) async throws -> [ChangedFile] {
+        async let statusResult = Process.git(
+            ["status", "--porcelain=v2", "-z", "--untracked-files=all"],
+            cwd: worktreePath
+        )
+        let s = try await statusResult
+        // Unlike `--no-index diff`/`check-ignore`, plain `git status` has no
+        // legitimate nonzero exit for a healthy repo — ANY failure here (a
+        // dropped SSH connection, an invalid/corrupt repository) is fatal
+        // and must propagate. This is a widely shared method (the desktop
+        // Changes panel, the remote nil-ref fallback, `alas` CLI actions);
+        // silently returning `[]` previously meant a genuine failure looked
+        // identical to "nothing has changed" everywhere it's called.
+        guard s.exitCode == 0 else {
+            throw ProcessError.nonZeroExit(s.exitCode, s.stderr)
+        }
+        return try StatusParser.parse(s.stdout)
     }
 
     func statusForRemoteChangeList(worktreePath: URL) async throws -> [ChangedFile] {

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -140,6 +140,9 @@ extension GitService {
             ? ["diff", "--numstat", "HEAD"]
             : ["diff", "--numstat", "4b825dc642cb6eb9a060e54bf8d69288fbee4904"]   // canonical empty tree
         let workingTreeNumstat = try await Process.git(workingTreeNumstatArgs, cwd: worktreePath)
+        guard workingTreeNumstat.exitCode == 0 else {
+            throw ProcessError.nonZeroExit(workingTreeNumstat.exitCode, workingTreeNumstat.stderr)
+        }
         let workingTreeCounts = NumstatParser.parse(workingTreeNumstat.stdout)
         // Index-only metric — correct for `.staged` entries. Without this,
         // an "AM" path (staged, then further modified in the working tree)
@@ -151,6 +154,9 @@ extension GitService {
             ? ["diff", "--cached", "--numstat", "HEAD"]
             : ["diff", "--cached", "--numstat", "4b825dc642cb6eb9a060e54bf8d69288fbee4904"]
         let stagedNumstat = try await Process.git(stagedNumstatArgs, cwd: worktreePath)
+        guard stagedNumstat.exitCode == 0 else {
+            throw ProcessError.nonZeroExit(stagedNumstat.exitCode, stagedNumstat.stderr)
+        }
         let stagedCounts = NumstatParser.parse(stagedNumstat.stdout)
         let untrackedPaths = entries.filter { $0.add == 0 && $0.del == 0 }.map(\.path)
         let remoteCounts: [String: Int]

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -210,7 +210,7 @@ extension GitService {
         // iff tracked) and fall back to comparing against /dev/null so the
         // user sees the file's contents as a single all-add hunk.
         let tracked = try await Process.git(
-            ["ls-files", "--error-unmatch", "--", file],
+            ["--literal-pathspecs", "ls-files", "--error-unmatch", "--", file],
             cwd: worktreePath
         )
         if tracked.exitCode != 0 && !staged {

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -203,21 +203,23 @@ extension GitService {
     func statusForRemoteChangeList(worktreePath: URL) async throws -> [ChangedFile] {
         var entries = try await status(worktreePath: worktreePath)
         let numstat = try await Process.git(
-            ["-c", "core.quotePath=false", "diff", "--numstat", "-M", "-C"],
+            ["-c", "core.quotePath=false", "diff", "--numstat", "-z", "-M", "-C"],
             cwd: worktreePath
         )
         guard numstat.exitCode == 0 else {
             throw ProcessError.nonZeroExit(numstat.exitCode, numstat.stderr)
         }
-        let counts = NumstatParser.parse(numstat.stdout)
+        let counts = Self.parseNumstatZOutput(numstat.stdout)
         for i in entries.indices where entries[i].stage == .unstaged {
-            guard let count = counts[entries[i].path] else { continue }
+            guard let add = counts.add[entries[i].path],
+                  let del = counts.del[entries[i].path]
+            else { continue }
             entries[i] = ChangedFile(
                 path: entries[i].path,
                 status: entries[i].status,
                 stage: entries[i].stage,
-                add: count.add,
-                del: count.del,
+                add: add,
+                del: del,
                 renameFrom: entries[i].renameFrom,
                 conflict: entries[i].conflict)
         }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -235,10 +235,31 @@ extension GitService {
             throw ProcessError.nonZeroExit(numstat.exitCode, numstat.stderr)
         }
         let counts = Self.parseNumstatZOutput(numstat.stdout)
+        let untrackedWithoutNumstat = entries
+            .filter { $0.stage == .unstaged && $0.status == "A" && counts.add[$0.path] == nil }
+            .map(\.path)
+        let remoteUntrackedCounts: [String: Int]
+        if worktreePath.isRemoteAlasPath, let host = RemoteHostRegistry.shared.host(forPath: worktreePath.path) {
+            remoteUntrackedCounts = try await RemoteFileStats.lineCounts(
+                host: host, cwd: worktreePath.path, paths: untrackedWithoutNumstat)
+        } else {
+            remoteUntrackedCounts = [:]
+        }
         for i in entries.indices where entries[i].stage == .unstaged {
-            guard let add = counts.add[entries[i].path],
-                  let del = counts.del[entries[i].path]
-            else { continue }
+            let add: Int
+            let del: Int
+            if let countedAdd = counts.add[entries[i].path],
+               let countedDel = counts.del[entries[i].path] {
+                add = countedAdd
+                del = countedDel
+            } else if entries[i].status == "A" {
+                add = worktreePath.isRemoteAlasPath
+                    ? (remoteUntrackedCounts[entries[i].path] ?? 0)
+                    : Self.addedLineCount(worktreePath: worktreePath, path: entries[i].path)
+                del = 0
+            } else {
+                continue
+            }
             entries[i] = ChangedFile(
                 path: entries[i].path,
                 status: entries[i].status,

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -206,6 +206,9 @@ extension GitService {
             ["-c", "core.quotePath=false", "diff", "--numstat", "-M", "-C"],
             cwd: worktreePath
         )
+        guard numstat.exitCode == 0 else {
+            throw ProcessError.nonZeroExit(numstat.exitCode, numstat.stderr)
+        }
         let counts = NumstatParser.parse(numstat.stdout)
         for i in entries.indices where entries[i].stage == .unstaged {
             guard let count = counts[entries[i].path] else { continue }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -237,7 +237,7 @@ extension GitService {
         //     vs empty tree) so initial-commit workflows still render the
         //     staged side.
         let head = try await hasHead(worktreePath: worktreePath)
-        var args = ["--literal-pathspecs", "diff", "--no-color", "-M", "-C"]
+        var args = ["--literal-pathspecs", "-c", "core.quotePath=false", "diff", "--no-color", "-M", "-C"]
         if staged {
             args.append("--cached")
             if head { args.append("HEAD") }

--- a/Alas/Sources/Git/StatusParser.swift
+++ b/Alas/Sources/Git/StatusParser.swift
@@ -90,7 +90,7 @@ enum StatusParser {
                 stage: .unstaged,
                 add: 0,
                 del: 0,
-                renameFrom: nil
+                renameFrom: worktreeStatus == "R" || worktreeStatus == "C" ? renameFrom : nil
             ))
         }
 

--- a/Alas/Sources/Git/StatusParser.swift
+++ b/Alas/Sources/Git/StatusParser.swift
@@ -79,7 +79,7 @@ enum StatusParser {
                 stage: .staged,
                 add: 0,
                 del: 0,
-                renameFrom: indexStatus == "R" ? renameFrom : nil
+                renameFrom: indexStatus == "R" || indexStatus == "C" ? renameFrom : nil
             ))
         }
 
@@ -104,6 +104,7 @@ enum StatusParser {
         switch status {
         case "A": return "A"
         case "D": return "D"
+        case "C": return "C"
         case "R": return "R"
         case "M": return "M"
         default: return fallback

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -297,11 +297,11 @@ final class RemoteSessionGateway {
             case .failure(let reason, let message):
                 send(.changeListFailed(sessionId: id, reason: reason, message: message))
             }
-        case .fileDiff(let id, let path):
-            let key = "fileDiff\u{0}\(id)\u{0}\(path)"
+        case .fileDiff(let id, let path, let stage):
+            let key = "fileDiff\u{0}\(id)\u{0}\(path)\u{0}\(stage ?? "")"
             guard inFlightFileRequests.insert(key).inserted else { return }
             defer { inFlightFileRequests.remove(key) }
-            switch await provider.remoteFileDiff(sessionId: id, path: path) {
+            switch await provider.remoteFileDiff(sessionId: id, path: path, stage: stage) {
             case .success(let hunks, let truncated, let metadataNote):
                 send(.fileDiffResult(
                     sessionId: id, path: path, hunks: hunks, truncated: truncated,

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -304,10 +304,10 @@ final class RemoteSessionGateway {
             switch await provider.remoteFileDiff(sessionId: id, path: path, stage: stage) {
             case .success(let hunks, let truncated, let metadataNote):
                 send(.fileDiffResult(
-                    sessionId: id, path: path, hunks: hunks, truncated: truncated,
+                    sessionId: id, path: path, stage: stage, hunks: hunks, truncated: truncated,
                     metadataNote: metadataNote))
             case .failure(let reason, let message):
-                send(.fileDiffFailed(sessionId: id, path: path, reason: reason, message: message))
+                send(.fileDiffFailed(sessionId: id, path: path, stage: stage, reason: reason, message: message))
             }
         case .listFiles(let id, let path):
             let key = "listFiles\u{0}\(id)\u{0}\(path ?? "")"

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -289,11 +289,11 @@ final class RemoteSessionGateway {
             guard inFlightFileRequests.insert(key).inserted else { return }
             defer { inFlightFileRequests.remove(key) }
             switch await provider.remoteChangeList(sessionId: id) {
-            case .success(let ref, let available, let files, let staged, let unstaged, let commits, let truncated):
+            case .success(let ref, let available, let files, let staged, let unstaged, let commits, let truncated, let commitsTruncated):
                 send(.changeList(
                     sessionId: id, comparisonRef: ref, metricsAvailable: available,
                     files: files, staged: staged, unstaged: unstaged, commits: commits,
-                    truncated: truncated))
+                    truncated: truncated, commitsTruncated: commitsTruncated))
             case .failure(let reason, let message):
                 send(.changeListFailed(sessionId: id, reason: reason, message: message))
             }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -289,10 +289,11 @@ final class RemoteSessionGateway {
             guard inFlightFileRequests.insert(key).inserted else { return }
             defer { inFlightFileRequests.remove(key) }
             switch await provider.remoteChangeList(sessionId: id) {
-            case .success(let ref, let available, let files, let truncated):
+            case .success(let ref, let available, let files, let staged, let unstaged, let commits, let truncated):
                 send(.changeList(
                     sessionId: id, comparisonRef: ref, metricsAvailable: available,
-                    files: files, truncated: truncated))
+                    files: files, staged: staged, unstaged: unstaged, commits: commits,
+                    truncated: truncated))
             case .failure(let reason, let message):
                 send(.changeListFailed(sessionId: id, reason: reason, message: message))
             }

--- a/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionsProvider.swift
@@ -57,7 +57,7 @@ protocol RemoteSessionsProvider: AnyObject {
     /// four resolve the session's worktree first and are ungated by the writer
     /// lease: seeing a session is enough to read its code.
     func remoteChangeList(sessionId: String) async -> RemoteChangeListResult
-    func remoteFileDiff(sessionId: String, path: String) async -> RemoteFileDiffResult
+    func remoteFileDiff(sessionId: String, path: String, stage: String?) async -> RemoteFileDiffResult
     func remoteFileTree(sessionId: String, path: String?) async -> RemoteFileTreeResult
     func remoteFileContents(sessionId: String, path: String) async -> RemoteFileContentsResult
 }

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -261,6 +261,14 @@ struct RemoteChangedFile: Codable, Equatable, Sendable {
     let renameFrom: String?
 }
 
+struct RemoteCommit: Codable, Equatable, Sendable {
+    let shortSha: String
+    let subject: String
+    let author: String
+    let add: Int
+    let del: Int
+}
+
 /// Wire projection of `ParsedDiff.Hunk.Line`. `kind` is "context", "add", or
 /// "delete"; `text` has no leading +/-/space. `noTrailingNewline` mirrors
 /// the source line's `\ No newline at end of file` sentinel, so a diff that
@@ -332,7 +340,8 @@ struct RemoteFileNode: Codable, Equatable, Sendable {
 enum RemoteChangeListResult: Equatable, Sendable {
     case success(
         comparisonRef: String?, metricsAvailable: Bool,
-        files: [RemoteChangedFile], truncated: Bool)
+        files: [RemoteChangedFile], staged: [RemoteChangedFile], unstaged: [RemoteChangedFile],
+        commits: [RemoteCommit], truncated: Bool)
     case failure(reason: RemoteFileAccessReason, message: String?)
 }
 

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -341,7 +341,7 @@ enum RemoteChangeListResult: Equatable, Sendable {
     case success(
         comparisonRef: String?, metricsAvailable: Bool,
         files: [RemoteChangedFile], staged: [RemoteChangedFile], unstaged: [RemoteChangedFile],
-        commits: [RemoteCommit], truncated: Bool)
+        commits: [RemoteCommit], truncated: Bool, commitsTruncated: Bool = false)
     case failure(reason: RemoteFileAccessReason, message: String?)
 }
 

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -389,9 +389,9 @@ enum RemoteServerMessage: Equatable, Sendable {
         commits: [RemoteCommit], truncated: Bool)
     case changeListFailed(sessionId: String, reason: RemoteFileAccessReason, message: String?)
     case fileDiffResult(
-        sessionId: String, path: String, hunks: [RemoteDiffHunk], truncated: Bool,
+        sessionId: String, path: String, stage: String? = nil, hunks: [RemoteDiffHunk], truncated: Bool,
         metadataNote: String? = nil)
-    case fileDiffFailed(sessionId: String, path: String, reason: RemoteFileAccessReason, message: String?)
+    case fileDiffFailed(sessionId: String, path: String, stage: String? = nil, reason: RemoteFileAccessReason, message: String?)
     case fileTree(sessionId: String, path: String?, nodes: [RemoteFileNode], truncated: Bool)
     case fileTreeFailed(sessionId: String, path: String?, reason: RemoteFileAccessReason, message: String?)
     case fileContents(sessionId: String, path: String, text: String, truncated: Bool)
@@ -538,6 +538,7 @@ extension RemoteServerMessage: Codable {
             self = .fileDiffResult(
                 sessionId: try c.decode(String.self, forKey: .sessionId),
                 path: try c.decode(String.self, forKey: .path),
+                stage: try c.decodeIfPresent(String.self, forKey: .stage),
                 hunks: try c.decode([RemoteDiffHunk].self, forKey: .hunks),
                 truncated: try c.decodeIfPresent(Bool.self, forKey: .truncated) ?? false,
                 metadataNote: try c.decodeIfPresent(String.self, forKey: .metadataNote))
@@ -545,6 +546,7 @@ extension RemoteServerMessage: Codable {
             self = .fileDiffFailed(
                 sessionId: try c.decode(String.self, forKey: .sessionId),
                 path: try c.decode(String.self, forKey: .path),
+                stage: try c.decodeIfPresent(String.self, forKey: .stage),
                 reason: try c.decode(RemoteFileAccessReason.self, forKey: .reason),
                 message: try c.decodeIfPresent(String.self, forKey: .message))
         case "fileTree":
@@ -709,17 +711,19 @@ extension RemoteServerMessage: Codable {
             try c.encode(s, forKey: .sessionId)
             try c.encode(reason.rawValue, forKey: .reason)
             try c.encodeIfPresent(message, forKey: .message)
-        case .fileDiffResult(let s, let path, let hunks, let truncated, let metadataNote):
+        case .fileDiffResult(let s, let path, let stage, let hunks, let truncated, let metadataNote):
             try c.encode("fileDiffResult", forKey: .type)
             try c.encode(s, forKey: .sessionId)
             try c.encode(path, forKey: .path)
+            try c.encodeIfPresent(stage, forKey: .stage)
             try c.encode(hunks, forKey: .hunks)
             try c.encode(truncated, forKey: .truncated)
             try c.encodeIfPresent(metadataNote, forKey: .metadataNote)
-        case .fileDiffFailed(let s, let path, let reason, let message):
+        case .fileDiffFailed(let s, let path, let stage, let reason, let message):
             try c.encode("fileDiffFailed", forKey: .type)
             try c.encode(s, forKey: .sessionId)
             try c.encode(path, forKey: .path)
+            try c.encodeIfPresent(stage, forKey: .stage)
             try c.encode(reason.rawValue, forKey: .reason)
             try c.encodeIfPresent(message, forKey: .message)
         case .fileTree(let s, let path, let nodes, let truncated):

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -383,7 +383,8 @@ enum RemoteServerMessage: Equatable, Sendable {
     case error(message: String)
     case changeList(
         sessionId: String, comparisonRef: String?, metricsAvailable: Bool,
-        files: [RemoteChangedFile], truncated: Bool)
+        files: [RemoteChangedFile], staged: [RemoteChangedFile], unstaged: [RemoteChangedFile],
+        commits: [RemoteCommit], truncated: Bool)
     case changeListFailed(sessionId: String, reason: RemoteFileAccessReason, message: String?)
     case fileDiffResult(
         sessionId: String, path: String, hunks: [RemoteDiffHunk], truncated: Bool,
@@ -404,7 +405,7 @@ extension RemoteServerMessage: Codable {
         case models, modes, currentModel, currentMode, autoRunEnabled, acceptsImages, title
         case firstIndex, totalCount, epoch, revision
         case items, steerUndoAvailable, itemId, text
-        case path, files, comparisonRef, metricsAvailable, truncated, hunks, nodes, reason, byteSize
+        case path, files, staged, unstaged, commits, comparisonRef, metricsAvailable, truncated, hunks, nodes, reason, byteSize
         case metadataNote
     }
 
@@ -522,6 +523,9 @@ extension RemoteServerMessage: Codable {
                 comparisonRef: try c.decodeIfPresent(String.self, forKey: .comparisonRef),
                 metricsAvailable: try c.decode(Bool.self, forKey: .metricsAvailable),
                 files: try c.decode([RemoteChangedFile].self, forKey: .files),
+                staged: try c.decodeIfPresent([RemoteChangedFile].self, forKey: .staged) ?? [],
+                unstaged: try c.decodeIfPresent([RemoteChangedFile].self, forKey: .unstaged) ?? [],
+                commits: try c.decodeIfPresent([RemoteCommit].self, forKey: .commits) ?? [],
                 truncated: try c.decodeIfPresent(Bool.self, forKey: .truncated) ?? false)
         case "changeListFailed":
             self = .changeListFailed(
@@ -688,12 +692,15 @@ extension RemoteServerMessage: Codable {
             try c.encode(text, forKey: .text)
         case .error(let m): try c.encode("error", forKey: .type)
         try c.encode(m, forKey: .message)
-        case .changeList(let s, let ref, let available, let files, let truncated):
+        case .changeList(let s, let ref, let available, let files, let staged, let unstaged, let commits, let truncated):
             try c.encode("changeList", forKey: .type)
             try c.encode(s, forKey: .sessionId)
             try c.encodeIfPresent(ref, forKey: .comparisonRef)
             try c.encode(available, forKey: .metricsAvailable)
             try c.encode(files, forKey: .files)
+            try c.encode(staged, forKey: .staged)
+            try c.encode(unstaged, forKey: .unstaged)
+            try c.encode(commits, forKey: .commits)
             try c.encode(truncated, forKey: .truncated)
         case .changeListFailed(let s, let reason, let message):
             try c.encode("changeListFailed", forKey: .type)

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -55,13 +55,13 @@ enum RemoteClientMessage: Equatable, Sendable {
     case queueClear(sessionId: String)
     case queueSteerUndo(sessionId: String)
     case listChanges(sessionId: String)
-    case fileDiff(sessionId: String, path: String)
+    case fileDiff(sessionId: String, path: String, stage: String?)
     case listFiles(sessionId: String, path: String?)
     case readFile(sessionId: String, path: String)
 }
 
 extension RemoteClientMessage: Codable {
-    private enum CodingKeys: String, CodingKey { case type, sessionId, requestId, optionId, persistScope, answers, action, content, text, attachments, modelId, modeId, enabled, title, worktreeId, agentId, beforeIndex, limit, itemId, intent, projectId, base, branch, path }
+    private enum CodingKeys: String, CodingKey { case type, sessionId, requestId, optionId, persistScope, answers, action, content, text, attachments, modelId, modeId, enabled, title, worktreeId, agentId, beforeIndex, limit, itemId, intent, projectId, base, branch, path, stage }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -156,7 +156,8 @@ extension RemoteClientMessage: Codable {
             self = .listChanges(sessionId: try c.decode(String.self, forKey: .sessionId))
         case "fileDiff":
             self = .fileDiff(sessionId: try c.decode(String.self, forKey: .sessionId),
-                             path: try c.decode(String.self, forKey: .path))
+                             path: try c.decode(String.self, forKey: .path),
+                             stage: try c.decodeIfPresent(String.self, forKey: .stage))
         case "listFiles":
             self = .listFiles(sessionId: try c.decode(String.self, forKey: .sessionId),
                               path: try c.decodeIfPresent(String.self, forKey: .path))
@@ -270,10 +271,11 @@ extension RemoteClientMessage: Codable {
         case .listChanges(let s):
             try c.encode("listChanges", forKey: .type)
             try c.encode(s, forKey: .sessionId)
-        case .fileDiff(let s, let path):
+        case .fileDiff(let s, let path, let stage):
             try c.encode("fileDiff", forKey: .type)
             try c.encode(s, forKey: .sessionId)
             try c.encode(path, forKey: .path)
+            try c.encodeIfPresent(stage, forKey: .stage)
         case .listFiles(let s, let path):
             try c.encode("listFiles", forKey: .type)
             try c.encode(s, forKey: .sessionId)
@@ -316,8 +318,8 @@ extension RemoteClientMessage {
         switch self {
         case .listChanges(let sessionId):
             return "listChanges\u{0}\(sessionId)"
-        case .fileDiff(let sessionId, let path):
-            return "fileDiff\u{0}\(sessionId)\u{0}\(path)"
+        case .fileDiff(let sessionId, let path, let stage):
+            return "fileDiff\u{0}\(sessionId)\u{0}\(path)\u{0}\(stage ?? "")"
         case .listFiles(let sessionId, let path):
             return "listFiles\u{0}\(sessionId)\u{0}\(path ?? "")"
         case .readFile(let sessionId, let path):

--- a/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteProtocol.swift
@@ -386,7 +386,7 @@ enum RemoteServerMessage: Equatable, Sendable {
     case changeList(
         sessionId: String, comparisonRef: String?, metricsAvailable: Bool,
         files: [RemoteChangedFile], staged: [RemoteChangedFile], unstaged: [RemoteChangedFile],
-        commits: [RemoteCommit], truncated: Bool)
+        commits: [RemoteCommit], truncated: Bool, commitsTruncated: Bool = false)
     case changeListFailed(sessionId: String, reason: RemoteFileAccessReason, message: String?)
     case fileDiffResult(
         sessionId: String, path: String, stage: String? = nil, hunks: [RemoteDiffHunk], truncated: Bool,
@@ -408,7 +408,7 @@ extension RemoteServerMessage: Codable {
         case firstIndex, totalCount, epoch, revision
         case items, steerUndoAvailable, itemId, text
         case path, files, staged, unstaged, commits, comparisonRef, metricsAvailable, truncated, hunks, nodes, reason, byteSize
-        case metadataNote
+        case metadataNote, commitsTruncated
     }
 
     init(from decoder: Decoder) throws {
@@ -528,7 +528,8 @@ extension RemoteServerMessage: Codable {
                 staged: try c.decodeIfPresent([RemoteChangedFile].self, forKey: .staged) ?? [],
                 unstaged: try c.decodeIfPresent([RemoteChangedFile].self, forKey: .unstaged) ?? [],
                 commits: try c.decodeIfPresent([RemoteCommit].self, forKey: .commits) ?? [],
-                truncated: try c.decodeIfPresent(Bool.self, forKey: .truncated) ?? false)
+                truncated: try c.decodeIfPresent(Bool.self, forKey: .truncated) ?? false,
+                commitsTruncated: try c.decodeIfPresent(Bool.self, forKey: .commitsTruncated) ?? false)
         case "changeListFailed":
             self = .changeListFailed(
                 sessionId: try c.decode(String.self, forKey: .sessionId),
@@ -696,7 +697,7 @@ extension RemoteServerMessage: Codable {
             try c.encode(text, forKey: .text)
         case .error(let m): try c.encode("error", forKey: .type)
         try c.encode(m, forKey: .message)
-        case .changeList(let s, let ref, let available, let files, let staged, let unstaged, let commits, let truncated):
+        case .changeList(let s, let ref, let available, let files, let staged, let unstaged, let commits, let truncated, let commitsTruncated):
             try c.encode("changeList", forKey: .type)
             try c.encode(s, forKey: .sessionId)
             try c.encodeIfPresent(ref, forKey: .comparisonRef)
@@ -706,6 +707,7 @@ extension RemoteServerMessage: Codable {
             try c.encode(unstaged, forKey: .unstaged)
             try c.encode(commits, forKey: .commits)
             try c.encode(truncated, forKey: .truncated)
+            try c.encode(commitsTruncated, forKey: .commitsTruncated)
         case .changeListFailed(let s, let reason, let message):
             try c.encode("changeListFailed", forKey: .type)
             try c.encode(s, forKey: .sessionId)

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -71,6 +71,23 @@ struct GitServiceRemoteChangesTests {
         #expect(files.map(\.path) == ["a.txt"])
     }
 
+    @Test func statusCountsStagedFilesWithTabsInTheirPath() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let path = "staged\tname.txt"
+        try "one\n".write(to: repo.appendingPathComponent(path), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", path], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+        try "one\ntwo\n".write(to: repo.appendingPathComponent(path), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", path], cwd: repo)
+
+        let files = try await GitService().status(worktreePath: repo)
+
+        let staged = try #require(files.first { $0.path == path && $0.stage == .staged })
+        #expect(staged.add == 1)
+        #expect(staged.del == 0)
+    }
+
     /// Unlike the nil-ref case above, a NON-nil ref that fails its numstat
     /// diff (an invalid ref, here) is not "no base to compare against" —
     /// falling back to `status()` would silently report only current

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -669,6 +669,30 @@ struct GitServiceRemoteChangesTests {
         #expect(added.map(\.text) == ["literal"])
     }
 
+    @Test func remoteDiff_throwsWhenAStagedCopySourceSectionAloneExceedsTheOutputCap() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let original = (1 ... 100).map { "line\($0)\n" }.joined()
+        try original.write(to: repo.appendingPathComponent("aaa.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "aaa.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+
+        let appended = original + (1 ... 10).map { "appended-line-\($0)-with-enough-padding-to-add-up\n" }.joined()
+        try appended.write(to: repo.appendingPathComponent("aaa.txt"), atomically: true, encoding: .utf8)
+        try (appended + "zzz-marker\n").write(to: repo.appendingPathComponent("zzz.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "-A"], cwd: repo)
+
+        await #expect(throws: (any Error).self) {
+            _ = try await GitService().remoteDiff(
+                worktreePath: repo,
+                file: "zzz.txt",
+                staged: true,
+                originalPath: "aaa.txt",
+                maxOutputBytes: 300
+            )
+        }
+    }
+
     /// A file declared binary purely via `.gitattributes` (content that
     /// still looks like valid UTF-8 at the byte level) produces a
     /// hunk-less diff with `Binary files ... differ` instead of `@@` hunks

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -921,6 +921,23 @@ struct GitServiceRemoteChangesTests {
         #expect(unstaged.add == 1)
     }
 
+    @Test func statusForRemoteChangeListCountsUntrackedRecreationContent() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "old\nold\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["rm", "a.txt"], cwd: repo)
+        try "new\nnew\nnew\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+
+        let files = try await GitService().statusForRemoteChangeList(worktreePath: repo)
+
+        let unstaged = try #require(files.first { $0.path == "a.txt" && $0.stage == .unstaged })
+        #expect(unstaged.status == "A")
+        #expect(unstaged.add == 3)
+        #expect(unstaged.del == 0)
+    }
+
     /// `diffAgainstHEAD`'s unborn-HEAD existence check used to be
     /// `FileManager.default.fileExists`, a purely LOCAL filesystem check
     /// that is meaningless for an SSH-backed worktree — nothing exists

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -650,6 +650,25 @@ struct GitServiceRemoteChangesTests {
         #expect(added.map(\.text) == ["fresh"])
     }
 
+    @Test func remoteDiff_treatsUntrackedProbePathAsLiteral() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "tracked\n".write(to: repo.appendingPathComponent("other.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "other.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+        try "literal\n".write(to: repo.appendingPathComponent("*.txt"), atomically: true, encoding: .utf8)
+
+        let diff = try await GitService().remoteDiff(
+            worktreePath: repo,
+            file: "*.txt",
+            staged: false,
+            originalPath: nil,
+            maxOutputBytes: nil
+        )
+        let added = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }
+        #expect(added.map(\.text) == ["literal"])
+    }
+
     /// A file declared binary purely via `.gitattributes` (content that
     /// still looks like valid UTF-8 at the byte level) produces a
     /// hunk-less diff with `Binary files ... differ` instead of `@@` hunks

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -669,6 +669,29 @@ struct GitServiceRemoteChangesTests {
         #expect(added.map(\.text) == ["literal"])
     }
 
+    @Test func remoteDiff_slicesStagedRenameWithNonASCIIDestinationName() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "one\ntwo\nthree\n".write(to: repo.appendingPathComponent("café.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "café.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["mv", "café.txt", "crème.txt"], cwd: repo)
+        try "one\nTWO\nthree\n".write(to: repo.appendingPathComponent("crème.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "-A"], cwd: repo)
+
+        let diff = try await GitService().remoteDiff(
+            worktreePath: repo,
+            file: "crème.txt",
+            staged: true,
+            originalPath: "café.txt",
+            maxOutputBytes: nil
+        )
+        let added = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }.map(\.text)
+        let deleted = diff.hunks.flatMap(\.lines).filter { $0.kind == .delete }.map(\.text)
+        #expect(added == ["TWO"])
+        #expect(deleted == ["two"])
+    }
+
     @Test func remoteDiff_throwsWhenAStagedCopySourceSectionAloneExceedsTheOutputCap() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceRemoteChangesTests.swift
+++ b/AlasTests/GitServiceRemoteChangesTests.swift
@@ -902,6 +902,25 @@ struct GitServiceRemoteChangesTests {
         #expect(entry.status == "A")
     }
 
+    @Test func changedFilesAgainstRefKeepsOverallCountsWhenReusingStatusForNilRef() async throws {
+        let repo = try await makeUnbornRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "line1\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        try "line1\nline2\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+
+        let status = try await GitService().status(worktreePath: repo)
+        let workingTree = try await GitService().statusForRemoteChangeList(
+            worktreePath: repo, knownStatusEntries: status)
+        let files = try await GitService().changedFilesAgainstRef(
+            worktreePath: repo, ref: nil, knownStatusEntries: status)
+
+        let row = try #require(files.first { $0.path == "a.txt" })
+        #expect(row.add == 2)
+        let unstaged = try #require(workingTree.first { $0.path == "a.txt" && $0.stage == .unstaged })
+        #expect(unstaged.add == 1)
+    }
+
     /// `diffAgainstHEAD`'s unborn-HEAD existence check used to be
     /// `FileManager.default.fileExists`, a purely LOCAL filesystem check
     /// that is meaningless for an SSH-backed worktree — nothing exists

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1618,6 +1618,41 @@ struct RemoteAppStateAccessTests {
         }
     }
 
+    @Test func remoteFileDiffUsesTheIndexForAMissingUnstagedDiffBinaryCheck() async throws {
+        let repository = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-remote-missing-unstaged-index-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repository, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: repository) }
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repository)
+        _ = try await Process.git(["config", "user.email", "test@example.com"], cwd: repository)
+        _ = try await Process.git(["config", "user.name", "Test User"], cwd: repository)
+        let file = repository.appendingPathComponent("mixed.dat")
+        try Data([0x00, 0x01, 0x02]).write(to: file)
+        _ = try await Process.git(["add", "mixed.dat"], cwd: repository)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: repository)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature/remote"], cwd: repository)
+        try "staged text\n".write(to: file, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "mixed.dat"], cwd: repository)
+        try FileManager.default.removeItem(at: file)
+
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId { cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId) }
+        }
+        let state = makeRemoteGitBackedState(repositoryPath: repository)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+
+        let diffResult = await state.remoteFileDiff(sessionId: tab.sessionId, path: "mixed.dat", stage: "unstaged")
+        guard case let .success(hunks, _, _) = diffResult else {
+            Issue.record("expected unstaged text deletion diff, got \(diffResult)")
+            return
+        }
+        #expect(hunks.flatMap(\.lines).contains { $0.kind == "delete" && $0.text == "staged text" })
+    }
+
     @Test func remoteFileDiffUsesOriginalPathForAnUnstagedRename() async throws {
         let repository = try await makeRemoteBranchesRepository()
         defer { try? FileManager.default.removeItem(at: repository) }

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1527,6 +1527,32 @@ struct RemoteAppStateAccessTests {
         #expect(diffResult == .failure(reason: .binary, message: nil))
     }
 
+    @Test func remoteFileDiffUsesTheIndexForAStagedDiffBinaryCheck() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        _ = try await Process.git(["checkout", "-q", "feature/remote"], cwd: repository)
+        let file = repository.appendingPathComponent("mixed.dat")
+        try "staged text\n".write(to: file, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "mixed.dat"], cwd: repository)
+        try Data([0x00, 0x01, 0x02]).write(to: file)
+
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId { cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId) }
+        }
+        let state = makeRemoteGitBackedState(repositoryPath: repository)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+
+        let diffResult = await state.remoteFileDiff(sessionId: tab.sessionId, path: "mixed.dat", stage: "staged")
+        guard case .success = diffResult else {
+            Issue.record("expected staged text diff, got \(diffResult)")
+            return
+        }
+    }
+
     private func statusCode(port: UInt16, host: String, path: String) async throws -> Int? {
         var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)\(path)")!)
         req.setValue(host, forHTTPHeaderField: "Host")

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1088,6 +1088,38 @@ struct RemoteAppStateAccessTests {
         #expect(unstaged.first { $0.path == "a.txt" }?.del == 1)
     }
 
+    @Test func remoteChangeListMatchesUnstagedTabPathCountsByRawPath() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        let path = "a\tb.txt"
+        let file = repository.appendingPathComponent(path)
+        try "one\n".write(to: file, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", path], cwd: repository)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: repository)
+        try "one\ntwo\n".write(to: file, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", path], cwd: repository)
+        try "one\nTWO\n".write(to: file, atomically: true, encoding: .utf8)
+
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId { cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId) }
+        }
+        let state = makeRemoteGitBackedState(repositoryPath: repository)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+
+        let result = await state.remoteChangeList(sessionId: tab.sessionId)
+        guard case let .success(_, _, _, _, unstaged, _, _, _) = result else {
+            Issue.record("expected a successful change list, got \(result)")
+            return
+        }
+        let row = try #require(unstaged.first { $0.path == path })
+        #expect(row.add == 1)
+        #expect(row.del == 1)
+    }
+
     @Test func remoteFileContentsAndDiffRejectAGitignoredFile() async throws {
         let repository = try await makeRemoteBranchesRepository()
         defer { try? FileManager.default.removeItem(at: repository) }

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1586,6 +1586,38 @@ struct RemoteAppStateAccessTests {
         }
     }
 
+    @Test func remoteFileDiffUsesOriginalPathForAnUnstagedRename() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        try "one\ntwo\n".write(to: repository.appendingPathComponent("old.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "old.txt"], cwd: repository)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: repository)
+        try FileManager.default.moveItem(
+            at: repository.appendingPathComponent("old.txt"),
+            to: repository.appendingPathComponent("new.txt"))
+        _ = try await Process.git(["add", "-N", "new.txt"], cwd: repository)
+        try "one\nTWO\n".write(to: repository.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId { cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId) }
+        }
+        let state = makeRemoteGitBackedState(repositoryPath: repository)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+
+        let diffResult = await state.remoteFileDiff(sessionId: tab.sessionId, path: "new.txt", stage: "unstaged")
+        guard case let .success(hunks, _, _) = diffResult else {
+            Issue.record("expected unstaged rename diff, got \(diffResult)")
+            return
+        }
+        let lines = hunks.flatMap(\.lines)
+        #expect(lines.contains { $0.kind == "delete" && $0.text == "two" })
+        #expect(lines.contains { $0.kind == "add" && $0.text == "TWO" })
+    }
+
     private func statusCode(port: UInt16, host: String, path: String) async throws -> Int? {
         var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)\(path)")!)
         req.setValue(host, forHTTPHeaderField: "Host")

--- a/AlasTests/Remote/RemoteAppStateAccessTests.swift
+++ b/AlasTests/Remote/RemoteAppStateAccessTests.swift
@@ -1055,6 +1055,39 @@ struct RemoteAppStateAccessTests {
         #expect(result == .failure(reason: .worktreeUnavailable, message: nil))
     }
 
+    @Test func remoteChangeListReportsUnstagedCountsAgainstTheIndex() async throws {
+        let repository = try await makeRemoteBranchesRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        try "A\n".write(to: repository.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repository)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: repository)
+        try "X\n".write(to: repository.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repository)
+        try "A\n".write(to: repository.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+
+        var cleanupWorktreeId: String?
+        defer {
+            if let cleanupWorktreeId {
+                cleanupRemoteRenameFiles(worktreeId: cleanupWorktreeId)
+            }
+        }
+        let state = makeRemoteGitBackedState(repositoryPath: repository)
+        let worktreeId = try #require(state.selectedWorktreeId)
+        cleanupWorktreeId = worktreeId
+        state.openNewACPSession(agentID: "test-agent")
+        let tab = try #require(acpTabs(in: state).first)
+
+        let result = await state.remoteChangeList(sessionId: tab.sessionId)
+        guard case let .success(_, _, _, staged, unstaged, _, _, _) = result else {
+            Issue.record("expected a successful change list, got \(result)")
+            return
+        }
+        #expect(staged.first { $0.path == "a.txt" }?.add == 1)
+        #expect(staged.first { $0.path == "a.txt" }?.del == 1)
+        #expect(unstaged.first { $0.path == "a.txt" }?.add == 1)
+        #expect(unstaged.first { $0.path == "a.txt" }?.del == 1)
+    }
+
     @Test func remoteFileContentsAndDiffRejectAGitignoredFile() async throws {
         let repository = try await makeRemoteBranchesRepository()
         defer { try? FileManager.default.removeItem(at: repository) }

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -659,7 +659,7 @@ struct RemoteProtocolTests {
 
     @Test func fileRequestDedupKeyCoversOnlyTheFourFileVerbs() {
         #expect(RemoteClientMessage.listChanges(sessionId: "s1").fileRequestDedupKey == "listChanges\u{0}s1")
-        #expect(RemoteClientMessage.fileDiff(sessionId: "s1", path: "a.txt").fileRequestDedupKey == "fileDiff\u{0}s1\u{0}a.txt")
+        #expect(RemoteClientMessage.fileDiff(sessionId: "s1", path: "a.txt", stage: nil).fileRequestDedupKey == "fileDiff\u{0}s1\u{0}a.txt\u{0}")
         #expect(RemoteClientMessage.listFiles(sessionId: "s1", path: "src").fileRequestDedupKey == "listFiles\u{0}s1\u{0}src")
         #expect(RemoteClientMessage.listFiles(sessionId: "s1", path: nil).fileRequestDedupKey == "listFiles\u{0}s1\u{0}")
         #expect(RemoteClientMessage.readFile(sessionId: "s1", path: "a.txt").fileRequestDedupKey == "readFile\u{0}s1\u{0}a.txt")
@@ -673,8 +673,8 @@ struct RemoteProtocolTests {
     /// is what makes "s1" + path "2/x" distinguishable from "s12" + path "x".
     @Test func fileRequestDedupKeyDoesNotCollideAcrossSessionsOrPaths() {
         #expect(
-            RemoteClientMessage.fileDiff(sessionId: "s1", path: "a.txt").fileRequestDedupKey
-                != RemoteClientMessage.fileDiff(sessionId: "s2", path: "a.txt").fileRequestDedupKey
+            RemoteClientMessage.fileDiff(sessionId: "s1", path: "a.txt", stage: nil).fileRequestDedupKey
+                != RemoteClientMessage.fileDiff(sessionId: "s2", path: "a.txt", stage: nil).fileRequestDedupKey
         )
         #expect(
             RemoteClientMessage.listFiles(sessionId: "s1", path: "a").fileRequestDedupKey
@@ -686,7 +686,7 @@ struct RemoteProtocolTests {
         let listChanges = RemoteClientMessage.listChanges(sessionId: "s1")
         #expect(try roundTrip(listChanges) == listChanges)
 
-        let fileDiff = RemoteClientMessage.fileDiff(sessionId: "s1", path: "src/main.swift")
+        let fileDiff = RemoteClientMessage.fileDiff(sessionId: "s1", path: "src/main.swift", stage: nil)
         #expect(try roundTrip(fileDiff) == fileDiff)
 
         let listRoot = RemoteClientMessage.listFiles(sessionId: "s1", path: nil)

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -711,7 +711,9 @@ struct RemoteProtocolTests {
             conflict: nil, renameFrom: nil)
         let changeList = RemoteServerMessage.changeList(
             sessionId: "s1", comparisonRef: "origin/main", metricsAvailable: true,
-            files: [file], truncated: false)
+            files: [file], staged: [file], unstaged: [],
+            commits: [RemoteCommit(shortSha: "abc1234", subject: "Add remote changes", author: "Nacho", add: 12, del: 3)],
+            truncated: false)
         #expect(try roundTrip(changeList) == changeList)
 
         let changeFailure = RemoteServerMessage.changeListFailed(

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -728,10 +728,13 @@ struct RemoteProtocolTests {
                 RemoteDiffLine(kind: "delete", text: "old", oldNumber: 3, newNumber: nil, noTrailingNewline: true)
             ])
         let diff = RemoteServerMessage.fileDiffResult(
-            sessionId: "s1", path: "src/main.swift", hunks: [hunk], truncated: true)
+            sessionId: "s1", path: "src/main.swift", stage: "staged", hunks: [hunk], truncated: true)
         #expect(try roundTrip(diff) == diff)
         #expect(try roundTrip(hunk) == hunk)
         #expect(try roundTrip(hunk).lines.last?.noTrailingNewline == true)
+        let diffObject = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(diff)) as? [String: Any])
+        #expect(diffObject["stage"] as? String == "staged")
 
         // Decoded leniently when the field is absent entirely (an older
         // host that hasn't been rebuilt yet), defaulting to `false` rather

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -291,7 +291,7 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
         return changeListResult
     }
 
-    func remoteFileDiff(sessionId: String, path: String) async -> RemoteFileDiffResult {
+    func remoteFileDiff(sessionId: String, path: String, stage: String?) async -> RemoteFileDiffResult {
         fileDiffRequests.append((sessionId, path))
         resumeWaiters(&fileDiffCallWaiters, through: fileDiffRequests.count)
         if pauseFileDiff {
@@ -2721,14 +2721,14 @@ struct RemoteSessionGatewayTests {
         var sent: [RemoteServerMessage] = []
         let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
 
-        await gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt"))
+        await gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt", stage: nil))
         #expect(provider.fileDiffRequests.map(\.path) == ["a.txt"])
         #expect(sent == [.fileDiffResult(
             sessionId: "s1", path: "a.txt", hunks: [hunk], truncated: true)])
 
         provider.fileDiffResult = .failure(reason: .pathRejected, message: nil)
         sent.removeAll()
-        await gateway.handle(.fileDiff(sessionId: "s1", path: "../etc/passwd"))
+        await gateway.handle(.fileDiff(sessionId: "s1", path: "../etc/passwd", stage: nil))
         #expect(sent == [.fileDiffFailed(
             sessionId: "s1", path: "../etc/passwd", reason: .pathRejected, message: nil)])
     }
@@ -2771,10 +2771,10 @@ struct RemoteSessionGatewayTests {
         var sent: [RemoteServerMessage] = []
         let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
 
-        async let first: Void = gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt"))
+        async let first: Void = gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt", stage: nil))
         await provider.waitForFileDiffCall(1)   // first call has entered the provider and is now suspended — the gateway's dedup key is held
 
-        await gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt"))   // must be dropped: the key is still held by the suspended first call
+        await gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt", stage: nil))   // must be dropped: the key is still held by the suspended first call
         #expect(provider.fileDiffRequests.count == 1)   // second call never reached the provider
         #expect(sent.isEmpty)   // dropped call sends nothing
 

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -36,7 +36,7 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     var fileTreeResult: RemoteFileTreeResult = .failure(reason: .sessionUnknown, message: nil)
     var fileContentsResult: RemoteFileContentsResult = .failure(reason: .sessionUnknown, byteSize: nil, message: nil)
     var changeListRequests: [String] = []
-    var fileDiffRequests: [(sessionId: String, path: String)] = []
+    var fileDiffRequests: [(sessionId: String, path: String, stage: String?)] = []
     var fileTreeRequests: [(sessionId: String, path: String?)] = []
     var fileContentsRequests: [(sessionId: String, path: String)] = []
     var queueForceSends: [(id: String, itemId: UUID)] = []
@@ -292,7 +292,7 @@ final class FakeSessionsProvider: RemoteSessionsProvider {
     }
 
     func remoteFileDiff(sessionId: String, path: String, stage: String?) async -> RemoteFileDiffResult {
-        fileDiffRequests.append((sessionId, path))
+        fileDiffRequests.append((sessionId, path, stage))
         resumeWaiters(&fileDiffCallWaiters, through: fileDiffRequests.count)
         if pauseFileDiff {
             return await withCheckedContinuation { continuation in
@@ -2721,16 +2721,17 @@ struct RemoteSessionGatewayTests {
         var sent: [RemoteServerMessage] = []
         let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
 
-        await gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt", stage: nil))
+        await gateway.handle(.fileDiff(sessionId: "s1", path: "a.txt", stage: "staged"))
         #expect(provider.fileDiffRequests.map(\.path) == ["a.txt"])
+        #expect(provider.fileDiffRequests.map(\.stage) == ["staged"])
         #expect(sent == [.fileDiffResult(
-            sessionId: "s1", path: "a.txt", hunks: [hunk], truncated: true)])
+            sessionId: "s1", path: "a.txt", stage: "staged", hunks: [hunk], truncated: true)])
 
         provider.fileDiffResult = .failure(reason: .pathRejected, message: nil)
         sent.removeAll()
-        await gateway.handle(.fileDiff(sessionId: "s1", path: "../etc/passwd", stage: nil))
+        await gateway.handle(.fileDiff(sessionId: "s1", path: "../etc/passwd", stage: "unstaged"))
         #expect(sent == [.fileDiffFailed(
-            sessionId: "s1", path: "../etc/passwd", reason: .pathRejected, message: nil)])
+            sessionId: "s1", path: "../etc/passwd", stage: "unstaged", reason: .pathRejected, message: nil)])
     }
 
     @Test func listFilesAndReadFileSendTreeAndContents() async {

--- a/AlasTests/Remote/RemoteSessionGatewayTests.swift
+++ b/AlasTests/Remote/RemoteSessionGatewayTests.swift
@@ -2687,7 +2687,8 @@ struct RemoteSessionGatewayTests {
         let file = RemoteChangedFile(
             path: "a.txt", status: "M", add: 2, del: 1, conflict: nil, renameFrom: nil)
         provider.changeListResult = .success(
-            comparisonRef: "origin/main", metricsAvailable: true, files: [file], truncated: false)
+            comparisonRef: "origin/main", metricsAvailable: true, files: [file], staged: [file], unstaged: [],
+            commits: [], truncated: false)
         var sent: [RemoteServerMessage] = []
         let gateway = RemoteSessionGateway(provider: provider) { sent.append($0) }
 
@@ -2696,7 +2697,7 @@ struct RemoteSessionGatewayTests {
         #expect(provider.changeListRequests == ["s1"])
         #expect(sent == [.changeList(
             sessionId: "s1", comparisonRef: "origin/main", metricsAvailable: true,
-            files: [file], truncated: false)])
+            files: [file], staged: [file], unstaged: [], commits: [], truncated: false)])
     }
 
     @Test func listChangesSendsFailureMessageOnProviderFailure() async {

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -51,11 +51,11 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"/session-ordering.js?v=1"#))
         #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=76"#)!.lowerBound)
         #expect(html.contains(#"/app.js?v=76"#))
-        #expect(html.contains(#"/style.css?v=43"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v55";"#))
+        #expect(html.contains(#"/style.css?v=44"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v56";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
         #expect(sw.contains(#""/app.js?v=76""#))
-        #expect(sw.contains(#""/style.css?v=43""#))
+        #expect(sw.contains(#""/style.css?v=44""#))
     }
 
     @Test func remoteWebToolRowsAvoidNativeButtonRenderingOnMobileSafari() throws {
@@ -69,10 +69,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
         #expect(html.contains(#"/app.js?v=76"#))
-        #expect(html.contains(#"/style.css?v=43"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v55";"#))
+        #expect(html.contains(#"/style.css?v=44"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v56";"#))
         #expect(sw.contains(#""/app.js?v=76""#))
-        #expect(sw.contains(#""/style.css?v=43""#))
+        #expect(sw.contains(#""/style.css?v=44""#))
     }
 
     @Test func remoteBareURLLinkifierPreservesIndentedCodeBlocks() throws {
@@ -120,7 +120,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
         #expect(html.contains("/app.js?v=76"))
-        #expect(html.contains("/style.css?v=43"))
+        #expect(html.contains("/style.css?v=44"))
     }
 
     @Test func remoteWebExposesSessionRenameControls() throws {
@@ -144,9 +144,11 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".rename-btn"))
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
+        #expect(css.contains("#detail-title { display: none; }"))
+        #expect(!css.contains("#detail-title, #detail-rename { display: none; }"))
         #expect(css.contains(".sheet-input"))
         #expect(sw.contains(#""/app.js?v=76""#))
-        #expect(sw.contains(#""/style.css?v=43""#))
+        #expect(sw.contains(#""/style.css?v=44""#))
     }
 
     @Test func configSheetScrollsWhenModelListOverflows() throws {
@@ -334,7 +336,7 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v55"))
+        #expect(sw.contains("alas-remote-shell-v56"))
         #expect(sw.contains("/app.js?v=76"))
         #expect(html.contains("app.js?v=76"))
     }
@@ -500,10 +502,10 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/app.js?v=76"#))
-        #expect(html.contains(#"/style.css?v=43"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v55";"#))
+        #expect(html.contains(#"/style.css?v=44"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v56";"#))
         #expect(sw.contains(#""/app.js?v=76""#))
-        #expect(sw.contains(#""/style.css?v=43""#))
+        #expect(sw.contains(#""/style.css?v=44""#))
     }
 
     @Test func remoteWebOffersUndoAfterASteerDiscardsTheQueue() throws {

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,13 +49,13 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=72"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=72"#))
-        #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v51";"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=73"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=73"#))
+        #expect(html.contains(#"/style.css?v=43"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v52";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=72""#))
-        #expect(sw.contains(#""/style.css?v=42""#))
+        #expect(sw.contains(#""/app.js?v=73""#))
+        #expect(sw.contains(#""/style.css?v=43""#))
     }
 
     @Test func remoteWebToolRowsAvoidNativeButtonRenderingOnMobileSafari() throws {
@@ -68,11 +68,11 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=72"#))
-        #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v51";"#))
-        #expect(sw.contains(#""/app.js?v=72""#))
-        #expect(sw.contains(#""/style.css?v=42""#))
+        #expect(html.contains(#"/app.js?v=73"#))
+        #expect(html.contains(#"/style.css?v=43"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v52";"#))
+        #expect(sw.contains(#""/app.js?v=73""#))
+        #expect(sw.contains(#""/style.css?v=43""#))
     }
 
     @Test func remoteBareURLLinkifierPreservesIndentedCodeBlocks() throws {
@@ -119,8 +119,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=72"))
-        #expect(html.contains("/style.css?v=42"))
+        #expect(html.contains("/app.js?v=73"))
+        #expect(html.contains("/style.css?v=43"))
     }
 
     @Test func remoteWebExposesSessionRenameControls() throws {
@@ -145,8 +145,8 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=72""#))
-        #expect(sw.contains(#""/style.css?v=42""#))
+        #expect(sw.contains(#""/app.js?v=73""#))
+        #expect(sw.contains(#""/style.css?v=43""#))
     }
 
     @Test func configSheetScrollsWhenModelListOverflows() throws {
@@ -196,7 +196,7 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/worktree-creation.js?v=1"#))
-        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=72"#)!.lowerBound)
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=73"#)!.lowerBound)
         #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
         #expect(js.contains(#"case "projectList":"#))
         #expect(js.contains(#"case "branchList":"#))
@@ -334,9 +334,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v51"))
-        #expect(sw.contains("/app.js?v=72"))
-        #expect(html.contains("app.js?v=72"))
+        #expect(sw.contains("alas-remote-shell-v52"))
+        #expect(sw.contains("/app.js?v=73"))
+        #expect(html.contains("app.js?v=73"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -499,11 +499,11 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=72"#))
-        #expect(html.contains(#"/style.css?v=42"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v51";"#))
-        #expect(sw.contains(#""/app.js?v=72""#))
-        #expect(sw.contains(#""/style.css?v=42""#))
+        #expect(html.contains(#"/app.js?v=73"#))
+        #expect(html.contains(#"/style.css?v=43"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v52";"#))
+        #expect(sw.contains(#""/app.js?v=73""#))
+        #expect(sw.contains(#""/style.css?v=43""#))
     }
 
     @Test func remoteWebOffersUndoAfterASteerDiscardsTheQueue() throws {
@@ -533,13 +533,13 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"id="file-list""#))
         #expect(html.contains(#"id="file-view-body""#))
 
-        #expect(html.contains(#"/changes-view.js?v=3"#))
+        #expect(html.contains(#"/changes-view.js?v=4"#))
         #expect(html.contains(#"/file-browser.js?v=3"#))
-        #expect(html.range(of: #"/changes-view.js?v=3"#)!.lowerBound
-            < html.range(of: #"/app.js?v=72"#)!.lowerBound)
+        #expect(html.range(of: #"/changes-view.js?v=4"#)!.lowerBound
+            < html.range(of: #"/app.js?v=73"#)!.lowerBound)
         #expect(html.range(of: #"/file-browser.js?v=3"#)!.lowerBound
-            < html.range(of: #"/app.js?v=72"#)!.lowerBound)
-        #expect(sw.contains(#""/changes-view.js?v=3""#))
+            < html.range(of: #"/app.js?v=73"#)!.lowerBound)
+        #expect(sw.contains(#""/changes-view.js?v=4""#))
         #expect(sw.contains(#""/file-browser.js?v=3""#))
     }
 

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,12 +49,12 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=74"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=74"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=75"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=75"#))
         #expect(html.contains(#"/style.css?v=43"#))
         #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v54";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=74""#))
+        #expect(sw.contains(#""/app.js?v=75""#))
         #expect(sw.contains(#""/style.css?v=43""#))
     }
 
@@ -68,10 +68,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=74"#))
+        #expect(html.contains(#"/app.js?v=75"#))
         #expect(html.contains(#"/style.css?v=43"#))
         #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v54";"#))
-        #expect(sw.contains(#""/app.js?v=74""#))
+        #expect(sw.contains(#""/app.js?v=75""#))
         #expect(sw.contains(#""/style.css?v=43""#))
     }
 
@@ -119,7 +119,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=74"))
+        #expect(html.contains("/app.js?v=75"))
         #expect(html.contains("/style.css?v=43"))
     }
 
@@ -145,7 +145,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=74""#))
+        #expect(sw.contains(#""/app.js?v=75""#))
         #expect(sw.contains(#""/style.css?v=43""#))
     }
 
@@ -196,7 +196,7 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/worktree-creation.js?v=1"#))
-        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=74"#)!.lowerBound)
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=75"#)!.lowerBound)
         #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
         #expect(js.contains(#"case "projectList":"#))
         #expect(js.contains(#"case "branchList":"#))
@@ -335,8 +335,8 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
         #expect(sw.contains("alas-remote-shell-v54"))
-        #expect(sw.contains("/app.js?v=74"))
-        #expect(html.contains("app.js?v=74"))
+        #expect(sw.contains("/app.js?v=75"))
+        #expect(html.contains("app.js?v=75"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -499,10 +499,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=74"#))
+        #expect(html.contains(#"/app.js?v=75"#))
         #expect(html.contains(#"/style.css?v=43"#))
         #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v54";"#))
-        #expect(sw.contains(#""/app.js?v=74""#))
+        #expect(sw.contains(#""/app.js?v=75""#))
         #expect(sw.contains(#""/style.css?v=43""#))
     }
 
@@ -536,9 +536,9 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"/changes-view.js?v=5"#))
         #expect(html.contains(#"/file-browser.js?v=3"#))
         #expect(html.range(of: #"/changes-view.js?v=5"#)!.lowerBound
-            < html.range(of: #"/app.js?v=74"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=75"#)!.lowerBound)
         #expect(html.range(of: #"/file-browser.js?v=3"#)!.lowerBound
-            < html.range(of: #"/app.js?v=74"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=75"#)!.lowerBound)
         #expect(sw.contains(#""/changes-view.js?v=5""#))
         #expect(sw.contains(#""/file-browser.js?v=3""#))
     }

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -52,7 +52,7 @@ struct RemoteWebAssetTests {
         #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=74"#)!.lowerBound)
         #expect(html.contains(#"/app.js?v=74"#))
         #expect(html.contains(#"/style.css?v=43"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v53";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v54";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
         #expect(sw.contains(#""/app.js?v=74""#))
         #expect(sw.contains(#""/style.css?v=43""#))
@@ -70,7 +70,7 @@ struct RemoteWebAssetTests {
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
         #expect(html.contains(#"/app.js?v=74"#))
         #expect(html.contains(#"/style.css?v=43"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v53";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v54";"#))
         #expect(sw.contains(#""/app.js?v=74""#))
         #expect(sw.contains(#""/style.css?v=43""#))
     }
@@ -334,7 +334,7 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v53"))
+        #expect(sw.contains("alas-remote-shell-v54"))
         #expect(sw.contains("/app.js?v=74"))
         #expect(html.contains("app.js?v=74"))
     }
@@ -501,7 +501,7 @@ struct RemoteWebAssetTests {
 
         #expect(html.contains(#"/app.js?v=74"#))
         #expect(html.contains(#"/style.css?v=43"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v53";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v54";"#))
         #expect(sw.contains(#""/app.js?v=74""#))
         #expect(sw.contains(#""/style.css?v=43""#))
     }

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,12 +49,12 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=75"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=75"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=76"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=76"#))
         #expect(html.contains(#"/style.css?v=43"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v54";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v55";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=75""#))
+        #expect(sw.contains(#""/app.js?v=76""#))
         #expect(sw.contains(#""/style.css?v=43""#))
     }
 
@@ -68,10 +68,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=75"#))
+        #expect(html.contains(#"/app.js?v=76"#))
         #expect(html.contains(#"/style.css?v=43"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v54";"#))
-        #expect(sw.contains(#""/app.js?v=75""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v55";"#))
+        #expect(sw.contains(#""/app.js?v=76""#))
         #expect(sw.contains(#""/style.css?v=43""#))
     }
 
@@ -119,7 +119,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=75"))
+        #expect(html.contains("/app.js?v=76"))
         #expect(html.contains("/style.css?v=43"))
     }
 
@@ -145,7 +145,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=75""#))
+        #expect(sw.contains(#""/app.js?v=76""#))
         #expect(sw.contains(#""/style.css?v=43""#))
     }
 
@@ -196,7 +196,7 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/worktree-creation.js?v=1"#))
-        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=75"#)!.lowerBound)
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=76"#)!.lowerBound)
         #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
         #expect(js.contains(#"case "projectList":"#))
         #expect(js.contains(#"case "branchList":"#))
@@ -334,9 +334,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v54"))
-        #expect(sw.contains("/app.js?v=75"))
-        #expect(html.contains("app.js?v=75"))
+        #expect(sw.contains("alas-remote-shell-v55"))
+        #expect(sw.contains("/app.js?v=76"))
+        #expect(html.contains("app.js?v=76"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -499,10 +499,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=75"#))
+        #expect(html.contains(#"/app.js?v=76"#))
         #expect(html.contains(#"/style.css?v=43"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v54";"#))
-        #expect(sw.contains(#""/app.js?v=75""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v55";"#))
+        #expect(sw.contains(#""/app.js?v=76""#))
         #expect(sw.contains(#""/style.css?v=43""#))
     }
 
@@ -533,13 +533,13 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"id="file-list""#))
         #expect(html.contains(#"id="file-view-body""#))
 
-        #expect(html.contains(#"/changes-view.js?v=5"#))
+        #expect(html.contains(#"/changes-view.js?v=6"#))
         #expect(html.contains(#"/file-browser.js?v=3"#))
-        #expect(html.range(of: #"/changes-view.js?v=5"#)!.lowerBound
-            < html.range(of: #"/app.js?v=75"#)!.lowerBound)
+        #expect(html.range(of: #"/changes-view.js?v=6"#)!.lowerBound
+            < html.range(of: #"/app.js?v=76"#)!.lowerBound)
         #expect(html.range(of: #"/file-browser.js?v=3"#)!.lowerBound
-            < html.range(of: #"/app.js?v=75"#)!.lowerBound)
-        #expect(sw.contains(#""/changes-view.js?v=5""#))
+            < html.range(of: #"/app.js?v=76"#)!.lowerBound)
+        #expect(sw.contains(#""/changes-view.js?v=6""#))
         #expect(sw.contains(#""/file-browser.js?v=3""#))
     }
 

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,12 +49,12 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=73"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=73"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=74"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=74"#))
         #expect(html.contains(#"/style.css?v=43"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v52";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v53";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=73""#))
+        #expect(sw.contains(#""/app.js?v=74""#))
         #expect(sw.contains(#""/style.css?v=43""#))
     }
 
@@ -68,10 +68,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=73"#))
+        #expect(html.contains(#"/app.js?v=74"#))
         #expect(html.contains(#"/style.css?v=43"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v52";"#))
-        #expect(sw.contains(#""/app.js?v=73""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v53";"#))
+        #expect(sw.contains(#""/app.js?v=74""#))
         #expect(sw.contains(#""/style.css?v=43""#))
     }
 
@@ -119,7 +119,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=73"))
+        #expect(html.contains("/app.js?v=74"))
         #expect(html.contains("/style.css?v=43"))
     }
 
@@ -145,7 +145,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-open"))
         #expect(css.contains("#detail-title"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=73""#))
+        #expect(sw.contains(#""/app.js?v=74""#))
         #expect(sw.contains(#""/style.css?v=43""#))
     }
 
@@ -196,7 +196,7 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/worktree-creation.js?v=1"#))
-        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=73"#)!.lowerBound)
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=74"#)!.lowerBound)
         #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
         #expect(js.contains(#"case "projectList":"#))
         #expect(js.contains(#"case "branchList":"#))
@@ -334,9 +334,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v52"))
-        #expect(sw.contains("/app.js?v=73"))
-        #expect(html.contains("app.js?v=73"))
+        #expect(sw.contains("alas-remote-shell-v53"))
+        #expect(sw.contains("/app.js?v=74"))
+        #expect(html.contains("app.js?v=74"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -499,10 +499,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=73"#))
+        #expect(html.contains(#"/app.js?v=74"#))
         #expect(html.contains(#"/style.css?v=43"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v52";"#))
-        #expect(sw.contains(#""/app.js?v=73""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v53";"#))
+        #expect(sw.contains(#""/app.js?v=74""#))
         #expect(sw.contains(#""/style.css?v=43""#))
     }
 
@@ -533,13 +533,13 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"id="file-list""#))
         #expect(html.contains(#"id="file-view-body""#))
 
-        #expect(html.contains(#"/changes-view.js?v=4"#))
+        #expect(html.contains(#"/changes-view.js?v=5"#))
         #expect(html.contains(#"/file-browser.js?v=3"#))
-        #expect(html.range(of: #"/changes-view.js?v=4"#)!.lowerBound
-            < html.range(of: #"/app.js?v=73"#)!.lowerBound)
+        #expect(html.range(of: #"/changes-view.js?v=5"#)!.lowerBound
+            < html.range(of: #"/app.js?v=74"#)!.lowerBound)
         #expect(html.range(of: #"/file-browser.js?v=3"#)!.lowerBound
-            < html.range(of: #"/app.js?v=73"#)!.lowerBound)
-        #expect(sw.contains(#""/changes-view.js?v=4""#))
+            < html.range(of: #"/app.js?v=74"#)!.lowerBound)
+        #expect(sw.contains(#""/changes-view.js?v=5""#))
         #expect(sw.contains(#""/file-browser.js?v=3""#))
     }
 

--- a/AlasTests/StatusParserTests.swift
+++ b/AlasTests/StatusParserTests.swift
@@ -58,6 +58,16 @@ struct StatusParserTests {
         #expect(entry.renameFrom == "docs/PANES.md")
     }
 
+    @Test func parsesCopy() throws {
+        let raw = "2 C. N... 100644 100644 100644 a a C100 docs/COPY.md\u{0}docs/PANES.md\u{0}"
+        let entries = try StatusParser.parse(raw)
+        let entry = try #require(entries.first)
+        #expect(entry.status == "C")
+        #expect(entry.stage == .staged)
+        #expect(entry.path == "docs/COPY.md")
+        #expect(entry.renameFrom == "docs/PANES.md")
+    }
+
     @Test func parsesRenameWithUnstagedModification() throws {
         let raw = "2 RM N... 100644 100644 100644 a a R100 docs/SPLIT.md\u{0}docs/PANES.md\u{0}"
         let entries = try StatusParser.parse(raw)

--- a/AlasTests/StatusParserTests.swift
+++ b/AlasTests/StatusParserTests.swift
@@ -68,6 +68,16 @@ struct StatusParserTests {
         #expect(entry.renameFrom == "docs/PANES.md")
     }
 
+    @Test func parsesUnstagedRename() throws {
+        let raw = "2 .R N... 100644 100644 100644 a a R050 docs/SPLIT.md\u{0}docs/PANES.md\u{0}"
+        let entries = try StatusParser.parse(raw)
+        let entry = try #require(entries.first)
+        #expect(entry.status == "R")
+        #expect(entry.stage == .unstaged)
+        #expect(entry.path == "docs/SPLIT.md")
+        #expect(entry.renameFrom == "docs/PANES.md")
+    }
+
     @Test func parsesRenameWithUnstagedModification() throws {
         let raw = "2 RM N... 100644 100644 100644 a a R100 docs/SPLIT.md\u{0}docs/PANES.md\u{0}"
         let entries = try StatusParser.parse(raw)

--- a/scripts/tests/remote-web-changes/test-changes-view.js
+++ b/scripts/tests/remote-web-changes/test-changes-view.js
@@ -36,6 +36,16 @@ const view = globalThis.RemoteChangesView;
 }
 
 {
+  const summary = view.formatSummary({
+    comparisonRef: null,
+    files: [{ path: "mixed.txt", add: 2, del: 0 }],
+    staged: [{ path: "mixed.txt", add: 1, del: 0 }],
+    unstaged: [{ path: "mixed.txt", add: 1, del: 0 }]
+  });
+  assert.equal(summary, "1 file · +2 −0");
+}
+
+{
   assert.equal(view.formatFileCounts({ add: 12, del: 3 }), "+12 −3");
 }
 

--- a/scripts/tests/remote-web-changes/test-changes-view.js
+++ b/scripts/tests/remote-web-changes/test-changes-view.js
@@ -40,6 +40,17 @@ const view = globalThis.RemoteChangesView;
 }
 
 {
+  const sections = view.changeSections({
+    staged: [{ path: "staged.swift", add: 3, del: 1 }],
+    unstaged: [{ path: "unstaged.swift", add: 2, del: 0 }],
+    commits: [{ shortSha: "abc1234", subject: "Add remote changes", author: "Nacho", add: 8, del: 2 }]
+  });
+  assert.deepEqual(sections.map((section) => section.title), ["Working Tree", "Staged", "Unstaged", "Commits"]);
+  assert.equal(sections[1].files[0].path, "staged.swift");
+  assert.equal(sections[3].commits[0].shortSha, "abc1234");
+}
+
+{
   const rows = view.diffRows([
     {
       header: "@@ -1,2 +1,3 @@",

--- a/scripts/tests/remote-web-changes/test-changes-view.js
+++ b/scripts/tests/remote-web-changes/test-changes-view.js
@@ -54,6 +54,17 @@ const view = globalThis.RemoteChangesView;
 }
 
 {
+  const sections = view.changeSections({
+    files: [{ path: "base-relative.swift", add: 1, del: 1 }],
+    staged: [],
+    unstaged: [],
+    commits: []
+  });
+  assert.deepEqual(sections.map((section) => section.title), ["Branch Changes"]);
+  assert.equal(sections[0].files[0].path, "base-relative.swift");
+}
+
+{
   const rows = view.diffRows([
     {
       header: "@@ -1,2 +1,3 @@",

--- a/scripts/tests/remote-web-changes/test-changes-view.js
+++ b/scripts/tests/remote-web-changes/test-changes-view.js
@@ -41,13 +41,16 @@ const view = globalThis.RemoteChangesView;
 
 {
   const sections = view.changeSections({
+    files: [{ path: "committed.swift", add: 8, del: 2 }],
     staged: [{ path: "staged.swift", add: 3, del: 1 }],
     unstaged: [{ path: "unstaged.swift", add: 2, del: 0 }],
     commits: [{ shortSha: "abc1234", subject: "Add remote changes", author: "Nacho", add: 8, del: 2 }]
   });
-  assert.deepEqual(sections.map((section) => section.title), ["Working Tree", "Staged", "Unstaged", "Commits"]);
-  assert.equal(sections[1].files[0].path, "staged.swift");
-  assert.equal(sections[3].commits[0].shortSha, "abc1234");
+  assert.deepEqual(sections.map((section) => section.title), ["Branch Changes", "Working Tree", "Staged", "Unstaged", "Commits"]);
+  assert.equal(sections[0].files[0].path, "committed.swift");
+  assert.equal(sections[2].stage, "staged");
+  assert.equal(sections[2].files[0].path, "staged.swift");
+  assert.equal(sections[4].commits[0].shortSha, "abc1234");
 }
 
 {


### PR DESCRIPTION
## Summary

The remote session header now uses compact icon controls that fit narrow screens. The Changes tab exposes the same useful Git context as the desktop app: staged and unstaged working-tree files, colored line counts, and commits ahead of the comparison ref.

## Changes

- Replace text tabs and the Sessions label with compact, accessible icon controls.
- Render staged, unstaged, and commit sections from the remote changes payload.
- Give the Files tab clearer folder/file hierarchy and status badges.
- Version the remote shell assets so connected devices receive the update.

## Verification

- `scripts/tests/remote-web-changes/run.sh`
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
