### PR TITLE
fix: retain landing cancellation before task attachment

### DIFF
--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -140,7 +140,8 @@ final class GGLandingStore {
         task: Task<Void, Error>,
         cancel: @escaping @MainActor () -> Void
     ) {
-        guard let session = sessions[projectId], session.phase == .running,
+        guard let session = sessions[projectId],
+              session.phase == .running || session.phase == .cancelling,
               operations[projectId] == nil
         else {
             cancel()
@@ -171,12 +172,13 @@ final class GGLandingStore {
             }
         }
         operations[projectId] = Operation(id: operationId, monitor: monitor, cancel: cancel)
+        if session.phase == .cancelling {
+            requestCancellation(projectId: projectId)
+        }
     }
 
     func cancel(projectId: String) {
-        guard var session = sessions[projectId], session.phase == .running,
-              operations[projectId] != nil
-        else { return }
+        guard var session = sessions[projectId], session.phase == .running else { return }
         session.phase = .cancelling
         sessions[projectId] = session
         requestCancellation(projectId: projectId)
@@ -200,11 +202,13 @@ final class GGLandingStore {
     }
 
     func fail(projectId: String, message: String) {
-        guard var session = sessions[projectId], session.phase == .running else { return }
-        session.phase = .failed
+        guard var session = sessions[projectId],
+              session.phase == .running || (session.phase == .cancelling && operations[projectId] == nil)
+        else { return }
+        session.phase = session.phase == .cancelling ? .cancelled : .failed
         session.activeWait = nil
         session.warning = nil
-        session.error = message
+        session.error = session.phase == .cancelled ? nil : message
         sessions[projectId] = session
     }
 

--- a/AlasTests/Integrations/GGLandingStoreTests.swift
+++ b/AlasTests/Integrations/GGLandingStoreTests.swift
@@ -70,6 +70,49 @@ struct GGLandingStoreTests {
         #expect(store.begin(seed(projectId: "other")))
     }
 
+    @Test func cancellationBeforeAttachCancelsRawOperationAndWaitsForCleanup() async {
+        let store = GGLandingStore()
+        let cleanup = LandingTestSuspension()
+        let rawOperation = Task<Void, Error> {
+            await cleanup.suspend()
+            try Task.checkCancellation()
+        }
+        let completion = Task<Void, Error> { try await rawOperation.value }
+        await cleanup.waitUntilSuspended()
+        store.begin(seed())
+        store.cancel(projectId: "p")
+        #expect(store.sessions["p"]?.phase == .cancelling)
+
+        var cancellationCount = 0
+        store.attach(projectId: "p", task: completion) {
+            cancellationCount += 1
+            rawOperation.cancel()
+        }
+        #expect(rawOperation.isCancelled)
+        #expect(!completion.isCancelled)
+        #expect(cancellationCount == 1)
+        store.cancel(projectId: "p")
+        #expect(cancellationCount == 1)
+        #expect(store.sessions["p"]?.phase == .cancelling)
+        #expect(!store.begin(seed()))
+
+        await cleanup.release()
+        await store.waitForOperation(projectId: "p")
+        #expect(store.sessions["p"]?.phase == .cancelled)
+        #expect(store.sessions["p"]?.error == nil)
+        #expect(store.begin(seed()))
+    }
+
+    @Test func preflightFailureAfterCancellationFinishesAsCancelled() {
+        let store = GGLandingStore()
+        store.begin(seed())
+        store.cancel(projectId: "p")
+        store.fail(projectId: "p", message: "Target no longer exists")
+        #expect(store.sessions["p"]?.phase == .cancelled)
+        #expect(store.sessions["p"]?.error == nil)
+        #expect(store.begin(seed()))
+    }
+
     @Test func beginSeedsSessionAndReplacesTerminalAttempt() throws {
         let store = GGLandingStore()
         let startedAt = Date(timeIntervalSince1970: 1_000)


### PR DESCRIPTION
<!-- gg:managed:start -->
Part of stack `gg-land-ui`

Commit: 648059b
<!-- gg:managed:end -->