### PR TITLE
fix(gg): steady Prepare during mutations

### DIFF
--- a/Alas/Sources/Right/ChangesPreparationCard.swift
+++ b/Alas/Sources/Right/ChangesPreparationCard.swift
@@ -48,6 +48,7 @@ struct ChangesPreparationCard: View {
     let onDismissSyncFailure: () -> Void
 
     @Environment(\.theme) private var theme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         VStack(alignment: .leading, spacing: 9) {
@@ -302,7 +303,9 @@ struct ChangesPreparationCard: View {
         }
         .buttonStyle(.plain)
         .disabled(!action.isEnabled)
-        .opacity(action.isEnabled || action.isInFlight ? 1 : 0.5)
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.2)) {
+            $0.opacity(action.isEnabled || action.isInFlight ? 1 : 0.65)
+        }
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(theme.color("bg-2").opacity(0.72))
@@ -367,7 +370,9 @@ struct ChangesPreparationCard: View {
         }
         .buttonStyle(.plain)
         .disabled(!action.isEnabled)
-        .opacity(action.isEnabled || action.isInFlight ? 1 : 0.5)
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.2)) {
+            $0.opacity(action.isEnabled || action.isInFlight ? 1 : 0.65)
+        }
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1282,6 +1282,7 @@ final class RightPaneState: GGSplitCommitServicing {
         // GG rewrites refs throughout mutations. Keep the last coherent stack
         // mounted until the coordinator performs its final refresh.
         if ggActionState.inFlightAction != nil, ggStackLoadState == .loaded {
+            supersedeGGStackRefreshForMutation()
             deferGGStackRefreshUntilMutationEnds()
             return nil
         }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -193,7 +193,7 @@ final class RightPaneState: GGSplitCommitServicing {
     /// Off-critical-path gg stack load. Cancelled+restarted per refresh so a
     /// slow `gg ls --json` never blocks the Changes-pane snapshot.
     @ObservationIgnored private var ggStackRefreshTask: Task<Void, Never>? = nil
-    @ObservationIgnored var ggStackRefreshDeferredUntilSyncEnds = false
+    @ObservationIgnored var ggStackRefreshDeferredUntilMutationEnds = false
     @ObservationIgnored private var ggStackRefreshDeferralGeneration: UInt = 0
     /// A refresh result may still arrive after its task was cancelled. Only
     /// the most recently started GG refresh may publish snapshot-derived
@@ -534,7 +534,7 @@ final class RightPaneState: GGSplitCommitServicing {
         remoteEventDebouncer.cancel()
         ggStackRefreshTask?.cancel()
         ggStackRefreshTask = nil
-        ggStackRefreshDeferredUntilSyncEnds = false
+        ggStackRefreshDeferredUntilMutationEnds = false
     }
 
     private func startRemoteHelperWatching() {
@@ -754,14 +754,14 @@ final class RightPaneState: GGSplitCommitServicing {
     }
 
     nonisolated static func shouldScheduleGGStackRefresh(inFlightAction: GGStackActionKind?) -> Bool {
-        inFlightAction != .sync
+        inFlightAction == nil
     }
 
     nonisolated static func shouldDeferGGStackRefresh(
         inFlightAction: GGStackActionKind?,
         refreshRequired: Bool
     ) -> Bool {
-        inFlightAction == .sync && refreshRequired
+        inFlightAction != nil && refreshRequired
     }
 
     nonisolated static func shouldPublishGGStackRefresh(
@@ -773,9 +773,9 @@ final class RightPaneState: GGSplitCommitServicing {
 
     nonisolated static func shouldForceGGStackRefresh(
         forceRemote: Bool,
-        deferredUntilSyncEnds: Bool
+        deferredUntilMutationEnds: Bool
     ) -> Bool {
-        forceRemote || deferredUntilSyncEnds
+        forceRemote || deferredUntilMutationEnds
     }
 
     @discardableResult
@@ -920,7 +920,7 @@ final class RightPaneState: GGSplitCommitServicing {
             if Self.shouldScheduleGGStackRefresh(inFlightAction: ggActionState.inFlightAction) {
                 let forceGGStackRemote = Self.shouldForceGGStackRefresh(
                     forceRemote: forceReviewLoopRemote,
-                    deferredUntilSyncEnds: ggStackRefreshDeferredUntilSyncEnds
+                    deferredUntilMutationEnds: ggStackRefreshDeferredUntilMutationEnds
                 )
                 ggStackRefreshTask?.cancel()
                 ggStackRefreshTask = Task { @MainActor [weak self] in
@@ -930,7 +930,7 @@ final class RightPaneState: GGSplitCommitServicing {
                 inFlightAction: ggActionState.inFlightAction,
                 refreshRequired: ggStackSourceCommitsChanged
             ) {
-                deferGGStackRefreshUntilSyncEnds()
+                deferGGStackRefreshUntilMutationEnds()
             }
             if self.comparisonRef != ref { self.comparisonRef = ref }
             let preferredCommitRemoteRef = ref ?? baseBranch
@@ -1171,7 +1171,7 @@ final class RightPaneState: GGSplitCommitServicing {
             if ggContext != resolvedContext { ggContext = resolvedContext }
             ggStackRemoteError = nil
             if deferralGeneration == ggStackRefreshDeferralGeneration {
-                ggStackRefreshDeferredUntilSyncEnds = false
+                ggStackRefreshDeferredUntilMutationEnds = false
             }
             ggStackCommitsKey = currentGGStackCommitsKey
             if ggStack != stack { ggStack = stack }
@@ -1279,10 +1279,10 @@ final class RightPaneState: GGSplitCommitServicing {
     func invalidateGGPresentation(
         startingRefresh shouldRefresh: Bool
     ) -> Task<Void, Never>? {
-        // GG rewrites refs throughout sync. Keep the last coherent stack
+        // GG rewrites refs throughout mutations. Keep the last coherent stack
         // mounted until the coordinator performs its final refresh.
-        if ggActionState.inFlightAction == .sync, ggStackLoadState == .loaded {
-            deferGGStackRefreshUntilSyncEnds()
+        if ggActionState.inFlightAction != nil, ggStackLoadState == .loaded {
+            deferGGStackRefreshUntilMutationEnds()
             return nil
         }
         // Advance ownership before cancellation: a direct/untracked caller may
@@ -1310,21 +1310,22 @@ final class RightPaneState: GGSplitCommitServicing {
         return task
     }
 
-    func supersedeGGStackRefreshForSync() {
-        ggStackRefreshDeferredUntilSyncEnds = false
+    func supersedeGGStackRefreshForMutation() {
+        // Retry the cancelled load even if mutation preflight fails before its final refresh.
+        ggStackRefreshDeferredUntilMutationEnds = true
         ggStackRefreshGeneration &+= 1
         ggStackRefreshTask?.cancel()
         ggStackRefreshTask = nil
     }
 
-    private func deferGGStackRefreshUntilSyncEnds() {
+    private func deferGGStackRefreshUntilMutationEnds() {
         ggStackRefreshDeferralGeneration &+= 1
-        ggStackRefreshDeferredUntilSyncEnds = true
+        ggStackRefreshDeferredUntilMutationEnds = true
     }
 
     private func scheduleDeferredGGStackRefreshIfNeeded() {
-        guard ggStackRefreshDeferredUntilSyncEnds,
-              ggActionState.inFlightAction != .sync
+        guard ggStackRefreshDeferredUntilMutationEnds,
+              ggActionState.inFlightAction == nil
         else { return }
         ggStackRefreshTask?.cancel()
         ggStackRefreshTask = Task { @MainActor [weak self] in
@@ -1939,7 +1940,7 @@ final class RightPaneState: GGSplitCommitServicing {
         _ operation: Task<Void, Error>,
         request: GGMutationRequest
     ) -> Task<Void, Error> {
-        if request == .sync { supersedeGGStackRefreshForSync() }
+        supersedeGGStackRefreshForMutation()
         let actionGeneration = ggActionState.actionGeneration
         return Task { @MainActor in
             defer { scheduleDeferredGGStackRefreshIfNeeded() }

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -660,13 +660,14 @@ struct RightPaneGGStackErrorPresentationTests {
 
 @MainActor
 struct RightPaneGGRefreshSchedulingTests {
-    @Test func watcherStackRefreshIsSuppressedOnlyDuringSync() {
+    @Test func watcherStackRefreshIsSuppressedDuringMutations() {
         #expect(!RightPaneState.shouldScheduleGGStackRefresh(inFlightAction: .sync))
-        #expect(RightPaneState.shouldScheduleGGStackRefresh(inFlightAction: .rebase))
+        #expect(!RightPaneState.shouldScheduleGGStackRefresh(inFlightAction: .rebase))
+        #expect(!RightPaneState.shouldScheduleGGStackRefresh(inFlightAction: .amendCurrent))
         #expect(RightPaneState.shouldScheduleGGStackRefresh(inFlightAction: nil))
     }
 
-    @Test func refreshWorkDefersOnlyDuringSync() {
+    @Test func refreshWorkDefersDuringMutations() {
         #expect(RightPaneState.shouldDeferGGStackRefresh(
             inFlightAction: .sync,
             refreshRequired: true
@@ -675,8 +676,12 @@ struct RightPaneGGRefreshSchedulingTests {
             inFlightAction: .sync,
             refreshRequired: false
         ))
-        #expect(!RightPaneState.shouldDeferGGStackRefresh(
+        #expect(RightPaneState.shouldDeferGGStackRefresh(
             inFlightAction: .rebase,
+            refreshRequired: true
+        ))
+        #expect(!RightPaneState.shouldDeferGGStackRefresh(
+            inFlightAction: nil,
             refreshRequired: true
         ))
     }
@@ -695,15 +700,15 @@ struct RightPaneGGRefreshSchedulingTests {
     @Test func deferredRefreshForcesTheNextStackLoad() {
         #expect(RightPaneState.shouldForceGGStackRefresh(
             forceRemote: false,
-            deferredUntilSyncEnds: true
+            deferredUntilMutationEnds: true
         ))
         #expect(RightPaneState.shouldForceGGStackRefresh(
             forceRemote: true,
-            deferredUntilSyncEnds: false
+            deferredUntilMutationEnds: false
         ))
         #expect(!RightPaneState.shouldForceGGStackRefresh(
             forceRemote: false,
-            deferredUntilSyncEnds: false
+            deferredUntilMutationEnds: false
         ))
     }
 }
@@ -2371,7 +2376,8 @@ struct RightPaneGGStackTests {
         #expect(GGStackSummaryStore.shared.summaries[worktree.path.path] == nil)
     }
 
-    @Test func headInvalidationKeepsLoadedStackVisibleDuringSync() async {
+    @Test(arguments: [GGStackActionKind.sync, .rebase, .amendCurrent, .reorder, .absorbStaged])
+    func headInvalidationKeepsLoadedStackVisibleDuringMutation(action: GGStackActionKind) async {
         let worktree = makeWorktree()
         let state = makeState(worktree: worktree)
         let staleSnapshot = GGStackModelsTests.fixture.replacingOccurrences(
@@ -2415,13 +2421,13 @@ struct RightPaneGGStackTests {
 
         let staleRefresh = Task { @MainActor in await state.refreshGGStack(forceRemote: true) }
         await runner.waitUntilCall(1)
-        _ = state.ggActionState.beginAction(.sync)
-        state.supersedeGGStackRefreshForSync()
+        _ = state.ggActionState.beginAction(action)
+        state.supersedeGGStackRefreshForMutation()
 
         let refresh = state.invalidateGGPresentation(startingRefresh: false)
 
         #expect(refresh == nil)
-        #expect(state.ggStackRefreshDeferredUntilSyncEnds)
+        #expect(state.ggStackRefreshDeferredUntilMutationEnds)
         #expect(state.ggStackLoadState == .loaded)
         #expect(state.ggStack?.name == "feature")
         #expect(state.ggStackCommitsKey == state.currentGGStackCommitsKey)
@@ -2436,10 +2442,10 @@ struct RightPaneGGStackTests {
         await runner.complete(call: 2)
         await finalRefresh.value
         #expect(state.ggStack?.name == "final-stack")
-        #expect(state.ggStackRefreshDeferredUntilSyncEnds)
+        #expect(state.ggStackRefreshDeferredUntilMutationEnds)
 
         await state.refreshGGStack(forceRemote: true)
-        #expect(!state.ggStackRefreshDeferredUntilSyncEnds)
+        #expect(!state.ggStackRefreshDeferredUntilMutationEnds)
     }
 
     @Test func activeHeadInvalidationReplacesInFlightColdDetachedRecovery() async throws {
@@ -3127,12 +3133,14 @@ struct RightPaneGGStackTests {
             commit(sha: String(repeating: "s", count: 40), stackShaped: true),
         ]
 
-        state.onGGStackAction(.sync, appState: AppState(store: MemoryStore()))
+        let operation = state.runGGMutation(.sync)
         await runner.waitUntilPostSyncReadSuspends()
 
         await state.reevaluateGGGate().value
 
         await runner.waitUntilPostSyncReadCancellationIsObserved()
+        // Cancellation is observed before the coordinator finishes clearing its busy state.
+        await operation?.value
         #expect(await runner.didObservePostSyncReadCancellation())
         #expect(state.ggStack?.name == "replacement-stack")
         #expect(state.ggActionState.inFlightAction == nil)

--- a/AlasTests/RightPaneGGStackTests.swift
+++ b/AlasTests/RightPaneGGStackTests.swift
@@ -2422,7 +2422,6 @@ struct RightPaneGGStackTests {
         let staleRefresh = Task { @MainActor in await state.refreshGGStack(forceRemote: true) }
         await runner.waitUntilCall(1)
         _ = state.ggActionState.beginAction(action)
-        state.supersedeGGStackRefreshForMutation()
 
         let refresh = state.invalidateGGPresentation(startingRefresh: false)
 
@@ -2436,13 +2435,12 @@ struct RightPaneGGStackTests {
         await staleRefresh.value
         #expect(state.ggStack?.name == "feature")
 
+        state.ggActionState.endAction(action)
         let finalRefresh = Task { @MainActor in await state.refreshGGStack(forceRemote: true) }
         await runner.waitUntilCall(2)
-        _ = state.invalidateGGPresentation(startingRefresh: false)
         await runner.complete(call: 2)
         await finalRefresh.value
         #expect(state.ggStack?.name == "final-stack")
-        #expect(state.ggStackRefreshDeferredUntilMutationEnds)
 
         await state.refreshGGStack(forceRemote: true)
         #expect(!state.ggStackRefreshDeferredUntilMutationEnds)


### PR DESCRIPTION
Keeps the Changes tab Prepare affordance visually stable while GG mutations rewrite refs.

- Retains the last coherent GG stack presentation until the mutation finishes, then performs one fresh refresh.
- Softens action availability changes with a 0.2-second fade and honors Reduce Motion.
- Covers sync, rebase, amend, reorder, and absorb stack retention.

Validation:
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Focused GG suites: 93 tests passed.
- Full suite ran 8,852 tests and has 18 existing failures outside this change, including workspace checkout, chat settings, review UI, issue suggestions, project refresh, and workspace cleanup tests.