### PR TITLE
feat(land): show live gg landing progress

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -366,6 +366,7 @@
 		376A08C73011C5CA9E445C4B /* ImageDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7D83CD76ABF9FED3B29F62 /* ImageDiffView.swift */; };
 		377280589802FA5CFA45B065 /* ReviewSessionSelectionPersister.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4556BB4983FEF2A4E4A12D /* ReviewSessionSelectionPersister.swift */; };
 		37DD3F3B818131973DAA2B9B /* ACPMessageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F79A184C86BE6C6BF72EB57 /* ACPMessageList.swift */; };
+		385D919650403F661CCE822C /* GGLandingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E3BD9A15E5E342941AF18B /* GGLandingStore.swift */; };
 		387EF12B6875648E422956F7 /* Highlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */; };
 		38866738CF237752206551FE /* CenterTabCompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8A59CAEF838F42C43EDE4C /* CenterTabCompositionTests.swift */; };
 		38A19A8CE98216F87C522952 /* DiffCodeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50700F7960B44D0116F09C8 /* DiffCodeText.swift */; };
@@ -843,6 +844,7 @@
 		83A76F6425CD1406DA85B0E9 /* ACPUserScrollEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0535D92433898E76670B9FF0 /* ACPUserScrollEventTests.swift */; };
 		83A9882DD3D7FF85A18C1B18 /* ACPSessionForkRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F9D4F91573E92AE4964353 /* ACPSessionForkRunnerTests.swift */; };
 		84103C99FE430DB2B36982D1 /* OpenSessionsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE35A47BA74E306A4699B27D /* OpenSessionsSection.swift */; };
+		842D223625D5B836AEBB9B1A /* GGLandingStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E74C405A6008FAD5837C1E /* GGLandingStoreTests.swift */; };
 		847356E199302CCFDA9172DA /* ACPMCPStatusPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64221361A2743CDAD692E64 /* ACPMCPStatusPolicyTests.swift */; };
 		847843D79763F873038C0C44 /* IssueAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CCEE8596C0788C6FC3A8B52 /* IssueAttachment.swift */; };
 		84AFBFC844DF35AF5D37445B /* ACPGoalPillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA7FA6A8011D88FDFEE30A0 /* ACPGoalPillTests.swift */; };
@@ -1826,6 +1828,7 @@
 		1892610460CE642A24A4F322 /* RunScriptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptDialog.swift; sourceTree = "<group>"; };
 		18B5372BF572EBA3A84113E4 /* AgentLifecycleEventMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLifecycleEventMapperTests.swift; sourceTree = "<group>"; };
 		18CA47D5E0D1BF962CF45ABE /* AgentHookInstallNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookInstallNudgeBanner.swift; sourceTree = "<group>"; };
+		18E3BD9A15E5E342941AF18B /* GGLandingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGLandingStore.swift; sourceTree = "<group>"; };
 		191BAF20EAD2D227D9E7B418 /* RemoteStatusFingerprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteStatusFingerprint.swift; sourceTree = "<group>"; };
 		1936C815E64C7DB204340469 /* ACPMCPStatusControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMCPStatusControl.swift; sourceTree = "<group>"; };
 		1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabFilterTests.swift; sourceTree = "<group>"; };
@@ -1994,6 +1997,7 @@
 		328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageRegistry.swift; sourceTree = "<group>"; };
 		329882D757C34246C9848C3A /* ACPMentionChipAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionChipAttachment.swift; sourceTree = "<group>"; };
 		32D6E47CC4523FDE263C764C /* WindowDragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDragHandle.swift; sourceTree = "<group>"; };
+		32E74C405A6008FAD5837C1E /* GGLandingStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGLandingStoreTests.swift; sourceTree = "<group>"; };
 		32EEB37C08A315D65558B273 /* RemoteWorktreePollTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreePollTests.swift; sourceTree = "<group>"; };
 		331B138E37587DF6FB4139F8 /* ACPOrchestrationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPOrchestrationStoreTests.swift; sourceTree = "<group>"; };
 		333EA07C2BCA5E18F55E2613 /* AppConfigChangesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigChangesTests.swift; sourceTree = "<group>"; };
@@ -5623,6 +5627,7 @@
 				98D60242BE2239AE96629EBC /* GGInboxStoreTests.swift */,
 				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
 				D42C474D412CA4FD762B4889 /* GGLandEventTests.swift */,
+				32E74C405A6008FAD5837C1E /* GGLandingStoreTests.swift */,
 				8C5274DFD1921985B585C291 /* GGMCPInjectionTests.swift */,
 				C70E37676F2A14E6C9E84B2D /* GGMutationCoordinatorTests.swift */,
 				1276253D1FB205BC9B5AEDF1 /* GGMutationModelsTests.swift */,
@@ -5941,6 +5946,7 @@
 				8C511B229168DDEA87173A41 /* GGInboxStore.swift */,
 				B32762D888121D56722E03F5 /* GGInboxTabView.swift */,
 				79485A502B7856609349A138 /* GGInstallController.swift */,
+				18E3BD9A15E5E342941AF18B /* GGLandingStore.swift */,
 				9B1E93FE66457A82A3348EDA /* GGMCPInjection.swift */,
 				CCB8945B6B3ECFCD8BA28B82 /* GGMutationCoordinator.swift */,
 				993FD1C9788DEA6AD643A444 /* GGMutationModels.swift */,
@@ -6730,6 +6736,7 @@
 				E073EEE9E37052E17CB026A0 /* GGInboxStore.swift in Sources */,
 				56286C44BC30C1716CD44363 /* GGInboxTabView.swift in Sources */,
 				EBF83E611756C005753D7F25 /* GGInstallController.swift in Sources */,
+				385D919650403F661CCE822C /* GGLandingStore.swift in Sources */,
 				E6119C80C9AFF38EB308301A /* GGMCPInjection.swift in Sources */,
 				99B188A81AF135564ED9EE17 /* GGMutationCoordinator.swift in Sources */,
 				04D55B4985BDF4CEF0BA3C0E /* GGMutationModels.swift in Sources */,
@@ -7563,6 +7570,7 @@
 				77D7244E04B1949523699AEB /* GGInboxTabsTests.swift in Sources */,
 				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,
 				AB02F5DE10D8BBF1E967B6B3 /* GGLandEventTests.swift in Sources */,
+				842D223625D5B836AEBB9B1A /* GGLandingStoreTests.swift in Sources */,
 				40EEB77C4E857AF1FBD7692A /* GGMCPInjectionTests.swift in Sources */,
 				0E054800F6B09275885CF5B6 /* GGMutationCoordinatorTests.swift in Sources */,
 				4A99239BAD338EDCE7BE5F0E /* GGMutationModelsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		14775ED3C1BC3A084B2147C1 /* HeadReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2EB554CB6AF797545DB95D /* HeadReader.swift */; };
 		1493B3473D1CA13C68582A09 /* BeautifulMermaidSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A9FD2E7C30AA7C998FD071 /* BeautifulMermaidSmokeTests.swift */; };
 		14BC25FE7259A545420F28AA /* ComposerAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5FDAB31C577FC38CE53032 /* ComposerAction.swift */; };
+		14D515D642F9EC21347CE983 /* GGLandingPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938CD8842F6D84614256B31C /* GGLandingPresentationTests.swift */; };
 		14D70126BAF735B2A66A23C5 /* DiffReviewScrollSpyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F649B493D42787FEA6D8E67B /* DiffReviewScrollSpyTests.swift */; };
 		14DC8D8191E6E39E8741108D /* ReviewTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CAED428443C9A7FE55E9A31 /* ReviewTabViewTests.swift */; };
 		151437414B3DA58FC2103572 /* WorkspaceSidebarLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9C0B9B3E26A743954A8DB13 /* WorkspaceSidebarLayoutTests.swift */; };
@@ -262,6 +263,7 @@
 		272EE1BE3B1A4A3BFA7B2703 /* ACPManagedAdapterDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA89D4C70102BCF7B6B2450B /* ACPManagedAdapterDescriptor.swift */; };
 		2731B28802538E4FD7CBB0EA /* AgentDefinitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */; };
 		2735F19DF0AD717CA3CF3B23 /* WorktreeServiceCreatedAtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA2F208DBC024A64D0ED065 /* WorktreeServiceCreatedAtTests.swift */; };
+		2743EB20FAF0A5C71C6286CA /* GGLandingTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F7AE8C449052BF2A83A92E /* GGLandingTabsTests.swift */; };
 		279BAFE41DCB69286B64CFB9 /* AdapterUpdateState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F239EBD79AA346B7976B544 /* AdapterUpdateState.swift */; };
 		27F842092C9CA4D871B6127A /* DraftReviewRequestDiffSessionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615B4D8618F0BDEAEB216942 /* DraftReviewRequestDiffSessionBuilder.swift */; };
 		27F8B3029CA5F11982515486 /* DiffReviewRenderContextCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC9FF2675A6904A01CAEE52 /* DiffReviewRenderContextCacheTests.swift */; };
@@ -441,6 +443,7 @@
 		40A21E55EB86B5F3D42AEFF2 /* InlineDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */; };
 		40C56ABCF57F6F3F7D40E020 /* RemoteHelperInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE8745F3A4C6F0645D1D44A /* RemoteHelperInstaller.swift */; };
 		40D9FD39D36ADE353B9971E8 /* MergeRegionVisualLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256257983A4B1E1E674DF5B8 /* MergeRegionVisualLayoutTests.swift */; };
+		40E0CA81ED98DDC94855BD8C /* GGLandingTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A595A3292A96562C2C89DC /* GGLandingTabView.swift */; };
 		40EEB77C4E857AF1FBD7692A /* GGMCPInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5274DFD1921985B585C291 /* GGMCPInjectionTests.swift */; };
 		4107D595F9EBF8A1FC69E101 /* EditorFindRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB950CFAAADD11E84E783E1F /* EditorFindRequestTests.swift */; };
 		412F8D73E3E5CD7F57CD799A /* CompletionWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */; };
@@ -2608,6 +2611,7 @@
 		9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSaveNormalizationTests.swift; sourceTree = "<group>"; };
 		934BCC470703CF2DF2303357 /* SectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeader.swift; sourceTree = "<group>"; };
 		935CE58001BA1459A556B397 /* MCPRegistrationRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPRegistrationRegistryTests.swift; sourceTree = "<group>"; };
+		938CD8842F6D84614256B31C /* GGLandingPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGLandingPresentationTests.swift; sourceTree = "<group>"; };
 		93C3F02ECEA5D545FA268DB8 /* ACPSlashPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSlashPicker.swift; sourceTree = "<group>"; };
 		93CDC9895F48619E97461875 /* CodePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodePane.swift; sourceTree = "<group>"; };
 		93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBuiltins.swift; sourceTree = "<group>"; };
@@ -2644,6 +2648,7 @@
 		98D60242BE2239AE96629EBC /* GGInboxStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGInboxStoreTests.swift; sourceTree = "<group>"; };
 		98DE51A11B5F4C7A84D715B4 /* RemoteQueueProjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteQueueProjectionTests.swift; sourceTree = "<group>"; };
 		98EE59978053FA18629BC280 /* GGCommitMenuModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGCommitMenuModelTests.swift; sourceTree = "<group>"; };
+		98F7AE8C449052BF2A83A92E /* GGLandingTabsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGLandingTabsTests.swift; sourceTree = "<group>"; };
 		9915EF45ACF7C0C4EBEFCE1F /* CodeHostIssueResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostIssueResolver.swift; sourceTree = "<group>"; };
 		993FD1C9788DEA6AD643A444 /* GGMutationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGMutationModels.swift; sourceTree = "<group>"; };
 		99890AC2531648EB5E9716A8 /* DragOutSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragOutSessionTests.swift; sourceTree = "<group>"; };
@@ -2988,6 +2993,7 @@
 		D02E429B37288215EBC89571 /* CommitHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderView.swift; sourceTree = "<group>"; };
 		D081C8802733D2532DBCD74D /* BlockedLanguageServerNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolverTests.swift; sourceTree = "<group>"; };
 		D0A01B605D486C5FE112088E /* ACPSpeechDictationEngineFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSpeechDictationEngineFormatTests.swift; sourceTree = "<group>"; };
+		D0A595A3292A96562C2C89DC /* GGLandingTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGLandingTabView.swift; sourceTree = "<group>"; };
 		D0A8DE0526D46C36C672213B /* TrackedRevisionTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackedRevisionTargetTests.swift; sourceTree = "<group>"; };
 		D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStateTests.swift; sourceTree = "<group>"; };
 		D0EE31A4EB90FFE45DC46420 /* BuildIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildIdentityTests.swift; sourceTree = "<group>"; };
@@ -3708,6 +3714,7 @@
 				4836677A0E66A8ADD2D9E89A /* GGConfigCodableTests.swift */,
 				5DB6D67179D2557D3A255AA3 /* GGInboxHostTests.swift */,
 				649D5CB480CE056B1C4457D6 /* GGInboxTabsTests.swift */,
+				98F7AE8C449052BF2A83A92E /* GGLandingTabsTests.swift */,
 				70BDCB22C2FDC36F6022ADB3 /* GGStackCreateModeTests.swift */,
 				8792D7045679FE1E12AAFA04 /* GGWorktreeMenuModelTests.swift */,
 				3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */,
@@ -5627,6 +5634,7 @@
 				98D60242BE2239AE96629EBC /* GGInboxStoreTests.swift */,
 				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
 				D42C474D412CA4FD762B4889 /* GGLandEventTests.swift */,
+				938CD8842F6D84614256B31C /* GGLandingPresentationTests.swift */,
 				32E74C405A6008FAD5837C1E /* GGLandingStoreTests.swift */,
 				8C5274DFD1921985B585C291 /* GGMCPInjectionTests.swift */,
 				C70E37676F2A14E6C9E84B2D /* GGMutationCoordinatorTests.swift */,
@@ -5947,6 +5955,7 @@
 				B32762D888121D56722E03F5 /* GGInboxTabView.swift */,
 				79485A502B7856609349A138 /* GGInstallController.swift */,
 				18E3BD9A15E5E342941AF18B /* GGLandingStore.swift */,
+				D0A595A3292A96562C2C89DC /* GGLandingTabView.swift */,
 				9B1E93FE66457A82A3348EDA /* GGMCPInjection.swift */,
 				CCB8945B6B3ECFCD8BA28B82 /* GGMutationCoordinator.swift */,
 				993FD1C9788DEA6AD643A444 /* GGMutationModels.swift */,
@@ -6737,6 +6746,7 @@
 				56286C44BC30C1716CD44363 /* GGInboxTabView.swift in Sources */,
 				EBF83E611756C005753D7F25 /* GGInstallController.swift in Sources */,
 				385D919650403F661CCE822C /* GGLandingStore.swift in Sources */,
+				40E0CA81ED98DDC94855BD8C /* GGLandingTabView.swift in Sources */,
 				E6119C80C9AFF38EB308301A /* GGMCPInjection.swift in Sources */,
 				99B188A81AF135564ED9EE17 /* GGMutationCoordinator.swift in Sources */,
 				04D55B4985BDF4CEF0BA3C0E /* GGMutationModels.swift in Sources */,
@@ -7570,7 +7580,9 @@
 				77D7244E04B1949523699AEB /* GGInboxTabsTests.swift in Sources */,
 				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,
 				AB02F5DE10D8BBF1E967B6B3 /* GGLandEventTests.swift in Sources */,
+				14D515D642F9EC21347CE983 /* GGLandingPresentationTests.swift in Sources */,
 				842D223625D5B836AEBB9B1A /* GGLandingStoreTests.swift in Sources */,
+				2743EB20FAF0A5C71C6286CA /* GGLandingTabsTests.swift in Sources */,
 				40EEB77C4E857AF1FBD7692A /* GGMCPInjectionTests.swift in Sources */,
 				0E054800F6B09275885CF5B6 /* GGMutationCoordinatorTests.swift in Sources */,
 				4A99239BAD338EDCE7BE5F0E /* GGMutationModelsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1094,6 +1094,7 @@
 		AA6F188E5E31B83D45380279 /* SSHCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A3C6694C4027DE1A26EC59 /* SSHCommandTests.swift */; };
 		AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */; };
 		AA9C6D213883037790F00042 /* GGServiceActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7532F1267DB3F18530C9AD84 /* GGServiceActionsTests.swift */; };
+		AB02F5DE10D8BBF1E967B6B3 /* GGLandEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42C474D412CA4FD762B4889 /* GGLandEventTests.swift */; };
 		AB3BD2843C0923FD0E30458C /* CommitsSectionTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5B0671AB91057B6B196EBD /* CommitsSectionTitleTests.swift */; };
 		AB4B19ECC0C3D7242ECD42C6 /* DiffReviewInlineFeedbackActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8B46B2287CA16E683490301 /* DiffReviewInlineFeedbackActions.swift */; };
 		AB81A1DA27A87F7C7E49D9CF /* ACPPlanChecklist.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF02DDF9183C6C8D28EC68C0 /* ACPPlanChecklist.swift */; };
@@ -3008,6 +3009,7 @@
 		D3D8F686002C542458620289 /* PiMCPAdapterInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiMCPAdapterInspector.swift; sourceTree = "<group>"; };
 		D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitEventFilterTests.swift; sourceTree = "<group>"; };
 		D3EDEEB00185F9C717205540 /* ACPAutoRunToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAutoRunToggle.swift; sourceTree = "<group>"; };
+		D42C474D412CA4FD762B4889 /* GGLandEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGLandEventTests.swift; sourceTree = "<group>"; };
 		D43B2247BD2DC3FE9E1EA2CC /* RangeReviewLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeReviewLoader.swift; sourceTree = "<group>"; };
 		D43F393A27EF521D4A73B050 /* PendingReviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingReviewTests.swift; sourceTree = "<group>"; };
 		D46B68FD01B15E3EEA09CB79 /* ACPMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessages.swift; sourceTree = "<group>"; };
@@ -5620,6 +5622,7 @@
 				52F3B3FDD90A41F9BCC0D5DD /* GGInboxModelsTests.swift */,
 				98D60242BE2239AE96629EBC /* GGInboxStoreTests.swift */,
 				611F2522E4A89EA38B0779AC /* GGInstallControllerTests.swift */,
+				D42C474D412CA4FD762B4889 /* GGLandEventTests.swift */,
 				8C5274DFD1921985B585C291 /* GGMCPInjectionTests.swift */,
 				C70E37676F2A14E6C9E84B2D /* GGMutationCoordinatorTests.swift */,
 				1276253D1FB205BC9B5AEDF1 /* GGMutationModelsTests.swift */,
@@ -7559,6 +7562,7 @@
 				16B6CE9E05F7E9B72D191F0C /* GGInboxStoreTests.swift in Sources */,
 				77D7244E04B1949523699AEB /* GGInboxTabsTests.swift in Sources */,
 				6E2597E7FB61606C9A9F04AC /* GGInstallControllerTests.swift in Sources */,
