### PR TITLE
fix: retain landing scope and drain cancellation

### DIFF
--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -9,7 +9,7 @@ struct GGLandingRow: Equatable, Identifiable, Sendable {
     let position: Int
     let title: String
     let ggId: String?
-    let stableID: String? = nil
+    var stableID: String? = nil
     let prNumber: Int?
     var wait: GGLandWait? = nil
     var outcome: GGLandedEntry? = nil
@@ -18,7 +18,7 @@ struct GGLandingRow: Equatable, Identifiable, Sendable {
 }
 
 struct GGLandingSession: Equatable, Identifiable, Sendable {
-    struct Seed: Sendable {
+    struct Seed: Equatable, Sendable {
         let projectId: String
         let worktreeId: String
         let stack: String
@@ -33,6 +33,7 @@ struct GGLandingSession: Equatable, Identifiable, Sendable {
     let stack: String
     let base: String
     let target: String
+    let confirmedScope: Seed
     let startedAt: Date
     var rows: [GGLandingRow]
     var phase: GGLandingPhase
@@ -75,6 +76,7 @@ final class GGLandingStore {
             stack: seed.stack,
             base: seed.base,
             target: seed.target,
+            confirmedScope: seed,
             startedAt: now,
             rows: seed.rows,
             phase: .running,
@@ -84,6 +86,11 @@ final class GGLandingStore {
             error: nil
         )
         return true
+    }
+
+    func updatePendingRows(_ rows: [GGLandingRow], projectId: String) {
+        guard sessions[projectId]?.phase == .running else { return }
+        sessions[projectId]?.rows = rows
     }
 
     func receive(_ event: GGLandEvent, projectId: String) {

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -36,7 +36,7 @@ protocol GGMutationExecuting {
         supportsSyncJSONL: Bool,
         supportsLandJSONL: Bool,
         onSyncEvent: (GGSyncEvent) -> Void,
-        onLandEvent: (GGLandEvent) -> Void
+        onLandEvent: @escaping (GGLandEvent) -> Void
     ) async throws -> GGMutationExecutionResult
     func listUndoOperations(worktreePath: String, limit: Int) async throws -> [GGOperationSummary]
     func previewRestack(worktreePath: String) async throws -> GGRestackResult
@@ -819,7 +819,7 @@ extension GGService: GGMutationExecuting {
         supportsSyncJSONL: Bool,
         supportsLandJSONL: Bool,
         onSyncEvent: (GGSyncEvent) -> Void,
-        onLandEvent: (GGLandEvent) -> Void
+        onLandEvent: @escaping (GGLandEvent) -> Void
     ) async throws -> GGMutationExecutionResult {
         let service = clientOperationID.map {
             GGService(runner: GGClientOperationRunner(base: runner, clientOperationID: $0))

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -14,6 +14,12 @@ protocol GGCommandRunning: Sendable {
         cwd: URL?,
         timeout: TimeInterval?
     ) -> AsyncThrowingStream<String, Error>
+    func runStreaming(
+        args: [String],
+        cwd: URL?,
+        timeout: TimeInterval?,
+        interruption: GGStreamingCancellation?
+    ) -> AsyncThrowingStream<String, Error>
 }
 
 extension GGCommandRunning {
@@ -23,7 +29,20 @@ extension GGCommandRunning {
         timeout: TimeInterval?,
         interruption: GGStreamingCancellation?
     ) -> AsyncThrowingStream<String, Error> {
-        runStreaming(args: args, cwd: cwd, timeout: timeout)
+        AsyncThrowingStream { continuation in
+            let consumer = Task {
+                do {
+                    for try await line in runStreaming(args: args, cwd: cwd, timeout: timeout) {
+                        continuation.yield(line)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            interruption?.install { consumer.cancel() }
+            continuation.onTermination = { _ in consumer.cancel() }
+        }
     }
 
     func runStreaming(
@@ -248,7 +267,9 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                     rootIdentity: rootIdentity,
                     wrapperIdentity: wrapperIdentity
                 )
-                interruption?.install { processTree.interruptAndWait() }
+                interruption?.install {
+                    Task.detached { processTree.interruptAndWait() }
+                }
                 let watchdog = timeout.map { timeout in
                     Task {
                         try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
@@ -709,7 +730,7 @@ struct GGService {
                 producer.cancel()
             }
         }
-        return GGLandStream(events: events, cancel: interruption.cancel)
+        return GGLandStream(events: events, cancel: { interruption.cancel() })
     }
 
     func clean(worktreePath: String) async throws {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1883,14 +1883,7 @@ final class RightPaneState: GGSplitCommitServicing {
             await ggLandingStore.waitForOperation(projectId: projectId)
             guard !Task.isCancelled else { return }
             guard ggLandingStore.sessions[projectId]?.id == session.id else { return }
-            let seed = ggLandingSeed(target: target) ?? GGLandingSession.Seed(
-                projectId: projectId, worktreeId: worktree.id,
-                stack: session.stack, base: session.base, target: target,
-                rows: session.rows.map {
-                    GGLandingRow(position: $0.position, title: $0.title, ggId: $0.ggId, prNumber: $0.prNumber)
-                }
-            )
-            guard ggLandingStore.begin(seed) else { return }
+            guard ggLandingStore.begin(session.confirmedScope) else { return }
             let sessionId = ggLandingStore.sessions[projectId]?.id
             do {
                 guard ggCapabilities().landJSONL else {
@@ -1899,9 +1892,11 @@ final class RightPaneState: GGSplitCommitServicing {
                 let prepared = try await ggMutationCoordinator.prepare(.land(target: target))
                 try Task.checkCancellation()
                 guard let stack = prepared.stack,
-                      Self.ggLandingScopeMatches(session, target: target, stack: stack)
+                      Self.ggLandingScopeMatches(session.confirmedScope, target: target, stack: stack),
+                      let seed = ggLandingSeed(target: target, stack: stack)
                 else { throw GGMutationError.staleConfirmation }
                 guard ggLandingStore.sessions[projectId]?.id == sessionId else { return }
+                ggLandingStore.updatePendingRows(seed.rows, projectId: projectId)
                 startGGLanding(prepared)
             } catch {
                 guard ggLandingStore.sessions[projectId]?.id == sessionId else { return }
@@ -1910,8 +1905,8 @@ final class RightPaneState: GGSplitCommitServicing {
         }
     }
 
-    private func ggLandingSeed(target: String) -> GGLandingSession.Seed? {
-        guard let stack = ggStack,
+    private func ggLandingSeed(target: String, stack: GGStack? = nil) -> GGLandingSession.Seed? {
+        guard let stack = stack ?? ggStack,
               let entry = stack.entries.first(where: { $0.id == target || $0.sha == target })
         else { return nil }
         return GGLandingSession.Seed(
@@ -1932,7 +1927,7 @@ final class RightPaneState: GGSplitCommitServicing {
     }
 
     private static func ggLandingScopeMatches(
-        _ session: GGLandingSession,
+        _ session: GGLandingSession.Seed,
         target: String,
         stack: GGStack
     ) -> Bool {
@@ -1943,17 +1938,12 @@ final class RightPaneState: GGSplitCommitServicing {
         else { return false }
         let originalIDs = session.rows.compactMap { $0.stableID ?? $0.ggId }
         guard originalIDs.count == session.rows.count,
-              originalIDs.last == target,
-              let currentTargetIndex = stack.entries.firstIndex(of: targetEntry)
+              originalIDs.last == targetEntry.id
         else { return false }
-        let currentIDs = stack.entries[..<currentTargetIndex].map(\.id) + [targetEntry.id]
-        guard currentIDs.allSatisfy(originalIDs.contains) else { return false }
-        var nextOriginalIndex = 0
-        for id in currentIDs {
-            guard let index = originalIDs[nextOriginalIndex...].firstIndex(of: id) else { return false }
-            nextOriginalIndex = index + 1
-        }
-        return true
+        let currentIDs = stack.entries.sorted { $0.position < $1.position }
+            .filter { $0.position <= targetEntry.position }.map(\.id)
+        let remainingIDs = Set(stack.entries.map(\.id))
+        return currentIDs == originalIDs.filter { remainingIDs.contains($0) }
     }
 
     private func startGGLanding(_ prepared: GGPreparedMutation) {

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -507,6 +507,10 @@ struct ChangesTabViewTests {
             stack: "feat",
             base: "main",
             target: "stack",
+            confirmedScope: .init(
+                projectId: "project", worktreeId: "worktree", stack: "feat",
+                base: "main", target: "stack", rows: []
+            ),
             startedAt: Date(timeIntervalSince1970: 0),
             rows: [
                 GGLandingRow(position: 1, title: "First", ggId: nil, prNumber: 41),

--- a/AlasTests/Integrations/GGCommandRunningStreamingTests.swift
+++ b/AlasTests/Integrations/GGCommandRunningStreamingTests.swift
@@ -147,7 +147,7 @@ struct GGCommandRunningStreamingTests {
             range: wrapperIdentity.upperBound ..< serviceSource.endIndex
         ))
         let release = try #require(serviceSource.range(of: "launchGate.fileHandleForWriting.write", range: start.upperBound ..< serviceSource.endIndex))
-        let cleanup = try #require(serviceSource.range(of: "continuation.onTermination ="))
+        let cleanup = try #require(serviceSource.range(of: "continuation.onTermination =", range: start.upperBound ..< serviceSource.endIndex))
         #expect(run.lowerBound < identity.lowerBound)
         #expect(closeWriter.lowerBound < launchedPID.lowerBound)
         #expect(launchedPID.lowerBound < identity.lowerBound)
@@ -245,7 +245,7 @@ struct GGCommandRunningStreamingTests {
         let interruption = GGStreamingCancellation()
         let stream = ProcessGGCommandRunner.streamProcess(
             executable: "/bin/sh",
-            args: ["-c", "trap 'printf terminal\\n; exit 130' INT; printf ready > \"$1\"; printf ready\\n; while :; do sleep 1; done", "alas", ready.path],
+            args: ["-c", #"trap 'printf "%s\n" terminal; exit 130' INT; printf ready > "$1"; printf '%s\n' ready; while :; do sleep 1; done"#, "alas", ready.path],
             cwd: nil,
             env: nil,
             timeout: nil,

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -59,7 +59,8 @@ private final class CancellableLandGGRunner: GGCommandRunning, @unchecked Sendab
     func runStreaming(
         args: [String],
         cwd: URL?,
-        timeout: TimeInterval?
+        timeout: TimeInterval?,
+        interruption: GGStreamingCancellation?
     ) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             self.lock.lock()
@@ -70,6 +71,10 @@ private final class CancellableLandGGRunner: GGCommandRunning, @unchecked Sendab
                 self?.lock.lock()
                 self?.cancelled = true
                 self?.lock.unlock()
+            }
+            interruption?.install {
+                continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"entry","position":1,"pr_number":5,"action":"merged"}"#)
+                continuation.finish(throwing: CancellationError())
             }
         }
     }
@@ -204,6 +209,28 @@ struct GGServiceActionsTests {
         task.cancel()
         _ = try? await task.value
         #expect(await runner.cancellationObserved())
+    }
+
+    @Test func landJSONLInterruptDrainsTerminalEntryThroughRunnerExistential() async {
+        let stream = GGService(runner: CancellableLandGGRunner())
+            .landStream(worktreePath: "/tmp/wt", until: "c-abc")
+        let consumer = Task {
+            var entries: [GGLandedEntry] = []
+            do {
+                for try await event in stream.events {
+                    if case .start = event { stream.cancel() }
+                    if case .entry(let entry) = event { entries.append(entry) }
+                }
+            } catch {}
+            return entries
+        }
+        let watchdog = Task {
+            try? await Task.sleep(for: .seconds(5))
+            if !Task.isCancelled { consumer.cancel() }
+        }
+        let entries = await consumer.value
+        watchdog.cancel()
+        #expect(entries == [.init(position: 1, prNumber: 5, action: "merged")])
     }
 
     @Test func syncStreamsParsedEventsFromDefaultRunner() async throws {
@@ -454,7 +481,9 @@ struct GGServiceActionsTests {
             worktreePath: "/repo",
             clientOperationID: "alas:1234",
             supportsSyncJSONL: false,
-            onSyncEvent: { _ in }
+            supportsLandJSONL: false,
+            onSyncEvent: { _ in },
+            onLandEvent: { _ in }
         )
 
         #expect(runner.calls == [["--client-operation-id", "alas:1234", "sc", "--staged-only"]])
@@ -470,7 +499,9 @@ struct GGServiceActionsTests {
             worktreePath: "/repo",
             clientOperationID: nil,
             supportsSyncJSONL: false,
-            onSyncEvent: { _ in }
+            supportsLandJSONL: false,
+            onSyncEvent: { _ in },
+            onLandEvent: { _ in }
         )
 
         #expect(runner.calls == [["sc", "--staged-only"]])

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -27,7 +27,7 @@ private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {
     private var recordedCalls: [[String]] = []
     private var cancellations = 0
     private var targetExists = true
-    private var stackOutput = Self.stackJSON
+    private var stackOutput = LiveLandGGRunner.stackJSON
     private var nextPreflight: LandPreflightSuspension?
     private var continuations: [AsyncThrowingStream<String, Error>.Continuation] = []
     var calls: [[String]] { lock.withLock { recordedCalls } }
@@ -42,7 +42,7 @@ private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
         let (hasTarget, stackOutput) = lock.withLock {
             recordedCalls.append(args)
-            return (targetExists, stackOutput)
+            return (targetExists, self.stackOutput)
         }
         if args.first == "ls" {
             let preflight = lock.withLock {
@@ -63,15 +63,7 @@ private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {
     }
 
     func runStreaming(args: [String], cwd: URL?, timeout: TimeInterval?) -> AsyncThrowingStream<String, Error> {
-        lock.withLock { recordedCalls.append(args) }
-        return AsyncThrowingStream { continuation in
-            lock.withLock { continuations.append(continuation) }
-            continuation.onTermination = { [weak self] _ in
-                guard let self else { return }
-                self.lock.withLock { self.cancellations += 1 }
-            }
-            continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"start","stack":"feat","base":"main","total_entries":1}"#)
-        }
+        runStreaming(args: args, cwd: cwd, timeout: timeout, interruption: nil)
     }
 
     func runStreaming(
@@ -87,8 +79,11 @@ private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {
                 guard let self else { return }
                 self.lock.withLock { self.cancellations += 1 }
             }
-            interruption?.install { continuation.finish(throwing: CancellationError()) }
             continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"start","stack":"feat","base":"main","total_entries":1}"#)
+            interruption?.install {
+                continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"entry","position":1,"pr_number":5,"action":"merged"}"#)
+                continuation.finish(throwing: CancellationError())
+            }
         }
     }
 
@@ -213,6 +208,7 @@ struct RightPaneGGLandTests {
         await store.waitForOperation(projectId: "live-project")
         #expect(runner.cancellationCount == 1)
         #expect(store.sessions["live-project"]?.phase == .cancelled)
+        #expect(store.sessions["live-project"]?.rows.first?.outcome?.action == "merged")
         #expect(state.ggActionState.lastError == nil)
     }
 
@@ -331,20 +327,64 @@ struct RightPaneGGLandTests {
         #expect(store.sessions["live-project"]?.error != nil)
     }
 
-    @Test func restartRejectsChangedScopeWithStableTarget() async throws {
+    @Test func restartSkipsMissingEntriesAndKeepsOriginalScope() async throws {
         let store = GGLandingStore()
         let runner = LiveLandGGRunner()
         let state = landingState(store: store, runner: runner, supported: true)
-        state.requestGGLand(.ready)
-        try await waitForLand { state.pendingGGLand != nil }
-        state.performGGLand(appState: AppState(store: MemoryStore()))
-        try await waitForLand { runner.calls.contains { $0.first == "land" } }
-        await store.cancelAllAndWait()
+        store.begin(.init(
+            projectId: "live-project", worktreeId: "live-wt", stack: "feat", base: "main",
+            target: "change-1", rows: [
+                .init(position: 1, title: "Lower", ggId: "lower", prNumber: 4),
+                .init(position: 2, title: "Target", ggId: "change-1", prNumber: 5),
+            ]
+        ))
+        store.receive(.entry(.init(position: 1, prNumber: 4, action: "merged")), projectId: "live-project")
+        store.fail(projectId: "live-project", message: "Previous attempt failed")
 
-        runner.replaceStack(with: LiveLandGGRunner.stackJSON.replacingOccurrences(of: "\"base\":\"main\"", with: "\"base\":\"release\""))
-        state.restartGGLand(target: "change-1")
-        try await waitForLand { store.sessions["live-project"]?.phase == .failed }
-        #expect(runner.calls.filter { $0.first == "land" }.count == 1)
+        for attempt in 1...2 {
+            state.restartGGLand(target: "change-1")
+            try await waitForLand { runner.calls.filter { $0.first == "land" }.count == attempt }
+            #expect(store.sessions["live-project"]?.rows.count == 1)
+            #expect(store.sessions["live-project"]?.rows.first?.position == 1)
+            #expect(store.sessions["live-project"]?.confirmedScope.rows.map(\.ggId) == ["lower", "change-1"])
+            await store.cancelAllAndWait()
+            #expect(store.sessions["live-project"]?.phase == .cancelled)
+            #expect(store.sessions["live-project"]?.rows.first?.outcome?.action == "merged")
+        }
+    }
+
+    @Test(arguments: ["base", "lower", "above-target"])
+    func repeatedRestartRejectsChangedScopeWithStableTarget(change: String) async throws {
+        let store = GGLandingStore()
+        let runner = LiveLandGGRunner()
+        let state = landingState(store: store, runner: runner, supported: true)
+        store.begin(.init(
+            projectId: "live-project", worktreeId: "live-wt", stack: "feat", base: "main",
+            target: "change-1", rows: [
+                .init(position: 1, title: "Lower", ggId: "lower", prNumber: 4),
+                .init(position: 2, title: "Target", ggId: "change-1", prNumber: 5),
+            ]
+        ))
+        store.fail(projectId: "live-project", message: "Previous attempt failed")
+        let base = change == "base" ? "release" : "main"
+        let lowerID = change == "lower" ? "replacement" : "lower"
+        let lowerPosition = change == "above-target" ? 3 : 1
+        let output = #"{"version":1,"stack":{"name":"feat","base":"\#(base)","total_commits":2,"synced_commits":2,"entries":[{"position":\#(lowerPosition),"sha":"l","title":"Lower","gg_id":"\#(lowerID)","pr_number":4,"pr_state":"open","approved":true},{"position":2,"sha":"s","title":"Target","gg_id":"change-1","pr_number":5,"pr_state":"open","approved":true}]}}"#
+        runner.replaceStack(with: output)
+        state.ggStack = try GGStackSnapshot.decode(fromJSON: Data(output.utf8)).stack
+
+        for _ in 0..<2 {
+            let previousID = store.sessions["live-project"]?.id
+            state.restartGGLand(target: "change-1")
+            try await waitForLand { store.sessions["live-project"]?.id != previousID }
+            try await waitForLand {
+                store.sessions["live-project"]?.phase == .failed || runner.calls.contains { $0.first == "land" }
+            }
+            #expect(store.sessions["live-project"]?.phase == .failed)
+            #expect(!runner.calls.contains { $0.first == "land" })
+            #expect(store.sessions["live-project"]?.base == "main")
+            await store.cancelAllAndWait()
+        }
     }
 
     private func entry(id: String, prState: GGPRState, approved: Bool, ci: GGCIStatus?) -> GGStackEntry {


### PR DESCRIPTION
<!-- gg:managed:start -->
- Preserve the confirmed scope across repeated restart attempts.
- Dispatch interruption through the runner protocol and retain final events.
- Repair callback and fixture compilation and cover restart regressions.
<!-- gg:managed:end -->