### PR TITLE
polish(workspace): workspace sidebar and overview

### DIFF
--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -27,6 +27,8 @@ struct RootView: View {
     @State private var editingProject: ProjectConfig?
     @State private var removingProject: ProjectConfig?
     @State private var newWorktreePresentation: NewWorktreePresentation?
+    @State private var creatingWorkspaceCheckout: Workspace?
+    @State private var editingWorkspace: Workspace?
     @State private var commitReviewSessionLaunchError: CommitReviewSessionLaunchError?
     @Environment(\.openWindow) private var openWindow
 
@@ -61,6 +63,26 @@ struct RootView: View {
                 removingProject: $removingProject,
                 newWorktreePresentation: $newWorktreePresentation
             ))
+            .sheet(item: $creatingWorkspaceCheckout) { workspace in
+                CreateWorkspaceCheckoutDialog(
+                    state: state,
+                    workspace: workspace,
+                    presented: Binding(
+                        get: { creatingWorkspaceCheckout != nil },
+                        set: { if !$0 { creatingWorkspaceCheckout = nil } }
+                    )
+                )
+            }
+            .sheet(item: $editingWorkspace) { workspace in
+                EditWorkspaceDialog(
+                    state: state,
+                    workspace: workspace,
+                    presented: Binding(
+                        get: { editingWorkspace != nil },
+                        set: { if !$0 { editingWorkspace = nil } }
+                    )
+                )
+            }
             .alert(
                 "Could not open review session",
                 isPresented: Binding(
@@ -280,7 +302,16 @@ struct RootView: View {
         case .loadingProject:
             LoadingProjectView()
         case .empty:
-            if let checkout = state.selectedWorkspaceCheckout,
+            if let workspace = state.workspaceNavigationState.selectedWorkspace(
+                in: state.workspacesManager.workspaces
+            ) {
+                WorkspaceOverviewView(
+                    workspace: workspace,
+                    projects: state.projects,
+                    onNewCheckout: { creatingWorkspaceCheckout = workspace },
+                    onEdit: { editingWorkspace = workspace }
+                )
+            } else if let checkout = state.selectedWorkspaceCheckout,
                let fallback = state.sharedSessionFallbackWorktreeForSelectedWorkspaceCheckout() {
                 CenterPaneView(
                     state: state,
@@ -396,6 +427,54 @@ struct RootView: View {
                 )
             }
         )
+    }
+}
+
+private struct WorkspaceOverviewView: View {
+    let workspace: Workspace
+    let projects: [ProjectConfig]
+    let onNewCheckout: () -> Void
+    let onEdit: () -> Void
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(spacing: 18) {
+            VStack(spacing: 8) {
+                WorkspaceRepositoryPile(workspace: workspace, projects: projects)
+                Text(workspace.name)
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundColor(theme.color("fg"))
+                Text("\(workspace.members.count) \(workspace.members.count == 1 ? "repository" : "repositories") on \(workspace.executionLocation.sshHost ?? "This Mac")")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(workspace.members) { member in
+                        HStack(spacing: 8) {
+                            if let project = projects.first(where: { $0.id == member.projectID }) {
+                                ProjectIconView(icon: project.icon, fallbackName: project.name, size: .sidebar)
+                            } else {
+                                Icon(name: "folder", size: 14)
+                            }
+                            Text(member.fallbackProjectName)
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundColor(theme.color("fg-muted"))
+                                .lineLimit(1)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxHeight: 180)
+            .frame(width: 280)
+            HStack(spacing: 8) {
+                AlasButton(title: "New checkout", icon: "plus", style: .primary, action: onNewCheckout)
+                AlasButton(title: "Edit workspace", icon: "gear", action: onEdit)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.color("bg-1"))
     }
 }
 

--- a/Alas/Sources/Dialogs/Workspace/WorkspaceCheckoutCreationModel.swift
+++ b/Alas/Sources/Dialogs/Workspace/WorkspaceCheckoutCreationModel.swift
@@ -30,7 +30,8 @@ struct WorkspaceCheckoutCreationModel: Equatable {
     }
 
     static func checkoutRoot(parentPath: String, branch: String) -> String {
-        guard !branch.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return "" }
+        let branch = branch.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !branch.isEmpty else { return "" }
         URL(fileURLWithPath: parentPath)
             .appendingPathComponent(branch.replacingOccurrences(of: "/", with: "-"))
             .path

--- a/Alas/Sources/Dialogs/Workspace/WorkspaceCheckoutCreationModel.swift
+++ b/Alas/Sources/Dialogs/Workspace/WorkspaceCheckoutCreationModel.swift
@@ -28,6 +28,12 @@ struct WorkspaceCheckoutCreationModel: Equatable {
         self.init(workspace: workspace, branch: branchPrefix, rootPath: rootPath, baseReference: baseReference)
     }
 
+    static func checkoutRoot(parentPath: String, branch: String) -> String {
+        URL(fileURLWithPath: parentPath)
+            .appendingPathComponent(branch.replacingOccurrences(of: "/", with: "-"))
+            .path
+    }
+
     var preflightMessages: [String] {
         guard case .failure(let diagnostics) = preflightResult else { return [] }
         return diagnostics.map(\.message)

--- a/Alas/Sources/Dialogs/Workspace/WorkspaceCheckoutCreationModel.swift
+++ b/Alas/Sources/Dialogs/Workspace/WorkspaceCheckoutCreationModel.swift
@@ -72,6 +72,11 @@ struct WorkspaceCheckoutCreationModel: Equatable {
     mutating func receivePreflight(_ result: WorkspaceCheckoutPreflightResult) { preflightResult = result
     step = .preflight
     selectedCheckoutID = nil }
+    mutating func returnToDetails() {
+        step = .details
+        preflightResult = nil
+        selectedCheckoutID = nil
+    }
     mutating func beginCreation() -> Bool { guard case .success = preflightResult else { return false }
     step = .creating
     return true }

--- a/Alas/Sources/Dialogs/Workspace/WorkspaceCheckoutCreationModel.swift
+++ b/Alas/Sources/Dialogs/Workspace/WorkspaceCheckoutCreationModel.swift
@@ -12,6 +12,7 @@ struct WorkspaceCheckoutCreationModel: Equatable {
     var branch: String
     var rootPath: String
     var baseReference: String
+    private(set) var checkoutParentPath: String?
     var memberBaseReferences: [UUID: String] = [:]
     private(set) var step: WorkspaceCheckoutCreationStep = .details
     private(set) var preflightResult: WorkspaceCheckoutPreflightResult?
@@ -29,9 +30,27 @@ struct WorkspaceCheckoutCreationModel: Equatable {
     }
 
     static func checkoutRoot(parentPath: String, branch: String) -> String {
+        guard !branch.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return "" }
         URL(fileURLWithPath: parentPath)
             .appendingPathComponent(branch.replacingOccurrences(of: "/", with: "-"))
             .path
+    }
+
+    mutating func selectCheckoutParent(_ parentPath: String) {
+        checkoutParentPath = parentPath
+        rootPath = Self.checkoutRoot(parentPath: parentPath, branch: branch)
+    }
+
+    mutating func setBranch(_ branch: String) {
+        self.branch = branch
+        if let checkoutParentPath {
+            rootPath = Self.checkoutRoot(parentPath: checkoutParentPath, branch: branch)
+        }
+    }
+
+    mutating func setRootPath(_ rootPath: String) {
+        checkoutParentPath = nil
+        self.rootPath = rootPath
     }
 
     var preflightMessages: [String] {

--- a/Alas/Sources/Dialogs/Workspace/WorkspaceCheckoutCreationModel.swift
+++ b/Alas/Sources/Dialogs/Workspace/WorkspaceCheckoutCreationModel.swift
@@ -24,6 +24,10 @@ struct WorkspaceCheckoutCreationModel: Equatable {
         self.baseReference = baseReference
     }
 
+    init(workspace: Workspace, branchPrefix: String, rootPath: String = "", baseReference: String = "main") {
+        self.init(workspace: workspace, branch: branchPrefix, rootPath: rootPath, baseReference: baseReference)
+    }
+
     var preflightMessages: [String] {
         guard case .failure(let diagnostics) = preflightResult else { return [] }
         return diagnostics.map(\.message)

--- a/Alas/Sources/Dialogs/Workspace/WorkspaceCheckoutCreationModel.swift
+++ b/Alas/Sources/Dialogs/Workspace/WorkspaceCheckoutCreationModel.swift
@@ -32,7 +32,7 @@ struct WorkspaceCheckoutCreationModel: Equatable {
     static func checkoutRoot(parentPath: String, branch: String) -> String {
         let branch = branch.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !branch.isEmpty else { return "" }
-        URL(fileURLWithPath: parentPath)
+        return URL(fileURLWithPath: parentPath)
             .appendingPathComponent(branch.replacingOccurrences(of: "/", with: "-"))
             .path
     }

--- a/Alas/Sources/Dialogs/Workspace/WorkspaceDialogs.swift
+++ b/Alas/Sources/Dialogs/Workspace/WorkspaceDialogs.swift
@@ -419,11 +419,7 @@ struct CreateWorkspaceCheckoutDialog: View {
 
     private func goBackOrClose() {
         if model.step == .preflight && !isChecking {
-            var details = WorkspaceCheckoutCreationModel(
-                workspace: workspace, branch: model.branch, rootPath: model.rootPath, baseReference: model.baseReference
-            )
-            details.memberBaseReferences = model.memberBaseReferences
-            model = details
+            model.returnToDetails()
             error = nil
         } else {
             presented = false

--- a/Alas/Sources/Dialogs/Workspace/WorkspaceDialogs.swift
+++ b/Alas/Sources/Dialogs/Workspace/WorkspaceDialogs.swift
@@ -313,7 +313,7 @@ struct CreateWorkspaceCheckoutDialog: View {
                 HStack(spacing: 8) {
                     AlasField(text: $model.rootPath, placeholder: "/path/to/checkouts/my-change", monospaced: true)
                     if workspace.executionLocation == .local {
-                        ToolbarBtn(icon: "folder", tooltip: "Choose checkout folder", action: chooseCheckoutFolder)
+                        ToolbarBtn(icon: "folder", tooltip: "Choose checkout parent folder", action: chooseCheckoutFolder)
                     }
                 }
             }
@@ -436,7 +436,10 @@ struct CreateWorkspaceCheckoutDialog: View {
         panel.canChooseFiles = false
         panel.allowsMultipleSelection = false
         if panel.runModal() == .OK, let url = panel.url {
-            model.rootPath = url.path
+            model.rootPath = WorkspaceCheckoutCreationModel.checkoutRoot(
+                parentPath: url.path,
+                branch: model.branch
+            )
         }
     }
 

--- a/Alas/Sources/Dialogs/Workspace/WorkspaceDialogs.swift
+++ b/Alas/Sources/Dialogs/Workspace/WorkspaceDialogs.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct NewWorkspaceDialog: View {
@@ -254,7 +255,7 @@ struct CreateWorkspaceCheckoutDialog: View {
         self.state = state
         self.workspace = workspace
         self._presented = presented
-        self._model = State(initialValue: .init(workspace: workspace))
+        self._model = State(initialValue: .init(workspace: workspace, branchPrefix: state.config.worktrees.branchPrefix))
     }
 
     var body: some View {
@@ -309,7 +310,12 @@ struct CreateWorkspaceCheckoutDialog: View {
                 AlasField(text: $model.branch, placeholder: "feature/my-change", monospaced: true, focusOnAppear: true)
             }
             DialogField(label: "Checkout folder") {
-                AlasField(text: $model.rootPath, placeholder: "/path/to/checkouts/my-change", monospaced: true)
+                HStack(spacing: 8) {
+                    AlasField(text: $model.rootPath, placeholder: "/path/to/checkouts/my-change", monospaced: true)
+                    if workspace.executionLocation == .local {
+                        ToolbarBtn(icon: "folder", tooltip: "Choose checkout folder", action: chooseCheckoutFolder)
+                    }
+                }
             }
             DialogField(label: "Base reference") {
                 AlasField(text: $model.baseReference, placeholder: "main", monospaced: true)
@@ -421,6 +427,16 @@ struct CreateWorkspaceCheckoutDialog: View {
             error = nil
         } else {
             presented = false
+        }
+    }
+
+    private func chooseCheckoutFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url {
+            model.rootPath = url.path
         }
     }
 

--- a/Alas/Sources/Dialogs/Workspace/WorkspaceDialogs.swift
+++ b/Alas/Sources/Dialogs/Workspace/WorkspaceDialogs.swift
@@ -307,11 +307,11 @@ struct CreateWorkspaceCheckoutDialog: View {
     private var details: some View {
         VStack(alignment: .leading, spacing: 14) {
             DialogField(label: "Shared branch") {
-                AlasField(text: $model.branch, placeholder: "feature/my-change", monospaced: true, focusOnAppear: true)
+                AlasField(text: Binding(get: { model.branch }, set: { model.setBranch($0) }), placeholder: "feature/my-change", monospaced: true, focusOnAppear: true)
             }
             DialogField(label: "Checkout folder") {
                 HStack(spacing: 8) {
-                    AlasField(text: $model.rootPath, placeholder: "/path/to/checkouts/my-change", monospaced: true)
+                    AlasField(text: Binding(get: { model.rootPath }, set: { model.setRootPath($0) }), placeholder: "/path/to/checkouts/my-change", monospaced: true)
                     if workspace.executionLocation == .local {
                         ToolbarBtn(icon: "folder", tooltip: "Choose checkout parent folder", action: chooseCheckoutFolder)
                     }
@@ -436,10 +436,7 @@ struct CreateWorkspaceCheckoutDialog: View {
         panel.canChooseFiles = false
         panel.allowsMultipleSelection = false
         if panel.runModal() == .OK, let url = panel.url {
-            model.rootPath = WorkspaceCheckoutCreationModel.checkoutRoot(
-                parentPath: url.path,
-                branch: model.branch
-            )
+            model.selectCheckoutParent(url.path)
         }
     }
 

--- a/Alas/Sources/Sidebar/SidebarHeaderView.swift
+++ b/Alas/Sources/Sidebar/SidebarHeaderView.swift
@@ -26,7 +26,7 @@ struct SidebarHeaderView: View {
                 if let onNewWorkspace {
                     Menu {
                         Button("Add repository...", systemImage: "folder.badge.plus", action: onAddProject)
-                        Button("New workspace...", systemImage: "square.stack.3d.up", action: onNewWorkspace)
+                        Button("New workspace...", systemImage: "square.grid.2x2", action: onNewWorkspace)
                     } label: {
                         Icon(name: "folder-plus", size: 13, color: theme.color(addMenuHovered ? "fg" : "fg-muted"))
                             .frame(width: 26, height: 22)

--- a/Alas/Sources/Sidebar/WorkspaceSidebarTree.swift
+++ b/Alas/Sources/Sidebar/WorkspaceSidebarTree.swift
@@ -40,7 +40,7 @@ struct WorkspaceSidebarTree<ProjectRow: View>: View {
                     }
                 case .workspace(let id):
                     if let workspace = workspaces[id] {
-                        workspaceHeader(workspace)
+                        workspaceHeader(workspace, projects: projects)
                     }
                 case .formerWorkspace:
                     Label("Former Workspace", systemImage: "archivebox")
@@ -117,7 +117,7 @@ struct WorkspaceSidebarTree<ProjectRow: View>: View {
         }
     }
 
-    private func workspaceHeader(_ workspace: Workspace) -> some View {
+    private func workspaceHeader(_ workspace: Workspace, projects: [String: ProjectConfig]) -> some View {
         let collapsed = collapsedWorkspaces.contains(workspace.id)
         let selected = state.workspaceNavigationState.selectedWorkspaceID == workspace.id
             && state.workspaceNavigationState.selectedCheckoutID == nil
@@ -135,7 +135,7 @@ struct WorkspaceSidebarTree<ProjectRow: View>: View {
             .accessibilityLabel(collapsed ? "Expand workspace" : "Collapse workspace")
             Button { state.selectWorkspace(id: workspace.id) } label: {
                 HStack(spacing: 7) {
-                    Icon(name: "square.stack.3d.up", size: 13, color: theme.color(selected ? "accent" : "fg-muted"))
+                    WorkspaceRepositoryPile(workspace: workspace, projects: Array(projects.values))
                     Text(workspace.name)
                         .font(.system(size: 11.5, weight: .semibold))
                         .foregroundColor(theme.color(selected ? "fg" : "fg-muted"))
@@ -150,10 +150,19 @@ struct WorkspaceSidebarTree<ProjectRow: View>: View {
                 creatingCheckout = workspace
             }
         }
-        .padding(.leading, 12)
+        .padding(.leading, 6)
         .padding(.trailing, 8)
         .padding(.vertical, 3)
-        .background(selected ? theme.color("bg-3") : .clear)
+        .background(selected ? theme.color("bg-4") : .clear, in: RoundedRectangle(cornerRadius: 6))
+        .overlay(alignment: .leading) {
+            if selected {
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(theme.color("accent"))
+                    .frame(width: 3, height: 14)
+                    .padding(.leading, 2)
+            }
+        }
+        .padding(.horizontal, 6)
         .contextMenu {
             Button("New checkout...", systemImage: "plus") { creatingCheckout = workspace }
             Button("Edit workspace...", systemImage: "pencil") { editingWorkspace = workspace }
@@ -375,6 +384,30 @@ struct WorkspaceSidebarTree<ProjectRow: View>: View {
                 lifecycleError = error.localizedDescription
             }
         }
+    }
+}
+
+struct WorkspaceRepositoryPile: View {
+    let workspace: Workspace
+    let projects: [ProjectConfig]
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        let projectsByID = Dictionary(uniqueKeysWithValues: projects.map { ($0.id, $0) })
+        let repositories = workspace.members.compactMap { projectsByID[$0.projectID] }
+        Group {
+            if repositories.isEmpty {
+                Icon(name: "folder", size: 13, color: theme.color("fg-muted"))
+            } else {
+                HStack(spacing: -5) {
+                    ForEach(repositories.prefix(3)) { project in
+                        ProjectIconView(icon: project.icon, fallbackName: project.name, size: .sidebar)
+                    }
+                }
+                .fixedSize()
+            }
+        }
+        .accessibilityHidden(true)
     }
 }
 

--- a/Alas/Sources/Workspace/WorkspaceNavigationState.swift
+++ b/Alas/Sources/Workspace/WorkspaceNavigationState.swift
@@ -33,6 +33,11 @@ struct WorkspaceNavigationState: Equatable {
         repositoryFocusWorktreeID = nil
     }
 
+    func selectedWorkspace(in workspaces: [Workspace]) -> Workspace? {
+        guard selectedCheckoutID == nil, let selectedWorkspaceID else { return nil }
+        return workspaces.first { $0.id == selectedWorkspaceID }
+    }
+
     mutating func selectCheckout(
         _ checkout: WorkspaceCheckout,
         resolvedWorktreeIDs: [UUID: String]

--- a/AlasTests/Workspace/WorkspaceCheckoutCreationModelTests.swift
+++ b/AlasTests/Workspace/WorkspaceCheckoutCreationModelTests.swift
@@ -19,6 +19,16 @@ struct WorkspaceCheckoutCreationModelTests {
         )
     }
 
+    @Test func selectedCheckoutParentDerivesRootWhenBranchIsEnteredLater() {
+        var model = WorkspaceCheckoutCreationModel(workspace: fixtureWorkspace())
+
+        model.selectCheckoutParent("/checkouts")
+        #expect(model.rootPath.isEmpty)
+
+        model.setBranch("feature/my-change")
+        #expect(model.rootPath == "/checkouts/feature-my-change")
+    }
+
     @Test func advancesThroughThreeStepsOnlyWithSharedBranchAndRoot() {
         let workspace = fixtureWorkspace()
         var model = WorkspaceCheckoutCreationModel(workspace: workspace, rootPath: "")

--- a/AlasTests/Workspace/WorkspaceCheckoutCreationModelTests.swift
+++ b/AlasTests/Workspace/WorkspaceCheckoutCreationModelTests.swift
@@ -10,6 +10,15 @@ struct WorkspaceCheckoutCreationModelTests {
         #expect(model.request().branch == "feature/")
     }
 
+    @Test func checkoutFolderForSelectedParentIncludesBranch() {
+        #expect(
+            WorkspaceCheckoutCreationModel.checkoutRoot(
+                parentPath: "/checkouts",
+                branch: "feature/my-change"
+            ) == "/checkouts/feature-my-change"
+        )
+    }
+
     @Test func advancesThroughThreeStepsOnlyWithSharedBranchAndRoot() {
         let workspace = fixtureWorkspace()
         var model = WorkspaceCheckoutCreationModel(workspace: workspace, rootPath: "")

--- a/AlasTests/Workspace/WorkspaceCheckoutCreationModelTests.swift
+++ b/AlasTests/Workspace/WorkspaceCheckoutCreationModelTests.swift
@@ -4,6 +4,12 @@ import Testing
 
 @Suite("Workspace checkout creation model")
 struct WorkspaceCheckoutCreationModelTests {
+    @Test func initializesBranchWithConfiguredPrefix() {
+        let model = WorkspaceCheckoutCreationModel(workspace: fixtureWorkspace(), branchPrefix: "feature/")
+
+        #expect(model.request().branch == "feature/")
+    }
+
     @Test func advancesThroughThreeStepsOnlyWithSharedBranchAndRoot() {
         let workspace = fixtureWorkspace()
         var model = WorkspaceCheckoutCreationModel(workspace: workspace, rootPath: "")

--- a/AlasTests/Workspace/WorkspaceCheckoutCreationModelTests.swift
+++ b/AlasTests/Workspace/WorkspaceCheckoutCreationModelTests.swift
@@ -29,6 +29,18 @@ struct WorkspaceCheckoutCreationModelTests {
         #expect(model.rootPath == "/checkouts/feature-my-change")
     }
 
+    @Test func returningToDetailsPreservesSelectedCheckoutParent() {
+        var model = WorkspaceCheckoutCreationModel(workspace: fixtureWorkspace())
+        model.selectCheckoutParent("/checkouts")
+        model.setBranch("feature/first")
+        #expect(model.advance() == .success)
+
+        model.returnToDetails()
+        model.setBranch("feature/second")
+
+        #expect(model.rootPath == "/checkouts/feature-second")
+    }
+
     @Test func advancesThroughThreeStepsOnlyWithSharedBranchAndRoot() {
         let workspace = fixtureWorkspace()
         var model = WorkspaceCheckoutCreationModel(workspace: workspace, rootPath: "")

--- a/AlasTests/Workspace/WorkspaceCheckoutCreationModelTests.swift
+++ b/AlasTests/Workspace/WorkspaceCheckoutCreationModelTests.swift
@@ -19,6 +19,15 @@ struct WorkspaceCheckoutCreationModelTests {
         )
     }
 
+    @Test func checkoutFolderUsesTrimmedBranch() {
+        #expect(
+            WorkspaceCheckoutCreationModel.checkoutRoot(
+                parentPath: "/checkouts",
+                branch: " feature/my-change "
+            ) == "/checkouts/feature-my-change"
+        )
+    }
+
     @Test func selectedCheckoutParentDerivesRootWhenBranchIsEnteredLater() {
         var model = WorkspaceCheckoutCreationModel(workspace: fixtureWorkspace())
 

--- a/AlasTests/Workspace/WorkspaceNavigationStateTests.swift
+++ b/AlasTests/Workspace/WorkspaceNavigationStateTests.swift
@@ -3,6 +3,20 @@ import Testing
 @testable import Alas
 
 struct WorkspaceNavigationStateTests {
+    @Test func selectedWorkspaceResolvesForWorkspaceTitleSelection() {
+        let workspace = Workspace(name: "Workspace", executionLocation: .local, members: [])
+        let state = WorkspaceNavigationState(selectedWorkspaceID: workspace.id)
+
+        #expect(state.selectedWorkspace(in: [workspace]) == workspace)
+    }
+
+    @Test func selectedWorkspaceDoesNotResolveWhileCheckoutIsSelected() {
+        let workspace = Workspace(name: "Workspace", executionLocation: .local, members: [])
+        let state = WorkspaceNavigationState(selectedWorkspaceID: workspace.id, selectedCheckoutID: UUID())
+
+        #expect(state.selectedWorkspace(in: [workspace]) == nil)
+    }
+
     @Test func checkoutRestoresLastAvailableFocusedMember() {
         let checkout = fixtureCheckout(members: [availableMember, unavailableMember])
         var state = WorkspaceNavigationState()


### PR DESCRIPTION
## Summary

Makes the workspace itself a useful selection in the sidebar instead of a generic empty tab state.

- Aligns workspace selection styling with worktree rows and replaces stack imagery with repository icon piles.
- Adds a workspace overview with repository context plus checkout and edit actions.
- Prefills shared branches from worktree settings and adds a native local checkout-folder picker.

## Verification

- Swift syntax and diff checks passed.
- Local Xcode build/test is blocked before compilation because Xcode cannot resolve the generated GhosttyKit XCFramework in this worktree. GitHub CI will validate from a clean checkout.