### PR TITLE
fix(acp): stabilize transcript scrolling

### DIFF
--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -990,7 +990,9 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             guard let host, !host.session.followsTranscriptTail else { return }
             host.session.followsTranscriptTail = true
             reconciler?.setFollowsTail(true)
-            host.transcript.resetWindowToTail()
+            // Follow new messages now, but keep older rows through the rebound.
+            // Trimming them changes document geometry while AppKit is scrolling.
+            host.transcript.visibleTail = nil
             host.onRememberScrollAnchor(nil, nil, true)
         }
 
@@ -1005,6 +1007,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 return
             }
             if host.session.followsTranscriptTail {
+                host.transcript.resetWindowToTail()
                 update(host: host)
                 return
             }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift
@@ -256,10 +256,7 @@ final class ACPTranscriptScrollerReconciler {
         keepMountedOffscreenIds = Set(specs.lazy.filter(\.keepsMountedOffscreen).map(\.id))
         lastAppliedSpecs = specs
         lastFollowsTail = followsTail
-        if repins {
-            scroller.scrollToBottom()
-        }
-        layoutMountedRows()
+        layoutMountedRows(pinToTail: repins)
     }
 
     /// Drops any remembered vanished anchor. Called by the coordinator on
@@ -651,10 +648,7 @@ final class ACPTranscriptScrollerReconciler {
         defer { isApplyingSpecs = false }
         let repins = repinsToTail(followsTail: lastFollowsTail, wasFollowingTail: lastFollowsTail)
         performReset(specs: lastAppliedSpecs, widthChanged: true, repinsToTail: repins)
-        if repins {
-            scroller.scrollToBottom()
-        }
-        layoutMountedRows()
+        layoutMountedRows(pinToTail: repins)
     }
 
     /// Re-apply specs whose equality token changed; re-measure those rows and