+				AB02F5DE10D8BBF1E967B6B3 /* GGLandEventTests.swift in Sources */,
 				40EEB77C4E857AF1FBD7692A /* GGMCPInjectionTests.swift in Sources */,
 				0E054800F6B09275885CF5B6 /* GGMutationCoordinatorTests.swift in Sources */,
 				4A99239BAD338EDCE7BE5F0E /* GGMutationModelsTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -960,6 +960,14 @@ final class AppState {
 
     private func cleanupMissingWorktreeState(beforeIds: Set<String>, afterIds: Set<String>) {
         let disappeared = beforeIds.subtracting(afterIds)
+        let landingProjectsToMigrate = Set(disappeared.flatMap { id in
+            tabs.tabs(forWorktree: id).compactMap { tab -> String? in
+                guard case .ggLanding(let state) = tab,
+                      GGLandingStore.shared.sessions[state.projectId] != nil
+                else { return nil }
+                return state.projectId
+            }
+        })
         for id in disappeared {
             cleanupWorktreeState(worktreeId: id)
         }
@@ -975,8 +983,12 @@ final class AppState {
         if reconcileMissingSpaceProjects() {
             saveSpaces()
         }
+        let selectedWasRemoved = selectedWorktreeId.map(disappeared.contains) ?? false
         if let current = selectedWorktreeId, !afterIds.contains(current) {
             selectWorktree(id: resolvedSelectionForActiveSpace())
+        }
+        for projectId in landingProjectsToMigrate {
+            migrateGGLanding(projectId: projectId, selectHost: selectedWasRemoved)
         }
     }
 
@@ -9576,6 +9588,10 @@ final class AppState {
     }
 
     func openGGLanding(projectId: String) {
+        migrateGGLanding(projectId: projectId, selectHost: true)
+    }
+
+    private func migrateGGLanding(projectId: String, selectHost: Bool) {
         guard let session = GGLandingStore.shared.sessions[projectId] else { return }
         let projectWorktreeIds = projectsManager.visibleWorktrees(projectId: projectId).map(\.id)
         guard let worktreeId = Self.landingHostWorktreeId(
@@ -9589,7 +9605,9 @@ final class AppState {
         tabs.openOrFocusGGLanding(
             worktreeId: worktreeId, projectId: projectId, stackName: session.stack
         )
-        selectWorktree(id: worktreeId)
+        if selectHost {
+            selectWorktree(id: worktreeId)
+        }
     }
 
     func cancelGGLanding(projectId: String) {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -9561,6 +9561,14 @@ final class AppState {
         selectWorktree(id: worktreeId)
     }
 
+    func openGGLanding(projectId: String) {
+        guard let session = GGLandingStore.shared.sessions[projectId] else { return }
+        tabs.openOrFocusGGLanding(
+            worktreeId: session.worktreeId, projectId: projectId, stackName: session.stack
+        )
+        selectWorktree(id: session.worktreeId)
+    }
+
     func cancelGGLanding(projectId: String) {
         GGLandingStore.shared.cancel(projectId: projectId)
     }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -713,6 +713,7 @@ final class AppState {
         // refreshAll() returns.
         rightPaneStore.appState = self
         AlasTerminationCoordinator.shared.flush = { [weak self] in
+            await GGLandingStore.shared.cancelAllAndWait()
             await self?.cancelAllRunScriptCompletionTasks()
             await self?.flushAllACPComposerDrafts()
         }
@@ -970,6 +971,7 @@ final class AppState {
         })
         GGStackSummaryStore.shared.prune(keepingPaths: livePaths)
         GGInboxStore.shared.prune(keepingProjectIds: Set(projects.map(\.id)))
+        GGLandingStore.shared.prune(keepingProjectIds: Set(projects.map(\.id)))
         if reconcileMissingSpaceProjects() {
             saveSpaces()
         }
@@ -9557,6 +9559,17 @@ final class AppState {
         ) else { return }
         tabs.openOrFocusGGInbox(worktreeId: worktreeId, projectId: projectId, projectName: project.name)
         selectWorktree(id: worktreeId)
+    }
+
+    func cancelGGLanding(projectId: String) {
+        GGLandingStore.shared.cancel(projectId: projectId)
+    }
+
+    func restartGGLanding(projectId: String) {
+        guard let session = GGLandingStore.shared.sessions[projectId],
+              let state = rightPaneStore.activeState(worktreeId: session.worktreeId)
+        else { return }
+        state.restartGGLand(target: session.target)
     }
 }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -9547,6 +9547,20 @@ final class AppState {
         return projectWorktreeIds.first
     }
 
+    nonisolated static func landingHostWorktreeId(
+        sessionWorktreeId: String,
+        selectedWorktreeId: String?,
+        projectWorktreeIds: [String]
+    ) -> String? {
+        if projectWorktreeIds.contains(sessionWorktreeId) {
+            return sessionWorktreeId
+        }
+        return inboxHostWorktreeId(
+            selectedWorktreeId: selectedWorktreeId,
+            projectWorktreeIds: projectWorktreeIds
+        )
+    }
+
     /// Opens (or focuses) the gg inbox tab for `projectId` in the currently
     /// selected worktree's tab strip, falling back to the project's first
     /// worktree when the current selection belongs to a different project.
@@ -9563,10 +9577,19 @@ final class AppState {
 
     func openGGLanding(projectId: String) {
         guard let session = GGLandingStore.shared.sessions[projectId] else { return }
+        let projectWorktreeIds = projectsManager.visibleWorktrees(projectId: projectId).map(\.id)
+        guard let worktreeId = Self.landingHostWorktreeId(
+            sessionWorktreeId: session.worktreeId,
+            selectedWorktreeId: selectedWorktreeId,
+            projectWorktreeIds: projectWorktreeIds
+        ) else {
+            GGLandingStore.shared.cancel(projectId: projectId)
+            return
+        }
         tabs.openOrFocusGGLanding(
-            worktreeId: session.worktreeId, projectId: projectId, stackName: session.stack
+            worktreeId: worktreeId, projectId: projectId, stackName: session.stack
         )
-        selectWorktree(id: session.worktreeId)
+        selectWorktree(id: worktreeId)
     }
 
     func cancelGGLanding(projectId: String) {
@@ -9574,8 +9597,14 @@ final class AppState {
     }
 
     func restartGGLanding(projectId: String) {
-        guard let session = GGLandingStore.shared.sessions[projectId],
-              let state = rightPaneStore.activeState(worktreeId: session.worktreeId)
+        guard let session = GGLandingStore.shared.sessions[projectId] else { return }
+        let projectWorktreeIds = projectsManager.visibleWorktrees(projectId: projectId).map(\.id)
+        guard let worktreeId = Self.landingHostWorktreeId(
+            sessionWorktreeId: session.worktreeId,
+            selectedWorktreeId: selectedWorktreeId,
+            projectWorktreeIds: projectWorktreeIds
+        ),
+            let state = rightPaneStore.activeState(worktreeId: worktreeId)
         else { return }
         state.restartGGLand(target: session.target)
     }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -717,7 +717,7 @@ private struct RootGGConfirmationHandlers: ViewModifier {
                 presenting: state.rightPaneStore.stateWithPendingGGLand()?.pendingGGLand
             ) { _ in
                 Button("Land", role: .destructive) {
-                    state.rightPaneStore.stateWithPendingGGLand()?.performGGLand()
+                    state.rightPaneStore.stateWithPendingGGLand()?.performGGLand(appState: state)
                 }
                 Button("Cancel", role: .cancel) {
                     state.rightPaneStore.stateWithPendingGGLand()?.cancelGGLand()

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -612,6 +612,9 @@ struct CenterPaneView: View {
                             onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) }
                         )
                             .id(s.id)
+                    case .ggLanding(let s):
+                        GGLandingTabView(state: state, tabState: s)
+                            .id(s.id)
                     case .ggInbox(let s):
                         GGInboxTabView(
                             state: state,

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -23,6 +23,7 @@ enum Tab: Codable, Equatable, Identifiable {
     case fileHistory(FileHistoryTabState)
     case ggInbox(GGInboxTabState)
     case ggSplitCommit(GGSplitCommitTabState)
+    case ggLanding(GGLandingTabState)
 
     var id: TabID {
         switch self {
@@ -45,6 +46,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .fileHistory(let s):  return s.id
         case .ggInbox(let s):      return s.id
         case .ggSplitCommit(let s): return s.id
+        case .ggLanding(let s):    return s.id
         }
     }
 
@@ -69,6 +71,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .fileHistory(let s):  return s.title
         case .ggInbox(let s):      return s.title
         case .ggSplitCommit:       return "Split Commit"
+        case .ggLanding(let s):    return s.title
         }
     }
 
@@ -93,7 +96,13 @@ enum Tab: Codable, Equatable, Identifiable {
         case .fileHistory:  return "clock.arrow.circlepath"
         case .ggInbox:      return "branch"
         case .ggSplitCommit: return "arrow.trianglehead.branch"
+        case .ggLanding:    return "arrow.down.to.line"
         }
+    }
+
+    var isRestorable: Bool {
+        if case .ggLanding = self { return false }
+        return true
     }
 
     var supportsRevisionFollowActions: Bool {

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -969,6 +969,24 @@ final class TabsManager {
     }
 
     @discardableResult
+    func openOrFocusGGLanding(worktreeId: String, projectId: String, stackName: String) -> Tab {
+        let state = GGLandingTabState(projectId: projectId, stackName: stackName)
+        for otherWorktreeId in Array(byWorktree.keys) where otherWorktreeId != worktreeId {
+            if tabs(forWorktree: otherWorktreeId).contains(where: { $0.id == state.id }) {
+                close(worktreeId: otherWorktreeId, tabId: state.id)
+            }
+        }
+        let tab = Tab.ggLanding(state)
+        if let index = byWorktree[worktreeId]?.tabs.firstIndex(where: { $0.id == state.id }) {
+            byWorktree[worktreeId]?.tabs[index] = tab
+            activate(worktreeId: worktreeId, tabId: state.id)
+            return tab
+        }
+        append(tab, to: worktreeId)
+        return tab
+    }
+
+    @discardableResult
     func openOrFocusGGInbox(worktreeId: String, projectId: String, projectName: String) -> Tab {
         let state = GGInboxTabState(projectId: projectId, projectName: projectName)
         if tabs(forWorktree: worktreeId).contains(where: { $0.id == state.id }) {
@@ -1700,7 +1718,13 @@ final class TabsManager {
     }
 
     private func persistThrowing(_ file: TabsFile, worktreeId: String) throws {
-        try store.write(file, to: tabsFile(forWorktreeId: worktreeId))
+        var restorable = file
+        restorable.tabs = file.tabs.filter(\.isRestorable)
+        if let activeId = file.activeTabId,
+           !restorable.tabs.contains(where: { $0.id == activeId }) {
+            restorable.activeTabId = restorable.tabs.last?.id
+        }
+        try store.write(restorable, to: tabsFile(forWorktreeId: worktreeId))
     }
 
     private func tabsFile(forWorktreeId worktreeId: String) -> URL {

--- a/Alas/Sources/Integrations/GG/GGActionEvents.swift
+++ b/Alas/Sources/Integrations/GG/GGActionEvents.swift
@@ -172,12 +172,50 @@ enum GGErrorPresentation {
 }
 
 /// Decoded result of `gg land … --json`.
-struct GGLandResult: Equatable {
+struct GGLandResult: Equatable, Decodable, Sendable {
+    let stack: String?
+    let base: String?
     let landed: [GGLandedEntry]
+    let remaining: Int?
+    let cleaned: Bool?
+    let warnings: [String]
+    let error: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case stack, base, landed, remaining, cleaned, warnings, error
+    }
+
+    init(
+        stack: String? = nil,
+        base: String? = nil,
+        landed: [GGLandedEntry],
+        remaining: Int? = nil,
+        cleaned: Bool? = nil,
+        warnings: [String] = [],
+        error: String? = nil
+    ) {
+        self.stack = stack
+        self.base = base
+        self.landed = landed
+        self.remaining = remaining
+        self.cleaned = cleaned
+        self.warnings = warnings
+        self.error = error
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        stack = try container.decodeIfPresent(String.self, forKey: .stack)
+        base = try container.decodeIfPresent(String.self, forKey: .base)
+        landed = try container.decode([GGLandedEntry].self, forKey: .landed)
+        remaining = try container.decodeIfPresent(Int.self, forKey: .remaining)
+        cleaned = try container.decodeIfPresent(Bool.self, forKey: .cleaned)
+        warnings = try container.decodeIfPresent([String].self, forKey: .warnings) ?? []
+        error = try container.decodeIfPresent(String.self, forKey: .error)
+    }
 
     private struct Envelope: Decodable {
-        struct Land: Decodable { let landed: [GGLandedEntry] }
-        let land: Land
+        let land: GGLandResult
     }
 
     static func decode(fromJSON data: Data) throws -> GGLandResult {
@@ -188,15 +226,83 @@ struct GGLandResult: Equatable {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         do {
             let envelope = try decoder.decode(Envelope.self, from: data)
-            return GGLandResult(landed: envelope.land.landed)
+            return envelope.land
         } catch {
             throw GGServiceError.malformedOutput(String(describing: error))
         }
     }
 }
 
-struct GGLandedEntry: Equatable, Decodable {
+struct GGLandedEntry: Equatable, Decodable, Sendable {
     let position: Int
+    var sha: String? = nil
+    var title: String? = nil
+    var ggId: String? = nil
     let prNumber: Int?
     var action: String? = nil
+    var error: String? = nil
+}
+
+enum GGLandPhase: String, Decodable, Equatable, Sendable {
+    case readiness
+    case mergeTrain = "merge_train"
+}
+
+struct GGLandWait: Decodable, Equatable, Sendable {
+    let position: Int
+    let prNumber: Int
+    let phase: GGLandPhase
+    let poll: Int
+    let elapsedSeconds: Int
+    let ciStatus: String?
+    let approved: Bool?
+    let mergeTrainStatus: String?
+    let mergeTrainPosition: Int?
+    let pipelineRunning: Bool?
+    let error: String?
+}
+
+enum GGLandEvent: Equatable, Sendable {
+    case start(stack: String, base: String, totalEntries: Int)
+    case wait(GGLandWait)
+    case entry(GGLandedEntry)
+    case summary(GGLandResult)
+    case error(message: String)
+
+    static func decode(line: String) throws -> GGLandEvent {
+        let data = Data(line.utf8)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let envelope = try decoder.decode(GGLandEventEnvelope.self, from: data)
+        guard envelope.version == 1 else { throw GGServiceError.unsupportedSchema(envelope.version) }
+        guard envelope.command == "land" else {
+            throw GGServiceError.malformedOutput("Expected gg land event, got \(envelope.command).")
+        }
+        switch envelope.event {
+        case "start":
+            let value = try decoder.decode(GGLandStartPayload.self, from: data)
+            return .start(stack: value.stack, base: value.base, totalEntries: value.totalEntries)
+        case "wait": return .wait(try decoder.decode(GGLandWait.self, from: data))
+        case "entry": return .entry(try decoder.decode(GGLandedEntry.self, from: data))
+        case "summary": return .summary(try decoder.decode(GGLandResult.self, from: data))
+        case "error": return .error(message: try decoder.decode(GGLandErrorPayload.self, from: data).message)
+        default: throw GGServiceError.malformedOutput("Unknown gg land event: \(envelope.event)")
+        }
+    }
+}
+
+private struct GGLandEventEnvelope: Decodable {
+    let version: Int
+    let command: String
+    let event: String
+}
+
+private struct GGLandStartPayload: Decodable {
+    let stack: String
+    let base: String
+    let totalEntries: Int
+}
+
+private struct GGLandErrorPayload: Decodable {
+    let message: String
 }

--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -39,6 +39,7 @@ struct GGLandingSession: Equatable, Identifiable, Sendable {
     var warning: String?
     var result: GGLandResult?
     var error: String?
+    var endedAt: Date? = nil
 }
 
 @MainActor
@@ -140,6 +141,9 @@ final class GGLandingStore {
             }
         }
 
+        if session.phase == .succeeded || session.phase == .failed {
+            session.endedAt = Date()
+        }
         sessions[projectId] = session
     }
 
@@ -167,6 +171,7 @@ final class GGLandingStore {
             guard let phase = self.sessions[projectId]?.phase else { return }
             if phase == .cancelling {
                 self.sessions[projectId]?.phase = .cancelled
+                self.sessions[projectId]?.endedAt = Date()
                 self.sessions[projectId]?.activeWait = nil
                 self.sessions[projectId]?.warning = nil
                 self.sessions[projectId]?.error = nil
@@ -231,6 +236,7 @@ final class GGLandingStore {
         session.activeWait = nil
         session.warning = nil
         session.error = session.phase == .cancelled ? nil : message
+        session.endedAt = Date()
         sessions[projectId] = session
     }
 

--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -127,19 +127,29 @@ final class GGLandingStore {
             }
 
         case .wait(let wait):
+            guard let index = session.rows.firstIndex(where: { $0.position == wait.position }),
+                  Self.row(session.rows[index], matches: wait)
+            else {
+                Self.rejectStreamMismatch(&session)
+                sessions[projectId] = session
+                return false
+            }
             session.activeWait = wait
             session.warning = wait.error
-            if let index = session.rows.firstIndex(where: { $0.position == wait.position }) {
-                session.rows[index].wait = wait
-            }
+            session.rows[index].wait = wait
 
         case .entry(let entry):
-            if let index = session.rows.firstIndex(where: { $0.position == entry.position }) {
-                session.rows[index].wait = nil
-                session.rows[index].outcome = entry
-                if entry.error == nil, let id = Self.completedID(for: session.rows[index]) {
-                    session.completedIDs.insert(id)
-                }
+            guard let index = session.rows.firstIndex(where: { $0.position == entry.position }),
+                  Self.row(session.rows[index], matches: entry)
+            else {
+                Self.rejectStreamMismatch(&session)
+                sessions[projectId] = session
+                return false
+            }
+            session.rows[index].wait = nil
+            session.rows[index].outcome = entry
+            if entry.error == nil, let id = Self.completedID(for: session.rows[index]) {
+                session.completedIDs.insert(id)
             }
             if session.activeWait?.position == entry.position {
                 session.activeWait = nil
@@ -147,6 +157,15 @@ final class GGLandingStore {
             }
 
         case .summary(let result):
+            for entry in result.landed {
+                guard let index = session.rows.firstIndex(where: { $0.position == entry.position }),
+                      Self.row(session.rows[index], matches: entry)
+                else {
+                    Self.rejectStreamMismatch(&session)
+                    sessions[projectId] = session
+                    return false
+                }
+            }
             session.result = result
             session.activeWait = nil
             session.warning = nil
@@ -182,6 +201,24 @@ final class GGLandingStore {
 
     private static func completedID(for row: GGLandingRow) -> String? {
         row.stableID ?? row.ggId
+    }
+
+    private static func rejectStreamMismatch(_ session: inout GGLandingSession) {
+        session.phase = .failed
+        session.activeWait = nil
+        session.warning = nil
+        session.error = "gg land reported progress for a different stack. Refresh and try again."
+        session.endedAt = Date()
+    }
+
+    private static func row(_ row: GGLandingRow, matches wait: GGLandWait) -> Bool {
+        row.prNumber == nil || row.prNumber == wait.prNumber
+    }
+
+    private static func row(_ row: GGLandingRow, matches entry: GGLandedEntry) -> Bool {
+        if let prNumber = row.prNumber, prNumber != entry.prNumber { return false }
+        if let ggId = entry.ggId, ggId != row.stableID, ggId != row.ggId { return false }
+        return true
     }
 
     func attach(

--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -218,6 +218,7 @@ final class GGLandingStore {
     private static func row(_ row: GGLandingRow, matches entry: GGLandedEntry) -> Bool {
         if let prNumber = row.prNumber, prNumber != entry.prNumber { return false }
         if let ggId = entry.ggId, ggId != row.stableID, ggId != row.ggId { return false }
+        if row.ggId == nil, row.prNumber == nil, entry.sha != row.stableID { return false }
         return true
     }
 

--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -195,6 +195,10 @@ final class GGLandingStore {
         }
     }
 
+    func waitForOperation(projectId: String) async {
+        await operations[projectId]?.monitor.value
+    }
+
     func fail(projectId: String, message: String) {
         guard var session = sessions[projectId], session.phase == .running else { return }
         session.phase = .failed

--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -1,0 +1,220 @@
+import Foundation
+import Observation
+
+enum GGLandingPhase: Equatable, Sendable {
+    case running, cancelling, cancelled, succeeded, failed
+}
+
+struct GGLandingRow: Equatable, Identifiable, Sendable {
+    let position: Int
+    let title: String
+    let ggId: String?
+    let prNumber: Int?
+    var wait: GGLandWait? = nil
+    var outcome: GGLandedEntry? = nil
+
+    var id: Int { position }
+}
+
+struct GGLandingSession: Equatable, Identifiable, Sendable {
+    struct Seed: Sendable {
+        let projectId: String
+        let worktreeId: String
+        let stack: String
+        let base: String
+        let target: String
+        let rows: [GGLandingRow]
+    }
+
+    let id: UUID
+    let projectId: String
+    let worktreeId: String
+    let stack: String
+    let base: String
+    let target: String
+    let startedAt: Date
+    var rows: [GGLandingRow]
+    var phase: GGLandingPhase
+    var activeWait: GGLandWait?
+    var warning: String?
+    var result: GGLandResult?
+    var error: String?
+}
+
+@MainActor
+@Observable
+final class GGLandingStore {
+    private struct Operation {
+        let monitor: Task<Void, Never>
+        let cancel: @MainActor () -> Void
+    }
+
+    static let shared = GGLandingStore()
+
+    private(set) var sessions: [String: GGLandingSession] = [:]
+    @ObservationIgnored private var operations: [String: Operation] = [:]
+
+    @discardableResult
+    func begin(_ seed: GGLandingSession.Seed, now: Date = Date()) -> Bool {
+        if let session = sessions[seed.projectId],
+           session.phase == .running || session.phase == .cancelling
+        {
+            return false
+        }
+        if let previous = operations.removeValue(forKey: seed.projectId) {
+            previous.cancel()
+            previous.monitor.cancel()
+        }
+        sessions[seed.projectId] = GGLandingSession(
+            id: UUID(),
+            projectId: seed.projectId,
+            worktreeId: seed.worktreeId,
+            stack: seed.stack,
+            base: seed.base,
+            target: seed.target,
+            startedAt: now,
+            rows: seed.rows,
+            phase: .running,
+            activeWait: nil,
+            warning: nil,
+            result: nil,
+            error: nil
+        )
+        return true
+    }
+
+    func receive(_ event: GGLandEvent, projectId: String) {
+        guard var session = sessions[projectId],
+              session.phase == .running || session.phase == .cancelling
+        else { return }
+
+        switch event {
+        case .start:
+            break
+
+        case .wait(let wait):
+            session.activeWait = wait
+            session.warning = wait.error
+            if let index = session.rows.firstIndex(where: { $0.position == wait.position }) {
+                session.rows[index].wait = wait
+            }
+
+        case .entry(let entry):
+            if let index = session.rows.firstIndex(where: { $0.position == entry.position }) {
+                session.rows[index].wait = nil
+                session.rows[index].outcome = entry
+            }
+            if session.activeWait?.position == entry.position {
+                session.activeWait = nil
+                session.warning = nil
+            }
+
+        case .summary(let result):
+            session.result = result
+            session.activeWait = nil
+            session.warning = nil
+            for entry in result.landed {
+                if let index = session.rows.firstIndex(where: { $0.position == entry.position }) {
+                    session.rows[index].wait = nil
+                    session.rows[index].outcome = entry
+                }
+            }
+            if session.phase == .running {
+                session.phase = result.error == nil ? .succeeded : .failed
+                session.error = result.error
+            }
+
+        case .error(let message):
+            if session.phase == .running {
+                session.phase = .failed
+                session.activeWait = nil
+                session.warning = nil
+                session.error = message
+            }
+        }
+
+        sessions[projectId] = session
+    }
+
+    func attach(
+        projectId: String,
+        task: Task<Void, Error>,
+        cancel: @escaping @MainActor () -> Void
+    ) {
+        guard let session = sessions[projectId], session.phase == .running,
+              operations[projectId] == nil
+        else {
+            cancel()
+            return
+        }
+
+        let sessionId = session.id
+        let monitor = Task { @MainActor [weak self] in
+            let result = await task.result
+            guard let self, self.sessions[projectId]?.id == sessionId else { return }
+            self.operations[projectId] = nil
+
+            guard let phase = self.sessions[projectId]?.phase else { return }
+            if phase == .cancelling {
+                self.sessions[projectId]?.phase = .cancelled
+                self.sessions[projectId]?.activeWait = nil
+                self.sessions[projectId]?.warning = nil
+                self.sessions[projectId]?.error = nil
+            } else if phase == .running {
+                switch result {
+                case .success:
+                    self.fail(projectId: projectId, message: "gg land ended without a summary.")
+                case .failure(let error):
+                    self.fail(projectId: projectId, message: GGErrorPresentation.message(for: error))
+                }
+            }
+        }
+        operations[projectId] = Operation(monitor: monitor, cancel: cancel)
+    }
+
+    func cancel(projectId: String) {
+        guard var session = sessions[projectId], session.phase == .running,
+              let operation = operations[projectId]
+        else { return }
+        session.phase = .cancelling
+        sessions[projectId] = session
+        operation.cancel()
+    }
+
+    func cancelAllAndWait() async {
+        let activeOperations = operations
+        for (projectId, operation) in activeOperations {
+            if sessions[projectId]?.phase == .running {
+                sessions[projectId]?.phase = .cancelling
+                operation.cancel()
+            } else if sessions[projectId]?.phase != .cancelling {
+                operation.cancel()
+            }
+        }
+        for operation in activeOperations.values {
+            await operation.monitor.value
+        }
+    }
+
+    func fail(projectId: String, message: String) {
+        guard var session = sessions[projectId], session.phase == .running else { return }
+        session.phase = .failed
+        session.activeWait = nil
+        session.warning = nil
+        session.error = message
+        sessions[projectId] = session
+    }
+
+    func prune(keepingProjectIds: Set<String>) {
+        let removedProjectIds = sessions.keys.filter { !keepingProjectIds.contains($0) }
+        for projectId in removedProjectIds {
+            if let operation = operations.removeValue(forKey: projectId) {
+                if sessions[projectId]?.phase != .cancelling {
+                    operation.cancel()
+                }
+                operation.monitor.cancel()
+            }
+            sessions[projectId] = nil
+        }
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -55,10 +55,12 @@ final class GGLandingStore {
 
     private(set) var sessions: [String: GGLandingSession] = [:]
     @ObservationIgnored private var operations: [String: Operation] = [:]
+    @ObservationIgnored private var preparations: [String: Task<Void, Never>] = [:]
+    @ObservationIgnored private var isCancellingAll = false
 
     @discardableResult
     func begin(_ seed: GGLandingSession.Seed, now: Date = Date()) -> Bool {
-        guard operations[seed.projectId] == nil else { return false }
+        guard !isCancellingAll, operations[seed.projectId] == nil else { return false }
         if let session = sessions[seed.projectId],
            session.phase == .running || session.phase == .cancelling
         {
@@ -83,8 +85,14 @@ final class GGLandingStore {
     }
 
     func receive(_ event: GGLandEvent, projectId: String) {
-        guard var session = sessions[projectId],
-              session.phase == .running || session.phase == .cancelling
+        guard var session = sessions[projectId] else { return }
+        let streamFailedAfterSummary: Bool
+        if case .error = event {
+            streamFailedAfterSummary = session.phase == .succeeded && operations[projectId] != nil
+        } else {
+            streamFailedAfterSummary = false
+        }
+        guard session.phase == .running || session.phase == .cancelling || streamFailedAfterSummary
         else { return }
 
         switch event {
@@ -124,7 +132,7 @@ final class GGLandingStore {
             }
 
         case .error(let message):
-            if session.phase == .running {
+            if session.phase != .cancelling {
                 session.phase = .failed
                 session.activeWait = nil
                 session.warning = nil
@@ -140,7 +148,7 @@ final class GGLandingStore {
         task: Task<Void, Error>,
         cancel: @escaping @MainActor () -> Void
     ) {
-        guard let session = sessions[projectId],
+        guard !isCancellingAll, let session = sessions[projectId],
               session.phase == .running || session.phase == .cancelling,
               operations[projectId] == nil
         else {
@@ -185,8 +193,11 @@ final class GGLandingStore {
     }
 
     func cancelAllAndWait() async {
+        isCancellingAll = true
+        defer { isCancellingAll = false }
         let activeOperations = operations
-        for projectId in activeOperations.keys {
+        let activePreparations = preparations
+        for projectId in Set(activeOperations.keys).union(activePreparations.keys) {
             if sessions[projectId]?.phase == .running {
                 sessions[projectId]?.phase = .cancelling
             }
@@ -194,6 +205,17 @@ final class GGLandingStore {
         }
         for operation in activeOperations.values {
             await operation.monitor.value
+        }
+        for preparation in activePreparations.values {
+            await preparation.value
+        }
+    }
+
+    func startPreparation(projectId: String, operation: @escaping @MainActor () async -> Void) {
+        guard !isCancellingAll, preparations[projectId] == nil else { return }
+        preparations[projectId] = Task { @MainActor in
+            defer { preparations[projectId] = nil }
+            await operation()
         }
     }
 
@@ -221,6 +243,7 @@ final class GGLandingStore {
     }
 
     private func requestCancellation(projectId: String) {
+        preparations[projectId]?.cancel()
         guard var operation = operations[projectId], !operation.cancellationRequested else { return }
         operation.cancellationRequested = true
         operations[projectId] = operation

--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -9,7 +9,7 @@ struct GGLandingRow: Equatable, Identifiable, Sendable {
     let position: Int
     let title: String
     let ggId: String?
-    let stableID: String? = nil
+    var stableID: String? = nil
     let prNumber: Int?
     var wait: GGLandWait? = nil
     var outcome: GGLandedEntry? = nil
@@ -18,7 +18,7 @@ struct GGLandingRow: Equatable, Identifiable, Sendable {
 }
 
 struct GGLandingSession: Equatable, Identifiable, Sendable {
-    struct Seed: Sendable {
+    struct Seed: Equatable, Sendable {
         let projectId: String
         let worktreeId: String
         let stack: String
@@ -33,6 +33,7 @@ struct GGLandingSession: Equatable, Identifiable, Sendable {
     let stack: String
     let base: String
     let target: String
+    let confirmedScope: Seed
     let startedAt: Date
     var rows: [GGLandingRow]
     var phase: GGLandingPhase
@@ -75,6 +76,7 @@ final class GGLandingStore {
             stack: seed.stack,
             base: seed.base,
             target: seed.target,
+            confirmedScope: seed,
             startedAt: now,
             rows: seed.rows,
             phase: .running,
@@ -84,6 +86,11 @@ final class GGLandingStore {
             error: nil
         )
         return true
+    }
+
+    func updatePendingRows(_ rows: [GGLandingRow], projectId: String) {
+        guard sessions[projectId]?.phase == .running else { return }
+        sessions[projectId]?.rows = rows
     }
 
     func receive(_ event: GGLandEvent, projectId: String) {

--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -140,7 +140,8 @@ final class GGLandingStore {
         task: Task<Void, Error>,
         cancel: @escaping @MainActor () -> Void
     ) {
-        guard let session = sessions[projectId], session.phase == .running,
+        guard let session = sessions[projectId],
+              session.phase == .running || session.phase == .cancelling,
               operations[projectId] == nil
         else {
             cancel()
@@ -171,12 +172,13 @@ final class GGLandingStore {
             }
         }
         operations[projectId] = Operation(id: operationId, monitor: monitor, cancel: cancel)
+        if session.phase == .cancelling {
+            requestCancellation(projectId: projectId)
+        }
     }
 
     func cancel(projectId: String) {
-        guard var session = sessions[projectId], session.phase == .running,
-              operations[projectId] != nil
-        else { return }
+        guard var session = sessions[projectId], session.phase == .running else { return }
         session.phase = .cancelling
         sessions[projectId] = session
         requestCancellation(projectId: projectId)
@@ -200,11 +202,13 @@ final class GGLandingStore {
     }
 
     func fail(projectId: String, message: String) {
-        guard var session = sessions[projectId], session.phase == .running else { return }
-        session.phase = .failed
+        guard var session = sessions[projectId],
+              session.phase == .running || (session.phase == .cancelling && operations[projectId] == nil)
+        else { return }
+        session.phase = session.phase == .cancelling ? .cancelled : .failed
         session.activeWait = nil
         session.warning = nil
-        session.error = message
+        session.error = session.phase == .cancelled ? nil : message
         sessions[projectId] = session
     }
 

--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -173,8 +173,12 @@ final class GGLandingStore {
                 if let index = session.rows.firstIndex(where: { $0.position == entry.position }) {
                     session.rows[index].wait = nil
                     session.rows[index].outcome = entry
-                    if entry.error == nil, let id = Self.completedID(for: session.rows[index]) {
-                        session.completedIDs.insert(id)
+                    if let id = Self.completedID(for: session.rows[index]) {
+                        if entry.error == nil {
+                            session.completedIDs.insert(id)
+                        } else {
+                            session.completedIDs.remove(id)
+                        }
                     }
                 }
             }

--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -41,6 +41,7 @@ struct GGLandingSession: Equatable, Identifiable, Sendable {
     var warning: String?
     var result: GGLandResult?
     var error: String?
+    var completedIDs: Set<String>
     var endedAt: Date? = nil
 }
 
@@ -62,7 +63,11 @@ final class GGLandingStore {
     @ObservationIgnored private var isCancellingAll = false
 
     @discardableResult
-    func begin(_ seed: GGLandingSession.Seed, now: Date = Date()) -> Bool {
+    func begin(
+        _ seed: GGLandingSession.Seed,
+        completedIDs: Set<String> = [],
+        now: Date = Date()
+    ) -> Bool {
         guard !isCancellingAll, operations[seed.projectId] == nil else { return false }
         if let session = sessions[seed.projectId],
            session.phase == .running || session.phase == .cancelling
@@ -83,7 +88,8 @@ final class GGLandingStore {
             activeWait: nil,
             warning: nil,
             result: nil,
-            error: nil
+            error: nil,
+            completedIDs: completedIDs
         )
         return true
     }
@@ -131,6 +137,9 @@ final class GGLandingStore {
             if let index = session.rows.firstIndex(where: { $0.position == entry.position }) {
                 session.rows[index].wait = nil
                 session.rows[index].outcome = entry
+                if entry.error == nil, let id = Self.completedID(for: session.rows[index]) {
+                    session.completedIDs.insert(id)
+                }
             }
             if session.activeWait?.position == entry.position {
                 session.activeWait = nil
@@ -145,6 +154,9 @@ final class GGLandingStore {
                 if let index = session.rows.firstIndex(where: { $0.position == entry.position }) {
                     session.rows[index].wait = nil
                     session.rows[index].outcome = entry
+                    if entry.error == nil, let id = Self.completedID(for: session.rows[index]) {
+                        session.completedIDs.insert(id)
+                    }
                 }
             }
             if session.phase == .running {
@@ -166,6 +178,10 @@ final class GGLandingStore {
         }
         sessions[projectId] = session
         return true
+    }
+
+    private static func completedID(for row: GGLandingRow) -> String? {
+        row.stableID ?? row.ggId
     }
 
     func attach(

--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -45,8 +45,10 @@ struct GGLandingSession: Equatable, Identifiable, Sendable {
 @Observable
 final class GGLandingStore {
     private struct Operation {
+        let id: UUID
         let monitor: Task<Void, Never>
         let cancel: @MainActor () -> Void
+        var cancellationRequested = false
     }
 
     static let shared = GGLandingStore()
@@ -56,14 +58,11 @@ final class GGLandingStore {
 
     @discardableResult
     func begin(_ seed: GGLandingSession.Seed, now: Date = Date()) -> Bool {
+        guard operations[seed.projectId] == nil else { return false }
         if let session = sessions[seed.projectId],
            session.phase == .running || session.phase == .cancelling
         {
             return false
-        }
-        if let previous = operations.removeValue(forKey: seed.projectId) {
-            previous.cancel()
-            previous.monitor.cancel()
         }
         sessions[seed.projectId] = GGLandingSession(
             id: UUID(),
@@ -149,10 +148,12 @@ final class GGLandingStore {
         }
 
         let sessionId = session.id
+        let operationId = UUID()
         let monitor = Task { @MainActor [weak self] in
             let result = await task.result
-            guard let self, self.sessions[projectId]?.id == sessionId else { return }
+            guard let self, self.operations[projectId]?.id == operationId else { return }
             self.operations[projectId] = nil
+            guard self.sessions[projectId]?.id == sessionId else { return }
 
             guard let phase = self.sessions[projectId]?.phase else { return }
             if phase == .cancelling {
@@ -169,27 +170,25 @@ final class GGLandingStore {
                 }
             }
         }
-        operations[projectId] = Operation(monitor: monitor, cancel: cancel)
+        operations[projectId] = Operation(id: operationId, monitor: monitor, cancel: cancel)
     }
 
     func cancel(projectId: String) {
         guard var session = sessions[projectId], session.phase == .running,
-              let operation = operations[projectId]
+              operations[projectId] != nil
         else { return }
         session.phase = .cancelling
         sessions[projectId] = session
-        operation.cancel()
+        requestCancellation(projectId: projectId)
     }
 
     func cancelAllAndWait() async {
         let activeOperations = operations
-        for (projectId, operation) in activeOperations {
+        for projectId in activeOperations.keys {
             if sessions[projectId]?.phase == .running {
                 sessions[projectId]?.phase = .cancelling
-                operation.cancel()
-            } else if sessions[projectId]?.phase != .cancelling {
-                operation.cancel()
             }
+            requestCancellation(projectId: projectId)
         }
         for operation in activeOperations.values {
             await operation.monitor.value
@@ -208,13 +207,15 @@ final class GGLandingStore {
     func prune(keepingProjectIds: Set<String>) {
         let removedProjectIds = sessions.keys.filter { !keepingProjectIds.contains($0) }
         for projectId in removedProjectIds {
-            if let operation = operations.removeValue(forKey: projectId) {
-                if sessions[projectId]?.phase != .cancelling {
-                    operation.cancel()
-                }
-                operation.monitor.cancel()
-            }
+            requestCancellation(projectId: projectId)
             sessions[projectId] = nil
         }
+    }
+
+    private func requestCancellation(projectId: String) {
+        guard var operation = operations[projectId], !operation.cancellationRequested else { return }
+        operation.cancellationRequested = true
+        operations[projectId] = operation
+        operation.cancel()
     }
 }

--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -109,7 +109,7 @@ final class GGLandingStore {
         case .start(let stack, let base, let totalEntries):
             guard stack == session.confirmedScope.stack,
                   base == session.confirmedScope.base,
-                  totalEntries == session.confirmedScope.rows.count
+                  totalEntries == session.rows.count
             else {
                 session.phase = .failed
                 session.activeWait = nil

--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -93,8 +93,9 @@ final class GGLandingStore {
         sessions[projectId]?.rows = rows
     }
 
-    func receive(_ event: GGLandEvent, projectId: String) {
-        guard var session = sessions[projectId] else { return }
+    @discardableResult
+    func receive(_ event: GGLandEvent, projectId: String) -> Bool {
+        guard var session = sessions[projectId] else { return true }
         let streamFailedAfterSummary: Bool
         if case .error = event {
             streamFailedAfterSummary = session.phase == .succeeded && operations[projectId] != nil
@@ -102,11 +103,22 @@ final class GGLandingStore {
             streamFailedAfterSummary = false
         }
         guard session.phase == .running || session.phase == .cancelling || streamFailedAfterSummary
-        else { return }
+        else { return true }
 
         switch event {
-        case .start:
-            break
+        case .start(let stack, let base, let totalEntries):
+            guard stack == session.confirmedScope.stack,
+                  base == session.confirmedScope.base,
+                  totalEntries == session.confirmedScope.rows.count
+            else {
+                session.phase = .failed
+                session.activeWait = nil
+                session.warning = nil
+                session.error = "gg land started for a different stack. Refresh and try again."
+                session.endedAt = Date()
+                sessions[projectId] = session
+                return false
+            }
 
         case .wait(let wait):
             session.activeWait = wait
@@ -153,6 +165,7 @@ final class GGLandingStore {
             session.endedAt = Date()
         }
         sessions[projectId] = session
+        return true
     }
 
     func attach(

--- a/Alas/Sources/Integrations/GG/GGLandingStore.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingStore.swift
@@ -9,6 +9,7 @@ struct GGLandingRow: Equatable, Identifiable, Sendable {
     let position: Int
     let title: String
     let ggId: String?
+    let stableID: String? = nil
     let prNumber: Int?
     var wait: GGLandWait? = nil
     var outcome: GGLandedEntry? = nil

--- a/Alas/Sources/Integrations/GG/GGLandingTabView.swift
+++ b/Alas/Sources/Integrations/GG/GGLandingTabView.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+
+struct GGLandingTabState: Codable, Equatable, Identifiable {
+    let projectId: String
+    let stackName: String
+    var id: TabID { "gg-land:\(projectId)" }
+    var title: String { "Land · \(stackName)" }
+}
+
+enum GGLandingPresentation {
+    static func duration(seconds: Int) -> String {
+        let seconds = max(0, seconds)
+        if seconds < 60 { return "\(seconds)s" }
+        return "\(seconds / 60)m \(seconds % 60)s"
+    }
+
+    static func detail(for wait: GGLandWait) -> String {
+        var facts: [String] = []
+        switch wait.phase {
+        case .readiness:
+            if let ci = wait.ciStatus {
+                switch ci {
+                case "success": facts.append("CI passed")
+                case "failure", "failed": facts.append("CI failed")
+                default: facts.append("CI \(ci)")
+                }
+            }
+            if let approved = wait.approved {
+                facts.append(approved ? "Approved" : "Waiting for approval")
+            }
+            if facts.isEmpty { facts.append("Waiting for readiness") }
+        case .mergeTrain:
+            facts.append("Merge train")
+            if let position = wait.mergeTrainPosition { facts.append("Position \(position)") }
+            if wait.pipelineRunning == true { facts.append("Pipeline running") }
+        }
+        facts.append("Waiting \(duration(seconds: wait.elapsedSeconds))")
+        return facts.joined(separator: " · ")
+    }
+
+    static func isActive(_ row: GGLandingRow, in session: GGLandingSession) -> Bool {
+        guard session.phase == .running || session.phase == .cancelling, row.outcome == nil else { return false }
+        return row.position == (session.activeWait?.position ?? session.rows.first { $0.outcome == nil }?.position)
+    }
+
+    static func detail(for row: GGLandingRow, in session: GGLandingSession) -> String {
+        if let outcome = row.outcome {
+            if let error = outcome.error { return error }
+            switch outcome.action {
+            case "merged": return "Merged"
+            case "queued": return "Queued"
+            default: return outcome.action?.replacingOccurrences(of: "_", with: " ").capitalized ?? "Completed"
+            }
+        }
+        if session.phase == .cancelled { return "Cancelled" }
+        if session.phase == .failed { return "Not landed" }
+        if isActive(row, in: session) {
+            if let wait = row.wait { return detail(for: wait) }
+            return session.phase == .cancelling ? "Cancelling…" : "Landing…"
+        }
+        return "Pending"
+    }
+
+    static func progress(for session: GGLandingSession) -> String {
+        "\(session.rows.filter { $0.outcome != nil && $0.outcome?.error == nil }.count) / \(session.rows.count)"
+    }
+
+    static func summary(for session: GGLandingSession) -> String {
+        let outcomes = session.rows.compactMap(\.outcome).filter { $0.error == nil }
+        let merged = outcomes.filter { $0.action == "merged" }.count
+        let queued = outcomes.filter { $0.action == "queued" }.count
+        var facts: [String] = []
+        if session.phase == .cancelled { facts.append("Cancelled") }
+        if session.phase == .failed { facts.append("Failed") }
+        facts.append("\(merged) merged")
+        if queued > 0 { facts.append("\(queued) queued") }
+        let remaining = session.result?.remaining ?? max(0, session.rows.count - outcomes.count)
+        facts.append("\(remaining) remaining")
+        return facts.joined(separator: " · ")
+    }
+}
+
+struct GGLandingTabView: View {
+    let state: AppState
+    let tabState: GGLandingTabState
+    private let store = GGLandingStore.shared
+
+    var body: some View {
+        Group {
+            if let session = store.sessions[tabState.projectId] {
+                VStack(alignment: .leading, spacing: 16) {
+                    header(session)
+                    Divider()
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 16) {
+                            ForEach(session.rows) { row in
+                                landingRow(row, session: session)
+                            }
+                            if session.phase != .running && session.phase != .cancelling {
+                                terminalSummary(session)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(20)
+            } else {
+                ContentUnavailableView("Landing session unavailable", systemImage: "arrow.down.to.line")
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Landing \(tabState.stackName)")
+        .accessibilityIdentifier("gg-landing-tab")
+    }
+
+    private func header(_ session: GGLandingSession) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Land · \(session.stack)").font(.title2)
+                HStack {
+                    Text(GGLandingPresentation.progress(for: session))
+                    runtime(session).monospacedDigit()
+                }
+                .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if session.phase == .running || session.phase == .cancelling {
+                Button(session.phase == .cancelling ? "Cancelling…" : "Cancel") {
+                    state.cancelGGLanding(projectId: tabState.projectId)
+                }
+                .disabled(session.phase == .cancelling)
+                .accessibilityLabel(session.phase == .cancelling ? "Cancelling landing" : "Cancel landing")
+                .accessibilityIdentifier("gg-landing-cancel")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func runtime(_ session: GGLandingSession) -> some View {
+        if let endedAt = session.endedAt {
+            Text(GGLandingPresentation.duration(seconds: Int(endedAt.timeIntervalSince(session.startedAt))))
+        } else {
+            TimelineView(.periodic(from: .now, by: 1)) { context in
+                Text(GGLandingPresentation.duration(seconds: Int(context.date.timeIntervalSince(session.startedAt))))
+            }
+        }
+    }
+
+    private func landingRow(_ row: GGLandingRow, session: GGLandingSession) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Group {
+                if row.outcome?.error != nil {
+                    Image(systemName: "xmark.circle.fill").foregroundStyle(.red)
+                } else if row.outcome?.action == "queued" {
+                    Image(systemName: "clock").foregroundStyle(.secondary)
+                } else if row.outcome != nil {
+                    Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
+                } else if GGLandingPresentation.isActive(row, in: session) {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Image(systemName: "circle").foregroundStyle(.secondary)
+                }
+            }
+            .frame(width: 18)
+            .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("\(row.position). \(row.title)").font(.headline)
+                if let number = row.prNumber { Text("#\(number)").foregroundStyle(.secondary) }
+                Text(GGLandingPresentation.detail(for: row, in: session)).foregroundStyle(.secondary)
+                if GGLandingPresentation.isActive(row, in: session), let warning = session.warning {
+                    Label(warning, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.orange)
+                        .accessibilityLabel("Temporary warning: \(warning)")
+                        .accessibilityIdentifier("gg-landing-warning")
+                }
+            }
+            .textSelection(.enabled)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Entry \(row.position), \(row.title)")
+        .accessibilityIdentifier("gg-landing-row-\(row.position)")
+    }
+
+    private func terminalSummary(_ session: GGLandingSession) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Divider()
+            Text(GGLandingPresentation.summary(for: session)).font(.headline)
+            if let error = session.error {
+                Text(error).foregroundStyle(.red).textSelection(.enabled)
+            }
+            if let warnings = session.result?.warnings, !warnings.isEmpty {
+                Text(warnings.joined(separator: "\n")).foregroundStyle(.orange).textSelection(.enabled)
+            }
+            if session.phase == .cancelled || session.phase == .failed {
+                Button("Restart") { state.restartGGLanding(projectId: tabState.projectId) }
+                    .accessibilityLabel("Restart landing")
+                    .accessibilityIdentifier("gg-landing-restart")
+            }
+        }
+    }
+}

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -36,7 +36,7 @@ protocol GGMutationExecuting {
         supportsSyncJSONL: Bool,
         supportsLandJSONL: Bool,
         onSyncEvent: (GGSyncEvent) -> Void,
-        onLandEvent: (GGLandEvent) -> Void
+        onLandEvent: @escaping (GGLandEvent) -> Void
     ) async throws -> GGMutationExecutionResult
     func listUndoOperations(worktreePath: String, limit: Int) async throws -> [GGOperationSummary]
     func previewRestack(worktreePath: String) async throws -> GGRestackResult
@@ -819,7 +819,7 @@ extension GGService: GGMutationExecuting {
         supportsSyncJSONL: Bool,
         supportsLandJSONL: Bool,
         onSyncEvent: (GGSyncEvent) -> Void,
-        onLandEvent: (GGLandEvent) -> Void
+        onLandEvent: @escaping (GGLandEvent) -> Void
     ) async throws -> GGMutationExecutionResult {
         let service = clientOperationID.map {
             GGService(runner: GGClientOperationRunner(base: runner, clientOperationID: $0))

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -372,6 +372,16 @@ final class GGMutationCoordinator {
             if case .undo(let operationID) = request {
                 clearUndoCandidate(forOperationID: operationID)
             }
+        } catch where Task.isCancelled || error is CancellationError {
+            reconcilePausedState(after: request, error: nil)
+            if request == .sync {
+                await refresh(after: request, result: .none)
+                releaseAction()
+            } else {
+                releaseAction()
+                await refresh(after: request, result: .none)
+            }
+            throw CancellationError()
         } catch let error as GGServiceError {
             reconcilePausedState(after: request, error: error)
             let toleratesMalformedRemoteOutput: Bool
@@ -844,15 +854,22 @@ extension GGService: GGMutationExecuting {
             }
         case .land(let target):
             if supportsLandJSONL {
-                var summary: GGLandResult?
-                for try await event in service.landStream(worktreePath: worktreePath, until: target) {
-                    onLandEvent(event)
-                    if case .summary(let result) = event { summary = result }
+                do {
+                    var summary: GGLandResult?
+                    for try await event in service.landStream(worktreePath: worktreePath, until: target) {
+                        onLandEvent(event)
+                        if case .summary(let result) = event { summary = result }
+                    }
+                    try Task.checkCancellation()
+                    guard let summary else {
+                        throw GGServiceError.malformedOutput("gg land ended without a summary.")
+                    }
+                    return .land(summary)
+                } catch {
+                    if Task.isCancelled || error is CancellationError { throw CancellationError() }
+                    onLandEvent(.error(message: GGErrorPresentation.message(for: error)))
+                    throw error
                 }
-                guard let summary else {
-                    throw GGServiceError.malformedOutput("gg land ended without a summary.")
-                }
-                return .land(summary)
             }
             return .land(try await service.land(worktreePath: worktreePath, until: target))
         case .clean:

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -16,7 +16,7 @@ struct GGMutationContext {
     var selectWorktreeAtPath: (String) async -> Void
     /// The worktree's current branch, used to scope final-drop undo recovery.
     var currentBranch: () -> String?
-    var publishLandEvent: (GGLandEvent) -> Void
+    var publishLandEvent: (GGLandEvent) -> Bool
 }
 
 enum GGMutationExecutionResult {
@@ -36,7 +36,7 @@ protocol GGMutationExecuting {
         supportsSyncJSONL: Bool,
         supportsLandJSONL: Bool,
         onSyncEvent: (GGSyncEvent) -> Void,
-        onLandEvent: @escaping (GGLandEvent) -> Void
+        onLandEvent: @escaping (GGLandEvent) -> Bool
     ) async throws -> GGMutationExecutionResult
     func listUndoOperations(worktreePath: String, limit: Int) async throws -> [GGOperationSummary]
     func previewRestack(worktreePath: String) async throws -> GGRestackResult
@@ -819,7 +819,7 @@ extension GGService: GGMutationExecuting {
         supportsSyncJSONL: Bool,
         supportsLandJSONL: Bool,
         onSyncEvent: (GGSyncEvent) -> Void,
-        onLandEvent: @escaping (GGLandEvent) -> Void
+        onLandEvent: @escaping (GGLandEvent) -> Bool
     ) async throws -> GGMutationExecutionResult {
         let service = clientOperationID.map {
             GGService(runner: GGClientOperationRunner(base: runner, clientOperationID: $0))
@@ -860,7 +860,9 @@ extension GGService: GGMutationExecuting {
                     let consume = Task {
                         var summary: GGLandResult?
                         for try await event in stream.events {
-                            onLandEvent(event)
+                            guard onLandEvent(event) else {
+                                throw GGServiceError.malformedOutput("gg land stream did not match confirmed scope.")
+                            }
                             if case .summary(let result) = event { summary = result }
                         }
                         return summary
@@ -876,7 +878,7 @@ extension GGService: GGMutationExecuting {
                     return .land(summary)
                 } catch {
                     if Task.isCancelled || error is CancellationError { throw CancellationError() }
-                    onLandEvent(.error(message: GGErrorPresentation.message(for: error)))
+                    _ = onLandEvent(.error(message: GGErrorPresentation.message(for: error)))
                     throw error
                 }
             }

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -16,6 +16,7 @@ struct GGMutationContext {
     var selectWorktreeAtPath: (String) async -> Void
     /// The worktree's current branch, used to scope final-drop undo recovery.
     var currentBranch: () -> String?
+    var publishLandEvent: (GGLandEvent) -> Void
 }
 
 enum GGMutationExecutionResult {
@@ -33,7 +34,9 @@ protocol GGMutationExecuting {
         worktreePath: String,
         clientOperationID: String?,
         supportsSyncJSONL: Bool,
-        onSyncEvent: (GGSyncEvent) -> Void
+        supportsLandJSONL: Bool,
+        onSyncEvent: (GGSyncEvent) -> Void,
+        onLandEvent: (GGLandEvent) -> Void
     ) async throws -> GGMutationExecutionResult
     func listUndoOperations(worktreePath: String, limit: Int) async throws -> [GGOperationSummary]
     func previewRestack(worktreePath: String) async throws -> GGRestackResult
@@ -49,6 +52,7 @@ final class GGMutationCoordinator {
     private let undoMarkerStore: any GGUndoMarkerStoring
     private let clientOperationIDCapability: () -> Bool
     private let syncJSONLCapability: () -> Bool
+    private let landJSONLCapability: () -> Bool
     private let clientOperationIDGenerator: () -> String
     private let context: GGMutationContext
 
@@ -71,6 +75,9 @@ final class GGMutationCoordinator {
         syncJSONLCapability: @escaping () -> Bool = {
             GGAvailability.shared.capabilities.syncJSONL
         },
+        landJSONLCapability: @escaping () -> Bool = {
+            GGAvailability.shared.capabilities.landJSONL
+        },
         clientOperationIDGenerator: @escaping () -> String = {
             "alas:\(UUID().uuidString)"
         },
@@ -83,6 +90,7 @@ final class GGMutationCoordinator {
         self.undoMarkerStore = undoMarkerStore
         self.clientOperationIDCapability = clientOperationIDCapability
         self.syncJSONLCapability = syncJSONLCapability
+        self.landJSONLCapability = landJSONLCapability
         self.clientOperationIDGenerator = clientOperationIDGenerator
         self.context = context
     }
@@ -314,21 +322,27 @@ final class GGMutationCoordinator {
         let clientOperationID = request.generatesClientOperationID && clientOperationIDCapability()
             ? clientOperationIDGenerator()
             : nil
+        let supportsLandJSONL = landJSONLCapability()
+        let isLiveLand: Bool
+        if case .land = request { isLiveLand = supportsLandJSONL } else { isLiveLand = false }
         GGStackGate.markAlasGGOperationInProgress(repoPath: worktreePath)
 
         do {
+            try Task.checkCancellation()
             onExecutionStarted()
             let result = try await service.execute(
                 request,
                 worktreePath: worktreePath,
                 clientOperationID: clientOperationID,
                 supportsSyncJSONL: syncJSONLCapability(),
+                supportsLandJSONL: supportsLandJSONL,
                 onSyncEvent: { [actionState] event in
                     actionState.appendSyncEvent(event)
                     if case .error(_, _, let message) = event {
                         actionState.setError(message, for: request.actionKind)
                     }
-                }
+                },
+                onLandEvent: context.publishLandEvent
             )
             if request == .sync, actionState.syncProgress.contains(where: {
                 if case .error = $0 { return true }
@@ -361,7 +375,7 @@ final class GGMutationCoordinator {
         } catch let error as GGServiceError {
             reconcilePausedState(after: request, error: error)
             let toleratesMalformedRemoteOutput: Bool
-            if request != .sync, request.touchesRemote, case .malformedOutput = error {
+            if request != .sync, !isLiveLand, request.touchesRemote, case .malformedOutput = error {
                 toleratesMalformedRemoteOutput = true
             } else {
                 toleratesMalformedRemoteOutput = false
@@ -792,7 +806,9 @@ extension GGService: GGMutationExecuting {
         worktreePath: String,
         clientOperationID: String?,
         supportsSyncJSONL: Bool,
-        onSyncEvent: (GGSyncEvent) -> Void
+        supportsLandJSONL: Bool,
+        onSyncEvent: (GGSyncEvent) -> Void,
+        onLandEvent: (GGLandEvent) -> Void
     ) async throws -> GGMutationExecutionResult {
         let service = clientOperationID.map {
             GGService(runner: GGClientOperationRunner(base: runner, clientOperationID: $0))
@@ -827,6 +843,17 @@ extension GGService: GGMutationExecuting {
                 onSyncEvent(event)
             }
         case .land(let target):
+            if supportsLandJSONL {
+                var summary: GGLandResult?
+                for try await event in service.landStream(worktreePath: worktreePath, until: target) {
+                    onLandEvent(event)
+                    if case .summary(let result) = event { summary = result }
+                }
+                guard let summary else {
+                    throw GGServiceError.malformedOutput("gg land ended without a summary.")
+                }
+                return .land(summary)
+            }
             return .land(try await service.land(worktreePath: worktreePath, until: target))
         case .clean:
             try await service.clean(worktreePath: worktreePath)

--- a/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationCoordinator.swift
@@ -446,7 +446,8 @@ final class GGMutationCoordinator {
         return GGPreparedMutation(
             request: request,
             snapshot: identity,
-            confirmation: confirmation(for: request, stack: stack)
+            confirmation: confirmation(for: request, stack: stack),
+            stack: stack
         )
     }
 
@@ -855,11 +856,19 @@ extension GGService: GGMutationExecuting {
         case .land(let target):
             if supportsLandJSONL {
                 do {
-                    var summary: GGLandResult?
-                    for try await event in service.landStream(worktreePath: worktreePath, until: target) {
-                        onLandEvent(event)
-                        if case .summary(let result) = event { summary = result }
+                    let stream = service.landStream(worktreePath: worktreePath, until: target)
+                    let consume = Task {
+                        var summary: GGLandResult?
+                        for try await event in stream.events {
+                            onLandEvent(event)
+                            if case .summary(let result) = event { summary = result }
+                        }
+                        return summary
                     }
+                    let summary = try await withTaskCancellationHandler(
+                        operation: { try await consume.value },
+                        onCancel: stream.cancel
+                    )
                     try Task.checkCancellation()
                     guard let summary else {
                         throw GGServiceError.malformedOutput("gg land ended without a summary.")

--- a/Alas/Sources/Integrations/GG/GGMutationModels.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationModels.swift
@@ -107,6 +107,7 @@ struct GGPreparedMutation: Equatable, Sendable {
     var request: GGMutationRequest
     var snapshot: GGStackIdentity
     var confirmation: GGMutationConfirmation?
+    var stack: GGStack? = nil
 }
 
 struct GGPreparedRestack: Equatable, Sendable {

--- a/Alas/Sources/Integrations/GG/GGMutationModels.swift
+++ b/Alas/Sources/Integrations/GG/GGMutationModels.swift
@@ -18,6 +18,7 @@ struct GGCapabilities: Equatable, Sendable {
     var clientOperationID: Bool = false
     var stagedOnlyAmend: Bool = false
     var syncJSONL: Bool = false
+    var landJSONL: Bool = false
     var localStackSnapshot: Bool = false
 }
 

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -6,12 +6,25 @@ import Observation
 /// tests can fake CLI output. Local-only in phase 1 (no SSH rewrite).
 protocol GGCommandRunning: Sendable {
     func run(args: [String], cwd: URL?) async throws -> ProcessResult
-/// Streams stdout lines as they arrive (for `gg sync --jsonl`). Finishes
+    /// Streams stdout lines as they arrive (for `gg sync --jsonl`). Finishes
     /// with `.commandFailed`/`.cliMissing` on a non-zero exit.
     func runStreaming(args: [String], cwd: URL?) -> AsyncThrowingStream<String, Error>
+    func runStreaming(
+        args: [String],
+        cwd: URL?,
+        timeout: TimeInterval?
+    ) -> AsyncThrowingStream<String, Error>
 }
 
 extension GGCommandRunning {
+    func runStreaming(
+        args: [String],
+        cwd: URL?,
+        timeout: TimeInterval?
+    ) -> AsyncThrowingStream<String, Error> {
+        runStreaming(args: args, cwd: cwd)
+    }
+
     /// Default: buffer the whole command then split into lines. Good enough
     /// for tests and any non-streaming conformer; `ProcessGGCommandRunner`
     /// overrides this with a truly incremental implementation.
@@ -74,7 +87,15 @@ struct ProcessGGCommandRunner: GGCommandRunning {
     }
 
     func runStreaming(args: [String], cwd: URL?) -> AsyncThrowingStream<String, Error> {
-        Self.streamProcess(executable: "/usr/bin/env", args: ["gg"] + args, cwd: cwd, env: Process.gitEnv(), timeout: Self.commandTimeout)
+        runStreaming(args: args, cwd: cwd, timeout: Self.commandTimeout)
+    }
+
+    func runStreaming(
+        args: [String],
+        cwd: URL?,
+        timeout: TimeInterval?
+    ) -> AsyncThrowingStream<String, Error> {
+        Self.streamProcess(executable: "/usr/bin/env", args: ["gg"] + args, cwd: cwd, env: Process.gitEnv(), timeout: timeout)
     }
 
     /// Pipe-lifecycle core of `runStreaming`, parameterized on the
@@ -87,7 +108,7 @@ struct ProcessGGCommandRunner: GGCommandRunning {
         args: [String],
         cwd: URL?,
         env: [String: String]?,
-        timeout: TimeInterval = Process.defaultTimeout
+        timeout: TimeInterval? = Process.defaultTimeout
     ) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             let processTreeID = UUID().uuidString
@@ -168,7 +189,7 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                     async let outClosed = stdoutEOF.waitForClose(timeoutNanoseconds: 2_000_000_000)
                     async let errClosed = stderrAccum.waitForClose(timeoutNanoseconds: 2_000_000_000)
                     _ = await (outClosed, errClosed)
-                    if timeoutState.didTimeOut {
+                    if timeoutState.didTimeOut, let timeout {
                         continuation.finish(throwing: ProcessError.timedOut(executable: executable, args: args, seconds: timeout))
                     } else if status == 0 {
                         continuation.finish()
@@ -199,21 +220,30 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                     rootIdentity: rootIdentity,
                     wrapperIdentity: wrapperIdentity
                 )
-                let watchdog = Task {
-                    try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-                    if Task.isCancelled { return }
-                    if process.isRunning {
-                        timeoutState.markTimedOut()
-                        fputs(
-                            "[Process watchdog] \(timeout)s timeout — terminating: \(executable) \(args.joined(separator: " "))\n",
-                            stderr
-                        )
-                        processTree.terminateAndWait()
+                let watchdog = timeout.map { timeout in
+                    Task {
+                        try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                        if Task.isCancelled { return }
+                        if process.isRunning {
+                            timeoutState.markTimedOut()
+                            fputs(
+                                "[Process watchdog] \(timeout)s timeout — terminating: \(executable) \(args.joined(separator: " "))\n",
+                                stderr
+                            )
+                            processTree.terminateAndWait()
+                        }
                     }
                 }
-                continuation.onTermination = { _ in
-                    watchdog.cancel()
-                    processTree.terminateAndWait()
+                continuation.onTermination = { termination in
+                    watchdog?.cancel()
+                    switch termination {
+                    case .cancelled:
+                        processTree.interruptAndWait()
+                    case .finished:
+                        processTree.terminateAndWait()
+                    @unknown default:
+                        processTree.terminateAndWait()
+                    }
                     outPipe.fileHandleForReading.readabilityHandler = nil
                     errPipe.fileHandleForReading.readabilityHandler = nil
                 }

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -1006,6 +1006,7 @@ struct GGLandStream {
 private struct GGLandStreamValidator {
     private var start: (stack: String, base: String, totalEntries: Int)?
     private var terminalPositions = Set<Int>()
+    private var successfulTerminalPositions = Set<Int>()
     private var sawTerminalEvent = false
 
     mutating func accept(_ event: GGLandEvent) throws {
@@ -1031,6 +1032,9 @@ private struct GGLandStreamValidator {
             guard terminalPositions.insert(entry.position).inserted else {
                 throw GGServiceError.malformedOutput("gg land emitted duplicate terminal entry positions.")
             }
+            if entry.error == nil {
+                successfulTerminalPositions.insert(entry.position)
+            }
 
         case .summary(let summary):
             guard let start else {
@@ -1047,6 +1051,9 @@ private struct GGLandStreamValidator {
                 guard summaryPositions.insert(entry.position).inserted else {
                     throw GGServiceError.malformedOutput("gg land summary reported duplicate entry positions.")
                 }
+            }
+            guard successfulTerminalPositions.isSubset(of: summaryPositions) else {
+                throw GGServiceError.malformedOutput("gg land summary omitted a completed entry.")
             }
             sawTerminalEvent = true
 

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -20,6 +20,15 @@ extension GGCommandRunning {
     func runStreaming(
         args: [String],
         cwd: URL?,
+        timeout: TimeInterval?,
+        interruption: GGStreamingCancellation?
+    ) -> AsyncThrowingStream<String, Error> {
+        runStreaming(args: args, cwd: cwd, timeout: timeout)
+    }
+
+    func runStreaming(
+        args: [String],
+        cwd: URL?,
         timeout: TimeInterval?
     ) -> AsyncThrowingStream<String, Error> {
         runStreaming(args: args, cwd: cwd)
@@ -98,6 +107,22 @@ struct ProcessGGCommandRunner: GGCommandRunning {
         Self.streamProcess(executable: "/usr/bin/env", args: ["gg"] + args, cwd: cwd, env: Process.gitEnv(), timeout: timeout)
     }
 
+    func runStreaming(
+        args: [String],
+        cwd: URL?,
+        timeout: TimeInterval?,
+        interruption: GGStreamingCancellation?
+    ) -> AsyncThrowingStream<String, Error> {
+        Self.streamProcess(
+            executable: "/usr/bin/env",
+            args: ["gg"] + args,
+            cwd: cwd,
+            env: Process.gitEnv(),
+            timeout: timeout,
+            interruption: interruption
+        )
+    }
+
     /// Pipe-lifecycle core of `runStreaming`, parameterized on the
     /// executable/args so tests can exercise the readability-handler /
     /// write-end-close pattern against a trivial subprocess (e.g.
@@ -108,7 +133,8 @@ struct ProcessGGCommandRunner: GGCommandRunning {
         args: [String],
         cwd: URL?,
         env: [String: String]?,
-        timeout: TimeInterval? = Process.defaultTimeout
+        timeout: TimeInterval? = Process.defaultTimeout,
+        interruption: GGStreamingCancellation? = nil
     ) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             let processTreeID = UUID().uuidString
@@ -189,6 +215,8 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                     async let outClosed = stdoutEOF.waitForClose(timeoutNanoseconds: 2_000_000_000)
                     async let errClosed = stderrAccum.waitForClose(timeoutNanoseconds: 2_000_000_000)
                     _ = await (outClosed, errClosed)
+                    outPipe.fileHandleForReading.readabilityHandler = nil
+                    errPipe.fileHandleForReading.readabilityHandler = nil
                     if timeoutState.didTimeOut, let timeout {
                         continuation.finish(throwing: ProcessError.timedOut(executable: executable, args: args, seconds: timeout))
                     } else if status == 0 {
@@ -220,6 +248,7 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                     rootIdentity: rootIdentity,
                     wrapperIdentity: wrapperIdentity
                 )
+                interruption?.install { processTree.interruptAndWait() }
                 let watchdog = timeout.map { timeout in
                     Task {
                         try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
@@ -236,6 +265,7 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                 }
                 continuation.onTermination = { termination in
                     watchdog?.cancel()
+                    interruption?.cancel()
                     switch termination {
                     case .cancelled:
                         processTree.interruptAndWait()
@@ -244,8 +274,6 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                     @unknown default:
                         processTree.terminateAndWait()
                     }
-                    outPipe.fileHandleForReading.readabilityHandler = nil
-                    errPipe.fileHandleForReading.readabilityHandler = nil
                 }
                 installStdoutHandler()
                 try? launchGate.fileHandleForWriting.write(contentsOf: Data([0x0A]))
@@ -303,6 +331,28 @@ private final class GGStreamingTimeoutState: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return timedOut
+    }
+}
+
+final class GGStreamingCancellation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var interrupt: (() -> Void)?
+    private var requested = false
+
+    func install(_ interrupt: @escaping () -> Void) {
+        lock.lock()
+        self.interrupt = interrupt
+        let requested = requested
+        lock.unlock()
+        if requested { interrupt() }
+    }
+
+    func cancel() {
+        lock.lock()
+        requested = true
+        let interrupt = interrupt
+        lock.unlock()
+        interrupt?()
     }
 }
 
@@ -629,15 +679,17 @@ struct GGService {
         // decode) and anything else still propagate.
     }
 
-    func landStream(worktreePath: String, until: String) -> AsyncThrowingStream<GGLandEvent, Error> {
-        AsyncThrowingStream { continuation in
+    func landStream(worktreePath: String, until: String) -> GGLandStream {
+        let interruption = GGStreamingCancellation()
+        let events = AsyncThrowingStream { continuation in
             let producer = Task {
                 var validator = GGLandStreamValidator()
                 do {
                     for try await line in runner.runStreaming(
                         args: ["land", "--until", until, "--wait", "--jsonl", "--no-clean"],
                         cwd: URL(fileURLWithPath: worktreePath),
-                        timeout: nil
+                        timeout: nil,
+                        interruption: interruption
                     ) {
                         let event = try GGLandEvent.decode(line: line)
                         try validator.accept(event)
@@ -652,8 +704,12 @@ struct GGService {
                     continuation.finish(throwing: error)
                 }
             }
-            continuation.onTermination = { _ in producer.cancel() }
+            continuation.onTermination = { _ in
+                interruption.cancel()
+                producer.cancel()
+            }
         }
+        return GGLandStream(events: events, cancel: interruption.cancel)
     }
 
     func clean(worktreePath: String) async throws {
@@ -919,6 +975,11 @@ struct GGService {
             return nil
         }
     }
+}
+
+struct GGLandStream {
+    let events: AsyncThrowingStream<GGLandEvent, Error>
+    let cancel: @Sendable () -> Void
 }
 
 private struct GGLandStreamValidator {

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -406,6 +406,7 @@ struct GGService {
         let unstack = try? await runner.run(args: ["unstack", "--help"], cwd: nil)
         let sc = try? await runner.run(args: ["sc", "--help"], cwd: nil)
         let sync = try? await runner.run(args: ["sync", "--help"], cwd: nil)
+        let land = try? await runner.run(args: ["land", "--help"], cwd: nil)
         let ls = try? await runner.run(args: ["ls", "--help"], cwd: nil)
         return GGCapabilities(
             structuredSplit: split?.exitCode == 0
@@ -418,6 +419,7 @@ struct GGService {
             stagedOnlyAmend: sc?.exitCode == 0
                 && sc?.stdout.contains("--staged-only") == true,
             syncJSONL: sync?.exitCode == 0 && sync?.stdout.contains("--jsonl") == true,
+            landJSONL: land?.exitCode == 0 && land?.stdout.contains("--jsonl") == true,
             localStackSnapshot: ls?.exitCode == 0
                 && ls?.stdout.contains("--no-refresh") == true
         )
@@ -625,6 +627,33 @@ struct GGService {
         }
         // A real in-band error (GGServiceError.commandFailed thrown by
         // decode) and anything else still propagate.
+    }
+
+    func landStream(worktreePath: String, until: String) -> AsyncThrowingStream<GGLandEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let producer = Task {
+                var validator = GGLandStreamValidator()
+                do {
+                    for try await line in runner.runStreaming(
+                        args: ["land", "--until", until, "--wait", "--jsonl", "--no-clean"],
+                        cwd: URL(fileURLWithPath: worktreePath),
+                        timeout: nil
+                    ) {
+                        let event = try GGLandEvent.decode(line: line)
+                        try validator.accept(event)
+                        continuation.yield(event)
+                        if case .error(let message) = event {
+                            throw GGServiceError.commandFailed(stderr: message)
+                        }
+                    }
+                    try validator.finish()
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in producer.cancel() }
+        }
     }
 
     func clean(worktreePath: String) async throws {
@@ -888,6 +917,77 @@ struct GGService {
         } catch let error as GGServiceError {
             if case .unsupportedSchema = error { throw error }
             return nil
+        }
+    }
+}
+
+private struct GGLandStreamValidator {
+    private var start: (stack: String, base: String, totalEntries: Int)?
+    private var terminalPositions = Set<Int>()
+    private var sawTerminalEvent = false
+
+    mutating func accept(_ event: GGLandEvent) throws {
+        guard !sawTerminalEvent else {
+            throw GGServiceError.malformedOutput("gg land emitted data after a terminal event.")
+        }
+
+        switch event {
+        case .start(let stack, let base, let totalEntries):
+            guard start == nil else {
+                throw GGServiceError.malformedOutput("gg land emitted duplicate start events.")
+            }
+            guard totalEntries >= 0 else {
+                throw GGServiceError.malformedOutput("gg land start reported a negative entry count.")
+            }
+            start = (stack, base, totalEntries)
+
+        case .wait(let wait):
+            try validateActivePosition(wait.position, event: "wait")
+
+        case .entry(let entry):
+            try validateActivePosition(entry.position, event: "entry")
+            guard terminalPositions.insert(entry.position).inserted else {
+                throw GGServiceError.malformedOutput("gg land emitted duplicate terminal entry positions.")
+            }
+
+        case .summary(let summary):
+            guard let start else {
+                throw GGServiceError.malformedOutput("gg land emitted summary before start.")
+            }
+            guard summary.stack == start.stack, summary.base == start.base else {
+                throw GGServiceError.malformedOutput("gg land summary did not match start identity.")
+            }
+            var summaryPositions = Set<Int>()
+            for entry in summary.landed {
+                guard entry.position >= 1, entry.position <= start.totalEntries else {
+                    throw GGServiceError.malformedOutput("gg land summary reported an entry outside its start range.")
+                }
+                guard summaryPositions.insert(entry.position).inserted else {
+                    throw GGServiceError.malformedOutput("gg land summary reported duplicate entry positions.")
+                }
+            }
+            sawTerminalEvent = true
+
+        case .error:
+            sawTerminalEvent = true
+        }
+    }
+
+    func finish() throws {
+        guard sawTerminalEvent else {
+            throw GGServiceError.malformedOutput("gg land ended without a summary or error event.")
+        }
+    }
+
+    private func validateActivePosition(_ position: Int, event: String) throws {
+        guard let start else {
+            throw GGServiceError.malformedOutput("gg land emitted \(event) before start.")
+        }
+        guard position >= 1, position <= start.totalEntries else {
+            throw GGServiceError.malformedOutput("gg land emitted \(event) outside its start range.")
+        }
+        guard !terminalPositions.contains(position) else {
+            throw GGServiceError.malformedOutput("gg land emitted \(event) after that entry completed.")
         }
     }
 }

--- a/Alas/Sources/Integrations/GG/GGService.swift
+++ b/Alas/Sources/Integrations/GG/GGService.swift
@@ -14,6 +14,12 @@ protocol GGCommandRunning: Sendable {
         cwd: URL?,
         timeout: TimeInterval?
     ) -> AsyncThrowingStream<String, Error>
+    func runStreaming(
+        args: [String],
+        cwd: URL?,
+        timeout: TimeInterval?,
+        interruption: GGStreamingCancellation?
+    ) -> AsyncThrowingStream<String, Error>
 }
 
 extension GGCommandRunning {
@@ -23,7 +29,20 @@ extension GGCommandRunning {
         timeout: TimeInterval?,
         interruption: GGStreamingCancellation?
     ) -> AsyncThrowingStream<String, Error> {
-        runStreaming(args: args, cwd: cwd, timeout: timeout)
+        AsyncThrowingStream { continuation in
+            let consumer = Task {
+                do {
+                    for try await line in runStreaming(args: args, cwd: cwd, timeout: timeout) {
+                        continuation.yield(line)
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            interruption?.install { consumer.cancel() }
+            continuation.onTermination = { _ in consumer.cancel() }
+        }
     }
 
     func runStreaming(
@@ -248,7 +267,9 @@ struct ProcessGGCommandRunner: GGCommandRunning {
                     rootIdentity: rootIdentity,
                     wrapperIdentity: wrapperIdentity
                 )
-                interruption?.install { processTree.interruptAndWait() }
+                interruption?.install {
+                    Task.detached { processTree.interruptAndWait() }
+                }
                 let watchdog = timeout.map { timeout in
                     Task {
                         try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
@@ -709,7 +730,7 @@ struct GGService {
                 producer.cancel()
             }
         }
-        return GGLandStream(events: events, cancel: interruption.cancel)
+        return GGLandStream(events: events, cancel: { interruption.cancel() })
     }
 
     func clean(worktreePath: String) async throws {

--- a/Alas/Sources/Integrations/GG/GGStreamingProcessTree.swift
+++ b/Alas/Sources/Integrations/GG/GGStreamingProcessTree.swift
@@ -60,6 +60,14 @@ final class GGStreamingProcessTree: @unchecked Sendable {
     }
 
     func terminateAndWait(graceNanoseconds: UInt64 = 2_000_000_000) {
+        stopAndWait(initialSignal: SIGTERM, graceNanoseconds: graceNanoseconds)
+    }
+
+    func interruptAndWait(graceNanoseconds: UInt64 = 2_000_000_000) {
+        stopAndWait(initialSignal: SIGINT, graceNanoseconds: graceNanoseconds)
+    }
+
+    private func stopAndWait(initialSignal: Int32, graceNanoseconds: UInt64) {
         condition.lock()
         while terminationInProgress {
             condition.wait()
@@ -77,8 +85,8 @@ final class GGStreamingProcessTree: @unchecked Sendable {
             return
         }
         var descendants = terminationTargets(rootPID: pid).union(environmentTargets(rootPID: pid))
-        signalRootAndGroup(pid, signal: SIGTERM)
-        signal(descendants, with: SIGTERM)
+        signalRootAndGroup(pid, signal: initialSignal)
+        signal(descendants, with: initialSignal)
 
         let deadline = DispatchTime.now().uptimeNanoseconds + graceNanoseconds
         var rootExitObservedAt: UInt64?
@@ -101,7 +109,7 @@ final class GGStreamingProcessTree: @unchecked Sendable {
                     scannedAfterRootExit = true
                 }
             }
-            signal(refreshed.subtracting(descendants), with: SIGTERM)
+            signal(refreshed.subtracting(descendants), with: initialSignal)
             descendants.formUnion(refreshed)
             if rootHasExited,
                scannedAfterRootExit,

--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -46,33 +46,19 @@ struct ChangesPreparationCard: View {
     let onGGStackAction: (GGStackActionKind) -> Void
     let onReviewRequestAction: (ReviewReadinessActionKind) -> Void
     let onDismissSyncFailure: () -> Void
+    let onOpenGGLanding: () -> Void
 
     @Environment(\.theme) private var theme
 
     var body: some View {
         VStack(alignment: .leading, spacing: 9) {
             header
-            if let syncProgress = model.syncProgress {
+            if let landing = model.landingStatus {
+                ggLandingStatusView(landing)
+            } else if let syncProgress = model.syncProgress {
                 syncProgressView(syncProgress)
             } else {
-                if let reviewAction = model.reviewAction {
-                    primaryReviewButton(reviewAction)
-                }
-                if let reconciliationAction = model.reconciliationAction {
-                    ggReconciliationButton(reconciliationAction)
-                }
-                if !model.ggActions.isEmpty {
-                    LazyVGrid(columns: [GridItem(.flexible(minimum: 0)), GridItem(.flexible(minimum: 0))], spacing: 6) {
-                        ForEach(model.ggActions, id: \.kind) { action in
-                            ggDestinationButton(action)
-                        }
-                    }
-                } else if model.draftAction != nil || model.publishAction != nil || !model.reviewRequestActions.isEmpty {
-                    ViewThatFits(in: .horizontal) {
-                        secondaryActionsHorizontal
-                        secondaryActionsVertical
-                    }
-                }
+                prepareActions
             }
             if let error = model.mutationError {
                 Text(error)
@@ -95,6 +81,71 @@ struct ChangesPreparationCard: View {
         .padding(.top, 8)
         .padding(.bottom, 6)
         .accessibilityIdentifier("changes-preparation-card")
+    }
+
+    @ViewBuilder
+    private var prepareActions: some View {
+        if let reviewAction = model.reviewAction {
+            primaryReviewButton(reviewAction)
+        }
+        if let reconciliationAction = model.reconciliationAction {
+            ggReconciliationButton(reconciliationAction)
+        }
+        if !model.ggActions.isEmpty {
+            LazyVGrid(columns: [GridItem(.flexible(minimum: 0)), GridItem(.flexible(minimum: 0))], spacing: 6) {
+                ForEach(model.ggActions, id: \.kind) { action in
+                    ggDestinationButton(action)
+                }
+            }
+        } else if model.draftAction != nil || model.publishAction != nil || !model.reviewRequestActions.isEmpty {
+            ViewThatFits(in: .horizontal) {
+                secondaryActionsHorizontal
+                secondaryActionsVertical
+            }
+        }
+    }
+
+    private func ggLandingStatusView(_ landing: ChangesPreparationModel.GGLandingStatus) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 8) {
+                Spinner(lineWidth: 1.5, duration: 0.8)
+                    .frame(width: 12, height: 12)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Landing \(landing.completed) of \(landing.total)")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(theme.color("fg"))
+                    Text(landingDetail(landing))
+                        .font(.system(size: 10.5))
+                        .foregroundStyle(theme.color("fg-faint"))
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 0)
+            }
+            Button(action: onOpenGGLanding) {
+                Text("Open landing")
+                    .font(.system(size: 11.5, weight: .semibold))
+                    .frame(maxWidth: .infinity, minHeight: 30)
+                    .contentShape(RoundedRectangle(cornerRadius: 6))
+            }
+            .buttonStyle(.plain)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(theme.color("bg-2").opacity(0.72))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(theme.color("line").opacity(0.65), lineWidth: 0.75)
+            )
+            .accessibilityIdentifier("changes-preparation-open-gg-landing")
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("changes-preparation-gg-landing")
+    }
+
+    private func landingDetail(_ landing: ChangesPreparationModel.GGLandingStatus) -> String {
+        let review = landing.reviewNumber.map { "#\($0) · " } ?? ""
+        return review + landing.detail
     }
 
     private func syncProgressView(_ progress: GGSyncProgressPresentation) -> some View {

--- a/Alas/Sources/Right/ChangesPreparationModel.swift
+++ b/Alas/Sources/Right/ChangesPreparationModel.swift
@@ -53,11 +53,19 @@ struct ChangesPreparationModel: Equatable {
         var isEnabled: Bool { disabledReason == nil }
     }
 
+    struct GGLandingStatus: Equatable {
+        let completed: Int
+        let total: Int
+        let reviewNumber: Int?
+        let detail: String
+    }
+
     let reviewAction: ReviewAction?
     let draftAction: DraftAction?
     let publishAction: CommitPublishAvailability?
     let reviewRequestActions: [ReviewRequestAction]
     let reconciliationAction: GGStackReadinessModel.Action?
+    let landingStatus: GGLandingStatus?
     let syncProgress: GGSyncProgressPresentation?
     let canDismissSyncFailure: Bool
     let ggActions: [GGAction]
@@ -66,6 +74,9 @@ struct ChangesPreparationModel: Equatable {
     var primaryAction: ReviewAction? { reviewAction }
 
     var isVisible: Bool {
+        if landingStatus != nil {
+            return true
+        }
         if !ggActions.isEmpty {
             return mutationError != nil
                 || reconciliationAction != nil
@@ -116,6 +127,7 @@ struct ChangesPreparationModel: Equatable {
         draftAction = builtDraftAction
         publishAction = builtDraftAction == nil ? nil : publishAvailability
         reconciliationAction = nil
+        landingStatus = nil
         syncProgress = nil
         canDismissSyncFailure = false
         ggActions = []
@@ -144,6 +156,7 @@ struct ChangesPreparationModel: Equatable {
         newCommitDisabledReason: String? = nil,
         mutationError: String? = nil,
         reconciliationAction: GGStackReadinessModel.Action? = nil,
+        landingStatus: GGLandingStatus? = nil,
         syncProgress: GGSyncProgressPresentation? = nil,
         canDismissSyncFailure: Bool = false
     ) -> ChangesPreparationModel {
@@ -164,6 +177,7 @@ struct ChangesPreparationModel: Equatable {
             newCommitDisabledReason: newCommitDisabledReason,
             mutationError: mutationError,
             reconciliationAction: reconciliationAction,
+            landingStatus: landingStatus,
             syncProgress: syncProgress,
             canDismissSyncFailure: canDismissSyncFailure,
             reviewSummary: summary
@@ -180,6 +194,7 @@ struct ChangesPreparationModel: Equatable {
         newCommitDisabledReason: String? = nil,
         mutationError: String? = nil,
         reconciliationAction: GGStackReadinessModel.Action? = nil,
+        landingStatus: GGLandingStatus? = nil,
         syncProgress: GGSyncProgressPresentation? = nil,
         canDismissSyncFailure: Bool = false
     ) -> ChangesPreparationModel {
@@ -200,6 +215,7 @@ struct ChangesPreparationModel: Equatable {
             newCommitDisabledReason: newCommitDisabledReason,
             mutationError: mutationError,
             reconciliationAction: reconciliationAction,
+            landingStatus: landingStatus,
             syncProgress: syncProgress,
             canDismissSyncFailure: canDismissSyncFailure,
             reviewSummary: summary
@@ -220,10 +236,17 @@ struct ChangesPreparationModel: Equatable {
         newCommitDisabledReason: String?,
         mutationError: String?,
         reconciliationAction: GGStackReadinessModel.Action?,
+        landingStatus: GGLandingStatus?,
         syncProgress: GGSyncProgressPresentation?,
         canDismissSyncFailure: Bool,
         reviewSummary: ReviewChangesTriggerSummary?
     ) -> ChangesPreparationModel {
+        if let landingStatus {
+            return ChangesPreparationModel(
+                landingStatus: landingStatus,
+                mutationError: mutationError
+            )
+        }
         let reviewAction = reviewSummary.map {
             ReviewAction(
                 title: "Review current changes",
@@ -246,6 +269,7 @@ struct ChangesPreparationModel: Equatable {
         return ChangesPreparationModel(
             reviewAction: reviewAction,
             reconciliationAction: reconciliationAction,
+            landingStatus: nil,
             syncProgress: syncProgress,
             canDismissSyncFailure: canDismissSyncFailure,
             mutationError: mutationError,
@@ -289,6 +313,7 @@ struct ChangesPreparationModel: Equatable {
     private init(
         reviewAction: ReviewAction?,
         reconciliationAction: GGStackReadinessModel.Action?,
+        landingStatus: GGLandingStatus?,
         syncProgress: GGSyncProgressPresentation?,
         canDismissSyncFailure: Bool,
         mutationError: String?,
@@ -299,10 +324,27 @@ struct ChangesPreparationModel: Equatable {
         publishAction = nil
         reviewRequestActions = []
         self.reconciliationAction = reconciliationAction
+        self.landingStatus = landingStatus
         self.syncProgress = syncProgress
         self.canDismissSyncFailure = canDismissSyncFailure
         self.mutationError = mutationError
         self.ggActions = ggActions
+    }
+
+    private init(
+        landingStatus: GGLandingStatus,
+        mutationError: String?
+    ) {
+        reviewAction = nil
+        draftAction = nil
+        publishAction = nil
+        reviewRequestActions = []
+        reconciliationAction = nil
+        self.landingStatus = landingStatus
+        syncProgress = nil
+        canDismissSyncFailure = false
+        self.mutationError = mutationError
+        ggActions = []
     }
 
     private static func compactReviewRequestActions(

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -22,7 +22,13 @@ struct ChangesTabView: View {
     }
 
     private var preparationModel: ChangesPreparationModel {
-        if isGGDrawerActive {
+        let landingStatus = Self.landingStatus(
+            from: GGLandingStore.shared.sessions[rps.worktree.projectId]
+        )
+        if Self.shouldUseGGPreparation(
+            drawerIsActive: isGGDrawerActive,
+            landingStatus: landingStatus
+        ) {
             return ChangesPreparationModel.makeGG(
                 changes: rps.changes,
                 hasDraft: draftNonEmpty,
@@ -38,9 +44,7 @@ struct ChangesTabView: View {
                 ),
                 mutationError: rps.ggActionState.lastError,
                 reconciliationAction: Self.reconciliationAction(from: ggReadinessModel),
-                landingStatus: Self.landingStatus(
-                    from: GGLandingStore.shared.sessions[rps.worktree.projectId]
-                ),
+                landingStatus: landingStatus,
                 syncProgress: GGStackReadinessModel.syncProgress(
                     action: rps.ggActionState,
                     base: rps.ggStack?.base ?? rps.baseBranch,
@@ -722,6 +726,13 @@ struct ChangesTabView: View {
         hasUndoCandidate: Bool
     ) -> Bool {
         contextIsActive || pausedGGOperation != nil || hasUndoCandidate
+    }
+
+    static func shouldUseGGPreparation(
+        drawerIsActive: Bool,
+        landingStatus: ChangesPreparationModel.GGLandingStatus?
+    ) -> Bool {
+        drawerIsActive || landingStatus != nil
     }
 
     static func shouldShowChangesPreparationCard(

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -38,6 +38,9 @@ struct ChangesTabView: View {
                 ),
                 mutationError: rps.ggActionState.lastError,
                 reconciliationAction: Self.reconciliationAction(from: ggReadinessModel),
+                landingStatus: Self.landingStatus(
+                    from: GGLandingStore.shared.sessions[rps.worktree.projectId]
+                ),
                 syncProgress: GGStackReadinessModel.syncProgress(
                     action: rps.ggActionState,
                     base: rps.ggStack?.base ?? rps.baseBranch,
@@ -237,6 +240,23 @@ struct ChangesTabView: View {
         }
     }
 
+    static func landingStatus(
+        from session: GGLandingSession?
+    ) -> ChangesPreparationModel.GGLandingStatus? {
+        guard let session,
+              session.phase == .running || session.phase == .cancelling
+        else { return nil }
+        let row = session.rows.first { GGLandingPresentation.isActive($0, in: session) }
+            ?? session.rows.first { $0.outcome == nil }
+        return ChangesPreparationModel.GGLandingStatus(
+            completed: session.rows.filter { $0.outcome != nil && $0.outcome?.error == nil }.count,
+            total: session.rows.count,
+            reviewNumber: row?.prNumber,
+            detail: row.map { GGLandingPresentation.detail(for: $0, in: session) }
+                ?? (session.phase == .cancelling ? "Cancelling..." : "Landing...")
+        )
+    }
+
     private var appKitScrollPlan: AppKitDiffRowPlan {
         let preparation = preparationModel
         let workingTree = workingTreeSection
@@ -321,7 +341,8 @@ struct ChangesTabView: View {
                     onGGAction: handleGGPreparationAction,
                     onGGStackAction: { rps.onGGStackAction($0, appState: appState) },
                     onReviewRequestAction: { rps.handleReviewReadinessAction($0, appState: appState) },
-                    onDismissSyncFailure: { rps.ggActionState.dismissCompletedSyncFailure() }
+                    onDismissSyncFailure: { rps.ggActionState.dismissCompletedSyncFailure() },
+                    onOpenGGLanding: { appState.openGGLanding(projectId: rps.worktree.projectId) }
                 )
             })
         }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1898,6 +1898,9 @@ final class RightPaneState: GGSplitCommitServicing {
                 }
                 let prepared = try await ggMutationCoordinator.prepare(.land(target: target))
                 try Task.checkCancellation()
+                guard let stack = prepared.stack,
+                      Self.ggLandingScopeMatches(session, target: target, stack: stack)
+                else { throw GGMutationError.staleConfirmation }
                 guard ggLandingStore.sessions[projectId]?.id == sessionId else { return }
                 startGGLanding(prepared)
             } catch {
@@ -1916,8 +1919,41 @@ final class RightPaneState: GGSplitCommitServicing {
             stack: stack.name, base: stack.base, target: target,
             rows: stack.entries.filter { $0.position <= entry.position }
                 .sorted { $0.position < $1.position }
-                .map { GGLandingRow(position: $0.position, title: $0.title, ggId: $0.ggId, prNumber: $0.prNumber) }
+                .map {
+                    GGLandingRow(
+                        position: $0.position,
+                        title: $0.title,
+                        ggId: $0.ggId,
+                        stableID: $0.id,
+                        prNumber: $0.prNumber
+                    )
+                }
         )
+    }
+
+    private static func ggLandingScopeMatches(
+        _ session: GGLandingSession,
+        target: String,
+        stack: GGStack
+    ) -> Bool {
+        guard target == session.target,
+              stack.name == session.stack,
+              stack.base == session.base,
+              let targetEntry = stack.entries.first(where: { $0.id == target || $0.sha == target })
+        else { return false }
+        let originalIDs = session.rows.compactMap { $0.stableID ?? $0.ggId }
+        guard originalIDs.count == session.rows.count,
+              originalIDs.last == target,
+              let currentTargetIndex = stack.entries.firstIndex(of: targetEntry)
+        else { return false }
+        let currentIDs = stack.entries[..<currentTargetIndex].map(\.id) + [targetEntry.id]
+        guard currentIDs.allSatisfy(originalIDs.contains) else { return false }
+        var nextOriginalIndex = 0
+        for id in currentIDs {
+            guard let index = originalIDs[nextOriginalIndex...].firstIndex(of: id) else { return false }
+            nextOriginalIndex = index + 1
+        }
+        return true
     }
 
     private func startGGLanding(_ prepared: GGPreparedMutation) {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1859,10 +1859,18 @@ final class RightPaneState: GGSplitCommitServicing {
             runGGMutation(prepared.request, confirmedAgainst: prepared.snapshot)
             return
         }
+        if let session = ggLandingStore.sessions[worktree.projectId],
+           session.phase == .running || session.phase == .cancelling {
+            appState.openGGLanding(projectId: worktree.projectId)
+            return
+        }
         guard case .land(let target) = prepared.request,
-              let seed = ggLandingSeed(target: target),
-              ggLandingStore.begin(seed)
-        else { return }
+              let seed = ggLandingSeed(target: target) else { return }
+        guard ggLandingStore.begin(seed) else {
+            appState.openGGLanding(projectId: worktree.projectId)
+            return
+        }
+        appState.openGGLanding(projectId: worktree.projectId)
         startGGLanding(prepared)
     }
 

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1891,8 +1891,17 @@ final class RightPaneState: GGSplitCommitServicing {
                 }
                 let prepared = try await ggMutationCoordinator.prepare(.land(target: target))
                 try Task.checkCancellation()
+                let landedIDs = Set(session.rows.compactMap { row -> String? in
+                    guard row.outcome?.error == nil, row.outcome != nil else { return nil }
+                    return row.stableID ?? row.ggId
+                })
                 guard let stack = prepared.stack,
-                      Self.ggLandingScopeMatches(session.confirmedScope, target: target, stack: stack),
+                      Self.ggLandingScopeMatches(
+                        session.confirmedScope,
+                        target: target,
+                        stack: stack,
+                        landedIDs: landedIDs
+                      ),
                       let seed = ggLandingSeed(target: target, stack: stack)
                 else { throw GGMutationError.staleConfirmation }
                 guard ggLandingStore.sessions[projectId]?.id == sessionId else { return }
@@ -1929,7 +1938,8 @@ final class RightPaneState: GGSplitCommitServicing {
     private static func ggLandingScopeMatches(
         _ session: GGLandingSession.Seed,
         target: String,
-        stack: GGStack
+        stack: GGStack,
+        landedIDs: Set<String>
     ) -> Bool {
         guard target == session.target,
               stack.name == session.stack,
@@ -1943,6 +1953,8 @@ final class RightPaneState: GGSplitCommitServicing {
         let currentIDs = stack.entries.sorted { $0.position < $1.position }
             .filter { $0.position <= targetEntry.position }.map(\.id)
         let remainingIDs = Set(stack.entries.map(\.id))
+        let missingIDs = originalIDs.filter { !remainingIDs.contains($0) }
+        guard missingIDs.allSatisfy({ landedIDs.contains($0) }) else { return false }
         return currentIDs == originalIDs.filter { remainingIDs.contains($0) }
     }
 

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1883,14 +1883,7 @@ final class RightPaneState: GGSplitCommitServicing {
             await ggLandingStore.waitForOperation(projectId: projectId)
             guard !Task.isCancelled else { return }
             guard ggLandingStore.sessions[projectId]?.id == session.id else { return }
-            let seed = ggLandingSeed(target: target) ?? GGLandingSession.Seed(
-                projectId: projectId, worktreeId: worktree.id,
-                stack: session.stack, base: session.base, target: target,
-                rows: session.rows.map {
-                    GGLandingRow(position: $0.position, title: $0.title, ggId: $0.ggId, prNumber: $0.prNumber)
-                }
-            )
-            guard ggLandingStore.begin(seed) else { return }
+            guard ggLandingStore.begin(session.confirmedScope) else { return }
             let sessionId = ggLandingStore.sessions[projectId]?.id
             do {
                 guard ggCapabilities().landJSONL else {
@@ -1899,9 +1892,11 @@ final class RightPaneState: GGSplitCommitServicing {
                 let prepared = try await ggMutationCoordinator.prepare(.land(target: target))
                 try Task.checkCancellation()
                 guard let stack = prepared.stack,
-                      Self.ggLandingScopeMatches(session, target: target, stack: stack)
+                      Self.ggLandingScopeMatches(session.confirmedScope, target: target, stack: stack),
+                      let seed = ggLandingSeed(target: target, stack: stack)
                 else { throw GGMutationError.staleConfirmation }
                 guard ggLandingStore.sessions[projectId]?.id == sessionId else { return }
+                ggLandingStore.updatePendingRows(seed.rows, projectId: projectId)
                 startGGLanding(prepared)
             } catch {
                 guard ggLandingStore.sessions[projectId]?.id == sessionId else { return }
@@ -1910,8 +1905,8 @@ final class RightPaneState: GGSplitCommitServicing {
         }
     }
 
-    private func ggLandingSeed(target: String) -> GGLandingSession.Seed? {
-        guard let stack = ggStack,
+    private func ggLandingSeed(target: String, stack: GGStack? = nil) -> GGLandingSession.Seed? {
+        guard let stack = stack ?? ggStack,
               let entry = stack.entries.first(where: { $0.id == target || $0.sha == target })
         else { return nil }
         return GGLandingSession.Seed(
@@ -1932,7 +1927,7 @@ final class RightPaneState: GGSplitCommitServicing {
     }
 
     private static func ggLandingScopeMatches(
-        _ session: GGLandingSession,
+        _ session: GGLandingSession.Seed,
         target: String,
         stack: GGStack
     ) -> Bool {
@@ -1943,17 +1938,12 @@ final class RightPaneState: GGSplitCommitServicing {
         else { return false }
         let originalIDs = session.rows.compactMap { $0.stableID ?? $0.ggId }
         guard originalIDs.count == session.rows.count,
-              originalIDs.last == target,
-              let currentTargetIndex = stack.entries.firstIndex(of: targetEntry)
+              originalIDs.last == targetEntry.id
         else { return false }
-        let currentIDs = stack.entries[..<currentTargetIndex].map(\.id) + [targetEntry.id]
-        guard currentIDs.allSatisfy(originalIDs.contains) else { return false }
-        var nextOriginalIndex = 0
-        for id in currentIDs {
-            guard let index = originalIDs[nextOriginalIndex...].firstIndex(of: id) else { return false }
-            nextOriginalIndex = index + 1
-        }
-        return true
+        let currentIDs = stack.entries.sorted { $0.position < $1.position }
+            .filter { $0.position <= targetEntry.position }.map(\.id)
+        let remainingIDs = Set(stack.entries.map(\.id))
+        return currentIDs == originalIDs.filter { remainingIDs.contains($0) }
     }
 
     private func startGGLanding(_ prepared: GGPreparedMutation) {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1865,7 +1865,7 @@ final class RightPaneState: GGSplitCommitServicing {
             return
         }
         guard case .land(let target) = prepared.request,
-              let seed = ggLandingSeed(target: target) else { return }
+              let seed = ggLandingSeed(target: target, stack: prepared.stack) else { return }
         guard ggLandingStore.begin(seed) else {
             appState.openGGLanding(projectId: worktree.projectId)
             return

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1871,8 +1871,9 @@ final class RightPaneState: GGSplitCommitServicing {
         guard let session = ggLandingStore.sessions[projectId],
               session.phase == .cancelled || session.phase == .failed || session.phase == .succeeded
         else { return }
-        Task { @MainActor in
+        ggLandingStore.startPreparation(projectId: projectId) { [self] in
             await ggLandingStore.waitForOperation(projectId: projectId)
+            guard !Task.isCancelled else { return }
             guard ggLandingStore.sessions[projectId]?.id == session.id else { return }
             let seed = ggLandingSeed(target: target) ?? GGLandingSession.Seed(
                 projectId: projectId, worktreeId: worktree.id,
@@ -1888,6 +1889,7 @@ final class RightPaneState: GGSplitCommitServicing {
                     throw GGServiceError.commandFailed(stderr: "Live landing is no longer supported by gg.")
                 }
                 let prepared = try await ggMutationCoordinator.prepare(.land(target: target))
+                try Task.checkCancellation()
                 guard ggLandingStore.sessions[projectId]?.id == sessionId else { return }
                 startGGLanding(prepared)
             } catch {
@@ -2019,6 +2021,7 @@ final class RightPaneState: GGSplitCommitServicing {
             do {
                 try await operation.value
             } catch {
+                if operation.isCancelled || error is CancellationError { throw CancellationError() }
                 publishGGMutationPresentationError(
                     error,
                     for: request.actionKind,

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1867,6 +1867,14 @@ final class RightPaneState: GGSplitCommitServicing {
         guard case .land(let target) = prepared.request,
               let seed = ggLandingSeed(target: target, stack: prepared.stack) else { return }
         guard ggLandingStore.begin(seed) else {
+            if let session = ggLandingStore.sessions[worktree.projectId],
+               session.phase != .running, session.phase != .cancelling {
+                ggLandingStore.startPreparation(projectId: worktree.projectId) { [self] in
+                    await ggLandingStore.waitForOperation(projectId: worktree.projectId)
+                    guard ggLandingStore.begin(seed) else { return }
+                    startGGLanding(prepared)
+                }
+            }
             appState.openGGLanding(projectId: worktree.projectId)
             return
         }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -161,6 +161,7 @@ final class RightPaneState: GGSplitCommitServicing {
     }
     @ObservationIgnored
     private var ggMutationCoordinatorStorage: GGMutationCoordinator? = nil
+    @ObservationIgnored private let ggLandingStore: GGLandingStore
     @ObservationIgnored private var didAttemptGGUndoRestore = false
     /// Backing store for the stack drawer's mutation UI (in-flight action,
     /// sync progress, paused/error state). Not snapshot-derived, so
@@ -436,8 +437,9 @@ final class RightPaneState: GGSplitCommitServicing {
         return true
     }
 
-    init(worktree: Worktree, baseBranch: String) {
+    init(worktree: Worktree, baseBranch: String, ggLandingStore: GGLandingStore = .shared) {
         self.worktree = worktree
+        self.ggLandingStore = ggLandingStore
         self.baseBranch = baseBranch
         self.currentBranch = worktree.branch
         self.reviewLoop = ReviewLoopState(worktreePath: worktree.path, baseBranch: baseBranch)
@@ -458,6 +460,7 @@ final class RightPaneState: GGSplitCommitServicing {
             worktreePath: worktree.path.path,
             service: ggService,
             actionState: ggActionState,
+            landJSONLCapability: { [weak self] in self?.ggCapabilities().landJSONL ?? false },
             context: GGMutationContext(
                 loadFreshStack: { [weak self] in
                     guard let self else { throw GGServiceError.commandFailed(stderr: "Worktree is no longer available.") }
@@ -493,7 +496,10 @@ final class RightPaneState: GGSplitCommitServicing {
                     GGInboxStore.shared.invalidate(projectId: self.worktree.projectId)
                 },
                 selectWorktreeAtPath: { [weak self] path in await self?.selectWorktreeAtPathAfterGGMutation?(path) },
-                currentBranch: { [weak self] in self?.currentBranch }
+                currentBranch: { [weak self] in self?.currentBranch },
+                publishLandEvent: { [ggLandingStore, projectId = worktree.projectId] event in
+                    ggLandingStore.receive(event, projectId: projectId)
+                }
             )
         )
         ggMutationCoordinatorStorage = coordinator
@@ -1845,11 +1851,78 @@ final class RightPaneState: GGSplitCommitServicing {
     }
 
     @MainActor
-    func performGGLand() {
+    func performGGLand(appState: AppState) {
         guard pendingGGLand != nil, let prepared = pendingGGLandPrepared else { return }
         pendingGGLand = nil
         pendingGGLandPrepared = nil
-        runGGMutation(prepared.request, confirmedAgainst: prepared.snapshot)
+        guard ggCapabilities().landJSONL else {
+            runGGMutation(prepared.request, confirmedAgainst: prepared.snapshot)
+            return
+        }
+        guard case .land(let target) = prepared.request,
+              let seed = ggLandingSeed(target: target),
+              ggLandingStore.begin(seed)
+        else { return }
+        startGGLanding(prepared)
+    }
+
+    func restartGGLand(target: String) {
+        let projectId = worktree.projectId
+        guard let session = ggLandingStore.sessions[projectId],
+              session.phase == .cancelled || session.phase == .failed || session.phase == .succeeded
+        else { return }
+        Task { @MainActor in
+            await ggLandingStore.waitForOperation(projectId: projectId)
+            guard ggLandingStore.sessions[projectId]?.id == session.id else { return }
+            let seed = ggLandingSeed(target: target) ?? GGLandingSession.Seed(
+                projectId: projectId, worktreeId: worktree.id,
+                stack: session.stack, base: session.base, target: target,
+                rows: session.rows.map {
+                    GGLandingRow(position: $0.position, title: $0.title, ggId: $0.ggId, prNumber: $0.prNumber)
+                }
+            )
+            guard ggLandingStore.begin(seed) else { return }
+            let sessionId = ggLandingStore.sessions[projectId]?.id
+            do {
+                guard ggCapabilities().landJSONL else {
+                    throw GGServiceError.commandFailed(stderr: "Live landing is no longer supported by gg.")
+                }
+                let prepared = try await ggMutationCoordinator.prepare(.land(target: target))
+                guard ggLandingStore.sessions[projectId]?.id == sessionId else { return }
+                startGGLanding(prepared)
+            } catch {
+                guard ggLandingStore.sessions[projectId]?.id == sessionId else { return }
+                ggLandingStore.fail(projectId: projectId, message: GGErrorPresentation.message(for: error))
+            }
+        }
+    }
+
+    private func ggLandingSeed(target: String) -> GGLandingSession.Seed? {
+        guard let stack = ggStack,
+              let entry = stack.entries.first(where: { $0.id == target || $0.sha == target })
+        else { return nil }
+        return GGLandingSession.Seed(
+            projectId: worktree.projectId, worktreeId: worktree.id,
+            stack: stack.name, base: stack.base, target: target,
+            rows: stack.entries.filter { $0.position <= entry.position }
+                .sorted { $0.position < $1.position }
+                .map { GGLandingRow(position: $0.position, title: $0.title, ggId: $0.ggId, prNumber: $0.prNumber) }
+        )
+    }
+
+    private func startGGLanding(_ prepared: GGPreparedMutation) {
+        guard let operation = ggMutationCoordinator.startApplying(prepared) else {
+            ggLandingStore.fail(
+                projectId: worktree.projectId,
+                message: GGErrorPresentation.message(for: GGMutationError.operationInFlight)
+            )
+            return
+        }
+        ggLandingStore.attach(
+            projectId: worktree.projectId,
+            task: completeGGMutation(operation, request: prepared.request),
+            cancel: { operation.cancel() }
+        )
     }
 
     @discardableResult

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1883,7 +1883,11 @@ final class RightPaneState: GGSplitCommitServicing {
             await ggLandingStore.waitForOperation(projectId: projectId)
             guard !Task.isCancelled else { return }
             guard ggLandingStore.sessions[projectId]?.id == session.id else { return }
-            guard ggLandingStore.begin(session.confirmedScope) else { return }
+            let completedIDs = session.completedIDs.union(session.rows.compactMap { row -> String? in
+                guard row.outcome?.error == nil, row.outcome != nil else { return nil }
+                return row.stableID ?? row.ggId
+            })
+            guard ggLandingStore.begin(session.confirmedScope, completedIDs: completedIDs) else { return }
             let sessionId = ggLandingStore.sessions[projectId]?.id
             do {
                 guard ggCapabilities().landJSONL else {
@@ -1891,16 +1895,12 @@ final class RightPaneState: GGSplitCommitServicing {
                 }
                 let prepared = try await ggMutationCoordinator.prepare(.land(target: target))
                 try Task.checkCancellation()
-                let landedIDs = Set(session.rows.compactMap { row -> String? in
-                    guard row.outcome?.error == nil, row.outcome != nil else { return nil }
-                    return row.stableID ?? row.ggId
-                })
                 guard let stack = prepared.stack,
                       Self.ggLandingScopeMatches(
                         session.confirmedScope,
                         target: target,
                         stack: stack,
-                        landedIDs: landedIDs
+                        landedIDs: completedIDs
                       ),
                       let seed = ggLandingSeed(target: target, stack: stack)
                 else { throw GGMutationError.staleConfirmation }

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -433,6 +433,17 @@ struct ChangesTabViewTests {
         #expect(ChangesTabView.landingStatus(from: session) == nil)
     }
 
+    @Test func activeLandingUsesGGPreparationWhenContextIsInactive() throws {
+        let status = try #require(
+            ChangesTabView.landingStatus(from: landingSession(phase: .running))
+        )
+
+        #expect(ChangesTabView.shouldUseGGPreparation(
+            drawerIsActive: false,
+            landingStatus: status
+        ))
+    }
+
     private func stack(
         currentPosition: Int?,
         entries: [GGStackEntry] = [

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -398,6 +398,41 @@ struct ChangesTabViewTests {
         #expect(ChangesTabView.reconciliationAction(from: readiness) == nil)
     }
 
+    @Test func landingStatusUsesOnlyActiveSessions() {
+        var session = landingSession(phase: .running)
+        session.activeWait = GGLandWait(
+            position: 2,
+            prNumber: 42,
+            phase: .readiness,
+            poll: 1,
+            elapsedSeconds: 12,
+            ciStatus: "running",
+            approved: true,
+            mergeTrainStatus: nil,
+            mergeTrainPosition: nil,
+            pipelineRunning: nil,
+            error: nil
+        )
+        session.rows[0].outcome = GGLandedEntry(
+            position: 1,
+            title: "First",
+            ggId: nil,
+            prNumber: 41,
+            action: "merged",
+            error: nil
+        )
+        session.rows[1].wait = session.activeWait
+
+        #expect(ChangesTabView.landingStatus(from: session) == .init(
+            completed: 1,
+            total: 2,
+            reviewNumber: 42,
+            detail: "CI running · Approved · Waiting 12s"
+        ))
+        session.phase = .succeeded
+        #expect(ChangesTabView.landingStatus(from: session) == nil)
+    }
+
     private func stack(
         currentPosition: Int?,
         entries: [GGStackEntry] = [
@@ -450,6 +485,27 @@ struct ChangesTabViewTests {
             currentPosition: 1,
             behindBase: behindBase,
             entries: [entry]
+        )
+    }
+
+    private func landingSession(phase: GGLandingPhase) -> GGLandingSession {
+        GGLandingSession(
+            id: UUID(),
+            projectId: "project",
+            worktreeId: "worktree",
+            stack: "feat",
+            base: "main",
+            target: "stack",
+            startedAt: Date(timeIntervalSince1970: 0),
+            rows: [
+                GGLandingRow(position: 1, title: "First", ggId: nil, prNumber: 41),
+                GGLandingRow(position: 2, title: "Second", ggId: nil, prNumber: 42),
+            ],
+            phase: phase,
+            activeWait: nil,
+            warning: nil,
+            result: nil,
+            error: nil
         )
     }
 }

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -520,7 +520,8 @@ struct ChangesTabViewTests {
             activeWait: nil,
             warning: nil,
             result: nil,
-            error: nil
+            error: nil,
+            completedIDs: []
         )
     }
 }

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -507,6 +507,10 @@ struct ChangesTabViewTests {
             stack: "feat",
             base: "main",
             target: "stack",
+            confirmedScope: .init(
+                projectId: "project", worktreeId: "worktree", stack: "feat",
+                base: "main", target: "stack", rows: []
+            ),
             startedAt: Date(timeIntervalSince1970: 0),
             rows: [
                 GGLandingRow(position: 1, title: "First", ggId: nil, prNumber: 41),

--- a/AlasTests/GGInboxHostTests.swift
+++ b/AlasTests/GGInboxHostTests.swift
@@ -15,4 +15,20 @@ struct GGInboxHostTests {
     @Test func nilWhenProjectHasNoWorktrees() {
         #expect(AppState.inboxHostWorktreeId(selectedWorktreeId: "w1", projectWorktreeIds: []) == nil)
     }
+
+    @Test func landingPrefersLiveSessionHost() {
+        #expect(AppState.landingHostWorktreeId(
+            sessionWorktreeId: "w1",
+            selectedWorktreeId: "w2",
+            projectWorktreeIds: ["w1", "w2"]
+        ) == "w1")
+    }
+
+    @Test func landingFallsBackWhenSessionHostDisappears() {
+        #expect(AppState.landingHostWorktreeId(
+            sessionWorktreeId: "deleted",
+            selectedWorktreeId: "w2",
+            projectWorktreeIds: ["w1", "w2"]
+        ) == "w2")
+    }
 }

--- a/AlasTests/GGLandingTabsTests.swift
+++ b/AlasTests/GGLandingTabsTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct GGLandingTabsTests {
+    @Test func openOrFocusLandingDedupesByProject() {
+        let manager = TabsManager(store: LandingMemoryStore())
+        let first = manager.openOrFocusGGLanding(worktreeId: "w", projectId: "p", stackName: "feature")
+        _ = manager.appendTerminal(worktreeId: "w", title: "shell", sessionId: "s")
+        let second = manager.openOrFocusGGLanding(worktreeId: "w", projectId: "p", stackName: "feature")
+        #expect(first.id == "gg-land:p")
+        #expect(first.id == second.id)
+        #expect(first.title == "Land · feature")
+        #expect(!first.isRestorable)
+        #expect(manager.tabs(forWorktree: "w").count == 2)
+        #expect(manager.activeTabId(forWorktree: "w") == first.id)
+    }
+
+    @Test(arguments: [false, true])
+    func landingTabIsNotRestored(withTerminal: Bool) throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let manager = TabsManager(tabsDirectory: directory)
+        let terminal = withTerminal
+            ? manager.appendTerminal(worktreeId: "w", title: "shell", sessionId: "s") : nil
+        let landing = manager.openOrFocusGGLanding(worktreeId: "w", projectId: "p", stackName: "feature")
+        let persisted = try PersistenceStore().readIfExists(TabsFile.self, from: directory.appendingPathComponent("w.json"))
+        #expect(persisted?.activeTabId == terminal?.id)
+        #expect(manager.activeTabId(forWorktree: "w") == landing.id)
+        let reloaded = TabsManager(tabsDirectory: directory)
+        reloaded.loadAll(worktreeIds: ["w"])
+        #expect(reloaded.tabs(forWorktree: "w").map(\.id) == (terminal.map { [$0.id] } ?? []))
+        #expect(reloaded.activeTabId(forWorktree: "w") == terminal?.id)
+    }
+
+    @Test func nextSessionMovesProjectTabToItsInitiatingWorktree() {
+        let manager = TabsManager(store: LandingMemoryStore())
+        _ = manager.openOrFocusGGLanding(worktreeId: "old", projectId: "p", stackName: "first")
+        let next = manager.openOrFocusGGLanding(worktreeId: "new", projectId: "p", stackName: "second")
+        #expect(manager.tabs(forWorktree: "old").isEmpty)
+        #expect(manager.tabs(forWorktree: "new") == [next])
+        #expect(next.title == "Land · second")
+        let renamed = manager.openOrFocusGGLanding(worktreeId: "new", projectId: "p", stackName: "third")
+        #expect(renamed.title == "Land · third")
+        #expect(manager.tabs(forWorktree: "new").count == 1)
+    }
+}
+
+private struct LandingMemoryStore: PersistenceStoreProtocol {
+    func readIfExists<T: Decodable>(_ type: T.Type, from url: URL) throws -> T? { nil }
+    func write<T: Encodable>(_ value: T, to url: URL) throws {}
+}

--- a/AlasTests/Integrations/GGAvailabilityTests.swift
+++ b/AlasTests/Integrations/GGAvailabilityTests.swift
@@ -21,6 +21,7 @@ private struct HelpGGRunner: GGCommandRunning {
     let sc: String?
     let sync: String?
     let ls: String?
+    let land: String?
 
     init(
         version: String? = "1.0.0",
@@ -29,7 +30,8 @@ private struct HelpGGRunner: GGCommandRunning {
         unstack: String?,
         sc: String? = nil,
         sync: String? = nil,
-        ls: String? = nil
+        ls: String? = nil,
+        land: String? = nil
     ) {
         self.version = version
         self.root = root
@@ -38,6 +40,7 @@ private struct HelpGGRunner: GGCommandRunning {
         self.sc = sc
         self.sync = sync
         self.ls = ls
+        self.land = land
     }
 
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
@@ -63,6 +66,9 @@ private struct HelpGGRunner: GGCommandRunning {
         case ["ls", "--help"]:
             guard let ls else { break }
             return ProcessResult(exitCode: 0, stdout: ls, stderr: "")
+        case ["land", "--help"]:
+            guard let land else { break }
+            return ProcessResult(exitCode: 0, stdout: land, stderr: "")
         default:
             break
         }
@@ -144,6 +150,14 @@ struct GGAvailabilityTests {
             split: "", unstack: "", sync: "--json"
         ))
         #expect(!(await old.probeCapabilities()).syncJSONL)
+    }
+
+    @Test func landJSONLCapabilityUsesLandHelpAndDefaultsOff() async {
+        let current = GGService(runner: HelpGGRunner(
+            split: "", unstack: "", land: "--json --jsonl"
+        ))
+        #expect((await current.probeCapabilities()).landJSONL)
+        #expect(!GGCapabilities(structuredSplit: false, keepCurrentUnstack: false).landJSONL)
     }
 
     @Test func localStackSnapshotCapabilityUsesListHelpAndDefaultsOff() async {

--- a/AlasTests/Integrations/GGCommandRunningStreamingTests.swift
+++ b/AlasTests/Integrations/GGCommandRunningStreamingTests.swift
@@ -2,6 +2,13 @@ import Foundation
 import Testing
 @testable import Alas
 
+private actor StreamLines {
+    private var values: [String] = []
+
+    func append(_ value: String) { values.append(value) }
+    func contains(_ value: String) -> Bool { values.contains(value) }
+}
+
 /// Exercises `ProcessGGCommandRunner`'s pipe-lifecycle handling (readability
 /// handlers on both stdout/stderr, closing the parent's write ends after
 /// `process.run()`) against a trivial `/bin/sh` subprocess. This does not
@@ -229,6 +236,31 @@ struct GGCommandRunningStreamingTests {
             try await Task.sleep(for: .milliseconds(10))
         }
         #expect(FileManager.default.fileExists(atPath: interrupted.path))
+    }
+
+    @Test func cancellingStreamDrainsTerminalStdoutBeforeFinishing() async throws {
+        let ready = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gg-stream-ready-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: ready) }
+        let interruption = GGStreamingCancellation()
+        let stream = ProcessGGCommandRunner.streamProcess(
+            executable: "/bin/sh",
+            args: ["-c", "trap 'printf terminal\\n; exit 130' INT; printf ready > \"$1\"; printf ready\\n; while :; do sleep 1; done", "alas", ready.path],
+            cwd: nil,
+            env: nil,
+            timeout: nil,
+            interruption: interruption
+        )
+        let lines = StreamLines()
+        let consumer = Task {
+            for try await line in stream { await lines.append(line) }
+        }
+        for _ in 0..<200 where !FileManager.default.fileExists(atPath: ready.path) {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        interruption.cancel()
+        _ = try? await consumer.value
+        #expect(await lines.contains("terminal"))
     }
 
     @Test func streamingRunTimesOutHungProcess() async throws {

--- a/AlasTests/Integrations/GGCommandRunningStreamingTests.swift
+++ b/AlasTests/Integrations/GGCommandRunningStreamingTests.swift
@@ -147,7 +147,7 @@ struct GGCommandRunningStreamingTests {
             range: wrapperIdentity.upperBound ..< serviceSource.endIndex
         ))
         let release = try #require(serviceSource.range(of: "launchGate.fileHandleForWriting.write", range: start.upperBound ..< serviceSource.endIndex))
-        let cleanup = try #require(serviceSource.range(of: "continuation.onTermination ="))
+        let cleanup = try #require(serviceSource.range(of: "continuation.onTermination =", range: start.upperBound ..< serviceSource.endIndex))
         #expect(run.lowerBound < identity.lowerBound)
         #expect(closeWriter.lowerBound < launchedPID.lowerBound)
         #expect(launchedPID.lowerBound < identity.lowerBound)
@@ -245,7 +245,7 @@ struct GGCommandRunningStreamingTests {
         let interruption = GGStreamingCancellation()
         let stream = ProcessGGCommandRunner.streamProcess(
             executable: "/bin/sh",
-            args: ["-c", "trap 'printf terminal\\n; exit 130' INT; printf ready > \"$1\"; printf ready\\n; while :; do sleep 1; done", "alas", ready.path],
+            args: ["-c", #"trap 'printf "%s\n" terminal; exit 130' INT; printf ready > "$1"; printf '%s\n' ready; while :; do sleep 1; done"#, "alas", ready.path],
             cwd: nil,
             env: nil,
             timeout: nil,

--- a/AlasTests/Integrations/GGCommandRunningStreamingTests.swift
+++ b/AlasTests/Integrations/GGCommandRunningStreamingTests.swift
@@ -188,6 +188,49 @@ struct GGCommandRunningStreamingTests {
         #expect(lines == ["é"])
     }
 
+    @Test func explicitNilTimeoutDoesNotStartWatchdog() async throws {
+        let stream = ProcessGGCommandRunner.streamProcess(
+            executable: "/bin/sh",
+            args: ["-c", "printf 'ready\\n'"],
+            cwd: nil,
+            env: nil,
+            timeout: nil
+        )
+        var lines: [String] = []
+        for try await line in stream { lines.append(line) }
+        #expect(lines == ["ready"])
+    }
+
+    @Test func cancellingStreamSendsInterruptBeforeTermination() async throws {
+        let interrupted = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gg-stream-int-\(UUID().uuidString)")
+        let ready = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gg-stream-ready-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: interrupted)
+            try? FileManager.default.removeItem(at: ready)
+        }
+        let stream = ProcessGGCommandRunner.streamProcess(
+            executable: "/bin/sh",
+            args: ["-c", "trap 'printf interrupted > \"$1\"; exit 130' INT; printf ready > \"$2\"; while :; do sleep 1; done", "alas", interrupted.path, ready.path],
+            cwd: nil,
+            env: nil,
+            timeout: nil
+        )
+        let task = Task<Void, Error> {
+            for try await _ in stream {}
+        }
+        for _ in 0..<200 where !FileManager.default.fileExists(atPath: ready.path) {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        task.cancel()
+        _ = await task.result
+        for _ in 0..<200 where !FileManager.default.fileExists(atPath: interrupted.path) {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(FileManager.default.fileExists(atPath: interrupted.path))
+    }
+
     @Test func streamingRunTimesOutHungProcess() async throws {
         let stream = ProcessGGCommandRunner.streamProcess(
             executable: "/bin/sh",

--- a/AlasTests/Integrations/GGLandEventTests.swift
+++ b/AlasTests/Integrations/GGLandEventTests.swift
@@ -1,0 +1,47 @@
+import Testing
+@testable import Alas
+
+struct GGLandEventTests {
+    @Test func decodesStartAndReadinessWait() throws {
+        #expect(try GGLandEvent.decode(line: #"{"version":1,"command":"land","status":"ok","event":"start","stack":"feature","base":"main","total_entries":2}"#)
+            == .start(stack: "feature", base: "main", totalEntries: 2))
+        #expect(try GGLandEvent.decode(line: #"{"version":1,"command":"land","status":"ok","event":"wait","position":1,"pr_number":42,"phase":"readiness","poll":3,"elapsed_seconds":20,"ci_status":"running","approved":true,"merge_train_status":null,"merge_train_position":null,"pipeline_running":null,"error":null}"#)
+            == .wait(GGLandWait(
+                position: 1, prNumber: 42, phase: .readiness, poll: 3,
+                elapsedSeconds: 20, ciStatus: "running", approved: true,
+                mergeTrainStatus: nil, mergeTrainPosition: nil,
+                pipelineRunning: nil, error: nil
+            )))
+    }
+
+    @Test func decodesEntrySummaryAndFatalError() throws {
+        #expect(try GGLandEvent.decode(line: #"{"version":1,"command":"land","status":"ok","event":"entry","position":1,"sha":"abc1234","title":"First","gg_id":"c-abc","pr_number":42,"action":"merged","error":null}"#)
+            == .entry(GGLandedEntry(
+                position: 1, sha: "abc1234", title: "First", ggId: "c-abc",
+                prNumber: 42, action: "merged", error: nil
+            )))
+
+        guard case .summary(let summary) = try GGLandEvent.decode(line: #"{"version":1,"command":"land","status":"warning","event":"summary","stack":"feature","base":"main","landed":[],"remaining":1,"cleaned":false,"warnings":["cleanup skipped"],"error":"CI failed"}"#) else {
+            Issue.record("Expected summary")
+            return
+        }
+        #expect(summary.remaining == 1)
+        #expect(summary.warnings == ["cleanup skipped"])
+        #expect(summary.error == "CI failed")
+
+        #expect(try GGLandEvent.decode(line: #"{"version":1,"command":"land","status":"error","event":"error","message":"Not in a repository"}"#)
+            == .error(message: "Not in a repository"))
+    }
+
+    @Test func rejectsWrongVersionCommandAndUnknownEvent() {
+        #expect(throws: GGServiceError.unsupportedSchema(2)) {
+            _ = try GGLandEvent.decode(line: #"{"version":2,"command":"land","event":"start","stack":"s","base":"main","total_entries":1}"#)
+        }
+        #expect(throws: GGServiceError.self) {
+            _ = try GGLandEvent.decode(line: #"{"version":1,"command":"sync","event":"start","stack":"s","base":"main","total_entries":1}"#)
+        }
+        #expect(throws: GGServiceError.self) {
+            _ = try GGLandEvent.decode(line: #"{"version":1,"command":"land","event":"mystery"}"#)
+        }
+    }
+}

--- a/AlasTests/Integrations/GGLandingPresentationTests.swift
+++ b/AlasTests/Integrations/GGLandingPresentationTests.swift
@@ -71,8 +71,10 @@ struct GGLandingPresentationTests {
 
     private func session() -> GGLandingSession {
         .init(id: UUID(), projectId: "p", worktreeId: "w", stack: "feature", base: "main",
-              target: "c3", startedAt: Date(), rows: (1...3).map {
+              target: "c3", confirmedScope: .init(
+                  projectId: "p", worktreeId: "w", stack: "feature", base: "main", target: "c3", rows: []
+              ), startedAt: Date(), rows: (1...3).map {
                   .init(position: $0, title: "Change \($0)", ggId: "c\($0)", prNumber: 40 + $0)
-              }, phase: .running, activeWait: nil, warning: nil, result: nil, error: nil)
+              }, phase: .running, activeWait: nil, warning: nil, result: nil, error: nil, completedIDs: [])
     }
 }

--- a/AlasTests/Integrations/GGLandingPresentationTests.swift
+++ b/AlasTests/Integrations/GGLandingPresentationTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct GGLandingPresentationTests {
+    @Test func readinessCombinesAvailableFacts() {
+        #expect(GGLandingPresentation.detail(for: wait(ci: "running", approved: true))
+            == "CI running · Approved · Waiting 20s")
+        #expect(GGLandingPresentation.detail(for: wait(approved: false))
+            == "Waiting for approval · Waiting 20s")
+        #expect(GGLandingPresentation.detail(for: wait(ci: "success"))
+            == "CI passed · Waiting 20s")
+        #expect(GGLandingPresentation.detail(for: wait(ci: "failure"))
+            == "CI failed · Waiting 20s")
+        #expect(GGLandingPresentation.detail(for: wait()) == "Waiting for readiness · Waiting 20s")
+    }
+
+    @Test func mergeTrainIncludesQueuePosition() {
+        let wait = GGLandWait(
+            position: 1, prNumber: 42, phase: .mergeTrain, poll: 4,
+            elapsedSeconds: 65, ciStatus: nil, approved: nil,
+            mergeTrainStatus: "fresh", mergeTrainPosition: 3,
+            pipelineRunning: true, error: nil
+        )
+        #expect(GGLandingPresentation.detail(for: wait)
+            == "Merge train · Position 3 · Pipeline running · Waiting 1m 5s")
+    }
+
+    @Test func queuedIsDistinctFromMergedAndSummaryCountsBoth() {
+        var session = session()
+        session.rows[0].outcome = .init(position: 1, prNumber: 41, action: "merged")
+        session.rows[1].outcome = .init(position: 2, prNumber: 42, action: "queued")
+        #expect(GGLandingPresentation.detail(for: session.rows[1], in: session) == "Queued")
+        #expect(GGLandingPresentation.progress(for: session) == "2 / 3")
+        session.phase = .succeeded
+        session.result = .init(landed: session.rows.compactMap(\.outcome), remaining: 1)
+        #expect(GGLandingPresentation.summary(for: session) == "1 merged · 1 queued · 1 remaining")
+    }
+
+    @Test func terminalStatesPreservePartialProgress() {
+        var session = session()
+        session.rows[0].outcome = .init(position: 1, prNumber: 41, action: "merged")
+        session.phase = .cancelled
+        #expect(GGLandingPresentation.summary(for: session) == "Cancelled · 1 merged · 2 remaining")
+        #expect(GGLandingPresentation.detail(for: session.rows[1], in: session) == "Cancelled")
+        session.phase = .failed
+        session.error = "Merge failed"
+        session.rows[1].outcome = .init(position: 2, prNumber: 42, error: "Conflict")
+        #expect(GGLandingPresentation.summary(for: session) == "Failed · 1 merged · 2 remaining")
+        #expect(GGLandingPresentation.detail(for: session.rows[1], in: session) == "Conflict")
+        #expect(GGLandingPresentation.detail(for: session.rows[2], in: session) == "Not landed")
+        #expect(GGLandingPresentation.progress(for: session) == "1 / 3")
+    }
+
+    @Test func onlyActiveRowsShowHeartbeatWhileRunning() {
+        var session = session()
+        session.activeWait = wait()
+        session.rows[0].wait = wait()
+        #expect(GGLandingPresentation.isActive(session.rows[0], in: session))
+        #expect(!GGLandingPresentation.isActive(session.rows[1], in: session))
+        session.phase = .cancelled
+        #expect(!GGLandingPresentation.isActive(session.rows[0], in: session))
+        #expect(GGLandingPresentation.detail(for: session.rows[0], in: session) == "Cancelled")
+    }
+
+    private func wait(ci: String? = nil, approved: Bool? = nil) -> GGLandWait {
+        .init(position: 1, prNumber: 42, phase: .readiness, poll: 2,
+              elapsedSeconds: 20, ciStatus: ci, approved: approved,
+              mergeTrainStatus: nil, mergeTrainPosition: nil, pipelineRunning: nil, error: nil)
+    }
+
+    private func session() -> GGLandingSession {
+        .init(id: UUID(), projectId: "p", worktreeId: "w", stack: "feature", base: "main",
+              target: "c3", startedAt: Date(), rows: (1...3).map {
+                  .init(position: $0, title: "Change \($0)", ggId: "c\($0)", prNumber: 40 + $0)
+              }, phase: .running, activeWait: nil, warning: nil, result: nil, error: nil)
+    }
+}

--- a/AlasTests/Integrations/GGLandingStoreTests.swift
+++ b/AlasTests/Integrations/GGLandingStoreTests.swift
@@ -113,6 +113,50 @@ struct GGLandingStoreTests {
         #expect(store.begin(seed()))
     }
 
+    @Test func shutdownWaitsForPreparationAndPreventsLaunch() async {
+        let store = GGLandingStore()
+        let preflight = LandingTestSuspension()
+        var landCommands = 0
+        store.startPreparation(projectId: "p") {
+            store.begin(seed())
+            await preflight.suspend()
+            guard !Task.isCancelled else {
+                store.fail(projectId: "p", message: "cancelled")
+                return
+            }
+            landCommands += 1
+        }
+        await preflight.waitUntilSuspended()
+        let started = AsyncStream<Void>.makeStream()
+        var shutdownFinished = false
+        let shutdown = Task {
+            started.continuation.yield(())
+            await store.cancelAllAndWait()
+            shutdownFinished = true
+        }
+        for await _ in started.stream { break }
+        #expect(!shutdownFinished)
+        #expect(store.sessions["p"]?.phase == .cancelling)
+        #expect(!store.begin(seed(projectId: "other")))
+        await preflight.release()
+        await shutdown.value
+        #expect(landCommands == 0)
+        #expect(store.sessions["p"]?.phase == .cancelled)
+    }
+
+    @Test func failureAfterValidatedOperationDoesNotOverwriteSummary() async {
+        let store = GGLandingStore()
+        store.begin(seed())
+        let task = Task<Void, Error> {
+            store.receive(.summary(.init(landed: [])), projectId: "p")
+            throw TestError.interrupted
+        }
+        store.attach(projectId: "p", task: task, cancel: { task.cancel() })
+        await store.waitForOperation(projectId: "p")
+        #expect(store.sessions["p"]?.phase == .succeeded)
+        #expect(store.sessions["p"]?.error == nil)
+    }
+
     @Test func beginSeedsSessionAndReplacesTerminalAttempt() throws {
         let store = GGLandingStore()
         let startedAt = Date(timeIntervalSince1970: 1_000)

--- a/AlasTests/Integrations/GGLandingStoreTests.swift
+++ b/AlasTests/Integrations/GGLandingStoreTests.swift
@@ -214,6 +214,25 @@ struct GGLandingStoreTests {
         #expect(store.sessions["p"]?.completedIDs.isEmpty == true)
     }
 
+    @Test func shaOnlyEntryEventsMustMatchConfirmedRows() throws {
+        let store = GGLandingStore()
+        #expect(store.begin(.init(
+            projectId: "p",
+            worktreeId: "w",
+            stack: "feature",
+            base: "main",
+            target: "sha-1",
+            rows: [.init(position: 1, title: "One", ggId: nil, stableID: "sha-1", prNumber: nil)]
+        )))
+
+        #expect(!store.receive(
+            .entry(.init(position: 1, sha: "sha-2", prNumber: nil, action: "merged")),
+            projectId: "p"
+        ))
+        #expect(store.sessions["p"]?.phase == .failed)
+        #expect(store.sessions["p"]?.completedIDs.isEmpty == true)
+    }
+
     @Test func beginSeedsSessionAndReplacesTerminalAttempt() throws {
         let store = GGLandingStore()
         let startedAt = Date(timeIntervalSince1970: 1_000)

--- a/AlasTests/Integrations/GGLandingStoreTests.swift
+++ b/AlasTests/Integrations/GGLandingStoreTests.swift
@@ -2,6 +2,46 @@ import Foundation
 import Testing
 @testable import Alas
 
+private actor LandingTestSuspension {
+    private var isSuspended = false
+    private var suspensionWaiters: [CheckedContinuation<Void, Never>] = []
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func suspend() async {
+        isSuspended = true
+        let waiters = suspensionWaiters
+        suspensionWaiters.removeAll()
+        for waiter in waiters { waiter.resume() }
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func waitUntilSuspended() async {
+        if isSuspended { return }
+        await withCheckedContinuation { suspensionWaiters.append($0) }
+    }
+
+    func release() {
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private enum GGLandingStoreTestTimeout: Error {
+    case timedOut
+}
+
+@MainActor
+private func waitUntil(
+    timeout: TimeInterval = 2,
+    _ condition: () -> Bool
+) async throws {
+    let deadline = Date().addingTimeInterval(timeout)
+    while !condition() {
+        guard Date() < deadline else { throw GGLandingStoreTestTimeout.timedOut }
+        try await Task.sleep(for: .milliseconds(1))
+    }
+}
+
 @MainActor
 struct GGLandingStoreTests {
     private enum TestError: Error {
@@ -48,6 +88,28 @@ struct GGLandingStoreTests {
         #expect(replacement.id != first.id)
         #expect(replacement.phase == .running)
         #expect(replacement.error == nil)
+    }
+
+    @Test func terminalSessionCannotRestartUntilAttachedOperationFinishes() async {
+        let store = GGLandingStore()
+        let operation = AsyncStream<Void>.makeStream()
+        let task = Task<Void, Error> {
+            for await _ in operation.stream {}
+        }
+        #expect(store.begin(seed()))
+        store.attach(projectId: "p", task: task) {
+            operation.continuation.finish()
+        }
+        store.receive(
+            .summary(.init(landed: [], error: "partial failure")),
+            projectId: "p"
+        )
+
+        #expect(!store.begin(seed()))
+
+        operation.continuation.finish()
+        await store.cancelAllAndWait()
+        #expect(store.begin(seed()))
     }
 
     @Test func heartbeatUpdatesActiveRowAndClearsRecoveredWarning() {
@@ -140,25 +202,20 @@ struct GGLandingStoreTests {
         }
         store.cancel(projectId: "p")
         store.cancel(projectId: "p")
-        _ = await task.result
-        for _ in 0..<20 where store.sessions["p"]?.phase != .cancelled {
-            await Task.yield()
-        }
+        await store.cancelAllAndWait()
         #expect(cancelCount == 1)
         #expect(store.sessions["p"]?.phase == .cancelled)
         #expect(store.sessions["p"]?.error == nil)
     }
 
-    @Test func unexpectedExitWithoutSummaryFailsSession() async {
+    @Test func unexpectedExitWithoutSummaryFailsSession() async throws {
         let store = GGLandingStore()
         store.begin(seed())
         let task = Task<Void, Error> {}
         store.attach(projectId: "p", task: task) {}
 
         _ = await task.result
-        for _ in 0..<20 where store.sessions["p"]?.phase == .running {
-            await Task.yield()
-        }
+        try await waitUntil { store.sessions["p"]?.phase == .failed }
 
         #expect(store.sessions["p"]?.phase == .failed)
         #expect(store.sessions["p"]?.error != nil)
@@ -199,11 +256,44 @@ struct GGLandingStoreTests {
         }
 
         store.prune(keepingProjectIds: ["other"])
-        _ = await task.result
+        await store.cancelAllAndWait()
 
         #expect(cancelCount == 1)
         #expect(store.sessions["p"] == nil)
         #expect(store.sessions["other"]?.phase == .running)
+    }
+
+    @Test func terminationWaitsForPrunedOperationCleanup() async {
+        let store = GGLandingStore()
+        let cancellation = AsyncStream<Void>.makeStream()
+        let cleanup = LandingTestSuspension()
+        let task = Task<Void, Error> {
+            for await _ in cancellation.stream {}
+            await cleanup.suspend()
+        }
+        #expect(store.begin(seed()))
+        store.attach(projectId: "p", task: task) {
+            cancellation.continuation.finish()
+        }
+
+        store.prune(keepingProjectIds: [])
+        await cleanup.waitUntilSuspended()
+
+        let started = AsyncStream<Void>.makeStream()
+        var didFinish = false
+        let termination = Task { @MainActor in
+            started.continuation.yield()
+            started.continuation.finish()
+            await store.cancelAllAndWait()
+            didFinish = true
+        }
+        for await _ in started.stream { break }
+        #expect(!didFinish)
+
+        await cleanup.release()
+        await termination.value
+        #expect(didFinish)
+        #expect(store.begin(seed()))
     }
 
     @Test func cancellationIgnoresLateFailureAndAppliesTerminalEntry() async {
@@ -216,10 +306,7 @@ struct GGLandingStoreTests {
         store.receive(.entry(outcome), projectId: "p")
         store.fail(projectId: "p", message: "interrupted")
 
-        _ = await task.result
-        for _ in 0..<20 where store.sessions["p"]?.phase != .cancelled {
-            await Task.yield()
-        }
+        await store.cancelAllAndWait()
 
         #expect(store.sessions["p"]?.phase == .cancelled)
         #expect(store.sessions["p"]?.rows[0].outcome == outcome)

--- a/AlasTests/Integrations/GGLandingStoreTests.swift
+++ b/AlasTests/Integrations/GGLandingStoreTests.swift
@@ -233,6 +233,20 @@ struct GGLandingStoreTests {
         #expect(store.sessions["p"]?.completedIDs.isEmpty == true)
     }
 
+    @Test func summaryErrorRemovesPreviouslyCompletedID() {
+        let store = GGLandingStore()
+        #expect(store.begin(seed()))
+        store.receive(.entry(.init(position: 1, ggId: "c-1", prNumber: 41, action: "merged")), projectId: "p")
+        #expect(store.sessions["p"]?.completedIDs == Set(["c-1"]))
+
+        store.receive(.summary(.init(
+            landed: [.init(position: 1, ggId: "c-1", prNumber: 41, error: "failed")],
+            error: "failed"
+        )), projectId: "p")
+
+        #expect(store.sessions["p"]?.completedIDs.isEmpty == true)
+    }
+
     @Test func beginSeedsSessionAndReplacesTerminalAttempt() throws {
         let store = GGLandingStore()
         let startedAt = Date(timeIntervalSince1970: 1_000)

--- a/AlasTests/Integrations/GGLandingStoreTests.swift
+++ b/AlasTests/Integrations/GGLandingStoreTests.swift
@@ -186,6 +186,34 @@ struct GGLandingStoreTests {
         #expect(failed.error == "gg land started for a different stack. Refresh and try again.")
     }
 
+    @Test func progressEventsMustMatchConfirmedRows() throws {
+        let store = GGLandingStore()
+        #expect(store.begin(seed()))
+
+        #expect(!store.receive(
+            .wait(.init(
+                position: 1, prNumber: 99, phase: .readiness, poll: 1, elapsedSeconds: 0,
+                ciStatus: nil, approved: nil, mergeTrainStatus: nil, mergeTrainPosition: nil,
+                pipelineRunning: nil, error: nil
+            )),
+            projectId: "p"
+        ))
+        #expect(store.sessions["p"]?.phase == .failed)
+        #expect(store.sessions["p"]?.error == "gg land reported progress for a different stack. Refresh and try again.")
+    }
+
+    @Test func entryEventsMustMatchConfirmedRows() throws {
+        let store = GGLandingStore()
+        #expect(store.begin(seed()))
+
+        #expect(!store.receive(
+            .entry(.init(position: 1, ggId: "other", prNumber: 41, action: "merged")),
+            projectId: "p"
+        ))
+        #expect(store.sessions["p"]?.phase == .failed)
+        #expect(store.sessions["p"]?.completedIDs.isEmpty == true)
+    }
+
     @Test func beginSeedsSessionAndReplacesTerminalAttempt() throws {
         let store = GGLandingStore()
         let startedAt = Date(timeIntervalSince1970: 1_000)

--- a/AlasTests/Integrations/GGLandingStoreTests.swift
+++ b/AlasTests/Integrations/GGLandingStoreTests.swift
@@ -70,6 +70,49 @@ struct GGLandingStoreTests {
         #expect(store.begin(seed(projectId: "other")))
     }
 
+    @Test func cancellationBeforeAttachCancelsRawOperationAndWaitsForCleanup() async {
+        let store = GGLandingStore()
+        let cleanup = LandingTestSuspension()
+        let rawOperation = Task<Void, Error> {
+            await cleanup.suspend()
+            try Task.checkCancellation()
+        }
+        let completion = Task<Void, Error> { try await rawOperation.value }
+        await cleanup.waitUntilSuspended()
+        store.begin(seed())
+        store.cancel(projectId: "p")
+        #expect(store.sessions["p"]?.phase == .cancelling)
+
+        var cancellationCount = 0
+        store.attach(projectId: "p", task: completion) {
+            cancellationCount += 1
+            rawOperation.cancel()
+        }
+        #expect(rawOperation.isCancelled)
+        #expect(!completion.isCancelled)
+        #expect(cancellationCount == 1)
+        store.cancel(projectId: "p")
+        #expect(cancellationCount == 1)
+        #expect(store.sessions["p"]?.phase == .cancelling)
+        #expect(!store.begin(seed()))
+
+        await cleanup.release()
+        await store.waitForOperation(projectId: "p")
+        #expect(store.sessions["p"]?.phase == .cancelled)
+        #expect(store.sessions["p"]?.error == nil)
+        #expect(store.begin(seed()))
+    }
+
+    @Test func preflightFailureAfterCancellationFinishesAsCancelled() {
+        let store = GGLandingStore()
+        store.begin(seed())
+        store.cancel(projectId: "p")
+        store.fail(projectId: "p", message: "Target no longer exists")
+        #expect(store.sessions["p"]?.phase == .cancelled)
+        #expect(store.sessions["p"]?.error == nil)
+        #expect(store.begin(seed()))
+    }
+
     @Test func beginSeedsSessionAndReplacesTerminalAttempt() throws {
         let store = GGLandingStore()
         let startedAt = Date(timeIntervalSince1970: 1_000)

--- a/AlasTests/Integrations/GGLandingStoreTests.swift
+++ b/AlasTests/Integrations/GGLandingStoreTests.swift
@@ -1,0 +1,227 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct GGLandingStoreTests {
+    private enum TestError: Error {
+        case interrupted
+    }
+
+    private func seed(projectId: String = "p") -> GGLandingSession.Seed {
+        .init(
+            projectId: projectId,
+            worktreeId: "w",
+            stack: "feature",
+            base: "main",
+            target: "c-2",
+            rows: [
+                .init(position: 1, title: "One", ggId: "c-1", prNumber: 41),
+                .init(position: 2, title: "Two", ggId: "c-2", prNumber: 42),
+            ]
+        )
+    }
+
+    @Test func refusesSecondActiveLandForProject() {
+        let store = GGLandingStore()
+
+        #expect(store.begin(seed()))
+        #expect(!store.begin(seed()))
+        #expect(store.begin(seed(projectId: "other")))
+    }
+
+    @Test func beginSeedsSessionAndReplacesTerminalAttempt() throws {
+        let store = GGLandingStore()
+        let startedAt = Date(timeIntervalSince1970: 1_000)
+        #expect(store.begin(seed(), now: startedAt))
+        let first = try #require(store.sessions["p"])
+        #expect(first.worktreeId == "w")
+        #expect(first.stack == "feature")
+        #expect(first.base == "main")
+        #expect(first.target == "c-2")
+        #expect(first.startedAt == startedAt)
+        #expect(first.phase == .running)
+
+        store.fail(projectId: "p", message: "stopped")
+        #expect(store.begin(seed(), now: startedAt.addingTimeInterval(1)))
+        let replacement = try #require(store.sessions["p"])
+        #expect(replacement.id != first.id)
+        #expect(replacement.phase == .running)
+        #expect(replacement.error == nil)
+    }
+
+    @Test func heartbeatUpdatesActiveRowAndClearsRecoveredWarning() {
+        let store = GGLandingStore()
+        store.begin(seed())
+        store.receive(.wait(.init(
+            position: 1, prNumber: 41, phase: .readiness, poll: 1,
+            elapsedSeconds: 10, ciStatus: "running", approved: true,
+            mergeTrainStatus: nil, mergeTrainPosition: nil,
+            pipelineRunning: nil, error: "temporary outage"
+        )), projectId: "p")
+        #expect(store.sessions["p"]?.warning == "temporary outage")
+        #expect(store.sessions["p"]?.rows[0].wait?.poll == 1)
+        store.receive(.wait(.init(
+            position: 1, prNumber: 41, phase: .readiness, poll: 2,
+            elapsedSeconds: 20, ciStatus: "success", approved: true,
+            mergeTrainStatus: nil, mergeTrainPosition: nil,
+            pipelineRunning: nil, error: nil
+        )), projectId: "p")
+        #expect(store.sessions["p"]?.warning == nil)
+        #expect(store.sessions["p"]?.activeWait?.elapsedSeconds == 20)
+        #expect(store.sessions["p"]?.rows[0].wait?.poll == 2)
+    }
+
+    @Test func entryRecordsTerminalRowAndClearsItsWait() {
+        let store = GGLandingStore()
+        store.begin(seed())
+        store.receive(.wait(.init(
+            position: 1, prNumber: 41, phase: .mergeTrain, poll: 3,
+            elapsedSeconds: 30, ciStatus: "success", approved: true,
+            mergeTrainStatus: "queued", mergeTrainPosition: 2,
+            pipelineRunning: false, error: nil
+        )), projectId: "p")
+
+        let outcome = GGLandedEntry(
+            position: 1, title: "One", ggId: "c-1", prNumber: 41,
+            action: "merged"
+        )
+        store.receive(.entry(outcome), projectId: "p")
+
+        #expect(store.sessions["p"]?.rows[0].outcome == outcome)
+        #expect(store.sessions["p"]?.rows[0].wait == nil)
+        #expect(store.sessions["p"]?.activeWait == nil)
+    }
+
+    @Test func summaryPublishesAuthoritativeRowsAndOutcome() {
+        let store = GGLandingStore()
+        store.begin(seed())
+        let outcome = GGLandedEntry(
+            position: 1, title: "One", ggId: "c-1", prNumber: 41,
+            action: "merged"
+        )
+        let result = GGLandResult(
+            stack: "feature", base: "main", landed: [outcome],
+            remaining: 1, cleaned: false, warnings: ["review skipped"]
+        )
+
+        store.receive(.summary(result), projectId: "p")
+
+        #expect(store.sessions["p"]?.phase == .succeeded)
+        #expect(store.sessions["p"]?.result == result)
+        #expect(store.sessions["p"]?.rows[0].outcome == outcome)
+        #expect(store.sessions["p"]?.warning == nil)
+        #expect(store.sessions["p"]?.error == nil)
+    }
+
+    @Test func summaryErrorAndFatalEventFailSession() {
+        let store = GGLandingStore()
+        store.begin(seed())
+        let result = GGLandResult(landed: [], error: "partial failure")
+
+        store.receive(.summary(result), projectId: "p")
+        #expect(store.sessions["p"]?.phase == .failed)
+        #expect(store.sessions["p"]?.error == "partial failure")
+
+        #expect(store.begin(seed()))
+        store.receive(.error(message: "setup failed"), projectId: "p")
+        #expect(store.sessions["p"]?.phase == .failed)
+        #expect(store.sessions["p"]?.error == "setup failed")
+    }
+
+    @Test func cancelledCompletionWinsOverInterruptedExit() async {
+        let store = GGLandingStore()
+        store.begin(seed())
+        var cancelCount = 0
+        let task = Task<Void, Error> { try await Task.sleep(for: .seconds(30)) }
+        store.attach(projectId: "p", task: task) {
+            cancelCount += 1
+            task.cancel()
+        }
+        store.cancel(projectId: "p")
+        store.cancel(projectId: "p")
+        _ = await task.result
+        for _ in 0..<20 where store.sessions["p"]?.phase != .cancelled {
+            await Task.yield()
+        }
+        #expect(cancelCount == 1)
+        #expect(store.sessions["p"]?.phase == .cancelled)
+        #expect(store.sessions["p"]?.error == nil)
+    }
+
+    @Test func unexpectedExitWithoutSummaryFailsSession() async {
+        let store = GGLandingStore()
+        store.begin(seed())
+        let task = Task<Void, Error> {}
+        store.attach(projectId: "p", task: task) {}
+
+        _ = await task.result
+        for _ in 0..<20 where store.sessions["p"]?.phase == .running {
+            await Task.yield()
+        }
+
+        #expect(store.sessions["p"]?.phase == .failed)
+        #expect(store.sessions["p"]?.error != nil)
+    }
+
+    @Test func cancelAllCancelsOnceAndWaitsForMonitors() async {
+        let store = GGLandingStore()
+        store.begin(seed())
+        store.begin(seed(projectId: "other"))
+        var cancelCount = 0
+        let first = Task<Void, Error> { try await Task.sleep(for: .seconds(30)) }
+        let second = Task<Void, Error> { try await Task.sleep(for: .seconds(30)) }
+        store.attach(projectId: "p", task: first) {
+            cancelCount += 1
+            first.cancel()
+        }
+        store.attach(projectId: "other", task: second) {
+            cancelCount += 1
+            second.cancel()
+        }
+
+        await store.cancelAllAndWait()
+
+        #expect(cancelCount == 2)
+        #expect(store.sessions["p"]?.phase == .cancelled)
+        #expect(store.sessions["other"]?.phase == .cancelled)
+    }
+
+    @Test func pruneCancelsRemovedProjectAndRetainsOthers() async {
+        let store = GGLandingStore()
+        store.begin(seed())
+        store.begin(seed(projectId: "other"))
+        var cancelCount = 0
+        let task = Task<Void, Error> { try await Task.sleep(for: .seconds(30)) }
+        store.attach(projectId: "p", task: task) {
+            cancelCount += 1
+            task.cancel()
+        }
+
+        store.prune(keepingProjectIds: ["other"])
+        _ = await task.result
+
+        #expect(cancelCount == 1)
+        #expect(store.sessions["p"] == nil)
+        #expect(store.sessions["other"]?.phase == .running)
+    }
+
+    @Test func cancellationIgnoresLateFailureAndAppliesTerminalEntry() async {
+        let store = GGLandingStore()
+        store.begin(seed())
+        let task = Task<Void, Error> { throw TestError.interrupted }
+        store.attach(projectId: "p", task: task) {}
+        store.cancel(projectId: "p")
+        let outcome = GGLandedEntry(position: 1, prNumber: 41, action: "merged")
+        store.receive(.entry(outcome), projectId: "p")
+        store.fail(projectId: "p", message: "interrupted")
+
+        _ = await task.result
+        for _ in 0..<20 where store.sessions["p"]?.phase != .cancelled {
+            await Task.yield()
+        }
+
+        #expect(store.sessions["p"]?.phase == .cancelled)
+        #expect(store.sessions["p"]?.rows[0].outcome == outcome)
+    }
+}

--- a/AlasTests/Integrations/GGLandingStoreTests.swift
+++ b/AlasTests/Integrations/GGLandingStoreTests.swift
@@ -70,6 +70,25 @@ struct GGLandingStoreTests {
         #expect(store.begin(seed(projectId: "other")))
     }
 
+    @Test func terminalRuntimeIsRecordedAndResetOnRestart() async {
+        let store = GGLandingStore()
+        store.begin(seed())
+        #expect(store.sessions["p"]?.endedAt == nil)
+        store.receive(.summary(.init(landed: [])), projectId: "p")
+        #expect(store.sessions["p"]?.endedAt != nil)
+        store.begin(seed())
+        #expect(store.sessions["p"]?.endedAt == nil)
+        store.fail(projectId: "p", message: "Failed")
+        #expect(store.sessions["p"]?.endedAt != nil)
+        store.begin(seed())
+        store.cancel(projectId: "p")
+        #expect(store.sessions["p"]?.endedAt == nil)
+        store.attach(projectId: "p", task: Task<Void, Error> {}) {}
+        await store.waitForOperation(projectId: "p")
+        #expect(store.sessions["p"]?.phase == .cancelled)
+        #expect(store.sessions["p"]?.endedAt != nil)
+    }
+
     @Test func cancellationBeforeAttachCancelsRawOperationAndWaitsForCleanup() async {
         let store = GGLandingStore()
         let cleanup = LandingTestSuspension()

--- a/AlasTests/Integrations/GGLandingStoreTests.swift
+++ b/AlasTests/Integrations/GGLandingStoreTests.swift
@@ -176,6 +176,16 @@ struct GGLandingStoreTests {
         #expect(store.sessions["p"]?.error == nil)
     }
 
+    @Test func startEventMustMatchConfirmedScope() throws {
+        let store = GGLandingStore()
+        #expect(store.begin(seed()))
+
+        #expect(!store.receive(.start(stack: "other", base: "main", totalEntries: 2), projectId: "p"))
+        let failed = try #require(store.sessions["p"])
+        #expect(failed.phase == .failed)
+        #expect(failed.error == "gg land started for a different stack. Refresh and try again.")
+    }
+
     @Test func beginSeedsSessionAndReplacesTerminalAttempt() throws {
         let store = GGLandingStore()
         let startedAt = Date(timeIntervalSince1970: 1_000)

--- a/AlasTests/Integrations/GGMutationCoordinatorTests.swift
+++ b/AlasTests/Integrations/GGMutationCoordinatorTests.swift
@@ -66,14 +66,16 @@ private final class RecordingGGMutationExecutor: GGMutationExecuting {
         supportsSyncJSONL: Bool,
         supportsLandJSONL: Bool,
         onSyncEvent: (GGSyncEvent) -> Void,
-        onLandEvent: (GGLandEvent) -> Void
+        onLandEvent: (GGLandEvent) -> Bool
     ) async throws -> GGMutationExecutionResult {
         requests.append(request)
         clientOperationIDs.append(clientOperationID)
         syncJSONLCapabilities.append(supportsSyncJSONL)
         landJSONLCapabilities.append(supportsLandJSONL)
         if case .land = request, supportsLandJSONL {
-            for event in landEvents { onLandEvent(event) }
+            for event in landEvents {
+                guard onLandEvent(event) else { break }
+            }
         }
         if request == .sync {
             for event in syncEvents { onSyncEvent(event) }
@@ -295,7 +297,10 @@ private final class GGMutationHarness {
                 invalidateInbox: { [unowned self] in refreshes.append(.inbox) },
                 selectWorktreeAtPath: { [unowned self] path in selectedPaths.append(path) },
                 currentBranch: { [unowned self] in currentBranch },
-                publishLandEvent: { [unowned self] in publishedLandEvents.append($0) }
+                publishLandEvent: { [unowned self] event in
+                    publishedLandEvents.append(event)
+                    return true
+                }
             )
         )
     }

--- a/AlasTests/Integrations/GGMutationCoordinatorTests.swift
+++ b/AlasTests/Integrations/GGMutationCoordinatorTests.swift
@@ -6,6 +6,21 @@ private enum GGMutationTestTimeout: Error {
     case timedOut
 }
 
+private struct InvalidTrailingLandRunner: GGCommandRunning {
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        throw GGServiceError.commandFailed(stderr: "Unexpected buffered command")
+    }
+
+    func runStreaming(args: [String], cwd: URL?, timeout: TimeInterval?) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"start","stack":"feature","base":"main","total_entries":1}"#)
+            continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"summary","stack":"feature","base":"main","landed":[{"position":1,"pr_number":41,"action":"merged"}],"remaining":0,"cleaned":false}"#)
+            continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"start","stack":"feature","base":"main","total_entries":1}"#)
+            continuation.finish()
+        }
+    }
+}
+
 @MainActor
 private func waitUntil(
     timeout: TimeInterval = 2,
@@ -314,6 +329,43 @@ private func stack(
 
 @MainActor
 struct GGMutationCoordinatorTests {
+    @Test func protocolFailureAfterSummaryFailsSessionAndKeepsOutcomes() async {
+        let store = GGLandingStore()
+        store.begin(.init(
+            projectId: "p", worktreeId: "w", stack: "feature", base: "main", target: "change-1",
+            rows: [.init(position: 1, title: "One", ggId: "change-1", prNumber: 41)]
+        ))
+        let task = Task<Void, Error> {
+            _ = try await GGService(runner: InvalidTrailingLandRunner()).execute(
+                .land(target: "change-1"), worktreePath: "/repo/wt", clientOperationID: nil,
+                supportsSyncJSONL: false, supportsLandJSONL: true,
+                onSyncEvent: { _ in }, onLandEvent: { store.receive($0, projectId: "p") }
+            )
+        }
+        store.attach(projectId: "p", task: task, cancel: { task.cancel() })
+        await store.waitForOperation(projectId: "p")
+        #expect(store.sessions["p"]?.phase == .failed)
+        #expect(store.sessions["p"]?.error == "gg land emitted data after a terminal event.")
+        #expect(store.sessions["p"]?.rows.first?.outcome?.action == "merged")
+        #expect(store.sessions["p"]?.result?.landed.count == 1)
+    }
+
+    @Test func cancelledStreamMissingSummaryDoesNotPublishAnError() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "a", entries: [
+            GGStackEntry(position: 1, sha: "a", title: "One", ggId: "change-1",
+                         prState: .open, approved: true, ciStatus: .success)
+        ])], landJSONL: true)
+        harness.service.blockExecution = true
+        harness.service.error = GGServiceError.malformedOutput("Missing summary")
+        let task = try #require(harness.coordinator.startApplying(.land(target: "change-1"), confirmedAgainst: nil))
+        try await waitUntil { !harness.service.requests.isEmpty }
+        task.cancel()
+        harness.service.resumeExecution()
+        await #expect(throws: CancellationError.self) { try await task.value }
+        #expect(harness.actionState.lastError == nil)
+        #expect(harness.refreshes == [.gitChanges, .stack, .providerReviews, .inbox])
+    }
+
     @Test(arguments: [true, false])
     func malformedLandOutputFailsOnlyForLiveExecution(live: Bool) async throws {
         let harness = GGMutationHarness(stacks: [stack(head: "a", entries: [
@@ -342,6 +394,7 @@ struct GGMutationCoordinatorTests {
         await #expect(throws: CancellationError.self) { try await task.value }
         #expect(harness.service.requests.isEmpty)
         #expect(harness.actionState.inFlightAction == nil)
+        #expect(harness.actionState.lastError == nil)
     }
 
     @Test func currentLandCapabilityPublishesEvents() async throws {

--- a/AlasTests/Integrations/GGMutationCoordinatorTests.swift
+++ b/AlasTests/Integrations/GGMutationCoordinatorTests.swift
@@ -23,6 +23,8 @@ private final class RecordingGGMutationExecutor: GGMutationExecuting {
     var requests: [GGMutationRequest] = []
     var clientOperationIDs: [String?] = []
     var syncJSONLCapabilities: [Bool] = []
+    var landJSONLCapabilities: [Bool] = []
+    var landEvents: [GGLandEvent] = []
     var result: GGMutationExecutionResult = .none
     var error: Error?
     var newestOperation: GGOperationSummary?
@@ -47,11 +49,17 @@ private final class RecordingGGMutationExecutor: GGMutationExecuting {
         worktreePath: String,
         clientOperationID: String?,
         supportsSyncJSONL: Bool,
-        onSyncEvent: (GGSyncEvent) -> Void
+        supportsLandJSONL: Bool,
+        onSyncEvent: (GGSyncEvent) -> Void,
+        onLandEvent: (GGLandEvent) -> Void
     ) async throws -> GGMutationExecutionResult {
         requests.append(request)
         clientOperationIDs.append(clientOperationID)
         syncJSONLCapabilities.append(supportsSyncJSONL)
+        landJSONLCapabilities.append(supportsLandJSONL)
+        if case .land = request, supportsLandJSONL {
+            for event in landEvents { onLandEvent(event) }
+        }
         if request == .sync {
             for event in syncEvents { onSyncEvent(event) }
         }
@@ -94,6 +102,12 @@ private final class GGClientOperationCapabilityBox {
 
 @MainActor
 private final class GGSyncJSONLCapabilityBox {
+    var isSupported: Bool
+    init(_ isSupported: Bool) { self.isSupported = isSupported }
+}
+
+@MainActor
+private final class GGLandJSONLCapabilityBox {
     var isSupported: Bool
     init(_ isSupported: Bool) { self.isSupported = isSupported }
 }
@@ -203,6 +217,8 @@ private final class GGMutationHarness {
     let actionState = GGStackActionState()
     let clientOperationCapability: GGClientOperationCapabilityBox
     let syncJSONLCapability: GGSyncJSONLCapabilityBox
+    let landJSONLCapability: GGLandJSONLCapabilityBox
+    var publishedLandEvents: [GGLandEvent] = []
     let tokenGenerator: GGClientOperationTokenGenerator
     var stacks: [GGStackSnapshot]
     var loadError: Error?
@@ -219,13 +235,16 @@ private final class GGMutationHarness {
     init(
         stacks: [GGStackSnapshot],
         supportsClientOperationID: Bool = false,
-        supportsSyncJSONL: Bool = false
+        supportsSyncJSONL: Bool = false,
+        landJSONL: Bool = false
     ) {
         self.stacks = stacks
         let capability = GGClientOperationCapabilityBox(supportsClientOperationID)
         clientOperationCapability = capability
         let syncCapability = GGSyncJSONLCapabilityBox(supportsSyncJSONL)
         syncJSONLCapability = syncCapability
+        let landCapability = GGLandJSONLCapabilityBox(landJSONL)
+        landJSONLCapability = landCapability
         let generator = GGClientOperationTokenGenerator()
         tokenGenerator = generator
         coordinator = GGMutationCoordinator(
@@ -236,6 +255,7 @@ private final class GGMutationHarness {
             undoMarkerStore: markers,
             clientOperationIDCapability: { capability.isSupported },
             syncJSONLCapability: { syncCapability.isSupported },
+            landJSONLCapability: { landCapability.isSupported },
             clientOperationIDGenerator: { generator.next() },
             context: GGMutationContext(
                 loadFreshStack: { [unowned self] in
@@ -259,7 +279,8 @@ private final class GGMutationHarness {
                 },
                 invalidateInbox: { [unowned self] in refreshes.append(.inbox) },
                 selectWorktreeAtPath: { [unowned self] path in selectedPaths.append(path) },
-                currentBranch: { [unowned self] in currentBranch }
+                currentBranch: { [unowned self] in currentBranch },
+                publishLandEvent: { [unowned self] in publishedLandEvents.append($0) }
             )
         )
     }
@@ -293,6 +314,60 @@ private func stack(
 
 @MainActor
 struct GGMutationCoordinatorTests {
+    @Test(arguments: [true, false])
+    func malformedLandOutputFailsOnlyForLiveExecution(live: Bool) async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "a", entries: [
+            GGStackEntry(position: 1, sha: "a", title: "One", ggId: "change-1",
+                         prState: .open, approved: true, ciStatus: .success)
+        ])], landJSONL: live)
+        harness.service.error = GGServiceError.malformedOutput("Missing summary")
+        if live {
+            await #expect(throws: GGServiceError.self) {
+                try await harness.coordinator.apply(.land(target: "change-1"), confirmedAgainst: nil)
+            }
+            #expect(harness.actionState.lastError == "Missing summary")
+        } else {
+            try await harness.coordinator.apply(.land(target: "change-1"), confirmedAgainst: nil)
+            #expect(harness.actionState.lastError == nil)
+        }
+    }
+
+    @Test func cancelledLandDoesNotLaunchAfterPreflight() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "a", entries: [
+            GGStackEntry(position: 1, sha: "a", title: "One", ggId: "change-1",
+                         prState: .open, approved: true, ciStatus: .success)
+        ])], landJSONL: true)
+        let task = try #require(harness.coordinator.startApplying(.land(target: "change-1"), confirmedAgainst: nil))
+        task.cancel()
+        await #expect(throws: CancellationError.self) { try await task.value }
+        #expect(harness.service.requests.isEmpty)
+        #expect(harness.actionState.inFlightAction == nil)
+    }
+
+    @Test func currentLandCapabilityPublishesEvents() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "a", entries: [
+            GGStackEntry(position: 1, sha: "a", title: "One", ggId: "change-1",
+                         prState: .open, approved: true, ciStatus: .success)
+        ])], landJSONL: true)
+        harness.service.landEvents = [
+            .start(stack: "feature", base: "main", totalEntries: 1),
+            .summary(GGLandResult(stack: "feature", base: "main", landed: [], remaining: 1, cleaned: false))
+        ]
+        try await harness.coordinator.apply(.land(target: "change-1"), confirmedAgainst: nil)
+        #expect(harness.service.landJSONLCapabilities == [true])
+        #expect(harness.publishedLandEvents == harness.service.landEvents)
+    }
+
+    @Test func oldLandCapabilityUsesAtomicExecution() async throws {
+        let harness = GGMutationHarness(stacks: [stack(head: "a", entries: [
+            GGStackEntry(position: 1, sha: "a", title: "One", ggId: "change-1",
+                         prState: .open, approved: true, ciStatus: .success)
+        ])], landJSONL: false)
+        try await harness.coordinator.apply(.land(target: "change-1"), confirmedAgainst: nil)
+        #expect(harness.service.landJSONLCapabilities == [false])
+        #expect(harness.publishedLandEvents.isEmpty)
+    }
+
     @Test func onlyStagedChangeMutationsWaitForStaging() {
         #expect(GGMutationRequest.amendCurrent.requiresStagedChanges)
         #expect(GGMutationRequest.absorbStaged.requiresStagedChanges)

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -159,6 +159,19 @@ struct GGServiceActionsTests {
         }
     }
 
+    @Test func landJSONLRejectsSummaryOmittingCompletedEntry() async {
+        let runner = RecordingGGRunner()
+        runner.streamingLines = [
+            #"{"version":1,"command":"land","status":"ok","event":"start","stack":"s","base":"main","total_entries":1}"#,
+            #"{"version":1,"command":"land","status":"ok","event":"entry","position":1,"sha":"a","title":"A","gg_id":"c-a","pr_number":9,"action":"merged","error":null}"#,
+            #"{"version":1,"command":"land","status":"ok","event":"summary","stack":"s","base":"main","landed":[],"remaining":1,"cleaned":false,"warnings":[],"error":null}"#,
+        ]
+
+        await #expect(throws: GGServiceError.malformedOutput("gg land summary omitted a completed entry.")) {
+            for try await _ in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc").events {}
+        }
+    }
+
     @Test(arguments: [
         [
             #"{"version":1,"command":"land","status":"ok","event":"start","stack":"s","base":"main","total_entries":1}"#,

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -140,6 +140,25 @@ struct GGServiceActionsTests {
         #expect(runner.lastTimeout == nil)
     }
 
+    @Test func landJSONLStopsWhenConsumerRejectsEvent() async {
+        let runner = RecordingGGRunner()
+        runner.streamingLines = [
+            #"{"version":1,"command":"land","status":"ok","event":"start","stack":"s","base":"main","total_entries":1}"#,
+        ]
+
+        await #expect(throws: GGServiceError.malformedOutput("gg land stream did not match confirmed scope.")) {
+            _ = try await GGService(runner: runner).execute(
+                .land(target: "c-abc"),
+                worktreePath: "/tmp/wt",
+                clientOperationID: nil,
+                supportsSyncJSONL: false,
+                supportsLandJSONL: true,
+                onSyncEvent: { _ in },
+                onLandEvent: { _ in false }
+            )
+        }
+    }
+
     @Test(arguments: [
         [
             #"{"version":1,"command":"land","status":"ok","event":"start","stack":"s","base":"main","total_entries":1}"#,
@@ -483,7 +502,7 @@ struct GGServiceActionsTests {
             supportsSyncJSONL: false,
             supportsLandJSONL: false,
             onSyncEvent: { _ in },
-            onLandEvent: { _ in }
+            onLandEvent: { _ in true }
         )
 
         #expect(runner.calls == [["--client-operation-id", "alas:1234", "sc", "--staged-only"]])
@@ -501,7 +520,7 @@ struct GGServiceActionsTests {
             supportsSyncJSONL: false,
             supportsLandJSONL: false,
             onSyncEvent: { _ in },
-            onLandEvent: { _ in }
+            onLandEvent: { _ in true }
         )
 
         #expect(runner.calls == [["sc", "--staged-only"]])

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -6,9 +6,12 @@ private final class RecordingGGRunner: GGCommandRunning, @unchecked Sendable {
     var stdout: String
     var exitCode: Int32
     var stderr: String
+    var streamingLines: [String]? = nil
     private(set) var lastArgs: [String] = []
     private(set) var lastCwd: URL?
     private(set) var calls: [[String]] = []
+    private(set) var requestedStreamingTimeout = false
+    private(set) var lastTimeout: TimeInterval?
 
     init(stdout: String = "", exitCode: Int32 = 0, stderr: String = "") {
         self.stdout = stdout
@@ -21,6 +24,65 @@ private final class RecordingGGRunner: GGCommandRunning, @unchecked Sendable {
         lastArgs = args
         lastCwd = cwd
         return ProcessResult(exitCode: exitCode, stdout: stdout, stderr: stderr)
+    }
+
+    func runStreaming(
+        args: [String],
+        cwd: URL?,
+        timeout: TimeInterval?
+    ) -> AsyncThrowingStream<String, Error> {
+        calls.append(args)
+        lastArgs = args
+        lastCwd = cwd
+        requestedStreamingTimeout = true
+        lastTimeout = timeout
+        return AsyncThrowingStream { continuation in
+            for line in streamingLines ?? [] { continuation.yield(line) }
+            if exitCode == 0 {
+                continuation.finish()
+            } else {
+                continuation.finish(throwing: GGServiceError.map(exitCode: exitCode, stderr: stderr))
+            }
+        }
+    }
+}
+
+private final class CancellableLandGGRunner: GGCommandRunning, @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: AsyncThrowingStream<String, Error>.Continuation?
+    private(set) var cancelled = false
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        ProcessResult(exitCode: 1, stdout: "", stderr: "unexpected buffered run")
+    }
+
+    func runStreaming(
+        args: [String],
+        cwd: URL?,
+        timeout: TimeInterval?
+    ) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            self.lock.lock()
+            self.continuation = continuation
+            self.lock.unlock()
+            continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"start","stack":"s","base":"main","total_entries":1}"#)
+            continuation.onTermination = { [weak self] _ in
+                self?.lock.lock()
+                self?.cancelled = true
+                self?.lock.unlock()
+            }
+        }
+    }
+
+    func cancellationObserved() async -> Bool {
+        for _ in 0..<1_000 {
+            lock.lock()
+            let didCancel = cancelled
+            lock.unlock()
+            if didCancel { return true }
+            await Task.yield()
+        }
+        return false
     }
 }
 
@@ -56,6 +118,94 @@ private struct SummaryThenDelayedFailureGGRunner: GGCommandRunning {
 }
 
 struct GGServiceActionsTests {
+    @Test func landJSONLStreamsValidatedEventsWithoutTimeout() async throws {
+        let runner = RecordingGGRunner()
+        runner.streamingLines = [
+            #"{"version":1,"command":"land","status":"ok","event":"start","stack":"s","base":"main","total_entries":1}"#,
+            #"{"version":1,"command":"land","status":"ok","event":"wait","position":1,"pr_number":9,"phase":"readiness","poll":1,"elapsed_seconds":0,"ci_status":"running","approved":true,"merge_train_status":null,"merge_train_position":null,"pipeline_running":null,"error":null}"#,
+            #"{"version":1,"command":"land","status":"ok","event":"summary","stack":"s","base":"main","landed":[],"remaining":1,"cleaned":false,"warnings":[],"error":null}"#,
+        ]
+        var events: [GGLandEvent] = []
+        for try await event in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc") {
+            events.append(event)
+        }
+        #expect(events.count == 3)
+        #expect(runner.lastArgs == ["land", "--until", "c-abc", "--wait", "--jsonl", "--no-clean"])
+        #expect(runner.requestedStreamingTimeout)
+        #expect(runner.lastTimeout == nil)
+    }
+
+    @Test(arguments: [
+        [
+            #"{"version":1,"command":"land","status":"ok","event":"start","stack":"s","base":"main","total_entries":1}"#,
+            #"{"version":1,"command":"land","status":"ok","event":"start","stack":"s","base":"main","total_entries":1}"#,
+        ],
+        [#"{"version":1,"command":"land","status":"ok","event":"wait","position":1,"pr_number":9,"phase":"readiness","poll":1,"elapsed_seconds":0,"ci_status":null,"approved":null,"merge_train_status":null,"merge_train_position":null,"pipeline_running":null,"error":null}"#],
+        [#"{"version":1,"command":"land","status":"ok","event":"entry","position":1,"sha":"a","title":"A","gg_id":"c-a","pr_number":9,"action":"merged","error":null}"#],
+        [#"{"version":1,"command":"land","status":"ok","event":"summary","stack":"s","base":"main","landed":[],"remaining":1,"cleaned":false,"warnings":[],"error":null}"#],
+        [
+            #"{"version":1,"command":"land","status":"ok","event":"start","stack":"s","base":"main","total_entries":1}"#,
+            #"{"version":1,"command":"land","status":"ok","event":"wait","position":2,"pr_number":9,"phase":"readiness","poll":1,"elapsed_seconds":0,"ci_status":null,"approved":null,"merge_train_status":null,"merge_train_position":null,"pipeline_running":null,"error":null}"#,
+        ],
+        [
+            #"{"version":1,"command":"land","status":"ok","event":"start","stack":"s","base":"main","total_entries":1}"#,
+            #"{"version":1,"command":"land","status":"ok","event":"entry","position":1,"sha":"a","title":"A","gg_id":"c-a","pr_number":9,"action":"merged","error":null}"#,
+            #"{"version":1,"command":"land","status":"ok","event":"entry","position":1,"sha":"a","title":"A","gg_id":"c-a","pr_number":9,"action":"merged","error":null}"#,
+        ],
+        [
+            #"{"version":1,"command":"land","status":"ok","event":"start","stack":"s","base":"main","total_entries":1}"#,
+            #"{"version":1,"command":"land","status":"ok","event":"summary","stack":"s","base":"main","landed":[],"remaining":1,"cleaned":false,"warnings":[],"error":null}"#,
+            #"{"version":1,"command":"land","status":"ok","event":"wait","position":1,"pr_number":9,"phase":"readiness","poll":1,"elapsed_seconds":0,"ci_status":null,"approved":null,"merge_train_status":null,"merge_train_position":null,"pipeline_running":null,"error":null}"#,
+        ],
+        [#"{"version":1,"command":"land","status":"error","event":"error","message":"setup failed"}"#],
+        [#"{"version":1,"command":"land","status":"ok","event":"start","stack":"s","base":"main","total_entries":1}"#],
+    ])
+    func landJSONLRejectsInvalidEventSequences(lines: [String]) async {
+        let runner = RecordingGGRunner()
+        runner.streamingLines = lines
+        await #expect(throws: GGServiceError.self) {
+            for try await _ in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc") {}
+        }
+    }
+
+    @Test func landJSONLRejectsSummaryWithDifferentStartIdentity() async {
+        let runner = RecordingGGRunner()
+        runner.streamingLines = [
+            #"{"version":1,"command":"land","status":"ok","event":"start","stack":"s","base":"main","total_entries":1}"#,
+            #"{"version":1,"command":"land","status":"ok","event":"summary","stack":"other","base":"main","landed":[],"remaining":1,"cleaned":false,"warnings":[],"error":null}"#,
+        ]
+        await #expect(throws: GGServiceError.malformedOutput("gg land summary did not match start identity.")) {
+            for try await _ in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc") {}
+        }
+    }
+
+    @Test func landJSONLYieldsFatalErrorBeforeFailing() async {
+        let runner = RecordingGGRunner()
+        runner.streamingLines = [
+            #"{"version":1,"command":"land","status":"error","event":"error","message":"setup failed"}"#,
+        ]
+        var events: [GGLandEvent] = []
+        await #expect(throws: GGServiceError.commandFailed(stderr: "setup failed")) {
+            for try await event in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc") {
+                events.append(event)
+            }
+        }
+        #expect(events == [.error(message: "setup failed")])
+    }
+
+    @Test func landJSONLPropagatesConsumerCancellation() async throws {
+        let runner = CancellableLandGGRunner()
+        let task = Task {
+            for try await _ in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc") {
+                try Task.checkCancellation()
+            }
+        }
+        await Task.yield()
+        task.cancel()
+        _ = try? await task.value
+        #expect(await runner.cancellationObserved())
+    }
+
     @Test func syncStreamsParsedEventsFromDefaultRunner() async throws {
         // The default runStreaming splits buffered stdout into lines, so a
         // fake that only implements run() still drives the streaming API.

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -126,7 +126,7 @@ struct GGServiceActionsTests {
             #"{"version":1,"command":"land","status":"ok","event":"summary","stack":"s","base":"main","landed":[],"remaining":1,"cleaned":false,"warnings":[],"error":null}"#,
         ]
         var events: [GGLandEvent] = []
-        for try await event in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc") {
+        for try await event in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc").events {
             events.append(event)
         }
         #expect(events.count == 3)
@@ -164,7 +164,7 @@ struct GGServiceActionsTests {
         let runner = RecordingGGRunner()
         runner.streamingLines = lines
         await #expect(throws: GGServiceError.self) {
-            for try await _ in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc") {}
+            for try await _ in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc").events {}
         }
     }
 
@@ -175,7 +175,7 @@ struct GGServiceActionsTests {
             #"{"version":1,"command":"land","status":"ok","event":"summary","stack":"other","base":"main","landed":[],"remaining":1,"cleaned":false,"warnings":[],"error":null}"#,
         ]
         await #expect(throws: GGServiceError.malformedOutput("gg land summary did not match start identity.")) {
-            for try await _ in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc") {}
+            for try await _ in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc").events {}
         }
     }
 
@@ -186,7 +186,7 @@ struct GGServiceActionsTests {
         ]
         var events: [GGLandEvent] = []
         await #expect(throws: GGServiceError.commandFailed(stderr: "setup failed")) {
-            for try await event in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc") {
+            for try await event in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc").events {
                 events.append(event)
             }
         }
@@ -196,7 +196,7 @@ struct GGServiceActionsTests {
     @Test func landJSONLPropagatesConsumerCancellation() async throws {
         let runner = CancellableLandGGRunner()
         let task = Task {
-            for try await _ in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc") {
+            for try await _ in GGService(runner: runner).landStream(worktreePath: "/tmp/wt", until: "c-abc").events {
                 try Task.checkCancellation()
             }
         }

--- a/AlasTests/Integrations/GGServiceActionsTests.swift
+++ b/AlasTests/Integrations/GGServiceActionsTests.swift
@@ -59,7 +59,8 @@ private final class CancellableLandGGRunner: GGCommandRunning, @unchecked Sendab
     func runStreaming(
         args: [String],
         cwd: URL?,
-        timeout: TimeInterval?
+        timeout: TimeInterval?,
+        interruption: GGStreamingCancellation?
     ) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream { continuation in
             self.lock.lock()
@@ -70,6 +71,10 @@ private final class CancellableLandGGRunner: GGCommandRunning, @unchecked Sendab
                 self?.lock.lock()
                 self?.cancelled = true
                 self?.lock.unlock()
+            }
+            interruption?.install {
+                continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"entry","position":1,"pr_number":5,"action":"merged"}"#)
+                continuation.finish(throwing: CancellationError())
             }
         }
     }
@@ -204,6 +209,28 @@ struct GGServiceActionsTests {
         task.cancel()
         _ = try? await task.value
         #expect(await runner.cancellationObserved())
+    }
+
+    @Test func landJSONLInterruptDrainsTerminalEntryThroughRunnerExistential() async {
+        let stream = GGService(runner: CancellableLandGGRunner())
+            .landStream(worktreePath: "/tmp/wt", until: "c-abc")
+        let consumer = Task {
+            var entries: [GGLandedEntry] = []
+            do {
+                for try await event in stream.events {
+                    if case .start = event { stream.cancel() }
+                    if case .entry(let entry) = event { entries.append(entry) }
+                }
+            } catch {}
+            return entries
+        }
+        let watchdog = Task {
+            try? await Task.sleep(for: .seconds(5))
+            if !Task.isCancelled { consumer.cancel() }
+        }
+        let entries = await consumer.value
+        watchdog.cancel()
+        #expect(entries == [.init(position: 1, prNumber: 5, action: "merged")])
     }
 
     @Test func syncStreamsParsedEventsFromDefaultRunner() async throws {
@@ -454,7 +481,9 @@ struct GGServiceActionsTests {
             worktreePath: "/repo",
             clientOperationID: "alas:1234",
             supportsSyncJSONL: false,
-            onSyncEvent: { _ in }
+            supportsLandJSONL: false,
+            onSyncEvent: { _ in },
+            onLandEvent: { _ in }
         )
 
         #expect(runner.calls == [["--client-operation-id", "alas:1234", "sc", "--staged-only"]])
@@ -470,7 +499,9 @@ struct GGServiceActionsTests {
             worktreePath: "/repo",
             clientOperationID: nil,
             supportsSyncJSONL: false,
-            onSyncEvent: { _ in }
+            supportsLandJSONL: false,
+            onSyncEvent: { _ in },
+            onLandEvent: { _ in }
         )
 
         #expect(runner.calls == [["sc", "--staged-only"]])

--- a/AlasTests/Right/ChangesPreparationModelTests.swift
+++ b/AlasTests/Right/ChangesPreparationModelTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import SwiftUI
 import Testing
 @testable import Alas
 
@@ -102,6 +103,57 @@ struct ChangesPreparationModelTests {
         #expect(model.ggActions.map(\.kind) == [.newStackCommit, .commitAndSync, .amendCurrent, .absorbIntoStack])
         #expect(model.ggActions.map(\.title) == ["New stack commit", "Commit & sync", "Amend current", "Absorb into stack"])
         #expect(model.ggActions.allSatisfy { $0.isEnabled })
+    }
+
+    @Test func activeLandingReplacesPrepareActionsWithCompactStatus() {
+        let status = ChangesPreparationModel.GGLandingStatus(
+            completed: 1,
+            total: 3,
+            reviewNumber: 42,
+            detail: "CI running"
+        )
+        let model = ChangesPreparationModel.makeGG(
+            staged: .zero,
+            hasDraft: false,
+            capabilities: .init(structuredSplit: false, keepCurrentUnstack: false),
+            landingStatus: status
+        )
+
+        #expect(model.landingStatus == status)
+        #expect(model.isVisible)
+        #expect(model.reviewAction == nil)
+        #expect(model.reconciliationAction == nil)
+        #expect(model.ggActions.isEmpty)
+        #expect(model.syncProgress == nil)
+    }
+
+    @MainActor
+    @Test func landingCardRendersOpenLandingControl() {
+        let model = ChangesPreparationModel.makeGG(
+            staged: .zero,
+            hasDraft: false,
+            capabilities: stagedOnlyCapabilities,
+            landingStatus: .init(completed: 1, total: 3, reviewNumber: 42, detail: "CI running")
+        )
+        let card = ChangesPreparationCard(
+            model: model,
+            onReviewChanges: {},
+            onDraftCommit: {},
+            onPublishCommit: {},
+            onGGAction: { _ in },
+            onGGStackAction: { _ in },
+            onReviewRequestAction: { _ in },
+            onDismissSyncFailure: {},
+            onOpenGGLanding: {}
+        )
+        .environment(\.theme, try! ThemeStore().current)
+
+        let controller = NSHostingController(rootView: card)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 260, height: 160)
+        controller.view.layoutSubtreeIfNeeded()
+
+        #expect(subview(withAccessibilityIdentifier: "changes-preparation-gg-landing", in: controller.view) != nil)
+        #expect(subview(withAccessibilityIdentifier: "changes-preparation-open-gg-landing", in: controller.view) != nil)
     }
 
     @Test func ggRewriteDestinationsRequireStagedChanges() {
@@ -371,4 +423,11 @@ private func changedFile(
         renameFrom: nil,
         conflict: nil
     )
+}
+
+private func subview(withAccessibilityIdentifier identifier: String, in view: NSView) -> NSView? {
+    if view.accessibilityIdentifier() == identifier {
+        return view
+    }
+    return view.subviews.lazy.compactMap { subview(withAccessibilityIdentifier: identifier, in: $0) }.first
 }

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -212,6 +212,21 @@ struct RightPaneGGLandTests {
         #expect(state.ggActionState.lastError == nil)
     }
 
+    @Test func liveLandingSeedsRowsFromFreshPreparedStack() async throws {
+        let store = GGLandingStore()
+        let runner = LiveLandGGRunner()
+        runner.replaceStack(with: #"{"version":1,"stack":{"name":"feat","base":"main","total_commits":2,"synced_commits":2,"entries":[{"position":1,"sha":"s1","title":"Lower","gg_id":"change-1","pr_number":5,"pr_state":"open","approved":true,"ci_status":"success"},{"position":2,"sha":"s2","title":"Target","gg_id":"change-2","pr_number":6,"pr_state":"open","approved":true,"ci_status":"success"}]}}"#)
+        let state = landingState(store: store, runner: runner, supported: true)
+        state.ggStack = stack([entry(id: "change-2", position: 2, prState: .open, approved: true, ci: .success)])
+
+        state.requestGGLand(.until(entryId: "change-2", title: "Target"))
+        try await waitForLand { state.pendingGGLand != nil }
+        state.performGGLand(appState: AppState(store: MemoryStore()))
+
+        #expect(store.sessions["live-project"]?.rows.map(\.ggId) == ["change-1", "change-2"])
+        await store.cancelAllAndWait()
+    }
+
     @Test func shutdownDuringRestartPreflightNeverLaunchesLand() async throws {
         let store = GGLandingStore()
         let runner = LiveLandGGRunner()

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -27,7 +27,7 @@ private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {
     private var recordedCalls: [[String]] = []
     private var cancellations = 0
     private var targetExists = true
-    private var stackOutput = Self.stackJSON
+    private var stackOutput = LiveLandGGRunner.stackJSON
     private var nextPreflight: LandPreflightSuspension?
     private var continuations: [AsyncThrowingStream<String, Error>.Continuation] = []
     var calls: [[String]] { lock.withLock { recordedCalls } }
@@ -42,7 +42,7 @@ private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
         let (hasTarget, stackOutput) = lock.withLock {
             recordedCalls.append(args)
-            return (targetExists, stackOutput)
+            return (targetExists, self.stackOutput)
         }
         if args.first == "ls" {
             let preflight = lock.withLock {
@@ -63,15 +63,7 @@ private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {
     }
 
     func runStreaming(args: [String], cwd: URL?, timeout: TimeInterval?) -> AsyncThrowingStream<String, Error> {
-        lock.withLock { recordedCalls.append(args) }
-        return AsyncThrowingStream { continuation in
-            lock.withLock { continuations.append(continuation) }
-            continuation.onTermination = { [weak self] _ in
-                guard let self else { return }
-                self.lock.withLock { self.cancellations += 1 }
-            }
-            continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"start","stack":"feat","base":"main","total_entries":1}"#)
-        }
+        runStreaming(args: args, cwd: cwd, timeout: timeout, interruption: nil)
     }
 
     func runStreaming(
@@ -87,8 +79,11 @@ private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {
                 guard let self else { return }
                 self.lock.withLock { self.cancellations += 1 }
             }
-            interruption?.install { continuation.finish(throwing: CancellationError()) }
             continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"start","stack":"feat","base":"main","total_entries":1}"#)
+            interruption?.install {
+                continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"entry","position":1,"pr_number":5,"action":"merged"}"#)
+                continuation.finish(throwing: CancellationError())
+            }
         }
     }
 
@@ -213,6 +208,7 @@ struct RightPaneGGLandTests {
         await store.waitForOperation(projectId: "live-project")
         #expect(runner.cancellationCount == 1)
         #expect(store.sessions["live-project"]?.phase == .cancelled)
+        #expect(store.sessions["live-project"]?.rows.first?.outcome?.action == "merged")
         #expect(state.ggActionState.lastError == nil)
     }
 
@@ -331,20 +327,64 @@ struct RightPaneGGLandTests {
         #expect(store.sessions["live-project"]?.error != nil)
     }
 
-    @Test func restartRejectsChangedScopeWithStableTarget() async throws {
+    @Test func restartSkipsMissingEntriesAndKeepsOriginalScope() async throws {
         let store = GGLandingStore()
         let runner = LiveLandGGRunner()
         let state = landingState(store: store, runner: runner, supported: true)
-        state.requestGGLand(.ready)
-        try await waitForLand { state.pendingGGLand != nil }
-        state.performGGLand(appState: AppState(store: MemoryStore()))
-        try await waitForLand { runner.calls.contains { $0.first == "land" } }
-        await store.cancelAllAndWait()
+        store.begin(.init(
+            projectId: "live-project", worktreeId: "live-wt", stack: "feat", base: "main",
+            target: "change-1", rows: [
+                .init(position: 1, title: "Lower", ggId: "lower", prNumber: 4),
+                .init(position: 2, title: "Target", ggId: "change-1", prNumber: 5),
+            ]
+        ))
+        store.receive(.entry(.init(position: 1, prNumber: 4, action: "merged")), projectId: "live-project")
+        store.fail(projectId: "live-project", message: "Previous attempt failed")
 
-        runner.replaceStack(with: LiveLandGGRunner.stackJSON.replacingOccurrences(of: "\"base\":\"main\"", with: "\"base\":\"release\""))
-        state.restartGGLand(target: "change-1")
-        try await waitForLand { store.sessions["live-project"]?.phase == .failed }
-        #expect(runner.calls.filter { $0.first == "land" }.count == 1)
+        for attempt in 1...2 {
+            state.restartGGLand(target: "change-1")
+            try await waitForLand { runner.calls.filter { $0.first == "land" }.count == attempt }
+            #expect(store.sessions["live-project"]?.rows.count == 1)
+            #expect(store.sessions["live-project"]?.rows.first?.position == 1)
+            #expect(store.sessions["live-project"]?.confirmedScope.rows.map(\.ggId) == ["lower", "change-1"])
+            await store.cancelAllAndWait()
+            #expect(store.sessions["live-project"]?.phase == .cancelled)
+            #expect(store.sessions["live-project"]?.rows.first?.outcome?.action == "merged")
+        }
+    }
+
+    @Test(arguments: ["base", "lower", "above-target"])
+    func repeatedRestartRejectsChangedScopeWithStableTarget(change: String) async throws {
+        let store = GGLandingStore()
+        let runner = LiveLandGGRunner()
+        let state = landingState(store: store, runner: runner, supported: true)
+        store.begin(.init(
+            projectId: "live-project", worktreeId: "live-wt", stack: "feat", base: "main",
+            target: "change-1", rows: [
+                .init(position: 1, title: "Lower", ggId: "lower", prNumber: 4),
+                .init(position: 2, title: "Target", ggId: "change-1", prNumber: 5),
+            ]
+        ))
+        store.fail(projectId: "live-project", message: "Previous attempt failed")
+        let base = change == "base" ? "release" : "main"
+        let lowerID = change == "lower" ? "replacement" : "lower"
+        let lowerPosition = change == "above-target" ? 3 : 1
+        let output = #"{"version":1,"stack":{"name":"feat","base":"\#(base)","total_commits":2,"synced_commits":2,"entries":[{"position":\#(lowerPosition),"sha":"l","title":"Lower","gg_id":"\#(lowerID)","pr_number":4,"pr_state":"open","approved":true},{"position":2,"sha":"s","title":"Target","gg_id":"change-1","pr_number":5,"pr_state":"open","approved":true}]}}"#
+        runner.replaceStack(with: output)
+        state.ggStack = try GGStackSnapshot.decode(fromJSON: Data(output.utf8)).stack
+
+        for _ in 0..<2 {
+            let previousID = store.sessions["live-project"]?.id
+            state.restartGGLand(target: "change-1")
+            try await waitForLand { store.sessions["live-project"]?.id != previousID }
+            try await waitForLand {
+                store.sessions["live-project"]?.phase == .failed || runner.calls.contains { $0.first == "land" }
+            }
+            #expect(store.sessions["live-project"]?.phase == .failed)
+            #expect(!runner.calls.contains { $0.first == "land" })
+            #expect(store.sessions["live-project"]?.base == "main")
+            await store.cancelAllAndWait()
+        }
     }
 
     private func entry(id: String, prState: GGPRState, approved: Bool, ci: GGCIStatus?) -> GGStackEntry {

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -257,6 +257,37 @@ struct RightPaneGGLandTests {
         await store.cancelAllAndWait()
     }
 
+    @Test func liveLandingOpensInitiatingTabAndDuplicateFocusesIt() async throws {
+        let store = GGLandingStore.shared
+        let projectId = "landing-routing-\(UUID().uuidString)"
+        defer { store.prune(keepingProjectIds: Set(store.sessions.keys).subtracting([projectId])) }
+        let firstRunner = LiveLandGGRunner()
+        let secondRunner = LiveLandGGRunner()
+        let first = landingState(store: store, runner: firstRunner, supported: true, projectId: projectId)
+        let second = landingState(
+            store: store, runner: secondRunner, supported: true, worktreeId: "other-wt", projectId: projectId
+        )
+        let tabs = TabsManager(store: MemoryStore())
+        let app = AppState(store: MemoryStore(), tabsManager: tabs)
+        first.requestGGLand(.ready)
+        second.requestGGLand(.ready)
+        try await waitForLand { first.pendingGGLand != nil && second.pendingGGLand != nil }
+        first.performGGLand(appState: app)
+        let tabId = "gg-land:\(projectId)"
+        #expect(app.selectedWorktreeId == "live-wt")
+        #expect(tabs.activeTabId(forWorktree: "live-wt") == tabId)
+        tabs.close(worktreeId: "live-wt", tabId: tabId)
+        app.selectWorktree(id: "other-wt")
+        second.performGGLand(appState: app)
+        #expect(app.selectedWorktreeId == "live-wt")
+        #expect(tabs.activeTabId(forWorktree: "live-wt") == tabId)
+        #expect(tabs.tabs(forWorktree: "live-wt").count == 1)
+        #expect(tabs.tabs(forWorktree: "other-wt").isEmpty)
+        #expect(!secondRunner.calls.contains { $0.first == "land" })
+        store.cancel(projectId: projectId)
+        await store.waitForOperation(projectId: projectId)
+    }
+
     @Test func restartRepreflightsStableTargetWithoutAnotherConfirmation() async throws {
         let store = GGLandingStore()
         let runner = LiveLandGGRunner()

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -361,6 +361,7 @@ struct RightPaneGGLandTests {
             try await waitForLand { runner.calls.filter { $0.first == "land" }.count == attempt }
             #expect(store.sessions["live-project"]?.rows.count == 1)
             #expect(store.sessions["live-project"]?.rows.first?.position == 1)
+            #expect(store.sessions["live-project"]?.phase == .running)
             #expect(store.sessions["live-project"]?.confirmedScope.rows.map(\.ggId) == ["lower", "change-1"])
             await store.cancelAllAndWait()
             #expect(store.sessions["live-project"]?.phase == .cancelled)
@@ -368,7 +369,7 @@ struct RightPaneGGLandTests {
         }
     }
 
-    @Test(arguments: ["base", "lower", "above-target"])
+    @Test(arguments: ["base", "lower", "above-target", "removed-lower"])
     func repeatedRestartRejectsChangedScopeWithStableTarget(change: String) async throws {
         let store = GGLandingStore()
         let runner = LiveLandGGRunner()
@@ -384,7 +385,11 @@ struct RightPaneGGLandTests {
         let base = change == "base" ? "release" : "main"
         let lowerID = change == "lower" ? "replacement" : "lower"
         let lowerPosition = change == "above-target" ? 3 : 1
-        let output = #"{"version":1,"stack":{"name":"feat","base":"\#(base)","total_commits":2,"synced_commits":2,"entries":[{"position":\#(lowerPosition),"sha":"l","title":"Lower","gg_id":"\#(lowerID)","pr_number":4,"pr_state":"open","approved":true},{"position":2,"sha":"s","title":"Target","gg_id":"change-1","pr_number":5,"pr_state":"open","approved":true}]}}"#
+        let totalCommits = change == "removed-lower" ? 1 : 2
+        let lowerEntry = change == "removed-lower"
+            ? ""
+            : #"{"position":\#(lowerPosition),"sha":"l","title":"Lower","gg_id":"\#(lowerID)","pr_number":4,"pr_state":"open","approved":true},"#
+        let output = #"{"version":1,"stack":{"name":"feat","base":"\#(base)","total_commits":\#(totalCommits),"synced_commits":\#(totalCommits),"entries":[\#(lowerEntry){"position":2,"sha":"s","title":"Target","gg_id":"change-1","pr_number":5,"pr_state":"open","approved":true}]}}"#
         runner.replaceStack(with: output)
         state.ggStack = try GGStackSnapshot.decode(fromJSON: Data(output.utf8)).stack
 

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -167,6 +167,11 @@ private final class FreshUnstackGGRunner: GGCommandRunning, @unchecked Sendable 
 
 @MainActor
 struct RightPaneGGLandTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    }
+
     private func landingState(
         store: GGLandingStore,
         runner: LiveLandGGRunner,

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -368,7 +368,7 @@ struct RightPaneGGLandTests {
             #expect(store.sessions["live-project"]?.confirmedScope.rows.map(\.ggId) == ["lower", "change-1"])
             await store.cancelAllAndWait()
             #expect(store.sessions["live-project"]?.phase == .cancelled)
-            #expect(store.sessions["live-project"]?.completedIDs == Set(["lower"]))
+            #expect(store.sessions["live-project"]?.completedIDs == Set(["lower", "change-1"]))
             #expect(store.sessions["live-project"]?.rows.first?.outcome?.action == "merged")
         }
     }

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -368,6 +368,7 @@ struct RightPaneGGLandTests {
             #expect(store.sessions["live-project"]?.confirmedScope.rows.map(\.ggId) == ["lower", "change-1"])
             await store.cancelAllAndWait()
             #expect(store.sessions["live-project"]?.phase == .cancelled)
+            #expect(store.sessions["live-project"]?.completedIDs == Set(["lower"]))
             #expect(store.sessions["live-project"]?.rows.first?.outcome?.action == "merged")
         }
     }

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -19,7 +19,10 @@ private actor LandPreflightSuspension {
         await withCheckedContinuation { waiters.append($0) }
     }
 
-    func release() { completion?.resume(); completion = nil }
+    func release() {
+        completion?.resume()
+        completion = nil
+    }
 }
 
 private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -27,20 +27,22 @@ private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {
     private var recordedCalls: [[String]] = []
     private var cancellations = 0
     private var targetExists = true
+    private var stackOutput = Self.stackJSON
     private var nextPreflight: LandPreflightSuspension?
     private var continuations: [AsyncThrowingStream<String, Error>.Continuation] = []
     var calls: [[String]] { lock.withLock { recordedCalls } }
     var cancellationCount: Int { lock.withLock { cancellations } }
 
     func removeTarget() { lock.withLock { targetExists = false } }
+    func replaceStack(with output: String) { lock.withLock { stackOutput = output } }
     func suspendNextPreflight(_ preflight: LandPreflightSuspension) {
         lock.withLock { nextPreflight = preflight }
     }
 
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
-        let hasTarget = lock.withLock {
+        let (hasTarget, stackOutput) = lock.withLock {
             recordedCalls.append(args)
-            return targetExists
+            return (targetExists, stackOutput)
         }
         if args.first == "ls" {
             let preflight = lock.withLock {
@@ -55,7 +57,7 @@ private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {
         } else if args.first == "undo" {
             stdout = #"{"version":1,"operations":[]}"#
         } else {
-            stdout = hasTarget ? Self.stackJSON : Self.stackJSON.replacingOccurrences(of: "change-1", with: "replacement")
+            stdout = hasTarget ? stackOutput : stackOutput.replacingOccurrences(of: "change-1", with: "replacement")
         }
         return ProcessResult(exitCode: 0, stdout: stdout, stderr: "")
     }
@@ -68,6 +70,24 @@ private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {
                 guard let self else { return }
                 self.lock.withLock { self.cancellations += 1 }
             }
+            continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"start","stack":"feat","base":"main","total_entries":1}"#)
+        }
+    }
+
+    func runStreaming(
+        args: [String],
+        cwd: URL?,
+        timeout: TimeInterval?,
+        interruption: GGStreamingCancellation?
+    ) -> AsyncThrowingStream<String, Error> {
+        lock.withLock { recordedCalls.append(args) }
+        return AsyncThrowingStream { continuation in
+            lock.withLock { continuations.append(continuation) }
+            continuation.onTermination = { [weak self] _ in
+                guard let self else { return }
+                self.lock.withLock { self.cancellations += 1 }
+            }
+            interruption?.install { continuation.finish(throwing: CancellationError()) }
             continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"start","stack":"feat","base":"main","total_entries":1}"#)
         }
     }
@@ -309,6 +329,22 @@ struct RightPaneGGLandTests {
         try await waitForLand { store.sessions["live-project"]?.phase == .failed }
         #expect(runner.calls.filter { $0.first == "land" }.count == 2)
         #expect(store.sessions["live-project"]?.error != nil)
+    }
+
+    @Test func restartRejectsChangedScopeWithStableTarget() async throws {
+        let store = GGLandingStore()
+        let runner = LiveLandGGRunner()
+        let state = landingState(store: store, runner: runner, supported: true)
+        state.requestGGLand(.ready)
+        try await waitForLand { state.pendingGGLand != nil }
+        state.performGGLand(appState: AppState(store: MemoryStore()))
+        try await waitForLand { runner.calls.contains { $0.first == "land" } }
+        await store.cancelAllAndWait()
+
+        runner.replaceStack(with: LiveLandGGRunner.stackJSON.replacingOccurrences(of: "\"base\":\"main\"", with: "\"base\":\"release\""))
+        state.restartGGLand(target: "change-1")
+        try await waitForLand { store.sessions["live-project"]?.phase == .failed }
+        #expect(runner.calls.filter { $0.first == "land" }.count == 1)
     }
 
     private func entry(id: String, prState: GGPRState, approved: Bool, ci: GGCIStatus?) -> GGStackEntry {

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -2,21 +2,52 @@ import Foundation
 import Testing
 @testable import Alas
 
+private actor LandPreflightSuspension {
+    private var suspended = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var completion: CheckedContinuation<Void, Never>?
+
+    func suspend() async {
+        suspended = true
+        for waiter in waiters { waiter.resume() }
+        waiters.removeAll()
+        await withCheckedContinuation { completion = $0 }
+    }
+
+    func waitUntilSuspended() async {
+        if suspended { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func release() { completion?.resume(); completion = nil }
+}
+
 private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {
     private let lock = NSLock()
     private var recordedCalls: [[String]] = []
     private var cancellations = 0
     private var targetExists = true
+    private var nextPreflight: LandPreflightSuspension?
     private var continuations: [AsyncThrowingStream<String, Error>.Continuation] = []
     var calls: [[String]] { lock.withLock { recordedCalls } }
     var cancellationCount: Int { lock.withLock { cancellations } }
 
     func removeTarget() { lock.withLock { targetExists = false } }
+    func suspendNextPreflight(_ preflight: LandPreflightSuspension) {
+        lock.withLock { nextPreflight = preflight }
+    }
 
     func run(args: [String], cwd: URL?) async throws -> ProcessResult {
         let hasTarget = lock.withLock {
             recordedCalls.append(args)
             return targetExists
+        }
+        if args.first == "ls" {
+            let preflight = lock.withLock {
+                defer { nextPreflight = nil }
+                return nextPreflight
+            }
+            await preflight?.suspend()
         }
         let stdout: String
         if args.first == "land" {
@@ -162,6 +193,37 @@ struct RightPaneGGLandTests {
         await store.waitForOperation(projectId: "live-project")
         #expect(runner.cancellationCount == 1)
         #expect(store.sessions["live-project"]?.phase == .cancelled)
+        #expect(state.ggActionState.lastError == nil)
+    }
+
+    @Test func shutdownDuringRestartPreflightNeverLaunchesLand() async throws {
+        let store = GGLandingStore()
+        let runner = LiveLandGGRunner()
+        let state = landingState(store: store, runner: runner, supported: true)
+        store.begin(.init(
+            projectId: "live-project", worktreeId: "live-wt", stack: "feat", base: "main",
+            target: "change-1", rows: [.init(position: 1, title: "t", ggId: "change-1", prNumber: 5)]
+        ))
+        store.fail(projectId: "live-project", message: "Previous attempt failed")
+        let preflight = LandPreflightSuspension()
+        runner.suspendNextPreflight(preflight)
+        state.restartGGLand(target: "change-1")
+        await preflight.waitUntilSuspended()
+        let started = AsyncStream<Void>.makeStream()
+        var shutdownFinished = false
+        let shutdown = Task {
+            started.continuation.yield(())
+            await store.cancelAllAndWait()
+            shutdownFinished = true
+        }
+        for await _ in started.stream { break }
+        #expect(!shutdownFinished)
+        #expect(store.sessions["live-project"]?.phase == .cancelling)
+        await preflight.release()
+        await shutdown.value
+        #expect(!runner.calls.contains { $0.first == "land" })
+        #expect(store.sessions["live-project"]?.phase == .cancelled)
+        #expect(state.ggActionState.lastError == nil)
     }
 
     @Test func oldGGLandingUsesAtomicCommandWithoutSession() async throws {

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -273,6 +273,31 @@ struct RightPaneGGLandTests {
         try await waitForLand { state.ggActionState.inFlightAction == nil }
     }
 
+    @Test func confirmedLandingWaitsForPreviousTerminalCleanup() async throws {
+        let store = GGLandingStore()
+        let runner = LiveLandGGRunner()
+        let state = landingState(store: store, runner: runner, supported: true)
+        let cleanup = AsyncStream<Void>.makeStream()
+        let cleanupTask = Task<Void, Error> {
+            for await _ in cleanup.stream {}
+        }
+        store.begin(.init(
+            projectId: "live-project", worktreeId: "live-wt", stack: "feat", base: "main",
+            target: "old", rows: [.init(position: 1, title: "old", ggId: "old", prNumber: 4)]
+        ))
+        store.attach(projectId: "live-project", task: cleanupTask, cancel: { cleanup.continuation.finish() })
+        store.receive(.summary(.init(landed: [])), projectId: "live-project")
+
+        state.requestGGLand(.ready)
+        try await waitForLand { state.pendingGGLand != nil }
+        state.performGGLand(appState: AppState(store: MemoryStore()))
+        #expect(!runner.calls.contains { $0.first == "land" })
+
+        cleanup.continuation.finish()
+        try await waitForLand { runner.calls.contains { $0.first == "land" } }
+        await store.cancelAllAndWait()
+    }
+
     @Test func duplicateProjectLandingDoesNotLaunchAnotherMutation() async throws {
         let store = GGLandingStore()
         let firstRunner = LiveLandGGRunner()

--- a/AlasTests/RightPaneGGLandTests.swift
+++ b/AlasTests/RightPaneGGLandTests.swift
@@ -2,6 +2,49 @@ import Foundation
 import Testing
 @testable import Alas
 
+private final class LiveLandGGRunner: GGCommandRunning, @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedCalls: [[String]] = []
+    private var cancellations = 0
+    private var targetExists = true
+    private var continuations: [AsyncThrowingStream<String, Error>.Continuation] = []
+    var calls: [[String]] { lock.withLock { recordedCalls } }
+    var cancellationCount: Int { lock.withLock { cancellations } }
+
+    func removeTarget() { lock.withLock { targetExists = false } }
+
+    func run(args: [String], cwd: URL?) async throws -> ProcessResult {
+        let hasTarget = lock.withLock {
+            recordedCalls.append(args)
+            return targetExists
+        }
+        let stdout: String
+        if args.first == "land" {
+            stdout = Self.summaryJSON
+        } else if args.first == "undo" {
+            stdout = #"{"version":1,"operations":[]}"#
+        } else {
+            stdout = hasTarget ? Self.stackJSON : Self.stackJSON.replacingOccurrences(of: "change-1", with: "replacement")
+        }
+        return ProcessResult(exitCode: 0, stdout: stdout, stderr: "")
+    }
+
+    func runStreaming(args: [String], cwd: URL?, timeout: TimeInterval?) -> AsyncThrowingStream<String, Error> {
+        lock.withLock { recordedCalls.append(args) }
+        return AsyncThrowingStream { continuation in
+            lock.withLock { continuations.append(continuation) }
+            continuation.onTermination = { [weak self] _ in
+                guard let self else { return }
+                self.lock.withLock { self.cancellations += 1 }
+            }
+            continuation.yield(#"{"version":1,"command":"land","status":"ok","event":"start","stack":"feat","base":"main","total_entries":1}"#)
+        }
+    }
+
+    static let stackJSON = #"{"version":1,"stack":{"name":"feat","base":"main","total_commits":1,"synced_commits":1,"current_position":1,"entries":[{"position":1,"sha":"s","title":"t","gg_id":"change-1","pr_number":5,"pr_state":"open","approved":true,"ci_status":"success"}]}}"#
+    static let summaryJSON = #"{"version":1,"command":"land","status":"ok","event":"summary","stack":"feat","base":"main","landed":[],"remaining":1,"cleaned":false,"warnings":[],"error":null}"#
+}
+
 private final class FreshUnstackGGRunner: GGCommandRunning, @unchecked Sendable {
     private(set) var calls: [[String]] = []
     private let stackResponses: [String]
@@ -75,6 +118,106 @@ private final class FreshUnstackGGRunner: GGCommandRunning, @unchecked Sendable 
 
 @MainActor
 struct RightPaneGGLandTests {
+    private func landingState(
+        store: GGLandingStore,
+        runner: LiveLandGGRunner,
+        supported: Bool,
+        worktreeId: String = "live-wt",
+        projectId: String = "live-project"
+    ) -> RightPaneState {
+        let worktree = Worktree(
+            id: worktreeId, projectId: projectId, name: "feat", branch: "feat",
+            path: URL(fileURLWithPath: "/tmp/alas-land-tests-\(UUID().uuidString)"),
+            status: .clean, lastActivity: Date()
+        )
+        let state = RightPaneState(worktree: worktree, baseBranch: "main", ggLandingStore: store)
+        state.ggCapabilities = { GGCapabilities(structuredSplit: false, keepCurrentUnstack: false, landJSONL: supported) }
+        state.ggService = GGService(runner: runner)
+        state.ggStack = stack([entry(id: "change-1", prState: .open, approved: true, ci: .success)])
+        return state
+    }
+
+    private func waitForLand(_ condition: () -> Bool) async throws {
+        for _ in 0..<200 {
+            if condition() { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        throw GGServiceError.commandFailed(stderr: "Timed out waiting for landing")
+    }
+
+    @Test func liveLandingBeginsBeforeExecutionAndCancelsRawOperation() async throws {
+        let store = GGLandingStore()
+        let runner = LiveLandGGRunner()
+        let state = landingState(store: store, runner: runner, supported: true)
+        state.requestGGLand(.ready)
+        try await waitForLand { state.pendingGGLand != nil }
+        #expect(store.sessions.isEmpty)
+        state.performGGLand(appState: AppState(store: MemoryStore()))
+        #expect(store.sessions["live-project"]?.phase == .running)
+        #expect(store.sessions["live-project"]?.target == "change-1")
+        #expect(!runner.calls.contains { $0.first == "land" })
+        try await waitForLand { runner.calls.contains { $0.first == "land" } }
+        #expect(runner.calls.contains(["land", "--until", "change-1", "--wait", "--jsonl", "--no-clean"]))
+        store.cancel(projectId: "live-project")
+        await store.waitForOperation(projectId: "live-project")
+        #expect(runner.cancellationCount == 1)
+        #expect(store.sessions["live-project"]?.phase == .cancelled)
+    }
+
+    @Test func oldGGLandingUsesAtomicCommandWithoutSession() async throws {
+        let store = GGLandingStore()
+        let runner = LiveLandGGRunner()
+        let state = landingState(store: store, runner: runner, supported: false)
+        state.requestGGLand(.ready)
+        try await waitForLand { state.pendingGGLand != nil }
+        state.performGGLand(appState: AppState(store: MemoryStore()))
+        try await waitForLand { runner.calls.contains { $0.first == "land" } }
+        #expect(runner.calls.contains(["land", "--until", "change-1", "--json", "--no-clean"]))
+        #expect(store.sessions.isEmpty)
+        try await waitForLand { state.ggActionState.inFlightAction == nil }
+    }
+
+    @Test func duplicateProjectLandingDoesNotLaunchAnotherMutation() async throws {
+        let store = GGLandingStore()
+        let firstRunner = LiveLandGGRunner()
+        let secondRunner = LiveLandGGRunner()
+        let first = landingState(store: store, runner: firstRunner, supported: true)
+        let second = landingState(store: store, runner: secondRunner, supported: true, worktreeId: "other-wt")
+        first.requestGGLand(.ready)
+        second.requestGGLand(.ready)
+        try await waitForLand { first.pendingGGLand != nil && second.pendingGGLand != nil }
+        let app = AppState(store: MemoryStore())
+        first.performGGLand(appState: app)
+        let sessionId = store.sessions["live-project"]?.id
+        second.performGGLand(appState: app)
+        #expect(store.sessions["live-project"]?.id == sessionId)
+        #expect(!secondRunner.calls.contains { $0.first == "land" })
+        await store.cancelAllAndWait()
+    }
+
+    @Test func restartRepreflightsStableTargetWithoutAnotherConfirmation() async throws {
+        let store = GGLandingStore()
+        let runner = LiveLandGGRunner()
+        let state = landingState(store: store, runner: runner, supported: true)
+        state.requestGGLand(.ready)
+        try await waitForLand { state.pendingGGLand != nil }
+        state.performGGLand(appState: AppState(store: MemoryStore()))
+        try await waitForLand { runner.calls.contains { $0.first == "land" } }
+        await store.cancelAllAndWait()
+        let oldSessionId = store.sessions["live-project"]?.id
+        state.restartGGLand(target: "change-1")
+        try await waitForLand { runner.calls.filter { $0.first == "land" }.count == 2 }
+        #expect(store.sessions["live-project"]?.id != oldSessionId)
+        #expect(state.pendingGGLand == nil)
+        #expect(runner.calls.filter { $0.first == "land" }.allSatisfy { $0.contains("change-1") })
+        await store.cancelAllAndWait()
+        runner.removeTarget()
+        state.restartGGLand(target: "change-1")
+        try await waitForLand { store.sessions["live-project"]?.phase == .failed }
+        #expect(runner.calls.filter { $0.first == "land" }.count == 2)
+        #expect(store.sessions["live-project"]?.error != nil)
+    }
+
     private func entry(id: String, prState: GGPRState, approved: Bool, ci: GGCIStatus?) -> GGStackEntry {
         GGStackEntry(position: 1, sha: "s", title: "t", ggId: id, prNumber: 5,
                      prState: prState, approved: approved, ciStatus: ci)

--- a/docs/superpowers/specs/2026-09-09-gg-live-land-ui-design.md
+++ b/docs/superpowers/specs/2026-09-09-gg-live-land-ui-design.md
@@ -1,0 +1,172 @@
+# Live gg landing UI
+
+## Goal
+
+Show a long-running `gg land` operation inside Alas while it waits for CI,
+approval, or a GitLab merge train. Users can leave the initiating worktree,
+return to the operation, cancel it, and restart after cancellation or failure.
+
+Alas allows one active landing per repository. Landing continues when its tab
+is closed or another worktree is selected. Quitting Alas cancels the process;
+sessions do not survive an app restart.
+
+## Compatibility
+
+Alas detects live landing support by checking `gg land --help` for `--jsonl`.
+With gg 0.10.2 or newer, confirmed lands use the live flow. Older gg versions
+keep the existing `gg land --json --no-clean` behavior and final-result-only UI.
+The upgrade does not remove or disable the existing landing action.
+
+## User interface
+
+### Landing tab
+
+Starting a supported land opens or focuses one center tab named
+`Land · <stack>`. The tab is scoped to the repository's active landing session,
+even though TabsManager hosts it under the initiating worktree.
+
+The header shows the stack name, completed count, total count, elapsed time,
+and a Cancel button while the process runs. Each target entry has one row:
+
+- Completed entries show their terminal outcome, such as merged, queued, or
+  skipped.
+- The active entry shows its current readiness or merge-train state, elapsed
+  wait time, and any available CI, approval, pipeline, or queue-position data.
+- Later entries remain pending.
+
+Transient provider errors appear below the active row as warnings. A later
+healthy heartbeat clears the transient warning. They do not mark the session
+failed.
+
+Cancel changes the button and header to a non-interactive Cancelling state.
+Once gg exits, the tab shows Cancelled, the number already completed, the
+number remaining, and Restart landing. A failed or partial result keeps all
+reported outcomes visible, shows the stopping error, and offers the same
+restart action. A successful result shows the final summary and no restart
+button.
+
+Closing the tab never cancels landing. Landing tabs are transient and are not
+written to the restored-tabs file, so relaunching Alas does not reopen a stale
+session.
+
+### Prepare card
+
+While any worktree from the repository is selected, the existing Prepare area
+shows a compact landing card. It contains the completed and total counts, the
+active PR or MR and its short state, and an Open landing button. It has no
+duplicate timeline or Cancel button. Open landing returns to the existing tab,
+using the initiating worktree as its host.
+
+After success, cancellation, or failure, the compact card disappears. The
+Landing tab retains the terminal result until the user closes it or starts a
+replacement session.
+
+## Process ownership
+
+A main-actor repository-scoped landing store owns the active session, its
+presentation state, and the task that consumes gg output. It is keyed by
+project ID, matching the repository scope already used by `GGInboxStore`.
+This placement keeps the process alive independently of worktree selection and
+lets every worktree's Prepare view find the same session.
+
+The session records:
+
+- Project, initiating worktree, stack, base, and original `--until` target.
+- The preflight stack entries used to seed the tab rows.
+- Start time, lifecycle state, latest wait heartbeat, terminal entry outcomes,
+  warnings, and summary.
+- The streaming task and a cancellation-request flag.
+
+The existing mutation coordinator remains responsible for stack preflight,
+stale-target protection, mutation gating, post-operation refreshes, inbox
+invalidation, and result summaries. Live landing adds an event callback to the
+land execution path rather than creating a second mutation pipeline.
+
+The store refuses a second land for the same project and focuses the existing
+tab. It does not block sync or other gg work in another stack while landing is
+waiting. gg 0.10.2 releases its repository operation lock between provider
+polls and reacquires it for mutations.
+
+## Command and event flow
+
+After the existing confirmation and fresh-stack validation succeed, Alas runs:
+
+```text
+gg land --until <stable-target> --wait --jsonl --no-clean
+```
+
+The runner reads and flushes each NDJSON line without imposing Alas's existing
+ten-minute streaming timeout. gg's configured landing wait timeout remains the
+only operation timeout.
+
+Alas accepts version 1 events whose command is `land`:
+
+- `start` confirms the stack, base, and total entry count.
+- `wait` updates the active position and heartbeat fields. `phase` selects
+  readiness or merge-train presentation.
+- `entry` records a terminal outcome for one position.
+- `summary` completes the normal result path. Alas inspects the summary's error
+  field because a partial failure may still exit successfully.
+- `error` terminates the session when setup fails before a summary.
+
+The parser rejects a mismatched command or version, duplicate start events,
+events before start, invalid positions, duplicate terminal outcomes, and any
+event after summary or fatal error. A stream that ends without a terminal event
+is a protocol failure unless the user requested cancellation.
+
+The preflight snapshot supplies titles and pending rows because `start` contains
+only the total. `wait` locates the active row by position and PR or MR number.
+`entry` replaces the corresponding pending or active row with gg's reported
+outcome. The summary is authoritative for final counts, warnings, and error.
+
+## Cancellation and restart
+
+Cancel sends SIGINT to the gg process group, matching terminal Ctrl-C behavior.
+The process runner waits for gg and its descendants to exit, then uses SIGKILL
+only after the existing grace period. Alas does not report user cancellation as
+a command error and never attempts to undo remote merges.
+
+The session remains Cancelling until process exit. Any terminal entry event
+received before exit is applied, so the final cancelled view reflects work that
+completed before gg reached its safe interruption point.
+
+Restart discards the previous attempt's event history and reruns the normal
+preflight with the original stable target. gg skips entries already merged. If
+the stack or target no longer matches the confirmed scope, Alas does not launch
+gg and shows the stale-target error. The user must then close the tab and start
+a new landing action from the current stack.
+
+## Errors
+
+- Transient `wait` errors are warnings and clear after a healthy heartbeat.
+- An `entry` error marks that row failed and remains visible through the final
+  summary.
+- A summary error produces a terminal partial-failure state with Restart.
+- A fatal `error`, nonzero exit without a terminal event, malformed event, or
+  premature EOF produces a terminal failure with the decoded message.
+- Cancellation requested by the user takes precedence over the expected
+  interrupted-process exit status.
+- Refresh failures after a terminal gg result do not rewrite the landing
+  outcome. They use the existing mutation error presentation.
+
+## Testing
+
+Use Swift Testing for model, service, store, and routing coverage:
+
+- Decode every version 1 event and reject invalid ordering, identity, and
+  positions.
+- Project heartbeats into readiness, approval, CI, merge-train, warning, and
+  elapsed-time presentation.
+- Apply terminal entry and summary outcomes, including queued entries and
+  partial failures.
+- Enforce one active landing per project while allowing other projects.
+- Keep a session alive across tab closure and worktree selection changes.
+- Cancel once, wait for exit, suppress the expected interruption error, and
+  retain completed outcomes.
+- Restart through fresh preflight and reject a stale or missing target.
+- Keep the existing final-only service path when `--jsonl` is unavailable.
+- Open or focus one Landing tab and render the compact Prepare card only while
+  the session is active.
+- Verify a streaming subprocess receives SIGINT and that its descendants exit.
+
+The normal project build and test suite remain the final verification.


### PR DESCRIPTION
## Summary
- add live `gg land --jsonl` streaming, cancellation, and restart handling
- show active landing in a transient Landing tab with Prepare linking into it
- keep older `gg land --json` final-result behavior for unsupported gg versions

## Verification
- `xcodegen`
- focused isolated Swift service/store and subprocess suites from the final repair pass passed
- local full `xcodebuild` build/test could not reach Swift compilation because this worktree is missing `ThirdParty/zmx`; optional zmx mode then reaches missing `ThirdParty/fff`

Replaces accidental stacked PRs #1138-#1151, which were closed.