### PR TITLE
fix(remote): prevent launch viewport gap

### DIFF
--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -3163,7 +3163,10 @@ if (vp) {
   };
   vp.addEventListener("resize", syncViewport);
   vp.addEventListener("scroll", syncViewport);
-  syncViewport();
+  // Safari can report a transiently short visual viewport while its browser
+  // chrome settles on initial load. Only take over the CSS viewport once the
+  // composer needs keyboard tracking.
+  $("prompt").addEventListener("focus", syncViewport);
 }
 
 setStatus("Connecting…", "connecting");

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -3169,9 +3169,11 @@ if (vp) {
     vp.addEventListener("scroll", syncViewport);
   };
   // Safari can report a transiently short visual viewport while its browser
-  // chrome settles on initial load. Only take over the CSS viewport once the
-  // composer needs keyboard tracking.
-  $("prompt").addEventListener("focus", beginViewportTracking);
+  // chrome settles on initial load. Only take over the CSS viewport when an
+  // input can open the keyboard.
+  document.addEventListener("focusin", (event) => {
+    if (event.target.matches("input, textarea, select")) beginViewportTracking();
+  });
 }
 
 setStatus("Connecting…", "connecting");

--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -3152,6 +3152,7 @@ $("gate-retry").onclick = retryConnection;
 // keyboard) and keep the transcript pinned to the bottom as it resizes.
 const vp = window.visualViewport;
 if (vp) {
+  let isTrackingViewport = false;
   const syncViewport = () => {
     // Pin the fixed shell to the visual viewport's box: height shrinks for the
     // keyboard, and top follows offsetTop so the shell doesn't slide off-screen
@@ -3161,12 +3162,16 @@ if (vp) {
     const box = $("messages");
     if (box) box.scrollTop = box.scrollHeight;
   };
-  vp.addEventListener("resize", syncViewport);
-  vp.addEventListener("scroll", syncViewport);
+  const beginViewportTracking = () => {
+    if (isTrackingViewport) return;
+    isTrackingViewport = true;
+    vp.addEventListener("resize", syncViewport);
+    vp.addEventListener("scroll", syncViewport);
+  };
   // Safari can report a transiently short visual viewport while its browser
   // chrome settles on initial load. Only take over the CSS viewport once the
   // composer needs keyboard tracking.
-  $("prompt").addEventListener("focus", syncViewport);
+  $("prompt").addEventListener("focus", beginViewportTracking);
 }
 
 setStatus("Connecting…", "connecting");

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -198,7 +198,7 @@
   <script src="/worktree-creation.js?v=1"></script>
   <script src="/changes-view.js?v=6"></script>
   <script src="/file-browser.js?v=3"></script>
-  <script src="/app.js?v=78"></script>
+  <script src="/app.js?v=79"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -198,7 +198,7 @@
   <script src="/worktree-creation.js?v=1"></script>
   <script src="/changes-view.js?v=6"></script>
   <script src="/file-browser.js?v=3"></script>
-  <script src="/app.js?v=76"></script>
+  <script src="/app.js?v=77"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -198,7 +198,7 @@
   <script src="/worktree-creation.js?v=1"></script>
   <script src="/changes-view.js?v=6"></script>
   <script src="/file-browser.js?v=3"></script>
-  <script src="/app.js?v=77"></script>
+  <script src="/app.js?v=78"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "alas-remote-shell-v56";
+const CACHE_NAME = "alas-remote-shell-v57";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
@@ -7,7 +7,7 @@ const SHELL_ASSETS = [
   "/worktree-creation.js?v=1",
   "/changes-view.js?v=6",
   "/file-browser.js?v=3",
-  "/app.js?v=76",
+  "/app.js?v=77",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "alas-remote-shell-v58";
+const CACHE_NAME = "alas-remote-shell-v59";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
@@ -7,7 +7,7 @@ const SHELL_ASSETS = [
   "/worktree-creation.js?v=1",
   "/changes-view.js?v=6",
   "/file-browser.js?v=3",
-  "/app.js?v=78",
+  "/app.js?v=79",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "alas-remote-shell-v57";
+const CACHE_NAME = "alas-remote-shell-v58";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
@@ -7,7 +7,7 @@ const SHELL_ASSETS = [
   "/worktree-creation.js?v=1",
   "/changes-view.js?v=6",
   "/file-browser.js?v=3",
-  "/app.js?v=77",
+  "/app.js?v=78",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,12 +49,12 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=77"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=77"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=78"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=78"#))
         #expect(html.contains(#"/style.css?v=44"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v57";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v58";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=77""#))
+        #expect(sw.contains(#""/app.js?v=78""#))
         #expect(sw.contains(#""/style.css?v=44""#))
     }
 
@@ -68,10 +68,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=77"#))
+        #expect(html.contains(#"/app.js?v=78"#))
         #expect(html.contains(#"/style.css?v=44"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v57";"#))
-        #expect(sw.contains(#""/app.js?v=77""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v58";"#))
+        #expect(sw.contains(#""/app.js?v=78""#))
         #expect(sw.contains(#""/style.css?v=44""#))
     }
 
@@ -119,7 +119,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=77"))
+        #expect(html.contains("/app.js?v=78"))
         #expect(html.contains("/style.css?v=44"))
     }
 
@@ -147,7 +147,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains("#detail-title { display: none; }"))
         #expect(!css.contains("#detail-title, #detail-rename { display: none; }"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=77""#))
