### PR TITLE
fix: retain landing operations through cleanup

### DIFF
--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -45,8 +45,10 @@ struct GGLandingSession: Equatable, Identifiable, Sendable {
 @Observable
 final class GGLandingStore {
     private struct Operation {
+        let id: UUID
         let monitor: Task<Void, Never>
         let cancel: @MainActor () -> Void
+        var cancellationRequested = false
     }
 
     static let shared = GGLandingStore()
@@ -56,14 +58,11 @@ final class GGLandingStore {
 
     @discardableResult
     func begin(_ seed: GGLandingSession.Seed, now: Date = Date()) -> Bool {
+        guard operations[seed.projectId] == nil else { return false }
         if let session = sessions[seed.projectId],
            session.phase == .running || session.phase == .cancelling
         {
             return false
-        }
-        if let previous = operations.removeValue(forKey: seed.projectId) {
-            previous.cancel()
-            previous.monitor.cancel()
         }
         sessions[seed.projectId] = GGLandingSession(
             id: UUID(),
@@ -149,10 +148,12 @@ final class GGLandingStore {
         }
 
         let sessionId = session.id
+        let operationId = UUID()
         let monitor = Task { @MainActor [weak self] in
             let result = await task.result
-            guard let self, self.sessions[projectId]?.id == sessionId else { return }
+            guard let self, self.operations[projectId]?.id == operationId else { return }
             self.operations[projectId] = nil
+            guard self.sessions[projectId]?.id == sessionId else { return }
 
             guard let phase = self.sessions[projectId]?.phase else { return }
             if phase == .cancelling {
@@ -169,27 +170,25 @@ final class GGLandingStore {
                 }
             }
         }
-        operations[projectId] = Operation(monitor: monitor, cancel: cancel)
+        operations[projectId] = Operation(id: operationId, monitor: monitor, cancel: cancel)
     }
 
     func cancel(projectId: String) {
         guard var session = sessions[projectId], session.phase == .running,
-              let operation = operations[projectId]
+              operations[projectId] != nil
         else { return }
         session.phase = .cancelling
         sessions[projectId] = session
-        operation.cancel()
+        requestCancellation(projectId: projectId)
     }
 
     func cancelAllAndWait() async {
         let activeOperations = operations
-        for (projectId, operation) in activeOperations {
+        for projectId in activeOperations.keys {
             if sessions[projectId]?.phase == .running {
                 sessions[projectId]?.phase = .cancelling
-                operation.cancel()
-            } else if sessions[projectId]?.phase != .cancelling {
-                operation.cancel()
             }
+            requestCancellation(projectId: projectId)
         }
         for operation in activeOperations.values {
             await operation.monitor.value
@@ -208,13 +207,15 @@ final class GGLandingStore {
     func prune(keepingProjectIds: Set<String>) {
         let removedProjectIds = sessions.keys.filter { !keepingProjectIds.contains($0) }
         for projectId in removedProjectIds {
-            if let operation = operations.removeValue(forKey: projectId) {
-                if sessions[projectId]?.phase != .cancelling {
-                    operation.cancel()
-                }
-                operation.monitor.cancel()
-            }
+            requestCancellation(projectId: projectId)
             sessions[projectId] = nil
         }
+    }
+
+    private func requestCancellation(projectId: String) {
+        guard var operation = operations[projectId], !operation.cancellationRequested else { return }
+        operation.cancellationRequested = true
+        operations[projectId] = operation
+        operation.cancel()
     }
 }

--- a/AlasTests/Integrations/GGLandingStoreTests.swift
+++ b/AlasTests/Integrations/GGLandingStoreTests.swift
@@ -2,6 +2,46 @@ import Foundation
 import Testing
 @testable import Alas
 
+private actor LandingTestSuspension {
+    private var isSuspended = false
+    private var suspensionWaiters: [CheckedContinuation<Void, Never>] = []
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func suspend() async {
+        isSuspended = true
+        let waiters = suspensionWaiters
+        suspensionWaiters.removeAll()
+        for waiter in waiters { waiter.resume() }
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func waitUntilSuspended() async {
+        if isSuspended { return }
+        await withCheckedContinuation { suspensionWaiters.append($0) }
+    }
+
+    func release() {
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private enum GGLandingStoreTestTimeout: Error {
+    case timedOut
+}
+
+@MainActor
+private func waitUntil(
+    timeout: TimeInterval = 2,
+    _ condition: () -> Bool
+) async throws {
+    let deadline = Date().addingTimeInterval(timeout)
+    while !condition() {
+        guard Date() < deadline else { throw GGLandingStoreTestTimeout.timedOut }
+        try await Task.sleep(for: .milliseconds(1))
+    }
+}
+
 @MainActor
 struct GGLandingStoreTests {
     private enum TestError: Error {
@@ -48,6 +88,28 @@ struct GGLandingStoreTests {
         #expect(replacement.id != first.id)
         #expect(replacement.phase == .running)
         #expect(replacement.error == nil)
+    }
+
+    @Test func terminalSessionCannotRestartUntilAttachedOperationFinishes() async {
+        let store = GGLandingStore()
+        let operation = AsyncStream<Void>.makeStream()
+        let task = Task<Void, Error> {
+            for await _ in operation.stream {}
+        }
+        #expect(store.begin(seed()))
+        store.attach(projectId: "p", task: task) {
+            operation.continuation.finish()
+        }
+        store.receive(
+            .summary(.init(landed: [], error: "partial failure")),
+            projectId: "p"
+        )
+
+        #expect(!store.begin(seed()))
+
+        operation.continuation.finish()
+        await store.cancelAllAndWait()
+        #expect(store.begin(seed()))
     }
 
     @Test func heartbeatUpdatesActiveRowAndClearsRecoveredWarning() {
@@ -140,25 +202,20 @@ struct GGLandingStoreTests {
         }
         store.cancel(projectId: "p")
         store.cancel(projectId: "p")
-        _ = await task.result
-        for _ in 0..<20 where store.sessions["p"]?.phase != .cancelled {
-            await Task.yield()
-        }
+        await store.cancelAllAndWait()
         #expect(cancelCount == 1)
         #expect(store.sessions["p"]?.phase == .cancelled)
         #expect(store.sessions["p"]?.error == nil)
     }
 
-    @Test func unexpectedExitWithoutSummaryFailsSession() async {
+    @Test func unexpectedExitWithoutSummaryFailsSession() async throws {
         let store = GGLandingStore()
         store.begin(seed())
         let task = Task<Void, Error> {}
         store.attach(projectId: "p", task: task) {}
 
         _ = await task.result
-        for _ in 0..<20 where store.sessions["p"]?.phase == .running {
-            await Task.yield()
-        }
+        try await waitUntil { store.sessions["p"]?.phase == .failed }
 
         #expect(store.sessions["p"]?.phase == .failed)
         #expect(store.sessions["p"]?.error != nil)
@@ -199,11 +256,44 @@ struct GGLandingStoreTests {
         }
 
         store.prune(keepingProjectIds: ["other"])
-        _ = await task.result
+        await store.cancelAllAndWait()
 
         #expect(cancelCount == 1)
         #expect(store.sessions["p"] == nil)
         #expect(store.sessions["other"]?.phase == .running)
+    }
+
+    @Test func terminationWaitsForPrunedOperationCleanup() async {
+        let store = GGLandingStore()
+        let cancellation = AsyncStream<Void>.makeStream()
+        let cleanup = LandingTestSuspension()
+        let task = Task<Void, Error> {
+            for await _ in cancellation.stream {}
+            await cleanup.suspend()
+        }
+        #expect(store.begin(seed()))
+        store.attach(projectId: "p", task: task) {
+            cancellation.continuation.finish()
+        }
+
+        store.prune(keepingProjectIds: [])
+        await cleanup.waitUntilSuspended()
+
+        let started = AsyncStream<Void>.makeStream()
+        var didFinish = false
+        let termination = Task { @MainActor in
+            started.continuation.yield()
+            started.continuation.finish()
+            await store.cancelAllAndWait()
+            didFinish = true
+        }
+        for await _ in started.stream { break }
+        #expect(!didFinish)
+
+        await cleanup.release()
+        await termination.value
+        #expect(didFinish)
+        #expect(store.begin(seed()))
     }
 
     @Test func cancellationIgnoresLateFailureAndAppliesTerminalEntry() async {
@@ -216,10 +306,7 @@ struct GGLandingStoreTests {
         store.receive(.entry(outcome), projectId: "p")
         store.fail(projectId: "p", message: "interrupted")
 
-        _ = await task.result
-        for _ in 0..<20 where store.sessions["p"]?.phase != .cancelled {
-            await Task.yield()
-        }
+        await store.cancelAllAndWait()
 
         #expect(store.sessions["p"]?.phase == .cancelled)
         #expect(store.sessions["p"]?.rows[0].outcome == outcome)


### PR DESCRIPTION
<!-- gg:managed:start -->
Part of stack `gg-land-ui`

Commit: 49ba103
<!-- gg:managed:end -->