### PR TITLE
fix(search): stop Cmd-P content scroll hangs

### DIFF
--- a/Alas/Sources/Search/Views/ContentResultGroup.swift
+++ b/Alas/Sources/Search/Views/ContentResultGroup.swift
@@ -16,12 +16,7 @@ struct ContentResultGroupView: View {
             ForEach(Array(group.hits.enumerated()), id: \.element.id) { offset, hit in
                 let absIndex = baseIndex + offset
                 hitRow(hit: hit, absIndex: absIndex, isSelected: absIndex == selectedIndex)
-                    // Identity/scroll anchor is the hit id, not the row
-                    // position: a stable position id (`.id(absIndex)`) froze
-                    // rows against data changes (see FileSearchDialog for the
-                    // LazyVStack caching rationale), while a data-based id
-                    // changes with the hit and still lets the dialog's
-                    // `scrollTo(selected hit id)` reach it during keyboard nav.
+                    // Keep identity and keyboard scroll targets tied to the hit.
                     .id(hit.id)
             }
         }

--- a/Alas/Sources/Search/Views/FileSearchDialog.swift
+++ b/Alas/Sources/Search/Views/FileSearchDialog.swift
@@ -59,7 +59,10 @@ struct FileSearchDialog: View {
         } else {
             ScrollViewReader { proxy in
                 ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 0) {
+                    // Results are capped at 50 files or 200 content hits. Eager
+                    // layout avoids LazyVStack's placement loop when scrolling
+                    // content groups of different heights on macOS 26.
+                    VStack(alignment: .leading, spacing: 0) {
                         switch model.kind {
                         case .files:
                             ForEach(Array(model.results.fileResults.enumerated()), id: \.element.id) { idx, r in
@@ -71,13 +74,8 @@ struct FileSearchDialog: View {
                                     onTap: { open(r) },
                                     onHover: { model.selectedIndex = idx }
                                 )
-                                // Identity/scroll anchor is the file id, not the
-                                // row position. A stable position id (`.id(idx)`)
-                                // let LazyVStack cache the row and never rebuild
-                                // it when the file at that position changed,
-                                // freezing stale results; a data-based id changes
-                                // with the file and still gives `scrollTo` an
-                                // explicit target for keyboard navigation.
+                                // Keep identity and keyboard scroll targets tied
+                                // to the result, not its position in the list.
                                 .id(r.id)
                             }
                         case .content:


### PR DESCRIPTION
Cmd-P Content search could beachball when scrolling while changing the selection. The macOS 26 sample showed the main thread repeatedly placing `LazyVStack` children.

The dialog renders at most 50 file results or 200 content hits, so it now uses `VStack`. Result IDs and `ScrollViewReader` targets are unchanged.

Validation:

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' build`
- Search suites passed: `SearchModelTests`, `ContentSearcherTests`, `ContentResultGroupViewTests`, and `FileSearchRankerTests`
- The full suite ran 8,845 tests and reported 15 pre-existing failures outside search. See `/tmp/alas-content-scroll-tests.log` locally.