+        #expect(sw.contains(#""/app.js?v=78""#))
         #expect(sw.contains(#""/style.css?v=44""#))
     }
 
@@ -198,7 +198,7 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/worktree-creation.js?v=1"#))
-        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=77"#)!.lowerBound)
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=78"#)!.lowerBound)
         #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
         #expect(js.contains(#"case "projectList":"#))
         #expect(js.contains(#"case "branchList":"#))
@@ -323,12 +323,18 @@ struct RemoteWebAssetTests {
     // Regression: syncing the fixed shell to visualViewport immediately during
     // page load can capture Safari's transient, shorter viewport before its
     // toolbar settles, leaving an unpainted strip above the browser controls.
-    @Test func remoteWebDoesNotApplyVisualViewportHeightUntilInputFocus() throws {
+    @Test func remoteWebDoesNotTrackVisualViewportUntilInputFocus() throws {
         let js = try asset("app.js")
         let viewportSetup = try #require(js.range(of: "const vp = window.visualViewport;").map { js[$0.lowerBound...] })
 
-        #expect(viewportSetup.contains(#"$("prompt").addEventListener("focus", syncViewport);"#))
-        #expect(!viewportSetup.contains("  syncViewport();\n}"))
+        #expect(viewportSetup.contains("const beginViewportTracking = () =>"))
+        #expect(viewportSetup.contains(#"$("prompt").addEventListener("focus", beginViewportTracking);"#))
+        let trackingStart = try #require(viewportSetup.range(of: "const beginViewportTracking = () =>")?.lowerBound)
+        #expect(!viewportSetup[..<trackingStart].contains(#"vp.addEventListener("resize", syncViewport);"#))
+        #expect(!viewportSetup[..<trackingStart].contains(#"vp.addEventListener("scroll", syncViewport);"#))
+        let trackingSetup = viewportSetup[trackingStart...]
+        #expect(trackingSetup.contains(#"vp.addEventListener("resize", syncViewport);"#))
+        #expect(trackingSetup.contains(#"vp.addEventListener("scroll", syncViewport);"#))
     }
 
     @Test func remoteWebSpeaksIncrementalTranscriptProtocol() throws {
@@ -347,9 +353,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v57"))
-        #expect(sw.contains("/app.js?v=77"))
-        #expect(html.contains("app.js?v=77"))
+        #expect(sw.contains("alas-remote-shell-v58"))
+        #expect(sw.contains("/app.js?v=78"))
+        #expect(html.contains("app.js?v=78"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -512,10 +518,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=77"#))
+        #expect(html.contains(#"/app.js?v=78"#))
         #expect(html.contains(#"/style.css?v=44"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v57";"#))
-        #expect(sw.contains(#""/app.js?v=77""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v58";"#))
+        #expect(sw.contains(#""/app.js?v=78""#))
         #expect(sw.contains(#""/style.css?v=44""#))
     }
 
@@ -549,9 +555,9 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"/changes-view.js?v=6"#))
         #expect(html.contains(#"/file-browser.js?v=3"#))
         #expect(html.range(of: #"/changes-view.js?v=6"#)!.lowerBound
-            < html.range(of: #"/app.js?v=77"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=78"#)!.lowerBound)
         #expect(html.range(of: #"/file-browser.js?v=3"#)!.lowerBound
-            < html.range(of: #"/app.js?v=77"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=78"#)!.lowerBound)
         #expect(sw.contains(#""/changes-view.js?v=6""#))
         #expect(sw.contains(#""/file-browser.js?v=3""#))
     }

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,12 +49,12 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=78"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=78"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=79"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=79"#))
         #expect(html.contains(#"/style.css?v=44"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v58";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v59";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=78""#))
+        #expect(sw.contains(#""/app.js?v=79""#))
         #expect(sw.contains(#""/style.css?v=44""#))
     }
 
@@ -68,10 +68,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=78"#))
+        #expect(html.contains(#"/app.js?v=79"#))
         #expect(html.contains(#"/style.css?v=44"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v58";"#))
-        #expect(sw.contains(#""/app.js?v=78""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v59";"#))
+        #expect(sw.contains(#""/app.js?v=79""#))
         #expect(sw.contains(#""/style.css?v=44""#))
     }
 
@@ -119,7 +119,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=78"))
+        #expect(html.contains("/app.js?v=79"))
         #expect(html.contains("/style.css?v=44"))
     }
 
