### PR TITLE
fix: preserve live landing scope on restart

### DIFF
--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -9,6 +9,7 @@ struct GGLandingRow: Equatable, Identifiable, Sendable {
     let position: Int
     let title: String
     let ggId: String?
+    let stableID: String? = nil
     let prNumber: Int?
     var wait: GGLandWait? = nil
     var outcome: GGLandedEntry? = nil

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -446,7 +446,8 @@ final class GGMutationCoordinator {
         return GGPreparedMutation(
             request: request,
             snapshot: identity,
-            confirmation: confirmation(for: request, stack: stack)
+            confirmation: confirmation(for: request, stack: stack),
+            stack: stack
         )
     }
 
@@ -855,11 +856,19 @@ extension GGService: GGMutationExecuting {
         case .land(let target):
             if supportsLandJSONL {
                 do {
-                    var summary: GGLandResult?
-                    for try await event in service.landStream(worktreePath: worktreePath, until: target) {
-                        onLandEvent(event)
-                        if case .summary(let result) = event { summary = result }
+                    let stream = service.landStream(worktreePath: worktreePath, until: target)
+                    let consume = Task {
+                        var summary: GGLandResult?
+                        for try await event in stream.events {
+                            onLandEvent(event)
+                            if case .summary(let result) = event { summary = result }
+                        }
+                        return summary
                     }
+                    let summary = try await withTaskCancellationHandler(
+                        operation: { try await consume.value },
+                        onCancel: stream.cancel
+                    )
                     try Task.checkCancellation()
                     guard let summary else {
                         throw GGServiceError.malformedOutput("gg land ended without a summary.")

--- a/Alas/Sources/Integrations/GG/GGMutationModels.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationModels.swift
@@ -107,6 +107,7 @@ struct GGPreparedMutation: Equatable, Sendable {
     var request: GGMutationRequest
     var snapshot: GGStackIdentity
     var confirmation: GGMutationConfirmation?
+    var stack: GGStack? = nil
 }
 
 struct GGPreparedRestack: Equatable, Sendable {

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -20,6 +20,15 @@ extension GGCommandRunning {
     func runStreaming(
         args: [String],
         cwd: URL?,
+        timeout: TimeInterval?,
+        interruption: GGStreamingCancellation?
+    ) -> AsyncThrowingStream<String, Error> {
+        runStreaming(args: args, cwd: cwd, timeout: timeout)
+    }
+
+    func runStreaming(
+        args: [String],
+        cwd: URL?,
         timeout: TimeInterval?
     ) -> AsyncThrowingStream<String, Error> {
         runStreaming(args: args, cwd: cwd)
@@ -98,6 +107,22 @@ struct ProcessGGCommandRunner: GGCommandRunning {
         Self.streamProcess(executable: "/usr/bin/env", args: ["gg"] + args, cwd: cwd, env: Process.gitEnv(), timeout: timeout)
     }
 
+    func runStreaming(
+        args: [String],
+        cwd: URL?,
+        timeout: TimeInterval?,
+        interruption: GGStreamingCancellation?
+    ) -> AsyncThrowingStream<String, Error> {
+        Self.streamProcess(
+            executable: "/usr/bin/env",
+            args: ["gg"] + args,
+            cwd: cwd,
+            env: Process.gitEnv(),
+            timeout: timeout,
+            interruption: interruption
+        )
+    }
+
     /// Pipe-lifecycle core of `runStreaming`, parameterized on the
     /// executable/args so tests can exercise the readability-handler /
     /// write-end-close pattern against a trivial subprocess (e.g.
@@ -108,7 +133,8 @@ struct ProcessGGCommandRunner: GGCommandRunning {
         args: [String],
         cwd: URL?,
         env: [String: String]?,
-        timeout: TimeInterval? = Process.defaultTimeout
+        timeout: TimeInterval? = Process.defaultTimeout,
+        interruption: GGStreamingCancellation? = nil
     ) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             let processTreeID = UUID().uuidString
@@ -189,6 +215,8 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                     async let outClosed = stdoutEOF.waitForClose(timeoutNanoseconds: 2_000_000_000)
                     async let errClosed = stderrAccum.waitForClose(timeoutNanoseconds: 2_000_000_000)
                     _ = await (outClosed, errClosed)
+                    outPipe.fileHandleForReading.readabilityHandler = nil
+                    errPipe.fileHandleForReading.readabilityHandler = nil
                     if timeoutState.didTimeOut, let timeout {
                         continuation.finish(throwing: ProcessError.timedOut(executable: executable, args: args, seconds: timeout))
                     } else if status == 0 {
@@ -220,6 +248,7 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                     rootIdentity: rootIdentity,
                     wrapperIdentity: wrapperIdentity
                 )
+                interruption?.install { processTree.interruptAndWait() }
                 let watchdog = timeout.map { timeout in
                     Task {
                         try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
@@ -236,6 +265,7 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                 }
                 continuation.onTermination = { termination in
                     watchdog?.cancel()
+                    interruption?.cancel()
                     switch termination {
                     case .cancelled:
                         processTree.interruptAndWait()
@@ -244,8 +274,6 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                     @unknown default:
                         processTree.terminateAndWait()
                     }
-                    outPipe.fileHandleForReading.readabilityHandler = nil
-                    errPipe.fileHandleForReading.readabilityHandler = nil
                 }
                 installStdoutHandler()
                 try? launchGate.fileHandleForWriting.write(contentsOf: Data([0x0A]))
@@ -303,6 +331,28 @@ private final class GGStreamingTimeoutState: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return timedOut
+    }
+}
+
+final class GGStreamingCancellation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var interrupt: (() -> Void)?
+    private var requested = false
+
+    func install(_ interrupt: @escaping () -> Void) {
+        lock.lock()
+        self.interrupt = interrupt
+        let requested = requested
+        lock.unlock()
+        if requested { interrupt() }
+    }
+
+    func cancel() {
+        lock.lock()
+        requested = true
+        let interrupt = interrupt
+        lock.unlock()
+        interrupt?()
     }
 }
 
@@ -629,15 +679,17 @@ struct GGService {
         // decode) and anything else still propagate.
     }
 
-    func landStream(worktreePath: String, until: String) -> AsyncThrowingStream<GGLandEvent, Error> {
-        AsyncThrowingStream { continuation in
+    func landStream(worktreePath: String, until: String) -> GGLandStream {
+        let interruption = GGStreamingCancellation()
+        let events = AsyncThrowingStream { continuation in
             let producer = Task {
                 var validator = GGLandStreamValidator()
                 do {
                     for try await line in runner.runStreaming(
                         args: ["land", "--until", until, "--wait", "--jsonl", "--no-clean"],
                         cwd: URL(fileURLWithPath: worktreePath),
-                        timeout: nil
+                        timeout: nil,
+                        interruption: interruption
                     ) {
                         let event = try GGLandEvent.decode(line: line)
                         try validator.accept(event)
@@ -652,8 +704,12 @@ struct GGService {
                     continuation.finish(throwing: error)
                 }
             }
-            continuation.onTermination = { _ in producer.cancel() }
+            continuation.onTermination = { _ in
+                interruption.cancel()
+                producer.cancel()
+            }
         }
+        return GGLandStream(events: events, cancel: interruption.cancel)
     }
 
     func clean(worktreePath: String) async throws {
@@ -919,6 +975,11 @@ struct GGService {
             return nil
         }
     }
+}
+
+struct GGLandStream {
+    let events: AsyncThrowingStream<GGLandEvent, Error>
+    let cancel: @Sendable () -> Void
 }
 
 private struct GGLandStreamValidator {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1898,6 +1898,9 @@ final class RightPaneState: GGSplitCommitServicing {
                 }
                 let prepared = try await ggMutationCoordinator.prepare(.land(target: target))
                 try Task.checkCancellation()
+                guard let stack = prepared.stack,
+                      Self.ggLandingScopeMatches(session, target: target, stack: stack)
+                else { throw GGMutationError.staleConfirmation }
                 guard ggLandingStore.sessions[projectId]?.id == sessionId else { return }
                 startGGLanding(prepared)
             } catch {
@@ -1916,8 +1919,41 @@ final class RightPaneState: GGSplitCommitServicing {
             stack: stack.name, base: stack.base, target: target,
             rows: stack.entries.filter { $0.position <= entry.position }
                 .sorted { $0.position < $1.position }
-                .map { GGLandingRow(position: $0.position, title: $0.title, ggId: $0.ggId, prNumber: $0.prNumber) }
+                .map {
+                    GGLandingRow(
+                        position: $0.position,
+                        title: $0.title,
+                        ggId: $0.ggId,
+                        stableID: $0.id,
+                        prNumber: $0.prNumber
+                    )
+                }
         )
+    }
+
+    private static func ggLandingScopeMatches(
+        _ session: GGLandingSession,
+        target: String,
+        stack: GGStack
+    ) -> Bool {
+        guard target == session.target,
+              stack.name == session.stack,
+              stack.base == session.base,
+              let targetEntry = stack.entries.first(where: { $0.id == target || $0.sha == target })
+        else { return false }
+        let originalIDs = session.rows.compactMap { $0.stableID ?? $0.ggId }
+        guard originalIDs.count == session.rows.count,
+              originalIDs.last == target,
+              let currentTargetIndex = stack.entries.firstIndex(of: targetEntry)
+        else { return false }
+        let currentIDs = stack.entries[..<currentTargetIndex].map(\.id) + [targetEntry.id]
+        guard currentIDs.allSatisfy(originalIDs.contains) else { return false }
+        var nextOriginalIndex = 0
+        for id in currentIDs {
+            guard let index = originalIDs[nextOriginalIndex...].firstIndex(of: id) else { return false }
+            nextOriginalIndex = index + 1
+        }
+        return true
     }
 
     private func startGGLanding(_ prepared: GGPreparedMutation) {

--- a/AlasTests/Integrations/GGCommandRunningStreamingTests.swift
+++ b/AlasTests/Integrations/GGCommandRunningStreamingTests.swift
@@ -2,6 +2,13 @@ import Foundation
 import Testing
 @testable import Alas
 
+private actor StreamLines {
+    private var values: [String] = []
+
+    func append(_ value: String) { values.append(value) }
+    func contains(_ value: String) -> Bool { values.contains(value) }
+}
+
 /// Exercises `ProcessGGCommandRunner`'s pipe-lifecycle handling (readability
 /// handlers on both stdout/stderr, closing the parent's write ends after
 /// `process.run()`) against a trivial `/bin/sh` subprocess. This does not
@@ -229,6 +236,31 @@ struct GGCommandRunningStreamingTests {
             try await Task.sleep(for: .milliseconds(10))
         }
         #expect(FileManager.default.fileExists(atPath: interrupted.path))
+    }
+
+    @Test func cancellingStreamDrainsTerminalStdoutBeforeFinishing() async throws {
+        let ready = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gg-stream-ready-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: ready) }
+        let interruption = GGStreamingCancellation()
+        let stream = ProcessGGCommandRunner.streamProcess(
+            executable: "/bin/sh",
+            args: ["-c", "trap 'printf terminal\\n; exit 130' INT; printf ready > \"$1\"; printf ready\\n; while :; do sleep 1; done", "alas", ready.path],
+            cwd: nil,
+            env: nil,
+            timeout: nil,
+            interruption: interruption
+        )
+        let lines = StreamLines()
+        let consumer = Task {
+            for try await line in stream { await lines.append(line) }
+        }
+        for _ in 0..<200 where !FileManager.default.fileExists(atPath: ready.path) {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        interruption.cancel()
+        _ = try? await consumer.value
+        #expect(await lines.contains("terminal"))
     }
 
     @Test func streamingRunTimesOutHungProcess() async throws {

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -126,7 +126,7 @@ struct GGServiceActionsTests {
             #"{"version":1,"command":"land","status":"ok","event":"summary","stack":"s","base":"main","landed":[],"remaining":1,"cleaned":false,"warnings":[],"error":null}"#,
         ]
         var events: [GGLandEvent] = []
-        for try await event in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc") {
+        for try await event in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc").events {
             events.append(event)
         }
         #expect(events.count == 3)
@@ -164,7 +164,7 @@ struct GGServiceActionsTests {
         let runner = RecordingGGRunner()
         runner.streamingLines = lines
         await #expect(throws: GGServiceError.self) {
-            for try await _ in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc") {}
+            for try await _ in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc").events {}
         }
     }
 
@@ -175,7 +175,7 @@ struct GGServiceActionsTests {
             #"{"version":1,"command":"land","status":"ok","event":"summary","stack":"other","base":"main","landed":[],"remaining":1,"cleaned":false,"warnings":[],"error":null}"#,
         ]
         await #expect(throws: GGServiceError.malformedOutput("gg land summary did not match start identity.")) {
-            for try await _ in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc") {}
+            for try await _ in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc").events {}
         }
     }
 
@@ -186,7 +186,7 @@ struct GGServiceActionsTests {
         ]
         var events: [GGLandEvent] = []
         await #expect(throws: GGServiceError.commandFailed(stderr: "setup failed")) {
-            for try await event in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc") {
+            for try await event in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc").events {
                 events.append(event)
             }
         }
@@ -196,7 +196,7 @@ struct GGServiceActionsTests {
     @Test func landJSONLPropagatesConsumerCancellation() async throws {
         let runner = CancellableLandGGRunner()
         let task = Task {
-            for try await _ in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc") {
+            for try await _ in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc").events {
                 try Task.checkCancellation()
             }
         }

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -27,20 +27,22 @@ private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {
     private var recordedCalls: [[String]] = []
     private var cancellations = 0
     private var targetExists = true
+    private var stackOutput = Self.stackJSON
     private var nextPreflight: LandPreflightSuspension?
     private var continuations: [AsyncThrowingStream<String, Error>.Continuation] = []
     var calls: [[String]] { lock.withLock { recordedCalls } }
     var cancellationCount: Int { lock.withLock { cancellations } }
 
     func removeTarget() { lock.withLock { targetExists = false } }
+    func replaceStack(with output: String) { lock.withLock { stackOutput = output } }
     func suspendNextPreflight(_ preflight: LandPreflightSuspension) {
         lock.withLock { nextPreflight = preflight }
     }
 
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
-        let hasTarget = lock.withLock {
+        let (hasTarget, stackOutput) = lock.withLock {
             recordedCalls.append(args)
-            return targetExists
+            return (targetExists, stackOutput)
         }
         if args.first == "ls" {
             let preflight = lock.withLock {
@@ -55,7 +57,7 @@ private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {
         } else if args.first == "undo" {
             stdout = #"{"version":1,"operations":[]}"#
         } else {
-            stdout = hasTarget ? Self.stackJSON : Self.stackJSON.replacingOccurrences(of: "change-1", with: "replacement")
+            stdout = hasTarget ? stackOutput : stackOutput.replacingOccurrences(of: "change-1", with: "replacement")
         }
         return ProcessResult(exitCode: 0, stdout: stdout, stderr: "")
     }
@@ -68,6 +70,24 @@ private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {
                 guard let self else { return }
                 self.lock.withLock { self.cancellations += 1 }
             }
+            continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"start","stack":"feat","base":"main","total_entries":1}"#)
+        }
+    }
+
+    func runStreaming(
+        args: [String],
+        cwd: URL?,
+        timeout: TimeInterval?,
+        interruption: GGStreamingCancellation?
+    ) -> AsyncThrowingStream<String, Error> {
+        lock.withLock { recordedCalls.append(args) }
+        return AsyncThrowingStream { continuation in
+            lock.withLock { continuations.append(continuation) }
+            continuation.onTermination = { [weak self] _ in
+                guard let self else { return }
+                self.lock.withLock { self.cancellations += 1 }
+            }
+            interruption?.install { continuation.finish(throwing: CancellationError()) }
             continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"start","stack":"feat","base":"main","total_entries":1}"#)
         }
     }
@@ -309,6 +329,22 @@ struct RightPaneGGLandTests {
         try await waitForLand { store.sessions["live-project"]?.phase == .failed }
         #expect(runner.calls.filter { $0.first == "land" }.count == 2)
         #expect(store.sessions["live-project"]?.error != nil)
+    }
+
+    @Test func restartRejectsChangedScopeWithStableTarget() async throws {
+        let store = GGLandingStore()
+        let runner = LiveLandGGRunner()
+        let state = landingState(store: store, runner: runner, supported: true)
+        state.requestGGLand(.ready)
+        try await waitForLand { state.pendingGGLand != nil }
+        state.performGGLand(appState: AppState(store: MemoryStore()))
+        try await waitForLand { runner.calls.contains { $0.first == "land" } }
+        await store.cancelAllAndWait()
+
+        runner.replaceStack(with: LiveLandGGRunner.stackJSON.replacingOccurrences(of: "\"base\":\"main\"", with: "\"base\":\"release\""))
+        state.restartGGLand(target: "change-1")
+        try await waitForLand { store.sessions["live-project"]?.phase == .failed }
+        #expect(runner.calls.filter { $0.first == "land" }.count == 1)
     }
 
     private func entry(id: String, prState: GGPRState, approved: Bool, ci: GGCIStatus?) -> GGStackEntry {


### PR DESCRIPTION
<!-- gg:managed:start -->
Part of stack `gg-land-ui`

Commit: 08c5655
<!-- gg:managed:end -->