### PR TITLE
style(workspace): Increase workspace overview repo logo facepile size

### DIFF
--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -440,7 +440,8 @@ private struct WorkspaceOverviewView: View {
     var body: some View {
         VStack(spacing: 18) {
             VStack(spacing: 8) {
-                WorkspaceRepositoryPile(workspace: workspace, projects: projects)
+                WorkspaceRepositoryPile(workspace: workspace, projects: projects, size: .overview)
+                    .padding(.bottom, 4)
                 Text(workspace.name)
                     .font(.system(size: 20, weight: .semibold))
                     .foregroundColor(theme.color("fg"))

--- a/Alas/Sources/Sidebar/ProjectIconView.swift
+++ b/Alas/Sources/Sidebar/ProjectIconView.swift
@@ -5,12 +5,14 @@ struct ProjectIconView: View {
     enum Size {
         case sidebar
         case picker
+        case overview
         case dialog
 
         var dimension: CGFloat {
             switch self {
             case .sidebar: 16
             case .picker: 18
+            case .overview: 52
             case .dialog: 72
             }
         }
@@ -19,6 +21,7 @@ struct ProjectIconView: View {
             switch self {
             case .sidebar: 4
             case .picker: 5
+            case .overview: 13
             case .dialog: 18
             }
         }
@@ -27,6 +30,7 @@ struct ProjectIconView: View {
             switch self {
             case .sidebar: 9.5
             case .picker: 10.5
+            case .overview: 20
             case .dialog: 26
             }
         }

--- a/Alas/Sources/Sidebar/WorkspaceSidebarTree.swift
+++ b/Alas/Sources/Sidebar/WorkspaceSidebarTree.swift
@@ -390,6 +390,7 @@ struct WorkspaceSidebarTree<ProjectRow: View>: View {
 struct WorkspaceRepositoryPile: View {
     let workspace: Workspace
     let projects: [ProjectConfig]
+    var size: ProjectIconView.Size = .sidebar
     @Environment(\.theme) private var theme
 
     var body: some View {
@@ -397,17 +398,27 @@ struct WorkspaceRepositoryPile: View {
         let repositories = workspace.members.compactMap { projectsByID[$0.projectID] }
         Group {
             if repositories.isEmpty {
-                Icon(name: "folder", size: 13, color: theme.color("fg-muted"))
+                Icon(name: "folder", size: size.dimension * 0.8, color: theme.color("fg-muted"))
             } else {
-                HStack(spacing: -5) {
+                HStack(spacing: -size.dimension * 0.3125) {
                     ForEach(repositories.prefix(3)) { project in
-                        ProjectIconView(icon: project.icon, fallbackName: project.name, size: .sidebar)
+                        ProjectIconView(icon: project.icon, fallbackName: project.name, size: size)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: size.cornerRadius)
+                                    .strokeBorder(theme.color("bg-1"), lineWidth: ringWidth)
+                            )
                     }
                 }
                 .fixedSize()
             }
         }
         .accessibilityHidden(true)
+    }
+
+    /// The sidebar pile is too small for a separating ring to read as anything
+    /// but grime, so only the larger piles get one.
+    private var ringWidth: CGFloat {
+        size.dimension >= 32 ? 2 : 0
     }
 }
 


### PR DESCRIPTION
## Summary

- Increases the repository logo facepile in the workspace empty-state/overview screen from 16pt sidebar-sized icons to a new 52pt `.overview` size, so the logos read clearly as the primary visual on that screen.
- Adds a subtle separating ring between overlapping icons in the larger pile so individual logos stay distinguishable when overlapped; kept off for the small sidebar pile where it would just look like grime.

### What changed

- `ProjectIconView.Size`: new `.overview` case (52pt, 13pt corner radius, 20pt font) alongside existing `.sidebar`/`.picker`/`.dialog` sizes.
- `WorkspaceRepositoryPile`: takes an optional `size` parameter (defaults to `.sidebar`, so the existing sidebar workspace row usage is untouched), scales icon overlap spacing to the icon size, and adds a themed separator ring for piles ≥32pt.
- `RootView.WorkspaceOverviewView`: passes `size: .overview` for the workspace empty-state facepile.

### Reviewer notes

- Sidebar usage of `WorkspaceRepositoryPile` (workspace tree rows) is unaffected — default size stays `.sidebar`, no ring.