### PR TITLE
fix(acp): restore config-option ACP models

### DIFF
--- a/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
@@ -107,6 +107,13 @@ struct ACPConfigOption: Codable, Equatable, Identifiable, Hashable {
         var merged: [ACPConfigOption] = []
         for option in configOptions {
             if option.id == configId {
+                if let baselineConfigOptions,
+                   let baseline = baselineConfigOptions.first(where: { $0.id == option.id }),
+                   let current = currentConfigOptions.first(where: { $0.id == option.id }),
+                   current != baseline {
+                    merged.append(current)
+                    continue
+                }
                 merged.append(ACPConfigOption(
                     id: option.id,
                     name: option.name,
@@ -135,8 +142,11 @@ struct ACPConfigOption: Codable, Equatable, Identifiable, Hashable {
         if let baselineConfigOptions {
             let mergedIds = Set(merged.map(\.id))
             merged.append(contentsOf: currentConfigOptions.filter { current in
-                !mergedIds.contains(current.id)
-                    && !baselineConfigOptions.contains(where: { $0.id == current.id })
+                guard !mergedIds.contains(current.id) else { return false }
+                guard let baseline = baselineConfigOptions.first(where: { $0.id == current.id }) else {
+                    return true
+                }
+                return current != baseline
             })
         }
         return merged

--- a/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
@@ -97,21 +97,30 @@ struct ACPConfigOption: Codable, Equatable, Identifiable, Hashable {
         _ configOptions: [ACPConfigOption],
         configId: String,
         selectedValue: ACPConfigValue,
-        currentConfigOptions: [ACPConfigOption]
+        currentConfigOptions: [ACPConfigOption],
+        baselineConfigOptions: [ACPConfigOption]? = nil
     ) -> [ACPConfigOption]? {
         guard currentConfigOptions.first(where: { $0.id == configId })?.currentValue == selectedValue else {
             return nil
         }
 
         return configOptions.map { option in
-            guard option.id == configId else { return option }
-            return ACPConfigOption(
-                id: option.id,
-                name: option.name,
-                type: option.type,
-                category: option.category,
-                currentValue: selectedValue,
-                options: option.options)
+            if option.id == configId {
+                return ACPConfigOption(
+                    id: option.id,
+                    name: option.name,
+                    type: option.type,
+                    category: option.category,
+                    currentValue: selectedValue,
+                    options: option.options)
+            }
+            if let baselineConfigOptions,
+               let baseline = baselineConfigOptions.first(where: { $0.id == option.id }),
+               let current = currentConfigOptions.first(where: { $0.id == option.id }),
+               current.currentValue != baseline.currentValue {
+                return current
+            }
+            return option
         }
     }
 }

--- a/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
@@ -104,24 +104,42 @@ struct ACPConfigOption: Codable, Equatable, Identifiable, Hashable {
             return nil
         }
 
-        return configOptions.map { option in
+        var merged: [ACPConfigOption] = []
+        for option in configOptions {
             if option.id == configId {
-                return ACPConfigOption(
+                merged.append(ACPConfigOption(
                     id: option.id,
                     name: option.name,
                     type: option.type,
                     category: option.category,
                     currentValue: selectedValue,
-                    options: option.options)
+                    options: option.options))
+                continue
             }
             if let baselineConfigOptions,
-               let baseline = baselineConfigOptions.first(where: { $0.id == option.id }),
-               let current = currentConfigOptions.first(where: { $0.id == option.id }),
-               current != baseline {
-                return current
+               let baseline = baselineConfigOptions.first(where: { $0.id == option.id }) {
+                guard let current = currentConfigOptions.first(where: { $0.id == option.id }) else {
+                    continue
+                }
+                merged.append(current == baseline ? option : current)
+                continue
             }
-            return option
+            if let baselineConfigOptions,
+               baselineConfigOptions.contains(where: { $0.id == option.id }) == false,
+               let current = currentConfigOptions.first(where: { $0.id == option.id }) {
+                merged.append(current)
+                continue
+            }
+            merged.append(option)
         }
+        if let baselineConfigOptions {
+            let mergedIds = Set(merged.map(\.id))
+            merged.append(contentsOf: currentConfigOptions.filter { current in
+                !mergedIds.contains(current.id)
+                    && !baselineConfigOptions.contains(where: { $0.id == current.id })
+            })
+        }
+        return merged
     }
 }
 

--- a/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
@@ -117,7 +117,7 @@ struct ACPConfigOption: Codable, Equatable, Identifiable, Hashable {
             if let baselineConfigOptions,
                let baseline = baselineConfigOptions.first(where: { $0.id == option.id }),
                let current = currentConfigOptions.first(where: { $0.id == option.id }),
-               current.currentValue != baseline.currentValue {
+               current != baseline {
                 return current
             }
             return option

--- a/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
@@ -98,7 +98,9 @@ struct ACPConfigOption: Codable, Equatable, Identifiable, Hashable {
         configId: String,
         selectedValue: ACPConfigValue,
         currentConfigOptions: [ACPConfigOption],
-        baselineConfigOptions: [ACPConfigOption]? = nil
+        baselineConfigOptions: [ACPConfigOption]? = nil,
+        baselineConfigOptionsRevision: Int? = nil,
+        currentConfigOptionsRevision: Int? = nil
     ) -> [ACPConfigOption]? {
         guard currentConfigOptions.first(where: { $0.id == configId })?.currentValue == selectedValue else {
             return nil
@@ -132,9 +134,13 @@ struct ACPConfigOption: Codable, Equatable, Identifiable, Hashable {
                 continue
             }
             if let baselineConfigOptions,
-               baselineConfigOptions.contains(where: { $0.id == option.id }) == false,
-               let current = currentConfigOptions.first(where: { $0.id == option.id }) {
-                merged.append(current)
+               baselineConfigOptions.contains(where: { $0.id == option.id }) == false {
+                if let current = currentConfigOptions.first(where: { $0.id == option.id }) {
+                    merged.append(current)
+                } else if baselineConfigOptionsRevision == nil
+                    || baselineConfigOptionsRevision == currentConfigOptionsRevision {
+                    merged.append(option)
+                }
                 continue
             }
             merged.append(option)

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -587,6 +587,10 @@ final class ACPSession: ObservableObject, Identifiable {
             return []
         case .sessionConfigOptionsUpdate(let opts):
             availableConfigOptions = opts
+            if case .configOption(let modelId) = chipState.models?.source {
+                currentModel = availableConfigOptions
+                    .first { $0.id == modelId }?.currentStringValue
+            }
             return []
         case .availableCommandsUpdate(let cmds):
             promptSuggestions = cmds

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -594,7 +594,8 @@ final class ACPSession: ObservableObject, Identifiable {
             if case .configOption(let modelId) = chipState.models?.source {
                 currentModel = availableConfigOptions
                     .first { $0.id == modelId }?.currentStringValue
-            } else if case .configOption = previousModelSource {
+            } else if case .configOption = previousModelSource,
+                      chipState.models == nil {
                 currentModel = nil
             }
             return []

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -54,7 +54,10 @@ final class ACPSession: ObservableObject, Identifiable {
     private(set) var origin: ACPSessionOrigin
     @Published var availableModels: [ACPModelInfo] = []
     @Published var availableModes: [ACPModeInfo] = []
-    @Published var availableConfigOptions: [ACPConfigOption] = []
+    @Published var availableConfigOptions: [ACPConfigOption] = [] {
+        didSet { availableConfigOptionsRevision += 1 }
+    }
+    private(set) var availableConfigOptionsRevision = 0
     /// Runtime-only provider state learned from the adapter on each attach.
     @Published var providerCapabilities: EmptyObject?
     @Published var availableProviders: [ACPProviderInfo] = []

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -589,10 +589,13 @@ final class ACPSession: ObservableObject, Identifiable {
             currentModel = modelId
             return []
         case .sessionConfigOptionsUpdate(let opts):
+            let previousModelSource = chipState.models?.source
             availableConfigOptions = opts
             if case .configOption(let modelId) = chipState.models?.source {
                 currentModel = availableConfigOptions
                     .first { $0.id == modelId }?.currentStringValue
+            } else if case .configOption = previousModelSource {
+                currentModel = nil
             }
             return []
         case .availableCommandsUpdate(let cmds):

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3887,6 +3887,7 @@ extension ACPSessionManager {
                         category: loadedOption.category, currentValue: .string(m), options: loadedOption.options)
                     do {
                         let baselineConfigOptions = session.availableConfigOptions
+                        let baselineConfigOptionsRevision = session.availableConfigOptionsRevision
                         let updated = try await runner.connection.setConfigOption(
                             sessionId: remoteId, configId: id, value: .string(m))
                         let stillRestoringModel = session.availableConfigOptions
@@ -3897,7 +3898,9 @@ extension ACPSessionManager {
                                let merged = ACPConfigOption.mergingSuccessfulSetResponse(
                                    updated, configId: id, selectedValue: .string(m),
                                    currentConfigOptions: session.availableConfigOptions,
-                                   baselineConfigOptions: baselineConfigOptions) {
+                                   baselineConfigOptions: baselineConfigOptions,
+                                   baselineConfigOptionsRevision: baselineConfigOptionsRevision,
+                                   currentConfigOptionsRevision: session.availableConfigOptionsRevision) {
                                 session.availableConfigOptions = merged
                             }
                             persist(session)

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3870,8 +3870,14 @@ extension ACPSessionManager {
                 let remoteId = session.remoteSessionId ?? sessionId
                 switch session.chipState.models?.source {
                 case .configOption(let id):
-                    let loadedValue = session.availableConfigOptions.first { $0.id == id }?.currentStringValue
-                    guard m != loadedValue else { break }
+                    guard let index = session.availableConfigOptions.firstIndex(where: { $0.id == id }),
+                          let loadedValue = session.availableConfigOptions[index].currentStringValue,
+                          m != loadedValue
+                    else { break }
+                    let loadedOption = session.availableConfigOptions[index]
+                    session.availableConfigOptions[index] = ACPConfigOption(
+                        id: loadedOption.id, name: loadedOption.name, type: loadedOption.type,
+                        category: loadedOption.category, currentValue: .string(m), options: loadedOption.options)
                     do {
                         let updated = try await runner.connection.setConfigOption(
                             sessionId: remoteId, configId: id, value: .string(m))
@@ -3887,6 +3893,8 @@ extension ACPSessionManager {
                         }
                     } catch {
                         if session.currentModel == loadedModel {
+                            session.currentModel = loadedValue
+                            session.availableConfigOptions[index] = loadedOption
                             persist(session)
                         }
                     }
@@ -3903,6 +3911,8 @@ extension ACPSessionManager {
                             persist(session)
                         }
                     }
+                case .mode:
+                    break
                 }
             }
             if let m = pendingMode.removeValue(forKey: sessionId),

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3902,10 +3902,8 @@ extension ACPSessionManager {
                                session.availableConfigOptions[currentIndex].currentValue == .string(m) {
                                 session.availableConfigOptions[currentIndex] = loadedOption
                             }
-                            if let loadedValue {
-                                session.currentModel = loadedValue
-                                persist(session)
-                            }
+                            session.currentModel = loadedValue
+                            persist(session)
                         }
                     }
                 case .model, nil:

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3865,17 +3865,19 @@ extension ACPSessionManager {
             let loadedMode = session.currentMode
             let modelToRestore = pendingModel.removeValue(forKey: sessionId)
                 ?? (localModelAfterRemoteIdPersist != result.currentModel ? localModelAfterRemoteIdPersist : persistedModel)
+            if case .configOption(let id) = session.chipState.models?.source,
+               let loadedValue = session.availableConfigOptions.first(where: { $0.id == id })?.currentStringValue {
+                session.currentModel = loadedValue
+            }
             if let m = modelToRestore {
                 let remoteId = session.remoteSessionId ?? sessionId
                 switch session.chipState.models?.source {
                 case .configOption(let id):
-                    guard let index = session.availableConfigOptions.firstIndex(where: { $0.id == id }),
-                          let loadedValue = session.availableConfigOptions[index].currentStringValue
-                    else { break }
-                    session.currentModel = loadedValue
-                    guard m != loadedValue else { break }
-                    let loadedModel = loadedValue
+                    guard let index = session.availableConfigOptions.firstIndex(where: { $0.id == id }) else { break }
                     let loadedOption = session.availableConfigOptions[index]
+                    let loadedValue = loadedOption.currentStringValue
+                    guard m != loadedValue else { break }
+                    let loadedModel = session.currentModel
                     session.availableConfigOptions[index] = ACPConfigOption(
                         id: loadedOption.id, name: loadedOption.name, type: loadedOption.type,
                         category: loadedOption.category, currentValue: .string(m), options: loadedOption.options)
@@ -3894,12 +3896,14 @@ extension ACPSessionManager {
                         }
                     } catch {
                         if session.currentModel == loadedModel {
-                            session.currentModel = loadedValue
                             if let currentIndex = session.availableConfigOptions.firstIndex(where: { $0.id == id }),
                                session.availableConfigOptions[currentIndex].currentValue == .string(m) {
                                 session.availableConfigOptions[currentIndex] = loadedOption
                             }
-                            persist(session)
+                            if let loadedValue {
+                                session.currentModel = loadedValue
+                                persist(session)
+                            }
                         }
                     }
                 case .model, nil:

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3866,7 +3866,7 @@ extension ACPSessionManager {
             let modelToRestore = pendingModel.removeValue(forKey: sessionId)
                 ?? (localModelAfterRemoteIdPersist != result.currentModel ? localModelAfterRemoteIdPersist : persistedModel)
             if case .configOption(let id) = session.chipState.models?.source,
-               let loadedValue = session.availableConfigOptions.first(where: { $0.id == id })?.currentStringValue {
+               let loadedValue = result.configOptions.first(where: { $0.id == id })?.currentStringValue {
                 session.currentModel = loadedValue
             }
             if let m = modelToRestore {
@@ -3875,7 +3875,7 @@ extension ACPSessionManager {
                 case .configOption(let id):
                     guard let index = session.availableConfigOptions.firstIndex(where: { $0.id == id }) else { break }
                     let loadedOption = session.availableConfigOptions[index]
-                    let loadedValue = loadedOption.currentStringValue
+                    let loadedValue = result.configOptions.first(where: { $0.id == id })?.currentStringValue
                     guard m != loadedValue else { break }
                     let loadedModel = session.currentModel
                     session.availableConfigOptions[index] = ACPConfigOption(

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3882,6 +3882,7 @@ extension ACPSessionManager {
                         id: loadedOption.id, name: loadedOption.name, type: loadedOption.type,
                         category: loadedOption.category, currentValue: .string(m), options: loadedOption.options)
                     do {
+                        let baselineConfigOptions = session.availableConfigOptions
                         let updated = try await runner.connection.setConfigOption(
                             sessionId: remoteId, configId: id, value: .string(m))
                         let stillRestoringModel = session.availableConfigOptions
@@ -3891,7 +3892,8 @@ extension ACPSessionManager {
                             if !updated.isEmpty,
                                let merged = ACPConfigOption.mergingSuccessfulSetResponse(
                                    updated, configId: id, selectedValue: .string(m),
-                                   currentConfigOptions: session.availableConfigOptions) {
+                                   currentConfigOptions: session.availableConfigOptions,
+                                   baselineConfigOptions: baselineConfigOptions) {
                                 session.availableConfigOptions = merged
                             }
                             persist(session)

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3867,7 +3867,11 @@ extension ACPSessionManager {
                 ?? (localModelAfterRemoteIdPersist != result.currentModel ? localModelAfterRemoteIdPersist : persistedModel)
             if case .configOption(let id) = session.chipState.models?.source,
                let loadedValue = result.configOptions.first(where: { $0.id == id })?.currentStringValue {
+                let shouldPersistLoadedModel = modelToRestore == nil && session.currentModel != loadedValue
                 session.currentModel = loadedValue
+                if shouldPersistLoadedModel {
+                    persist(session)
+                }
             }
             if let m = modelToRestore {
                 let remoteId = session.remoteSessionId ?? sessionId

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3865,19 +3865,43 @@ extension ACPSessionManager {
             let loadedMode = session.currentMode
             let modelToRestore = pendingModel.removeValue(forKey: sessionId)
                 ?? (localModelAfterRemoteIdPersist != result.currentModel ? localModelAfterRemoteIdPersist : persistedModel)
-            if let m = modelToRestore,
-               m != result.currentModel {
+            if let m = modelToRestore {
                 let loadedModel = session.currentModel
                 let remoteId = session.remoteSessionId ?? sessionId
-                do {
-                    try await runner.connection.setModel(sessionId: remoteId, modelId: m)
-                    if session.currentModel == loadedModel {
-                        session.currentModel = m
-                        persist(session)
+                switch session.chipState.models?.source {
+                case .configOption(let id):
+                    let loadedValue = session.availableConfigOptions.first { $0.id == id }?.currentStringValue
+                    guard m != loadedValue else { break }
+                    do {
+                        let updated = try await runner.connection.setConfigOption(
+                            sessionId: remoteId, configId: id, value: .string(m))
+                        if session.currentModel == loadedModel {
+                            session.currentModel = m
+                            if !updated.isEmpty,
+                               let merged = ACPConfigOption.mergingSuccessfulSetResponse(
+                                   updated, configId: id, selectedValue: .string(m),
+                                   currentConfigOptions: session.availableConfigOptions) {
+                                session.availableConfigOptions = merged
+                            }
+                            persist(session)
+                        }
+                    } catch {
+                        if session.currentModel == loadedModel {
+                            persist(session)
+                        }
                     }
-                } catch {
-                    if session.currentModel == loadedModel {
-                        persist(session)
+                case .model, nil:
+                    guard m != result.currentModel else { break }
+                    do {
+                        try await runner.connection.setModel(sessionId: remoteId, modelId: m)
+                        if session.currentModel == loadedModel {
+                            session.currentModel = m
+                            persist(session)
+                        }
+                    } catch {
+                        if session.currentModel == loadedModel {
+                            persist(session)
+                        }
                     }
                 }
             }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3866,14 +3866,15 @@ extension ACPSessionManager {
             let modelToRestore = pendingModel.removeValue(forKey: sessionId)
                 ?? (localModelAfterRemoteIdPersist != result.currentModel ? localModelAfterRemoteIdPersist : persistedModel)
             if let m = modelToRestore {
-                let loadedModel = session.currentModel
                 let remoteId = session.remoteSessionId ?? sessionId
                 switch session.chipState.models?.source {
                 case .configOption(let id):
                     guard let index = session.availableConfigOptions.firstIndex(where: { $0.id == id }),
-                          let loadedValue = session.availableConfigOptions[index].currentStringValue,
-                          m != loadedValue
+                          let loadedValue = session.availableConfigOptions[index].currentStringValue
                     else { break }
+                    session.currentModel = loadedValue
+                    guard m != loadedValue else { break }
+                    let loadedModel = loadedValue
                     let loadedOption = session.availableConfigOptions[index]
                     session.availableConfigOptions[index] = ACPConfigOption(
                         id: loadedOption.id, name: loadedOption.name, type: loadedOption.type,
@@ -3894,11 +3895,15 @@ extension ACPSessionManager {
                     } catch {
                         if session.currentModel == loadedModel {
                             session.currentModel = loadedValue
-                            session.availableConfigOptions[index] = loadedOption
+                            if let currentIndex = session.availableConfigOptions.firstIndex(where: { $0.id == id }),
+                               session.availableConfigOptions[currentIndex].currentValue == .string(m) {
+                                session.availableConfigOptions[currentIndex] = loadedOption
+                            }
                             persist(session)
                         }
                     }
                 case .model, nil:
+                    let loadedModel = session.currentModel
                     guard m != result.currentModel else { break }
                     do {
                         try await runner.connection.setModel(sessionId: remoteId, modelId: m)

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3877,9 +3877,9 @@ extension ACPSessionManager {
                 let remoteId = session.remoteSessionId ?? sessionId
                 switch session.chipState.models?.source {
                 case .configOption(let id):
-                    guard let index = session.availableConfigOptions.firstIndex(where: { $0.id == id }) else { break }
-                    let loadedOption = session.availableConfigOptions[index]
-                    let loadedValue = result.configOptions.first(where: { $0.id == id })?.currentStringValue
+                    guard let index = session.availableConfigOptions.firstIndex(where: { $0.id == id }),
+                          let loadedOption = result.configOptions.first(where: { $0.id == id }) else { break }
+                    let loadedValue = loadedOption.currentStringValue
                     guard m != loadedValue else { break }
                     let loadedModel = session.currentModel
                     session.availableConfigOptions[index] = ACPConfigOption(

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3884,7 +3884,9 @@ extension ACPSessionManager {
                     do {
                         let updated = try await runner.connection.setConfigOption(
                             sessionId: remoteId, configId: id, value: .string(m))
-                        if session.currentModel == loadedModel {
+                        let stillRestoringModel = session.availableConfigOptions
+                            .first { $0.id == id }?.currentValue == .string(m)
+                        if session.currentModel == loadedModel, stillRestoringModel {
                             session.currentModel = m
                             if !updated.isEmpty,
                                let merged = ACPConfigOption.mergingSuccessfulSetResponse(

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -616,12 +616,7 @@ final class ACPSessionRunner {
                     freezeStreamingPersistSnapshots()
                     streamingLeaseLost = true
                 }
-                let modelBeforeUpdate = session.currentModel
                 let dirty = session.apply(params.update)
-                if case .sessionConfigOptionsUpdate = params.update,
-                   session.currentModel != modelBeforeUpdate {
-                    persistSessionRow()
-                }
                 if !streamingLeaseLost {
                     scheduleStreamingPersist(
                         dirty,
@@ -633,13 +628,19 @@ final class ACPSessionRunner {
                 let modelBeforeUpdate = session.currentModel
                 let dirty = session.apply(params.update)
                 flushStreamingPersist()
-                persistIndices(
-                    dirty,
-                    completion: persistenceCompletion(acknowledging: durableConsumptionAcknowledgement)
-                )
                 if case .sessionConfigOptionsUpdate = params.update,
                    session.currentModel != modelBeforeUpdate {
-                    persistSessionRow()
+                    persistIndices(dirty)
+                    persistSessionRow { persisted in
+                        if persisted {
+                            durableConsumptionAcknowledgement?()
+                        }
+                    }
+                } else {
+                    persistIndices(
+                        dirty,
+                        completion: persistenceCompletion(acknowledging: durableConsumptionAcknowledgement)
+                    )
                 }
             }
         }
@@ -849,8 +850,11 @@ final class ACPSessionRunner {
     /// `ACPSessionManager.persist` does the same thing plus a recent-
     /// list refresh; the runner skips that because it has no manager
     /// handle, and the next open via the manager picks up the new row.
-    func persistSessionRow(preserveTitle: Bool = true) {
-        guard holdsLeaseForWrite() else { return }
+    func persistSessionRow(preserveTitle: Bool = true, completion: ((Bool) -> Void)? = nil) {
+        guard holdsLeaseForWrite() else {
+            completion?(false)
+            return
+        }
         let title = session.title
         let titleSource = session.titleSource
         let currentModel = session.currentModel
@@ -858,8 +862,8 @@ final class ACPSessionRunner {
         let autoRun = session.autoRunEnabled
         let fence = leaseFenceProvider()
         let sessionId = sessionId
-        enqueuePersistence { persistence in
-            _ = try await persistence.updateSessionFromRuntime(
+        enqueuePersistence({ persistence in
+            try await persistence.updateSessionFromRuntime(
                 id: sessionId,
                 title: title,
                 titleSource: titleSource,
@@ -869,7 +873,9 @@ final class ACPSessionRunner {
                 preserveTitle: preserveTitle,
                 fence: fence
             )
-        }
+        }, completion: { row in
+            completion?(row != nil)
+        })
     }
 
     func persistGeneratedTitleIfStoredPlaceholder() {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -625,10 +625,22 @@ final class ACPSessionRunner {
                     )
                 }
             } else {
+                let hadConfigBackedModel: Bool
+                if case .configOption = session.chipState.models?.source {
+                    hadConfigBackedModel = true
+                } else {
+                    hadConfigBackedModel = false
+                }
                 let dirty = session.apply(params.update)
                 flushStreamingPersist()
+                let hasConfigBackedModel: Bool
+                if case .configOption = session.chipState.models?.source {
+                    hasConfigBackedModel = true
+                } else {
+                    hasConfigBackedModel = false
+                }
                 if case .sessionConfigOptionsUpdate = params.update,
-                   case .configOption = session.chipState.models?.source {
+                   hadConfigBackedModel || hasConfigBackedModel {
                     persistIndices(dirty)
                     persistSessionRow { persisted in
                         if persisted {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -873,7 +873,7 @@ final class ACPSessionRunner {
                 fence: fence
             )
         }, completion: { row in
-            completion?(row != nil)
+            completion?(row.flatMap { $0 } != nil)
         })
     }
 

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -625,11 +625,10 @@ final class ACPSessionRunner {
                     )
                 }
             } else {
-                let modelBeforeUpdate = session.currentModel
                 let dirty = session.apply(params.update)
                 flushStreamingPersist()
                 if case .sessionConfigOptionsUpdate = params.update,
-                   session.currentModel != modelBeforeUpdate {
+                   case .configOption = session.chipState.models?.source {
                     persistIndices(dirty)
                     persistSessionRow { persisted in
                         if persisted {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -616,7 +616,12 @@ final class ACPSessionRunner {
                     freezeStreamingPersistSnapshots()
                     streamingLeaseLost = true
                 }
+                let modelBeforeUpdate = session.currentModel
                 let dirty = session.apply(params.update)
+                if case .sessionConfigOptionsUpdate = params.update,
+                   session.currentModel != modelBeforeUpdate {
+                    persistSessionRow()
+                }
                 if !streamingLeaseLost {
                     scheduleStreamingPersist(
                         dirty,
@@ -625,12 +630,17 @@ final class ACPSessionRunner {
                     )
                 }
             } else {
+                let modelBeforeUpdate = session.currentModel
                 let dirty = session.apply(params.update)
                 flushStreamingPersist()
                 persistIndices(
                     dirty,
                     completion: persistenceCompletion(acknowledging: durableConsumptionAcknowledgement)
                 )
+                if case .sessionConfigOptionsUpdate = params.update,
+                   session.currentModel != modelBeforeUpdate {
+                    persistSessionRow()
+                }
             }
         }
         if applyPendingCompletedOutputBoundaryIfReady(), flushQueueWhenBoundaryReady {

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -841,7 +841,10 @@ struct ACPComposer: View {
                 switch spec.source {
                 case .mode: manager.pendingMode[sid] = selectedId
                 case .model: manager.pendingModel[sid] = selectedId
-                case .configOption: manager.pendingModel[sid] = selectedId
+                case .configOption:
+                    if session.chipState.models?.source == spec.source {
+                        manager.pendingModel[sid] = selectedId
+                    }
                 }
                 return
             }

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -817,6 +817,9 @@ struct ACPComposer: View {
     private func apply(spec: ChipSpec, selectedId: String) {
         let sid = session.id
         let remoteId = session.remoteSessionId ?? sid
+        var rollbackConfigOption: ACPConfigOption?
+        let rollbackModel = session.currentModel
+        var configOptionUpdatesModel = false
         switch spec.source {
         case .mode:
             session.currentMode = selectedId
@@ -825,11 +828,13 @@ struct ACPComposer: View {
         case .configOption(let id):
             if let idx = session.availableConfigOptions.firstIndex(where: { $0.id == id }) {
                 let old = session.availableConfigOptions[idx]
+                rollbackConfigOption = old
                 session.availableConfigOptions[idx] = ACPConfigOption(
                     id: old.id, name: old.name, type: old.type,
                     category: old.category, currentValue: .string(selectedId),
                     options: old.options)
                 if old.category == "model" || old.category == "Model" {
+                    configOptionUpdatesModel = true
                     session.currentModel = selectedId
                 }
             }
@@ -860,11 +865,12 @@ struct ACPComposer: View {
                 // for that option while still accepting dependent updates.
                 let baselineConfigOptions = session.availableConfigOptions
                 let baselineConfigOptionsRevision = session.availableConfigOptionsRevision
-                if let updated = try? await runner.connection.setConfigOption(
-                    sessionId: remoteId,
-                    configId: id,
-                    value: .string(selectedId)),
-                   !updated.isEmpty {
+                do {
+                    let updated = try await runner.connection.setConfigOption(
+                        sessionId: remoteId,
+                        configId: id,
+                        value: .string(selectedId))
+                    guard !updated.isEmpty else { return }
                     guard let merged = ACPConfigOption.mergingSuccessfulSetResponse(
                         updated,
                         configId: id,
@@ -879,6 +885,18 @@ struct ACPComposer: View {
                     if case .configOption(let modelId) = session.chipState.models?.source {
                         session.currentModel = session.availableConfigOptions
                             .first { $0.id == modelId }?.currentStringValue
+                    }
+                    manager.persist(session)
+                } catch {
+                    guard session.availableConfigOptionsRevision == baselineConfigOptionsRevision,
+                          let rollbackConfigOption,
+                          let idx = session.availableConfigOptions.firstIndex(where: { $0.id == id }),
+                          session.availableConfigOptions[idx].currentValue == .string(selectedId) else {
+                        return
+                    }
+                    session.availableConfigOptions[idx] = rollbackConfigOption
+                    if configOptionUpdatesModel, session.currentModel == selectedId {
+                        session.currentModel = rollbackModel
                     }
                     manager.persist(session)
                 }

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -829,6 +829,9 @@ struct ACPComposer: View {
                     id: old.id, name: old.name, type: old.type,
                     category: old.category, currentValue: .string(selectedId),
                     options: old.options)
+                if old.category == "model" || old.category == "Model" {
+                    session.currentModel = selectedId
+                }
             }
         }
         manager.persist(session)

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -841,7 +841,7 @@ struct ACPComposer: View {
                 switch spec.source {
                 case .mode: manager.pendingMode[sid] = selectedId
                 case .model: manager.pendingModel[sid] = selectedId
-                case .configOption: break
+                case .configOption: manager.pendingModel[sid] = selectedId
                 }
                 return
             }

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -858,6 +858,7 @@ struct ACPComposer: View {
                 // (including dependent updates), but some agents echo a stale
                 // value for the option just set. Keep the successful selection
                 // for that option while still accepting dependent updates.
+                let baselineConfigOptions = session.availableConfigOptions
                 if let updated = try? await runner.connection.setConfigOption(
                     sessionId: remoteId,
                     configId: id,
@@ -867,10 +868,15 @@ struct ACPComposer: View {
                         updated,
                         configId: id,
                         selectedValue: .string(selectedId),
-                        currentConfigOptions: session.availableConfigOptions) else {
+                        currentConfigOptions: session.availableConfigOptions,
+                        baselineConfigOptions: baselineConfigOptions) else {
                         return
                     }
                     session.availableConfigOptions = merged
+                    if case .configOption(let modelId) = session.chipState.models?.source {
+                        session.currentModel = session.availableConfigOptions
+                            .first { $0.id == modelId }?.currentStringValue
+                    }
                     manager.persist(session)
                 }
             }
@@ -891,6 +897,7 @@ struct ACPComposer: View {
 
         Task { @MainActor in
             guard let runner = manager.runners[sid] else { return }
+            let baselineConfigOptions = session.availableConfigOptions
             if let updated = try? await runner.connection.setConfigOption(
                 sessionId: remoteId,
                 configId: id,
@@ -900,10 +907,15 @@ struct ACPComposer: View {
                     updated,
                     configId: id,
                     selectedValue: value,
-                    currentConfigOptions: session.availableConfigOptions) else {
+                    currentConfigOptions: session.availableConfigOptions,
+                    baselineConfigOptions: baselineConfigOptions) else {
                     return
                 }
                 session.availableConfigOptions = merged
+                if case .configOption(let modelId) = session.chipState.models?.source {
+                    session.currentModel = session.availableConfigOptions
+                        .first { $0.id == modelId }?.currentStringValue
+                }
                 manager.persist(session)
             }
         }

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -818,6 +818,7 @@ struct ACPComposer: View {
         let sid = session.id
         let remoteId = session.remoteSessionId ?? sid
         var rollbackConfigOption: ACPConfigOption?
+        var optimisticConfigOption: ACPConfigOption?
         let rollbackModel = session.currentModel
         var configOptionUpdatesModel = false
         switch spec.source {
@@ -829,10 +830,12 @@ struct ACPComposer: View {
             if let idx = session.availableConfigOptions.firstIndex(where: { $0.id == id }) {
                 let old = session.availableConfigOptions[idx]
                 rollbackConfigOption = old
-                session.availableConfigOptions[idx] = ACPConfigOption(
+                let optimistic = ACPConfigOption(
                     id: old.id, name: old.name, type: old.type,
                     category: old.category, currentValue: .string(selectedId),
                     options: old.options)
+                optimisticConfigOption = optimistic
+                session.availableConfigOptions[idx] = optimistic
                 if old.category == "model" || old.category == "Model" {
                     configOptionUpdatesModel = true
                     session.currentModel = selectedId
@@ -881,17 +884,21 @@ struct ACPComposer: View {
                         currentConfigOptionsRevision: session.availableConfigOptionsRevision) else {
                         return
                     }
+                    let previousModelSource = session.chipState.models?.source
                     session.availableConfigOptions = merged
                     if case .configOption(let modelId) = session.chipState.models?.source {
                         session.currentModel = session.availableConfigOptions
                             .first { $0.id == modelId }?.currentStringValue
+                    } else if case .configOption = previousModelSource,
+                              session.chipState.models == nil {
+                        session.currentModel = nil
                     }
                     manager.persist(session)
                 } catch {
-                    guard session.availableConfigOptionsRevision == baselineConfigOptionsRevision,
-                          let rollbackConfigOption,
+                    guard let rollbackConfigOption,
+                          let optimisticConfigOption,
                           let idx = session.availableConfigOptions.firstIndex(where: { $0.id == id }),
-                          session.availableConfigOptions[idx].currentValue == .string(selectedId) else {
+                          session.availableConfigOptions[idx] == optimisticConfigOption else {
                         return
                     }
                     session.availableConfigOptions[idx] = rollbackConfigOption

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -859,6 +859,7 @@ struct ACPComposer: View {
                 // value for the option just set. Keep the successful selection
                 // for that option while still accepting dependent updates.
                 let baselineConfigOptions = session.availableConfigOptions
+                let baselineConfigOptionsRevision = session.availableConfigOptionsRevision
                 if let updated = try? await runner.connection.setConfigOption(
                     sessionId: remoteId,
                     configId: id,
@@ -869,7 +870,9 @@ struct ACPComposer: View {
                         configId: id,
                         selectedValue: .string(selectedId),
                         currentConfigOptions: session.availableConfigOptions,
-                        baselineConfigOptions: baselineConfigOptions) else {
+                        baselineConfigOptions: baselineConfigOptions,
+                        baselineConfigOptionsRevision: baselineConfigOptionsRevision,
+                        currentConfigOptionsRevision: session.availableConfigOptionsRevision) else {
                         return
                     }
                     session.availableConfigOptions = merged
@@ -898,6 +901,7 @@ struct ACPComposer: View {
         Task { @MainActor in
             guard let runner = manager.runners[sid] else { return }
             let baselineConfigOptions = session.availableConfigOptions
+            let baselineConfigOptionsRevision = session.availableConfigOptionsRevision
             if let updated = try? await runner.connection.setConfigOption(
                 sessionId: remoteId,
                 configId: id,
@@ -908,7 +912,9 @@ struct ACPComposer: View {
                     configId: id,
                     selectedValue: value,
                     currentConfigOptions: session.availableConfigOptions,
-                    baselineConfigOptions: baselineConfigOptions) else {
+                    baselineConfigOptions: baselineConfigOptions,
+                    baselineConfigOptionsRevision: baselineConfigOptionsRevision,
+                    currentConfigOptionsRevision: session.availableConfigOptionsRevision) else {
                     return
                 }
                 session.availableConfigOptions = merged

--- a/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
@@ -246,6 +246,59 @@ struct ACPConfigOptionTests {
         #expect(merged.map(\.id) == ["fast", "added"])
     }
 
+    @Test("successful set response preserves selected option metadata changed concurrently")
+    func mergeSuccessfulSetResponsePreservesSelectedOptionMetadataChangedConcurrently() throws {
+        let baselineFast = ACPConfigOption(
+            id: "fast", name: "Fast", type: "select", currentValue: "true",
+            options: [
+                ACPConfigOptionItem(id: "false", name: "Off"),
+                ACPConfigOptionItem(id: "true", name: "On"),
+            ])
+        let staleFast = ACPConfigOption(
+            id: "fast", name: "Fast", type: "select", currentValue: "true",
+            options: baselineFast.options)
+        let currentFast = ACPConfigOption(
+            id: "fast", name: "Fast", type: "select", currentValue: "true",
+            options: [
+                ACPConfigOptionItem(id: "false", name: "Off"),
+                ACPConfigOptionItem(id: "auto", name: "Auto"),
+                ACPConfigOptionItem(id: "true", name: "On"),
+            ])
+
+        let merged = try #require(ACPConfigOption.mergingSuccessfulSetResponse(
+            [staleFast],
+            configId: "fast",
+            selectedValue: .string("true"),
+            currentConfigOptions: [currentFast],
+            baselineConfigOptions: [baselineFast]))
+
+        #expect(merged.first?.options.map(\.id) == ["false", "auto", "true"])
+    }
+
+    @Test("successful set response preserves omitted baseline option changed concurrently")
+    func mergeSuccessfulSetResponsePreservesOmittedBaselineOptionChangedConcurrently() throws {
+        let fast = ACPConfigOption(
+            id: "fast", name: "Fast", type: "select", currentValue: "true",
+            options: [
+                ACPConfigOptionItem(id: "false", name: "Off"),
+                ACPConfigOptionItem(id: "true", name: "On"),
+            ])
+        let baselineEffort = ACPConfigOption(
+            id: "effort", name: "Effort", type: "select", currentValue: "low")
+        let currentEffort = ACPConfigOption(
+            id: "effort", name: "Effort", type: "select", currentValue: "high")
+
+        let merged = try #require(ACPConfigOption.mergingSuccessfulSetResponse(
+            [fast],
+            configId: "fast",
+            selectedValue: .string("true"),
+            currentConfigOptions: [fast, currentEffort],
+            baselineConfigOptions: [fast, baselineEffort]))
+
+        #expect(merged.map(\.id) == ["fast", "effort"])
+        #expect(merged.first(where: { $0.id == "effort" })?.currentValue == .string("high"))
+    }
+
     @Test("successful boolean set response preserves the selected config value")
     func mergeSuccessfulBooleanSetResponsePreservesSelectedValue() throws {
         let staleFast = ACPConfigOption(

--- a/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
@@ -246,6 +246,29 @@ struct ACPConfigOptionTests {
         #expect(merged.map(\.id) == ["fast", "added"])
     }
 
+    @Test("successful set response does not resurrect option added then removed concurrently")
+    func mergeSuccessfulSetResponseSkipsOptionAddedThenRemovedConcurrently() throws {
+        let fast = ACPConfigOption(
+            id: "fast", name: "Fast", type: "select", currentValue: "true",
+            options: [
+                ACPConfigOptionItem(id: "false", name: "Off"),
+                ACPConfigOptionItem(id: "true", name: "On"),
+            ])
+        let transient = ACPConfigOption(
+            id: "transient", name: "Transient", type: "select", currentValue: "new")
+
+        let merged = try #require(ACPConfigOption.mergingSuccessfulSetResponse(
+            [fast, transient],
+            configId: "fast",
+            selectedValue: .string("true"),
+            currentConfigOptions: [fast],
+            baselineConfigOptions: [fast],
+            baselineConfigOptionsRevision: 1,
+            currentConfigOptionsRevision: 3))
+
+        #expect(merged.map(\.id) == ["fast"])
+    }
+
     @Test("successful set response preserves selected option metadata changed concurrently")
     func mergeSuccessfulSetResponsePreservesSelectedOptionMetadataChangedConcurrently() throws {
         let baselineFast = ACPConfigOption(

--- a/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
@@ -223,6 +223,29 @@ struct ACPConfigOptionTests {
         #expect(effort.options.map(\.id) == ["low", "medium", "high"])
     }
 
+    @Test("successful set response preserves concurrent option membership changes")
+    func mergeSuccessfulSetResponsePreservesConcurrentOptionMembershipChanges() throws {
+        let fast = ACPConfigOption(
+            id: "fast", name: "Fast", type: "select", currentValue: "true",
+            options: [
+                ACPConfigOptionItem(id: "false", name: "Off"),
+                ACPConfigOptionItem(id: "true", name: "On"),
+            ])
+        let removed = ACPConfigOption(
+            id: "removed", name: "Removed", type: "select", currentValue: "old")
+        let added = ACPConfigOption(
+            id: "added", name: "Added", type: "select", currentValue: "new")
+
+        let merged = try #require(ACPConfigOption.mergingSuccessfulSetResponse(
+            [fast, removed],
+            configId: "fast",
+            selectedValue: .string("true"),
+            currentConfigOptions: [fast, added],
+            baselineConfigOptions: [fast, removed]))
+
+        #expect(merged.map(\.id) == ["fast", "added"])
+    }
+
     @Test("successful boolean set response preserves the selected config value")
     func mergeSuccessfulBooleanSetResponsePreservesSelectedValue() throws {
         let staleFast = ACPConfigOption(

--- a/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
@@ -156,6 +156,37 @@ struct ACPConfigOptionTests {
         #expect(merged == nil)
     }
 
+    @Test("successful set response preserves concurrently changed dependent value")
+    func mergeSuccessfulSetResponsePreservesConcurrentlyChangedDependentValue() throws {
+        let baselineFast = ACPConfigOption(
+            id: "fast", name: "Fast", type: "select", currentValue: "true",
+            options: [
+                ACPConfigOptionItem(id: "false", name: "Off"),
+                ACPConfigOptionItem(id: "true", name: "On"),
+            ])
+        let baselineEffort = ACPConfigOption(
+            id: "effort", name: "Effort", type: "select", currentValue: "low",
+            options: [
+                ACPConfigOptionItem(id: "low", name: "Low"),
+                ACPConfigOptionItem(id: "high", name: "High"),
+            ])
+        let staleEffort = ACPConfigOption(
+            id: "effort", name: "Effort", type: "select", currentValue: "low",
+            options: baselineEffort.options)
+        let currentEffort = ACPConfigOption(
+            id: "effort", name: "Effort", type: "select", currentValue: "high",
+            options: baselineEffort.options)
+
+        let merged = try #require(ACPConfigOption.mergingSuccessfulSetResponse(
+            [baselineFast, staleEffort],
+            configId: "fast",
+            selectedValue: .string("true"),
+            currentConfigOptions: [baselineFast, currentEffort],
+            baselineConfigOptions: [baselineFast, baselineEffort]))
+
+        #expect(merged.first(where: { $0.id == "effort" })?.currentValue == .string("high"))
+    }
+
     @Test("successful boolean set response preserves the selected config value")
     func mergeSuccessfulBooleanSetResponsePreservesSelectedValue() throws {
         let staleFast = ACPConfigOption(

--- a/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
@@ -187,6 +187,42 @@ struct ACPConfigOptionTests {
         #expect(merged.first(where: { $0.id == "effort" })?.currentValue == .string("high"))
     }
 
+    @Test("successful set response preserves concurrently changed dependent metadata")
+    func mergeSuccessfulSetResponsePreservesConcurrentlyChangedDependentMetadata() throws {
+        let baselineFast = ACPConfigOption(
+            id: "fast", name: "Fast", type: "select", currentValue: "true",
+            options: [
+                ACPConfigOptionItem(id: "false", name: "Off"),
+                ACPConfigOptionItem(id: "true", name: "On"),
+            ])
+        let baselineEffort = ACPConfigOption(
+            id: "effort", name: "Effort", type: "select", currentValue: "low",
+            options: [
+                ACPConfigOptionItem(id: "low", name: "Low"),
+                ACPConfigOptionItem(id: "high", name: "High"),
+            ])
+        let staleEffort = ACPConfigOption(
+            id: "effort", name: "Effort", type: "select", currentValue: "low",
+            options: baselineEffort.options)
+        let currentEffort = ACPConfigOption(
+            id: "effort", name: "Effort", type: "select", currentValue: "low",
+            options: [
+                ACPConfigOptionItem(id: "low", name: "Low"),
+                ACPConfigOptionItem(id: "medium", name: "Medium"),
+                ACPConfigOptionItem(id: "high", name: "High"),
+            ])
+
+        let merged = try #require(ACPConfigOption.mergingSuccessfulSetResponse(
+            [baselineFast, staleEffort],
+            configId: "fast",
+            selectedValue: .string("true"),
+            currentConfigOptions: [baselineFast, currentEffort],
+            baselineConfigOptions: [baselineFast, baselineEffort]))
+
+        let effort = try #require(merged.first(where: { $0.id == "effort" }))
+        #expect(effort.options.map(\.id) == ["low", "medium", "high"])
+    }
+
     @Test("successful boolean set response preserves the selected config value")
     func mergeSuccessfulBooleanSetResponsePreservesSelectedValue() throws {
         let staleFast = ACPConfigOption(

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -649,6 +649,51 @@ struct ACPSessionManagerAttachRestoreTests {
         }
     }
 
+    @Test("reopened config-option session clears stale model when restoration fails without loaded value")
+    func reopenedConfigOptionSessionClearsStaleModelWhenRestorationFailsWithoutLoadedValue() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(
+            remoteSessionId: "remote-old",
+            agentId: "codex",
+            currentModel: "sonnet"
+        ))
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-old",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: [],
+                configOptions: [ACPConfigOption(
+                    id: "model",
+                    name: "Model",
+                    category: "model",
+                    currentValue: nil as ACPConfigValue?,
+                    options: [
+                        .init(id: "sonnet", name: "Sonnet"),
+                        .init(id: "opus", name: "Opus"),
+                    ])]
+            ))
+        }
+        client.script(method: "session/set_config_option") { _ in
+            throw ACPClientError.noScript(method: "session/set_config_option")
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(session.currentModel == nil)
+        #expect(session.availableConfigOptions.first?.currentStringValue == nil)
+        try await waitUntil {
+            (try? store.loadSession(id: "local"))?.currentModel == nil
+        }
+    }
+
     @Test("reopened config-option session preserves model reselected during restoration")
     func reopenedConfigOptionSessionPreservesModelReselectedDuringRestoration() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -819,6 +819,93 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(session.availableConfigOptions.first?.currentStringValue == "sonnet")
     }
 
+    @Test("reopened config-option session preserves option changed during restoration")
+    func reopenedConfigOptionSessionPreservesOptionChangedDuringRestoration() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(
+            remoteSessionId: "remote-old",
+            agentId: "codex",
+            currentModel: "sonnet"
+        ))
+        let client = ACPMockClient()
+        let modelGate = PromptGate()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-old",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: [],
+                configOptions: [
+                    ACPConfigOption(
+                        id: "model",
+                        name: "Model",
+                        category: "model",
+                        currentValue: "opus",
+                        options: [
+                            .init(id: "sonnet", name: "Sonnet"),
+                            .init(id: "opus", name: "Opus"),
+                        ]),
+                    ACPConfigOption(
+                        id: "effort",
+                        name: "Effort",
+                        currentValue: "low",
+                        options: [
+                            .init(id: "low", name: "Low"),
+                            .init(id: "high", name: "High"),
+                        ]),
+                ]
+            ))
+        }
+        client.scriptAsync(method: "session/set_config_option") { _ in
+            await modelGate.waitInPrompt()
+            return try JSONEncoder().encode(ACPSessionSetConfigOptionResult(configOptions: [
+                ACPConfigOption(
+                    id: "model",
+                    name: "Model",
+                    category: "model",
+                    currentValue: "sonnet",
+                    options: [
+                        .init(id: "sonnet", name: "Sonnet"),
+                        .init(id: "opus", name: "Opus"),
+                    ]),
+                ACPConfigOption(
+                    id: "effort",
+                    name: "Effort",
+                    currentValue: "low",
+                    options: [
+                        .init(id: "low", name: "Low"),
+                        .init(id: "high", name: "High"),
+                    ]),
+            ]))
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        let attachTask = Task {
+            await manager.attach(to: session.id, freshlyCreated: false)
+        }
+
+        try await waitUntilAsync { await modelGate.hasEntered }
+        session.availableConfigOptions[1] = ACPConfigOption(
+            id: "effort",
+            name: "Effort",
+            currentValue: "high",
+            options: [
+                .init(id: "low", name: "Low"),
+                .init(id: "high", name: "High"),
+            ])
+        await modelGate.release()
+        await attachTask.value
+
+        #expect(session.currentModel == "sonnet")
+        #expect(session.availableConfigOptions.first(where: { $0.id == "model" })?.currentStringValue == "sonnet")
+        #expect(session.availableConfigOptions.first(where: { $0.id == "effort" })?.currentStringValue == "high")
+    }
+
     @Test("reopened session keeps the loaded model when restoration fails")
     func reopenedSessionKeepsLoadedModelWhenRestorationFails() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -554,7 +554,16 @@ struct ACPSessionManagerAttachRestoreTests {
                     ])]
             ))
         }
-        client.script(method: "session/set_config_option") { _ in Data("{}".utf8) }
+        client.script(method: "session/set_config_option") { _ in
+            """
+            {"configOptions":[
+                {"id":"model","name":"Model","type":"select","category":"model","currentValue":"opus",
+                 "options":[{"value":"sonnet","name":"Sonnet"},{"value":"opus","name":"Opus"}]},
+                {"id":"effort","name":"Effort","type":"select","currentValue":"high",
+                 "options":[{"value":"high","name":"High"}]}
+            ]}
+            """.data(using: .utf8)!
+        }
         let manager = manager(store: store, client: client)
 
         let session = try #require(manager.placeholderSession(id: "local"))
@@ -566,6 +575,54 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(params.sessionId == "remote-old")
         #expect(params.configId == "model")
         #expect(params.value == .string("sonnet"))
+        #expect(session.currentModel == "sonnet")
+        #expect(session.availableConfigOptions.first?.currentStringValue == "sonnet")
+        #expect(session.availableConfigOptions.count == 2)
+    }
+
+    @Test("reopened config-option session keeps the loaded model when restoration fails")
+    func reopenedConfigOptionSessionKeepsLoadedModelWhenRestorationFails() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(
+            remoteSessionId: "remote-old",
+            agentId: "codex",
+            currentModel: "sonnet"
+        ))
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-old",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: [],
+                configOptions: [ACPConfigOption(
+                    id: "model",
+                    name: "Model",
+                    category: "model",
+                    currentValue: "opus",
+                    options: [
+                        .init(id: "sonnet", name: "Sonnet"),
+                        .init(id: "opus", name: "Opus"),
+                    ])]
+            ))
+        }
+        client.script(method: "session/set_config_option") { _ in
+            throw ACPClientError.noScript(method: "session/set_config_option")
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(session.currentModel == "opus")
+        #expect(session.availableConfigOptions.first?.currentStringValue == "opus")
+        try await waitUntil {
+            (try? store.loadSession(id: "local"))?.currentModel == "opus"
+        }
     }
 
     @Test("reopened session keeps the loaded model when restoration fails")

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -525,6 +525,49 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(session.currentModel == "sonnet")
     }
 
+    @Test("reopened session reapplies a persisted config-option model after load")
+    func reopenedSessionReappliesPersistedConfigOptionModel() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(
+            remoteSessionId: "remote-old",
+            agentId: "codex",
+            currentModel: "sonnet"
+        ))
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-old",
+                availableModels: [],
+                availableModes: [],
+                currentModel: "opus",
+                currentMode: nil,
+                promptSuggestions: [],
+                configOptions: [ACPConfigOption(
+                    id: "model",
+                    name: "Model",
+                    category: "model",
+                    currentValue: "opus",
+                    options: [
+                        .init(id: "sonnet", name: "Sonnet"),
+                        .init(id: "opus", name: "Opus"),
+                    ])]
+            ))
+        }
+        client.script(method: "session/set_config_option") { _ in Data("{}".utf8) }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/load", "session/set_config_option"])
+        let params = try #require(client.sent.last?.params as? ACPSessionSetConfigOptionParams)
+        #expect(params.sessionId == "remote-old")
+        #expect(params.configId == "model")
+        #expect(params.value == .string("sonnet"))
+    }
+
     @Test("reopened session keeps the loaded model when restoration fails")
     func reopenedSessionKeepsLoadedModelWhenRestorationFails() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -580,6 +580,30 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(session.availableConfigOptions.count == 2)
     }
 
+    @Test("reopened config-only session records its already-selected model")
+    func reopenedConfigOnlySessionRecordsAlreadySelectedModel() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-old", agentId: "codex", currentModel: "opus"))
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-old", availableModels: [], availableModes: [], currentModel: nil,
+                currentMode: nil, promptSuggestions: [], configOptions: [ACPConfigOption(
+                    id: "model", name: "Model", category: "model", currentValue: "opus",
+                    options: [.init(id: "opus", name: "Opus")])]
+            ))
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/load"])
+        #expect(session.currentModel == "opus")
+    }
+
     @Test("reopened config-option session keeps the loaded model when restoration fails")
     func reopenedConfigOptionSessionKeepsLoadedModelWhenRestorationFails() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -604,6 +604,33 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(session.currentModel == "opus")
     }
 
+    @Test("reopened config-only session persists loaded model when row has no model")
+    func reopenedConfigOnlySessionPersistsLoadedModelWhenRowHasNoModel() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-old", agentId: "codex", currentModel: nil))
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-old", availableModels: [], availableModes: [], currentModel: nil,
+                currentMode: nil, promptSuggestions: [], configOptions: [ACPConfigOption(
+                    id: "model", name: "Model", category: "model", currentValue: "opus",
+                    options: [.init(id: "opus", name: "Opus")])]
+            ))
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/load"])
+        #expect(session.currentModel == "opus")
+        try await waitUntil {
+            (try? store.loadSession(id: "local"))?.currentModel == "opus"
+        }
+    }
+
     @Test("reopened config-option session keeps the loaded model when restoration fails")
     func reopenedConfigOptionSessionKeepsLoadedModelWhenRestorationFails() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -709,6 +709,71 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(session.availableConfigOptions.first?.currentStringValue == "opus")
     }
 
+    @Test("config-option selection after load is restored against the loaded value")
+    func configOptionSelectionAfterLoadIsRestoredAgainstLoadedValue() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(
+            remoteSessionId: "remote-old",
+            agentId: "codex",
+            currentModel: "opus"
+        ))
+        let client = ACPMockClient()
+        let lockStore = try ACPSessionStore(path: store.path)
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            let data = try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-old",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: [],
+                configOptions: [ACPConfigOption(
+                    id: "model",
+                    name: "Model",
+                    category: "model",
+                    currentValue: "opus",
+                    options: [
+                        .init(id: "sonnet", name: "Sonnet"),
+                        .init(id: "opus", name: "Opus"),
+                    ])]
+            ))
+            try lockStore.db.exec("BEGIN IMMEDIATE")
+            return data
+        }
+        client.script(method: "session/set_config_option") { _ in Data("{}".utf8) }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        defer { try? lockStore.db.exec("ROLLBACK") }
+        let attachTask = Task {
+            await manager.attach(to: session.id, freshlyCreated: false)
+        }
+
+        try await waitUntil {
+            session.availableConfigOptions.first?.currentStringValue == "opus"
+        }
+        session.currentModel = "sonnet"
+        session.availableConfigOptions[0] = ACPConfigOption(
+            id: "model",
+            name: "Model",
+            category: "model",
+            currentValue: "sonnet",
+            options: [
+                .init(id: "sonnet", name: "Sonnet"),
+                .init(id: "opus", name: "Opus"),
+            ])
+        manager.pendingModel[session.id] = "sonnet"
+        try lockStore.db.exec("COMMIT")
+        await attachTask.value
+
+        let params = client.sent.compactMap { $0.params as? ACPSessionSetConfigOptionParams }
+        #expect(params.map(\.value) == [.string("sonnet")])
+        #expect(session.currentModel == "sonnet")
+        #expect(session.availableConfigOptions.first?.currentStringValue == "sonnet")
+    }
+
     @Test("reopened session keeps the loaded model when restoration fails")
     func reopenedSessionKeepsLoadedModelWhenRestorationFails() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -649,6 +649,66 @@ struct ACPSessionManagerAttachRestoreTests {
         }
     }
 
+    @Test("reopened config-option session preserves model reselected during restoration")
+    func reopenedConfigOptionSessionPreservesModelReselectedDuringRestoration() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(
+            remoteSessionId: "remote-old",
+            agentId: "codex",
+            currentModel: "sonnet"
+        ))
+        let client = ACPMockClient()
+        let modelGate = PromptGate()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-old",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: [],
+                configOptions: [ACPConfigOption(
+                    id: "model",
+                    name: "Model",
+                    category: "model",
+                    currentValue: "opus",
+                    options: [
+                        .init(id: "sonnet", name: "Sonnet"),
+                        .init(id: "opus", name: "Opus"),
+                    ])]
+            ))
+        }
+        client.scriptAsync(method: "session/set_config_option") { _ in
+            await modelGate.waitInPrompt()
+            return Data("{}".utf8)
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        let attachTask = Task {
+            await manager.attach(to: session.id, freshlyCreated: false)
+        }
+
+        try await waitUntilAsync { await modelGate.hasEntered }
+        session.currentModel = "opus"
+        session.availableConfigOptions[0] = ACPConfigOption(
+            id: "model",
+            name: "Model",
+            category: "model",
+            currentValue: "opus",
+            options: [
+                .init(id: "sonnet", name: "Sonnet"),
+                .init(id: "opus", name: "Opus"),
+            ])
+        await modelGate.release()
+        await attachTask.value
+
+        #expect(session.currentModel == "opus")
+        #expect(session.availableConfigOptions.first?.currentStringValue == "opus")
+    }
+
     @Test("reopened session keeps the loaded model when restoration fails")
     func reopenedSessionKeepsLoadedModelWhenRestorationFails() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -664,6 +664,33 @@ struct ACPSessionRunnerTests {
         #expect(goal.tokenBudget == 12_000)
     }
 
+    @Test("session_config_options_update persists config-backed currentModel")
+    func sessionConfigOptionsUpdatePersistsConfigBackedCurrentModel() async throws {
+        let (runner, mock) = try makeRunner()
+        runner.start()
+        defer { runner.stop() }
+
+        mock.emit(.init(
+            sessionId: "s",
+            update: .sessionConfigOptionsUpdate([ACPConfigOption(
+                id: "model",
+                name: "Model",
+                category: "model",
+                currentValue: "sonnet",
+                options: [
+                    ACPConfigOptionItem(id: "sonnet", name: "Sonnet"),
+                    ACPConfigOptionItem(id: "opus", name: "Opus"),
+                ])])
+        ))
+
+        try await waitUntil {
+            runner.session.currentModel == "sonnet"
+        }
+        await runner.flushPersistence()
+        let row = try #require(try await runner.persistence.loadSession(id: "s"))
+        #expect(row.currentModel == "sonnet")
+    }
+
     @Test("session_info_update preserves manual title")
     func sessionInfoUpdatePreservesManualTitle() async throws {
         let url = FileManager.default.temporaryDirectory

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -1283,7 +1283,7 @@ struct ACPSessionRunnerTests {
         #expect(try store.loadMessages(sessionId: "s").contains { $0.kind == "agent" })
     }
 
-    @Test("config update is acknowledged only after model persistence")
+    @Test("config update is acknowledged only after repairing stale stored model")
     func configUpdateAcknowledgesAfterModelPersistence() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")
         let store = try ACPSessionStore(path: url.path)
@@ -1291,7 +1291,7 @@ struct ACPSessionRunnerTests {
             currentModel: "opus", currentMode: nil, autoRun: false,
             createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "t")
-        session.currentModel = "opus"
+        session.currentModel = "sonnet"
         let runner = ACPSessionRunner(
             session: session,
             connection: ACPConnection(client: ACPMockClient()),

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -3189,6 +3189,47 @@ struct ACPSessionRunnerTests {
         #expect(row?.title == seedTitle)
     }
 
+    @Test("persistSessionRow reports failure when fence rejects queued write")
+    func persistSessionRowReportsFenceRejection() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rn-session-row-fence-rejected-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let sid = "s"
+        try store.upsertSession(.init(id: sid, agentId: "claude", title: "original",
+            currentModel: "old", currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        try store.seizeLease(
+            sessionId: sid,
+            instanceId: "ME",
+            pid: Int64(getpid()),
+            now: Int64(Date().timeIntervalSince1970),
+            leaseToken: "new"
+        )
+
+        let mock = ACPMockClient()
+        let session = ACPSession(id: sid, agentId: "claude", worktreeId: "wt", title: "original")
+        session.currentModel = "new"
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: sid,
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            ownerInstanceId: "ME",
+            canWrite: { true },
+            leaseFenceProvider: {
+                ACPSessionLeaseFence(sessionId: sid, ownerInstance: "ME", token: "old")
+            }
+        )
+
+        var persisted = true
+        runner.persistSessionRow { persisted = $0 }
+        await runner.flushPersistence()
+
+        #expect(persisted == false)
+        #expect(try store.loadSession(id: sid)?.currentModel == "old")
+    }
+
     @Test("generated prompt title does not overwrite stored manual title")
     func generatedPromptTitleDoesNotOverwriteStoredManualTitle() async throws {
         let url = FileManager.default.temporaryDirectory

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -1283,6 +1283,45 @@ struct ACPSessionRunnerTests {
         #expect(try store.loadMessages(sessionId: "s").contains { $0.kind == "agent" })
     }
 
+    @Test("config update is acknowledged only after model persistence")
+    func configUpdateAcknowledgesAfterModelPersistence() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "codex", title: "t",
+            currentModel: "opus", currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "t")
+        session.currentModel = "opus"
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: ACPMockClient()),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path
+        )
+        let acknowledgement = DurableAcknowledgementRecorder()
+
+        runner.applyIncomingUpdateForTesting(.init(
+            sessionId: "s",
+            update: .sessionConfigOptionsUpdate([ACPConfigOption(
+                id: "model",
+                name: "Model",
+                category: "model",
+                currentValue: "sonnet",
+                options: [
+                    ACPConfigOptionItem(id: "sonnet", name: "Sonnet"),
+                    ACPConfigOptionItem(id: "opus", name: "Opus"),
+                ]
+            )]),
+            durableConsumptionAcknowledgement: { acknowledgement.record() }
+        ))
+
+        #expect(!acknowledgement.wasRecorded)
+        await runner.flushPersistence()
+        #expect(acknowledgement.wasRecorded)
+        #expect(try store.loadSession(id: "s")?.currentModel == "sonnet")
+    }
+
     @Test("incoming streaming chunks are coalesced before applying")
     func incomingStreamingChunksCoalesceBeforeApplying() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -1359,6 +1359,45 @@ struct ACPSessionRunnerTests {
         #expect(try store.loadSession(id: "s")?.currentModel == nil)
     }
 
+    @Test("config update removing config model preserves legacy model fallback")
+    func configUpdateRemovingConfigModelPreservesLegacyModelFallback() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "codex", title: "t",
+            currentModel: "sonnet", currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "t")
+        session.currentModel = "sonnet"
+        session.availableModels = [ACPModelInfo(id: "sonnet", name: "Sonnet", description: nil)]
+        session.availableConfigOptions = [ACPConfigOption(
+            id: "model",
+            name: "Model",
+            category: "model",
+            currentValue: "sonnet",
+            options: [ACPConfigOptionItem(id: "sonnet", name: "Sonnet")]
+        )]
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: ACPMockClient()),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path
+        )
+        let acknowledgement = DurableAcknowledgementRecorder()
+
+        runner.applyIncomingUpdateForTesting(.init(
+            sessionId: "s",
+            update: .sessionConfigOptionsUpdate([]),
+            durableConsumptionAcknowledgement: { acknowledgement.record() }
+        ))
+
+        #expect(!acknowledgement.wasRecorded)
+        await runner.flushPersistence()
+        #expect(acknowledgement.wasRecorded)
+        #expect(session.chipState.models?.source == .model)
+        #expect(try store.loadSession(id: "s")?.currentModel == "sonnet")
+    }
+
     @Test("incoming streaming chunks are coalesced before applying")
     func incomingStreamingChunksCoalesceBeforeApplying() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -1322,6 +1322,43 @@ struct ACPSessionRunnerTests {
         #expect(try store.loadSession(id: "s")?.currentModel == "sonnet")
     }
 
+    @Test("config update removing model is acknowledged only after clearing stored model")
+    func configUpdateRemovingModelAcknowledgesAfterClearingStoredModel() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "codex", title: "t",
+            currentModel: "sonnet", currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "t")
+        session.currentModel = "sonnet"
+        session.availableConfigOptions = [ACPConfigOption(
+            id: "model",
+            name: "Model",
+            category: "model",
+            currentValue: "sonnet",
+            options: [ACPConfigOptionItem(id: "sonnet", name: "Sonnet")]
+        )]
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: ACPMockClient()),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path
+        )
+        let acknowledgement = DurableAcknowledgementRecorder()
+
+        runner.applyIncomingUpdateForTesting(.init(
+            sessionId: "s",
+            update: .sessionConfigOptionsUpdate([]),
+            durableConsumptionAcknowledgement: { acknowledgement.record() }
+        ))
+
+        #expect(!acknowledgement.wasRecorded)
+        await runner.flushPersistence()
+        #expect(acknowledgement.wasRecorded)
+        #expect(try store.loadSession(id: "s")?.currentModel == nil)
+    }
+
     @Test("incoming streaming chunks are coalesced before applying")
     func incomingStreamingChunksCoalesceBeforeApplying() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1467,6 +1467,22 @@ struct ACPSessionTests {
         #expect(session.currentModel == "sonnet")
     }
 
+    @Test("sessionConfigOptionsUpdate clears removed config-backed currentModel")
+    func configOptionsUpdateClearsRemovedConfigBackedCurrentModel() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.currentModel = "sonnet"
+        session.apply(.sessionConfigOptionsUpdate([ACPConfigOption(
+            id: "model",
+            name: "Model",
+            category: "model",
+            currentValue: "sonnet",
+            options: [ACPConfigOptionItem(id: "sonnet", name: "Sonnet")]
+        )]))
+        session.apply(.sessionConfigOptionsUpdate([]))
+
+        #expect(session.currentModel == nil)
+    }
+
     @Test("session info applies title and goal")
     func sessionInfoAppliesTitleAndGoal() async throws {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "Old title")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -1450,6 +1450,23 @@ struct ACPSessionTests {
         #expect(session.availableConfigOptions[0].currentValue == .string("high"))
     }
 
+    @Test("sessionConfigOptionsUpdate synchronizes config-backed currentModel")
+    func configOptionsUpdateSynchronizesConfigBackedCurrentModel() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.currentModel = "opus"
+        session.apply(.sessionConfigOptionsUpdate([ACPConfigOption(
+            id: "model",
+            name: "Model",
+            category: "model",
+            currentValue: "sonnet",
+            options: [
+                ACPConfigOptionItem(id: "sonnet", name: "Sonnet"),
+                ACPConfigOptionItem(id: "opus", name: "Opus"),
+            ])]))
+
+        #expect(session.currentModel == "sonnet")
+    }
+
     @Test("session info applies title and goal")
     func sessionInfoAppliesTitleAndGoal() async throws {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "Old title")


### PR DESCRIPTION
ACP sessions that expose model selection as a config option did not retain the selected model after restart. The existing restore path only handled the legacy model RPC.

This persists the config-option model selection in the existing session row and restores it through the matching config-option request. The regression test covers reopening a session whose provider returns a config-option model picker.