@@ -147,7 +147,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains("#detail-title { display: none; }"))
         #expect(!css.contains("#detail-title, #detail-rename { display: none; }"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=78""#))
+        #expect(sw.contains(#""/app.js?v=79""#))
         #expect(sw.contains(#""/style.css?v=44""#))
     }
 
@@ -198,7 +198,7 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/worktree-creation.js?v=1"#))
-        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=78"#)!.lowerBound)
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=79"#)!.lowerBound)
         #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
         #expect(js.contains(#"case "projectList":"#))
         #expect(js.contains(#"case "branchList":"#))
@@ -328,7 +328,8 @@ struct RemoteWebAssetTests {
         let viewportSetup = try #require(js.range(of: "const vp = window.visualViewport;").map { js[$0.lowerBound...] })
 
         #expect(viewportSetup.contains("const beginViewportTracking = () =>"))
-        #expect(viewportSetup.contains(#"$("prompt").addEventListener("focus", beginViewportTracking);"#))
+        #expect(viewportSetup.contains(#"document.addEventListener("focusin", (event) => {"#))
+        #expect(viewportSetup.contains(#"event.target.matches("input, textarea, select")"#))
         let trackingStart = try #require(viewportSetup.range(of: "const beginViewportTracking = () =>")?.lowerBound)
         #expect(!viewportSetup[..<trackingStart].contains(#"vp.addEventListener("resize", syncViewport);"#))
         #expect(!viewportSetup[..<trackingStart].contains(#"vp.addEventListener("scroll", syncViewport);"#))
@@ -353,9 +354,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v58"))
-        #expect(sw.contains("/app.js?v=78"))
-        #expect(html.contains("app.js?v=78"))
+        #expect(sw.contains("alas-remote-shell-v59"))
+        #expect(sw.contains("/app.js?v=79"))
+        #expect(html.contains("app.js?v=79"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -518,10 +519,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=78"#))
+        #expect(html.contains(#"/app.js?v=79"#))
         #expect(html.contains(#"/style.css?v=44"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v58";"#))
-        #expect(sw.contains(#""/app.js?v=78""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v59";"#))
+        #expect(sw.contains(#""/app.js?v=79""#))
         #expect(sw.contains(#""/style.css?v=44""#))
     }
 
@@ -555,9 +556,9 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"/changes-view.js?v=6"#))
         #expect(html.contains(#"/file-browser.js?v=3"#))
         #expect(html.range(of: #"/changes-view.js?v=6"#)!.lowerBound
-            < html.range(of: #"/app.js?v=78"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=79"#)!.lowerBound)
         #expect(html.range(of: #"/file-browser.js?v=3"#)!.lowerBound
-            < html.range(of: #"/app.js?v=78"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=79"#)!.lowerBound)
         #expect(sw.contains(#""/changes-view.js?v=6""#))
         #expect(sw.contains(#""/file-browser.js?v=3""#))
     }

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -49,12 +49,12 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/session-ordering.js?v=1"#))
-        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=76"#)!.lowerBound)
-        #expect(html.contains(#"/app.js?v=76"#))
+        #expect(html.range(of: #"/session-ordering.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=77"#)!.lowerBound)
+        #expect(html.contains(#"/app.js?v=77"#))
         #expect(html.contains(#"/style.css?v=44"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v56";"#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v57";"#))
         #expect(sw.contains(#""/session-ordering.js?v=1""#))
-        #expect(sw.contains(#""/app.js?v=76""#))
+        #expect(sw.contains(#""/app.js?v=77""#))
         #expect(sw.contains(#""/style.css?v=44""#))
     }
 
@@ -68,10 +68,10 @@ struct RemoteWebAssetTests {
         #expect(app.contains("toggle.tabIndex = 0"))
         #expect(app.contains("function handleCardToggleKeydown"))
         #expect(!app.contains(#"const button = el("button", "tool-toggle")"#))
-        #expect(html.contains(#"/app.js?v=76"#))
+        #expect(html.contains(#"/app.js?v=77"#))
         #expect(html.contains(#"/style.css?v=44"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v56";"#))
-        #expect(sw.contains(#""/app.js?v=76""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v57";"#))
+        #expect(sw.contains(#""/app.js?v=77""#))
         #expect(sw.contains(#""/style.css?v=44""#))
     }
 
@@ -119,7 +119,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains(".session-section"))
         #expect(css.contains(".session-section-title"))
         #expect(css.contains(".session-section-list"))
-        #expect(html.contains("/app.js?v=76"))
+        #expect(html.contains("/app.js?v=77"))
         #expect(html.contains("/style.css?v=44"))
     }
 
