### PR TITLE
fix: keep landing status across checkouts

### DIFF
--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -22,7 +22,13 @@ struct ChangesTabView: View {
     }
 
     private var preparationModel: ChangesPreparationModel {
-        if isGGDrawerActive {
+        let landingStatus = Self.landingStatus(
+            from: GGLandingStore.shared.sessions[rps.worktree.projectId]
+        )
+        if Self.shouldUseGGPreparation(
+            drawerIsActive: isGGDrawerActive,
+            landingStatus: landingStatus
+        ) {
             return ChangesPreparationModel.makeGG(
                 changes: rps.changes,
                 hasDraft: draftNonEmpty,
@@ -38,9 +44,7 @@ struct ChangesTabView: View {
                 ),
                 mutationError: rps.ggActionState.lastError,
                 reconciliationAction: Self.reconciliationAction(from: ggReadinessModel),
-                landingStatus: Self.landingStatus(
-                    from: GGLandingStore.shared.sessions[rps.worktree.projectId]
-                ),
+                landingStatus: landingStatus,
                 syncProgress: GGStackReadinessModel.syncProgress(
                     action: rps.ggActionState,
                     base: rps.ggStack?.base ?? rps.baseBranch,
@@ -722,6 +726,13 @@ struct ChangesTabView: View {
         hasUndoCandidate: Bool
     ) -> Bool {
         contextIsActive || pausedGGOperation != nil || hasUndoCandidate
+    }
+
+    static func shouldUseGGPreparation(
+        drawerIsActive: Bool,
+        landingStatus: ChangesPreparationModel.GGLandingStatus?
+    ) -> Bool {
+        drawerIsActive || landingStatus != nil
     }
 
     static func shouldShowChangesPreparationCard(

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -433,6 +433,17 @@ struct ChangesTabViewTests {
         #expect(ChangesTabView.landingStatus(from: session) == nil)
     }
 
+    @Test func activeLandingUsesGGPreparationWhenContextIsInactive() throws {
+        let status = try #require(
+            ChangesTabView.landingStatus(from: landingSession(phase: .running))
+        )
+
+        #expect(ChangesTabView.shouldUseGGPreparation(
+            drawerIsActive: false,
+            landingStatus: status
+        ))
+    }
+
     private func stack(
         currentPosition: Int?,
         entries: [GGStackEntry] = [


### PR DESCRIPTION
<!-- gg:managed:start -->
- Resolve active repository landing before GG drawer policy
- Cover inactive GG context during an active landing
<!-- gg:managed:end -->