### PR TITLE
feat(mcp): retry MCP registration

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMCPStatusControl.swift
+++ b/Alas/Sources/ACP/UI/ACPMCPStatusControl.swift
@@ -8,6 +8,7 @@ struct ACPMCPStatusControl: View {
     let currentServers: [ProjectMCPServer]
     var onInstallPiMCPAdapter: (() async -> Bool)? = nil
     var onSwitchToHTTP: (() -> Void)? = nil
+    var onReconnect: (() -> Void)? = nil
     @Environment(\.theme) private var theme
     @State private var popoverOpen = false
 
@@ -59,7 +60,8 @@ struct ACPMCPStatusControl: View {
                 ACPMCPStatusPopover(
                     status: status,
                     onInstallPiMCPAdapter: onInstallPiMCPAdapter,
-                    onSwitchToHTTP: onSwitchToHTTP
+                    onSwitchToHTTP: onSwitchToHTTP,
+                    onReconnect: onReconnect
                 )
             }
         }
@@ -83,6 +85,7 @@ private struct ACPMCPStatusPopover: View {
     let status: ACPMCPStatusState
     var onInstallPiMCPAdapter: (() async -> Bool)? = nil
     var onSwitchToHTTP: (() -> Void)? = nil
+    var onReconnect: (() -> Void)? = nil
     @Environment(\.theme) private var theme
     @State private var installState: InstallState = .idle
 
@@ -178,6 +181,14 @@ private struct ACPMCPStatusPopover: View {
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
                 .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if status.hasBuiltInWarning, let onReconnect {
+                AlasButton(title: "Reconnect session", style: .subtle) {
+                    onReconnect()
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
             }
 
             if let detail = status.preambleDetail {

--- a/Alas/Sources/ACP/UI/ACPToolbar.swift
+++ b/Alas/Sources/ACP/UI/ACPToolbar.swift
@@ -26,15 +26,9 @@ struct ACPToolbar: View {
                 onSwitchToHTTP: isWorkspaceCheckoutOwner ? nil : {
                     state.config.harness.alasMCPTransport = .http
                     _ = state.saveConfig()
-                    // A live session is `.ready`, for which `reattach` is a
-                    // no-op — so detach then attach (the same flow as the
-                    // explicit Reconnect action) to actually apply the new
-                    // transport now instead of on some later disconnect.
-                    Task {
-                        await manager.detach(sessionId: session.id)
-                        await manager.attach(to: session.id, freshlyCreated: false)
-                    }
-                }
+                    reconnectSession()
+                },
+                onReconnect: reconnectSession
             )
             ACPRecoveryPill(session: session)
             if let currentGoal = session.currentGoal {
@@ -60,6 +54,13 @@ struct ACPToolbar: View {
     private var isWorkspaceCheckoutOwner: Bool {
         if case .workspaceCheckout = owner { return true }
         return false
+    }
+
+    private func reconnectSession() {
+        Task {
+            await manager.detach(sessionId: session.id)
+            await manager.attach(to: session.id, freshlyCreated: false)
+        }
     }
 }
 

--- a/AlasCLI/crates/alas-client/src/lib.rs
+++ b/AlasCLI/crates/alas-client/src/lib.rs
@@ -602,20 +602,33 @@ pub fn hello_payload(session_id: &str, transport: &str) -> serde_json::Value {
     })
 }
 
-/// Best-effort: send the hello and ignore the ack/errors — a failed hello
-/// must never stop the MCP server from serving.
+/// Best-effort: retry the hello without delaying MCP initialization.
 pub fn send_hello(socket: &Path, session_id: &str, transport: &str) {
     let payload = match serde_json::to_vec(&hello_payload(session_id, transport)) {
         Ok(p) => p,
         Err(_) => return,
     };
-    if let Ok(mut stream) = UnixStream::connect(socket) {
-        let _ = stream.set_read_timeout(Some(PROBE_TIMEOUT));
-        let _ = stream.write_all(&payload);
-        let _ = stream.flush();
-        let mut buf = Vec::new();
-        let _ = stream.read_to_end(&mut buf);
-    }
+    let socket = socket.to_path_buf();
+    let _ = std::thread::Builder::new()
+        .name("alas-mcp-hello".into())
+        .spawn(move || {
+            for attempt in 0..3 {
+                let sent = UnixStream::connect(&socket).and_then(|mut stream| {
+                    stream.set_read_timeout(Some(PROBE_TIMEOUT))?;
+                    stream.write_all(&payload)?;
+                    stream.flush()?;
+                    let mut buf = Vec::new();
+                    stream.read_to_end(&mut buf)?;
+                    Ok(())
+                });
+                if sent.is_ok() {
+                    return;
+                }
+                if attempt < 2 {
+                    std::thread::sleep(Duration::from_secs(1));
+                }
+            }
+        });
 }
 
 /// How the CLI addresses the app: an exact pane (inside Alas) or a directory
@@ -735,8 +748,13 @@ pub fn dispatch_to_sockets(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
     use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::net::UnixListener;
     use std::path::Path;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     #[test]
     fn absolutize_joins_relative_against_base_without_resolving_symlinks() {
@@ -767,6 +785,76 @@ mod tests {
         assert_eq!(v["kind"], "mcp_hello");
         assert_eq!(v["session_id"], "SID-1");
         assert_eq!(v["transport"], "stdio");
+    }
+
+    #[test]
+    fn send_hello_retries_until_socket_is_available() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let socket = std::env::temp_dir().join(format!(
+            "alas-hello-{}-{unique}.sock",
+            std::process::id()
+        ));
+        let server_socket = socket.clone();
+        let server = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(100));
+            let listener = UnixListener::bind(&server_socket).unwrap();
+            listener.set_nonblocking(true).unwrap();
+            let deadline = Instant::now() + Duration::from_millis(2_500);
+            loop {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut payload = [0; 512];
+                        let count = stream.read(&mut payload).unwrap();
+                        stream.write_all(b"{}").unwrap();
+                        return Some(payload[..count].to_vec());
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        if Instant::now() >= deadline {
+                            return None;
+                        }
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("accept failed: {error}"),
+                }
+            }
+        });
+
+        send_hello(&socket, "SID-retry", "stdio");
+
+        let payload = server.join().unwrap().expect("hello was not retried");
+        let hello: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(hello["session_id"], "SID-retry");
+        let _ = std::fs::remove_file(socket);
+    }
+
+    #[test]
+    fn send_hello_does_not_block_when_ack_is_delayed() {
+        let socket = std::env::temp_dir().join(format!(
+            "alas-hello-{}-delayed.sock",
+            std::process::id()
+        ));
+        let listener = UnixListener::bind(&socket).unwrap();
+        let (accepted_tx, accepted_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut payload = [0; 512];
+            stream.read(&mut payload).unwrap();
+            accepted_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+
+        let started = Instant::now();
+        send_hello(&socket, "SID-delayed", "stdio");
+        assert!(started.elapsed() < Duration::from_millis(100));
+        accepted_rx.recv_timeout(Duration::from_millis(300)).unwrap();
+
+        release_tx.send(()).unwrap();
+        server.join().unwrap();
+        let _ = std::fs::remove_file(socket);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- retry the Alas MCP startup hello three times
- offer a session reconnect action from the MCP warning

## Verification
- cargo test -p alas-client
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- full macOS suite: 12 unrelated existing workspace/storage failures