@@ -147,7 +147,7 @@ struct RemoteWebAssetTests {
         #expect(css.contains("#detail-title { display: none; }"))
         #expect(!css.contains("#detail-title, #detail-rename { display: none; }"))
         #expect(css.contains(".sheet-input"))
-        #expect(sw.contains(#""/app.js?v=76""#))
+        #expect(sw.contains(#""/app.js?v=77""#))
         #expect(sw.contains(#""/style.css?v=44""#))
     }
 
@@ -198,7 +198,7 @@ struct RemoteWebAssetTests {
         let sw = try asset("sw.js")
 
         #expect(html.contains(#"/worktree-creation.js?v=1"#))
-        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=76"#)!.lowerBound)
+        #expect(html.range(of: #"/worktree-creation.js?v=1"#)!.lowerBound < html.range(of: #"/app.js?v=77"#)!.lowerBound)
         #expect(js.contains("const worktreeCreation = RemoteWorktreeCreation.createFlow(send);"))
         #expect(js.contains(#"case "projectList":"#))
         #expect(js.contains(#"case "branchList":"#))
@@ -320,6 +320,17 @@ struct RemoteWebAssetTests {
         #expect(css.contains("#status.chip::before"))
     }
 
+    // Regression: syncing the fixed shell to visualViewport immediately during
+    // page load can capture Safari's transient, shorter viewport before its
+    // toolbar settles, leaving an unpainted strip above the browser controls.
+    @Test func remoteWebDoesNotApplyVisualViewportHeightUntilInputFocus() throws {
+        let js = try asset("app.js")
+        let viewportSetup = try #require(js.range(of: "const vp = window.visualViewport;").map { js[$0.lowerBound...] })
+
+        #expect(viewportSetup.contains(#"$("prompt").addEventListener("focus", syncViewport);"#))
+        #expect(!viewportSetup.contains("  syncViewport();\n}"))
+    }
+
     @Test func remoteWebSpeaksIncrementalTranscriptProtocol() throws {
         let js = try asset("app.js")
         #expect(js.contains(#"case "transcriptPage""#))
@@ -336,9 +347,9 @@ struct RemoteWebAssetTests {
     @Test func incrementalTranscriptBustsServiceWorkerAssetCache() throws {
         let sw = try asset("sw.js")
         let html = try asset("index.html")
-        #expect(sw.contains("alas-remote-shell-v56"))
-        #expect(sw.contains("/app.js?v=76"))
-        #expect(html.contains("app.js?v=76"))
+        #expect(sw.contains("alas-remote-shell-v57"))
+        #expect(sw.contains("/app.js?v=77"))
+        #expect(html.contains("app.js?v=77"))
     }
 
     // Regression (codex review, PR #775): applyPage used to clear the
@@ -501,10 +512,10 @@ struct RemoteWebAssetTests {
         let html = try asset("index.html")
         let sw = try asset("sw.js")
 
-        #expect(html.contains(#"/app.js?v=76"#))
+        #expect(html.contains(#"/app.js?v=77"#))
         #expect(html.contains(#"/style.css?v=44"#))
-        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v56";"#))
-        #expect(sw.contains(#""/app.js?v=76""#))
+        #expect(sw.contains(#"const CACHE_NAME = "alas-remote-shell-v57";"#))
+        #expect(sw.contains(#""/app.js?v=77""#))
         #expect(sw.contains(#""/style.css?v=44""#))
     }
 
@@ -538,9 +549,9 @@ struct RemoteWebAssetTests {
         #expect(html.contains(#"/changes-view.js?v=6"#))
         #expect(html.contains(#"/file-browser.js?v=3"#))
         #expect(html.range(of: #"/changes-view.js?v=6"#)!.lowerBound
-            < html.range(of: #"/app.js?v=76"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=77"#)!.lowerBound)
         #expect(html.range(of: #"/file-browser.js?v=3"#)!.lowerBound
-            < html.range(of: #"/app.js?v=76"#)!.lowerBound)
+            < html.range(of: #"/app.js?v=77"#)!.lowerBound)
         #expect(sw.contains(#""/changes-view.js?v=6""#))
         #expect(sw.contains(#""/file-browser.js?v=3""#))
     }


### PR DESCRIPTION
## Summary

Prevent Mobile Safari from leaving a black strip below Remote Web on launch. The page uses its CSS dynamic viewport until the composer needs keyboard tracking.

## Changes

- Delay visual viewport sizing until composer focus.
- Refresh the service-worker cache so phones receive the new script.
- Add a regression check for launch-time viewport handling.

## Where to start

- `Alas/Resources/RemoteWeb/app.js` - viewport timing change.

## Notes for reviewers

- `node --check` and `git diff --check` pass.
- The local Xcode test build stalled during fresh package resolution. CI will run the full suite.