@@ -780,9 +774,10 @@ final class ACPTranscriptScrollerReconciler {
     private func applyHeightToTiling(id: String, height: CGFloat) -> Bool {
         guard let oldHeight = tiling.row(withId: id)?.height, oldHeight != height else { return false }
         let compensation = tiling.updateHeight(id: id, to: height, viewportMinY: scroller.scrollY)
-        scroller.setDocumentHeight(tiling.documentHeight)
         if compensation != 0 {
-            scroller.setScrollY(scroller.scrollY + compensation)
+            scroller.applyPrepend(delta: compensation, newDocumentHeight: tiling.documentHeight)
+        } else {
+            scroller.setDocumentHeight(tiling.documentHeight)
         }
         return true
     }
@@ -805,7 +800,7 @@ final class ACPTranscriptScrollerReconciler {
     /// Mount and position rows after content or geometry changes. Reentrant
     /// invalidations coalesce into another pass before the scroll fast path
     /// can reuse the resulting band.
-    func layoutMountedRows() {
+    func layoutMountedRows(pinToTail: Bool = false) {
         lastLaidOutBand = nil
         guard !isLayingOutRows else {
             pendingRelayout = true
@@ -814,11 +809,11 @@ final class ACPTranscriptScrollerReconciler {
         isLayingOutRows = true
         defer { isLayingOutRows = false }
 
-        performLayoutPass()
+        performLayoutPass(pinToTail: pinToTail)
         var safetyCount = 0
         while pendingRelayout {
             pendingRelayout = false
-            performLayoutPass()
+            performLayoutPass(pinToTail: pinToTail)
             safetyCount += 1
             if safetyCount > 8 {
                 assertionFailure("layoutMountedRows did not converge after \(safetyCount) extra passes")
@@ -831,14 +826,21 @@ final class ACPTranscriptScrollerReconciler {
     }
 
     private var currentMountBand: Range<Int> {
+        // Elastic overscroll reveals no new rows. Keep the edge's mount band
+        // stable so the rebound does not destroy and rebuild hosting views.
         tiling.mountBand(
-            viewportMinY: scroller.scrollY,
+            viewportMinY: min(max(0, scroller.scrollY), max(0, tiling.documentHeight - scroller.viewportHeight)),
             viewportHeight: scroller.viewportHeight,
             overscan: Self.overscan
         )
     }
 
-    private func performLayoutPass() {
+    private func performLayoutPass(pinToTail: Bool) {
+        // Mounting rows can correct stale offscreen heights. Re-pin before
+        // each resulting pass so tail-follow settles against the final geometry.
+        if pinToTail {
+            scroller.scrollToBottom()
+        }
         guard tiling.rowCount > 0 else {
             pool.releaseAll()
             return

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
@@ -280,8 +280,10 @@ final class ACPTranscriptScrollerView: NSScrollView {
     /// next user scroll happens to correct it.
     func applyPrepend(delta: CGFloat, newDocumentHeight: CGFloat) {
         performProgrammatic {
-            flippedDocumentView.frame.size.height = newDocumentHeight
+            // Shrinking the document can synchronously clamp the clip view.
+            // Compensation must start from the position before that clamp.
             let origin = contentView.bounds.origin
+            flippedDocumentView.frame.size.height = newDocumentHeight
             contentView.setBoundsOrigin(NSPoint(x: origin.x, y: clampedScrollY(origin.y + delta)))
             reflectScrolledClipView(contentView)
         }

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerLiveScrollTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerLiveScrollTests.swift
@@ -153,6 +153,38 @@ struct ACPTranscriptScrollerLiveScrollTests {
         withExtendedLifetime(coordinator) {}
     }
 
+    @Test("returning to the tail keeps the history window until rubberband scrolling settles")
+    func returningToTailDefersWindowCompaction() async throws {
+        let (host, scroller, coordinator) = tailFollowingHost()
+        defer { withExtendedLifetime(coordinator) {} }
+        let originalHeight = scroller.contentHeight
+        let bottom = originalHeight - scroller.viewportHeight
+        liveScroll(scroller, to: bottom - 470)
+        #expect(!host.session.followsTranscriptTail)
+
+        NotificationCenter.default.post(
+            name: NSScrollView.willStartLiveScrollNotification, object: scroller
+        )
+        scroller.contentView.setBoundsOrigin(NSPoint(x: 0, y: bottom))
+        scroller.reflectScrolledClipView(scroller.contentView)
+        #expect(host.session.followsTranscriptTail)
+        #expect(host.transcript.visibleTail == nil, "new messages must remain visible while following")
+        #expect(host.transcript.visibleHead == 0, "do not discard history during the gesture")
+
+        coordinator.update(host: host)
+        try await Task.sleep(for: .milliseconds(400))
+        #expect(host.transcript.visibleHead == 0, "the settle timer must wait for live scrolling to end")
+        #expect(scroller.contentHeight == originalHeight)
+
+        NotificationCenter.default.post(
+            name: NSScrollView.didEndLiveScrollNotification, object: scroller
+        )
+        try await Task.sleep(for: .milliseconds(700))
+        #expect(host.transcript.visibleHead == 120 - ACPTranscript.tailWindow)
+        #expect(host.transcript.visibleTail == nil)
+        #expect(scroller.distanceFromBottom < 1)
+    }
+
     @Test("settling an input-request chat does not compact the reading window")
     func settlingInputRequestChatDoesNotCompactReadingWindow() async throws {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerReconcilerTests.swift
@@ -117,6 +117,10 @@ private final class RowBuildCounter {
 @MainActor
 @Suite("ACPTranscriptScrollerReconciler apply")
 struct ACPTranscriptScrollerReconcilerApplyTests {
+    private final class ElasticClipView: NSClipView {
+        override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect { proposedBounds }
+    }
+
     private struct CountingToken: Equatable {
         var revision = 0
         let recordComparison: () -> Void
@@ -150,6 +154,45 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
             reconciler.layoutMountedRowsForScroll()
         }
 
+        #expect(comparisons == 0)
+    }
+
+    @Test("elastic rebound preserves mounted rows without revisiting content", arguments: [false, true])
+    func elasticReboundSkipsRowWork(atBottom: Bool) {
+        let (reconciler, scroller, _) = makeStack()
+        // Allow the out-of-bounds positions AppKit uses during elastic scrolling.
+        scroller.contentView = ElasticClipView(frame: scroller.contentView.frame)
+        scroller.documentView = scroller.flippedDocumentView
+        let builds = RowBuildCounter()
+        var comparisons = 0
+        let specs = (0..<100).map { index in
+            ACPTranscriptRowSpec(
+                id: "r\(index)",
+                equalityToken: ACPRowEqualityToken(CountingToken { comparisons += 1 }),
+                build: {
+                    builds.record("r\(index)")
+                    return AnyView(Color.clear.frame(height: 100))
+                }
+            )
+        }
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: false)
+        let edge = atBottom ? scroller.contentHeight - scroller.viewportHeight : 0
+        scroller.setScrollY(edge)
+        reconciler.layoutMountedRowsForScroll()
+        let mounted = reconciler.mountedRowIdsForTesting
+        let initialBuilds = builds.counts
+        comparisons = 0
+
+        for overshoot in [40, 100, 180, 100, 40, 0] {
+            let y = edge + CGFloat(atBottom ? overshoot : -overshoot)
+            scroller.contentView.setBoundsOrigin(NSPoint(x: 0, y: y))
+            reconciler.noteUserScroll()
+            reconciler.layoutMountedRowsForScroll()
+            #expect(scroller.scrollY == y, "row layout must leave the native bounce alone")
+            #expect(reconciler.mountedRowIdsForTesting == mounted)
+        }
+
+        #expect(builds.counts == initialBuilds)
         #expect(comparisons == 0)
     }
 
@@ -608,6 +651,38 @@ struct ACPTranscriptScrollerReconcilerApplyTests {
 
         #expect(tiling.row(withId: "r0")!.height == 250)
         #expect(scroller.scrollY > scrollYBefore)
+    }
+
+    @Test("a row shrinking above a reader near the bottom preserves the visible content")
+    func shrinkingRowAboveViewportPreservesPosition() {
+        let (reconciler, scroller, tiling, pool) = makeStackWithPool()
+        let specs = (0..<10).map { spec("r\($0)", height: $0 == 0 ? 300 : 100) }
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: false)
+        scroller.setScrollY(scroller.contentHeight - scroller.viewportHeight - 40)
+        let offsetBefore = screenOffset(of: "r8", tiling: tiling, scroller: scroller)
+
+        let (view, _) = pool.view(for: specs[0])
+        view.updateRootView(AnyView(Color.clear.frame(height: 100)))
+        reconciler.remeasureRow(id: "r0")
+
+        #expect(tiling.row(withId: "r0")?.height == 100)
+        #expect(abs(screenOffset(of: "r8", tiling: tiling, scroller: scroller) - offsetBefore) < 0.5)
+        #expect(abs(scroller.distanceFromBottom - 40) < 0.5)
+    }
+
+    @Test("resuming tail-follow measures changed offscreen rows before settling at the bottom")
+    func resumeTailFollowWithChangedOffscreenRow() {
+        let (reconciler, scroller, tiling) = makeStack()
+        let specs = (0..<100).map { spec("r\($0)") }
+        reconciler.apply(specs: specs, contentWidth: 600, followsTail: false)
+        #expect(!reconciler.mountedRowIdsForTesting.contains("r99"))
+        var updated = specs
+        updated[99] = spec("r99", token: 1, height: 300)
+
+        reconciler.apply(specs: updated, contentWidth: 600, followsTail: true)
+
+        #expect(tiling.row(withId: "r99")?.height == 300)
+        #expect(scroller.distanceFromBottom < 0.5)
     }
 
     @Test("remeasureRow re-pins to the bottom when a mounted tail row grows while following the tail")

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerViewTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerViewTests.swift
@@ -65,6 +65,18 @@ struct ACPTranscriptScrollerViewTests {
         #expect(abs(s.scrollY - 1200) < 0.5)
     }
 
+    @Test("removing content above a reader near the bottom preserves the reading position")
+    func removalNearBottomPreservesPosition() {
+        let s = scroller()
+        s.setScrollY(5000 - s.viewportHeight - 40)
+        let offsetBefore = s.scrollY
+
+        s.applyPrepend(delta: -700, newDocumentHeight: 4300)
+
+        #expect(abs(s.scrollY - (offsetBefore - 700)) < 0.5)
+        #expect(abs(s.distanceFromBottom - 40) < 0.5)
+    }
+
     @Test("scrollToBottom lands within tolerance of the bottom")
     func toBottom() {
         let s = scroller()


### PR DESCRIPTION
## Summary

Fixes several transcript-scroller cases that caused visible jumps or frame hitches: AppKit clamp compensation on shrinking rows, elastic rebound remounting, tail-follow geometry settling, and history-window cleanup during a bottom rebound.

## Changes

- Preserve the visible reading position when rows above the viewport shrink.
- Keep the mount band stable while rubberband scrolling passes the document edge.
- Re-pin tail-follow only after changed offscreen rows are measured.
- Defer tail-window compaction until the user scroll and rebound have settled.

## Verification

- User-tested the up-then-down rubberband gesture in the built app.
- 190 transcript tests across 24 suites pass.
- The full suite ran: 16 known baseline failures remain; three additional integration failures passed in an isolated rerun of 77 tests.

## Where to start

- `Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift` - return-to-tail behavior.
- `Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerReconciler.swift` - compensation and elastic mount-band behavior.
