### PR TITLE
fix(acp): preserve queue when steering

### DIFF
--- a/Alas/Sources/ACP/Protocol/ACPMockClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMockClient.swift
@@ -8,6 +8,7 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
     private var scripts: [String: (ACPRequest) throws -> Data] = [:]
     private var asyncScripts: [String: (ACPRequest) async throws -> Data] = [:]
     private var responseScripts: [String: (ACPRequest) async throws -> ACPResponse] = [:]
+    private var notificationAsyncScripts: [String: (ACPRequest) async throws -> Void] = [:]
     private let updatesCont: AsyncStream<ACPSessionUpdateParams>.Continuation
     private let permsCont: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>.Continuation
     private let questionsCont: AsyncStream<ACPQuestionRequest>.Continuation
@@ -79,6 +80,9 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
     /// order) without needing to script a reply.
     func notify(_ request: ACPRequest) async throws {
         sent.append(request)
+        if let script = notificationAsyncScripts[request.method] {
+            try await script(request)
+        }
     }
 
     func emit(_ update: ACPSessionUpdateParams) {
@@ -133,6 +137,10 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
 
     func scriptAsync(method: String, _ handler: @escaping (ACPRequest) async throws -> Data) {
         asyncScripts[method] = handler
+    }
+
+    func scriptNotifyAsync(method: String, _ handler: @escaping (ACPRequest) async throws -> Void) {
+        notificationAsyncScripts[method] = handler
     }
 
     func shutdown() async {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -107,6 +107,7 @@ final class ACPSessionRunner {
     /// restored snapshot ahead of the steer's replacement prompt. Once
     /// the redirect is in flight, normal drain semantics resume.
     private var steerInProgress: Bool = false
+    private var pendingForceSendQueuedItemID: UUID?
     /// Holds an idle source session at its persisted remote head while
     /// `session/fork` is in flight. New prompts remain queued until the
     /// target adapter has created the branch.
@@ -1343,7 +1344,7 @@ extension ACPSessionRunner {
     /// Primary entry. Resolves the routing then dispatches to one of:
     ///   - sendNow  → records the user prompt, awaits prompt RPC
     ///   - enqueue  → appends to queue + persists
-    ///   - steer    → cancels in-flight + clears queue + sends (Task 8)
+    ///   - steer    → cancels in-flight + preserves queue + sends
     ///   - noOp     → empty composer, ignore
     /// `draft` is the structured composer state for lossless edit-restore;
     /// it's consumed only on the `enqueue` route and ignored on the others
@@ -1567,6 +1568,11 @@ extension ACPSessionRunner {
               session.queue[idx].status == .pending
         else { return }
 
+        if steerInProgress {
+            pendingForceSendQueuedItemID = id
+            return
+        }
+
         if nativeForkBarrierActive {
             guard session.forceQueueItem(id: id) else { return }
             persistQueue()
@@ -1594,32 +1600,34 @@ extension ACPSessionRunner {
         steer(
             blocks: item.blocks,
             delegatedSource: item.delegatedSource,
-            recordUserPrompt: !item.transcriptRecorded
+            recordUserPrompt: !item.transcriptRecorded,
+            discardQueue: true
         )
     }
 
-    /// Cancel the in-flight turn (if any), discard the ENTIRE queue
-    /// (including any `.sending` head whose `sendNow` task is mid-RPC),
-    /// then send the new prompt as a fresh turn. Only the `.pending`
-    /// items are snapshotted for undo — restoring a previously-`.sending`
-    /// item would just re-fire the prompt the user just redirected away
-    /// from. The stale in-flight task gets neutralised because `sendNow`
-    /// guards every completion-side mutation on `queue.first?.id ==
-    /// queuedItemId`; once we've emptied the queue, the orphan task
-    /// resolves to a no-op.
+    /// Cancel the in-flight turn (if any), then send the new prompt as a
+    /// fresh turn without disturbing pending queued prompts. A `.sending`
+    /// queue head is still removed because it is the prompt being cancelled.
+    /// `forceSendQueuedItem` opts into discarding the remaining queue and
+    /// snapshots its pending items for undo.
     func steer(
         blocks: [ACPContentBlock],
         delegatedSource: ACPDelegatedPromptSource? = nil,
         recordUserPrompt: Bool = true,
+        discardQueue: Bool = false,
         draft: ACPComposerDraft? = nil,
         onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
     ) {
         flushPendingIncomingUpdates(flushQueueWhenBoundaryReady: false)
-        let snapshot = session.queue.filter { $0.status == .pending }
-        session.queue.removeAll()
-        if !snapshot.isEmpty {
-            session.steerUndo = .init(id: UUID(), snapshot: snapshot)
-            armSteerUndoExpiry()
+        if discardQueue {
+            let snapshot = session.queue.filter { $0.status == .pending }
+            session.queue.removeAll()
+            if !snapshot.isEmpty {
+                session.steerUndo = .init(id: UUID(), snapshot: snapshot)
+                armSteerUndoExpiry()
+            }
+        } else {
+            session.queue.removeAll { $0.status == .sending }
         }
         persistQueue()
         // Invalidate the in-flight prompt NOW (before awaiting userCancel)
@@ -1644,7 +1652,6 @@ extension ACPSessionRunner {
             guard let self else { return }
             await self.userCancel()
             await MainActor.run {
-                self.steerInProgress = false
                 // If the session was detached while we were awaiting
                 // `userCancel` (tab closed, worktree torn down), the
                 // runner has been removed from `ACPSessionManager` and
@@ -1654,6 +1661,8 @@ extension ACPSessionRunner {
                 // and tell the composer the submit didn't land so its
                 // draft stays put.
                 guard self.session.agentState == .ready else {
+                    self.steerInProgress = false
+                    self.pendingForceSendQueuedItemID = nil
                     onPromptFinished?(false)
                     return
                 }
@@ -1665,6 +1674,11 @@ extension ACPSessionRunner {
                     draft: draft,
                     onPromptFinished: onPromptFinished
                 )
+                self.steerInProgress = false
+                if let queuedID = self.pendingForceSendQueuedItemID {
+                    self.pendingForceSendQueuedItemID = nil
+                    self.forceSendQueuedItem(id: queuedID)
+                }
             }
         }
     }

--- a/Alas/Sources/ACP/Session/ACPSubmitIntent.swift
+++ b/Alas/Sources/ACP/Session/ACPSubmitIntent.swift
@@ -10,7 +10,7 @@ enum ACPSubmitRoute: Equatable {
     /// flusher's FIFO order intact even if the user submits another prompt
     /// in the microsecond gap between state→.idle and the flusher firing.
     case enqueue
-    /// User explicitly steered: cancel the in-flight turn (if any), clear
+    /// User explicitly steered: cancel the in-flight turn (if any), preserve
     /// the queue, and send the new prompt as a fresh turn. Falls back to
     /// `.sendNow` only when there's literally nothing to interrupt
     /// (idle + empty queue) — handled by the resolver.

--- a/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteSessionGateway.swift
@@ -183,9 +183,9 @@ final class RemoteSessionGateway {
                     if refusalIsSynchronous { self.discardAttachmentFiles(materialized) }
                 }
             }
-            // "steer" cancels the running turn and discards the queue before
-            // sending; "auto" (the default, and everything an older client
-            // sends) takes the ordinary enqueue-or-send route.
+            // "steer" cancels the running turn and sends immediately while
+            // preserving the queue; "auto" (the default, and everything an
+            // older client sends) takes the ordinary enqueue-or-send route.
             if intent == "steer" {
                 await provider.steerPrompt(for: id, text: trimmed, attachments: materialized, onResult: onResult)
             } else {

--- a/Alas/Sources/Settings/ChatPane.swift
+++ b/Alas/Sources/Settings/ChatPane.swift
@@ -88,7 +88,7 @@ struct ChatPane: View {
 
                 SettingsGroup(title: GroupTitles.composer) {
                     SettingsRow(name: RowLabels.sendOnEnter,
-                                desc: "Turn off to swap — ⏎ steers and ⌥⏎ queues. Steering cancels the running turn and discards any pending queue items.") {
+                                desc: "Turn off to swap — ⏎ steers and ⌥⏎ queues. Steering cancels the running turn while preserving pending queue items.") {
                         AlasToggle(on: Binding(
                             get: { state.config.harness.acpSendOnEnter },
                             set: {

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -218,31 +218,28 @@ struct ACPSessionRunnerQueueTests {
         #expect(acknowledgement.recordedCount == 1)
     }
 
-    @Test(".steer while streaming with queue → cancel sent, queue cleared, new prompt sent, snapshot captured")
-    func steerClearsAndSends() async throws {
+    @Test(".steer while streaming preserves the pending queue")
+    func steerPreservesPendingQueue() async throws {
         let (runner, mock, session, store) = try mkRunner()
         mock.script(method: "session/prompt") { _ in Data("null".utf8) }
-        // Pre-seed queue + put session in streaming.
         session.agentState = .ready
         session.transcript.streamingState = .streaming
-        session.enqueue(blocks: [.text("stale-a")])
-        session.enqueue(blocks: [.text("stale-b")])
+        session.enqueue(blocks: [.text("queued-a")])
+        session.enqueue(blocks: [.text("queued-b")])
         runner.persistQueue()
+        let queued = session.queue
 
         runner.send(blocks: [.text("redirect")], intent: .steer)
+
+        #expect(session.queue == queued)
+        #expect(runner.steerUndoSnapshot() == nil)
+
         try await Task.sleep(nanoseconds: 250_000_000)
 
-        // session/cancel was sent
         #expect(mock.sent.contains { $0.method == "session/cancel" })
-        // queue is empty after drain (cleared by steer, redirect popped after send)
         #expect(session.queue.isEmpty)
-        // session/prompt was sent with the steer blocks
         let prompts = mock.sent.filter { $0.method == "session/prompt" }
-        #expect(prompts.count == 1)
-        // Undo snapshot captured
-        #expect(runner.steerUndoSnapshot()?.count == 2)
-        #expect(runner.steerUndoSnapshot()?.map { $0.blocks } == [[.text("stale-a")], [.text("stale-b")]])
-        // Persisted queue empty
+        #expect(prompts.count == 3)
         #expect(try store.loadQueue(sessionId: "s").isEmpty)
     }
 
@@ -273,20 +270,20 @@ struct ACPSessionRunnerQueueTests {
         #expect(prompts.isEmpty)
     }
 
-    @Test("steerUndo() re-prepends snapshot and drains it on next idle")
-    func steerUndoRestores() async throws {
+    @Test("forceSendQueuedItem undo re-prepends discarded prompts and drains them on next idle")
+    func forceSendQueuedItemUndoRestores() async throws {
         let (runner, mock, session, store) = try mkRunner()
         mock.script(method: "session/prompt") { _ in Data("null".utf8) }
         session.agentState = .ready
         session.transcript.streamingState = .streaming
         session.enqueue(blocks: [.text("a")])
-        runner.send(blocks: [.text("redirect")], intent: .steer)
+        session.enqueue(blocks: [.text("selected")])
+        runner.forceSendQueuedItem(id: session.queue[1].id)
         try await Task.sleep(nanoseconds: 250_000_000)
-        // Steer fired: redirect sent, snapshot captured, state .idle.
         #expect(runner.steerUndoSnapshot() != nil)
         #expect(session.queue.isEmpty)
-        let promptsAfterSteer = mock.sent.filter { $0.method == "session/prompt" }.count
-        #expect(promptsAfterSteer == 1)
+        let promptsAfterForceSend = mock.sent.filter { $0.method == "session/prompt" }.count
+        #expect(promptsAfterForceSend == 1)
 
         runner.steerUndo()
         try await Task.sleep(nanoseconds: 200_000_000)
@@ -365,13 +362,12 @@ struct ACPSessionRunnerQueueTests {
         #expect(users.count == 1)
     }
 
-    @Test("steer drops a .sending head and excludes it from the undo snapshot")
-    func steerDiscardsSendingHead() async throws {
+    @Test("steer drops a .sending head and preserves the pending tail")
+    func steerDiscardsSendingHeadAndPreservesPendingTail() async throws {
         // Regression for the race where steer happens while the flusher
         // has already marked the head .sending. The .sending item must
-        // be evicted along with the .pending tail; otherwise the stale
-        // in-flight RPC would settle later and mutate session state
-        // behind the steer.
+        // be evicted while the pending tail stays queued; otherwise the
+        // stale in-flight RPC would settle later and mutate session state.
         let (runner, mock, session, store) = try mkRunner()
         mock.script(method: "session/prompt") { _ in Data("null".utf8) }
         session.agentState = .ready
@@ -382,21 +378,47 @@ struct ACPSessionRunnerQueueTests {
         session.enqueue(blocks: [.text("tail-pending")])
         runner.persistQueue()
         session.transcript.streamingState = .sending
+        let tail = session.queue[1]
 
         runner.send(blocks: [.text("redirect")], intent: .steer)
+
+        #expect(session.queue == [tail])
+        #expect(runner.steerUndoSnapshot() == nil)
+
         try await Task.sleep(nanoseconds: 250_000_000)
 
-        // Both queued items are gone; only the redirect prompt fired.
+        // The interrupted head is not retried. The redirect runs first,
+        // followed by the preserved tail.
         #expect(session.queue.isEmpty)
         #expect(mock.sent.contains { $0.method == "session/cancel" })
         let prompts = mock.sent.filter { $0.method == "session/prompt" }
-        #expect(prompts.count == 1)
-        // The .sending head MUST NOT appear in the undo snapshot — it was
-        // mid-flight; resurrecting it would just re-fire the prompt the
-        // user steered away from. Only the .pending tail is restorable.
-        let snapshot = runner.steerUndoSnapshot() ?? []
-        #expect(snapshot.map { $0.blocks } == [[.text("tail-pending")]])
+        #expect(prompts.count == 2)
         #expect(try store.loadQueue(sessionId: "s").isEmpty)
+    }
+
+    @Test("force send waits for an in-progress steer to install its redirect")
+    func forceSendWaitsForSteer() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        let cancelStarted = QueueTestGate()
+        let releaseCancel = QueueTestGate()
+        mock.scriptNotifyAsync(method: "session/cancel") { _ in
+            await cancelStarted.open()
+            await releaseCancel.wait()
+        }
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        session.agentState = .ready
+        session.transcript.streamingState = .streaming
+        session.enqueue(blocks: [.text("send-now")])
+        let queuedID = session.queue[0].id
+
+        runner.send(blocks: [.text("redirect")], intent: .steer)
+        await cancelStarted.wait()
+        runner.forceSendQueuedItem(id: queuedID)
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        #expect(mock.sent.filter { $0.method == "session/cancel" }.count == 1)
+
+        await releaseCancel.open()
     }
 
     @Test("forceSendQueuedItem while busy steers with the selected queued item")
@@ -661,6 +683,23 @@ struct ACPSessionRunnerQueueTests {
         #expect(session2.queue.isEmpty)
         let prompts = mock2.sent.filter { $0.method == "session/prompt" }
         #expect(prompts.count == 2)
+    }
+}
+
+private actor QueueTestGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        waiters.forEach { $0.resume() }
+        waiters.removeAll()
     }
 }
 

--- a/AlasTests/ACP/Session/ACPSubmitIntentTests.swift
+++ b/AlasTests/ACP/Session/ACPSubmitIntentTests.swift
@@ -73,7 +73,7 @@ struct ACPSubmitRouteTests {
         #expect(r == .sendNow)
     }
 
-    @Test(".steer + idle + non-empty queue → steer (clears queue, sends now)")
+    @Test(".steer + idle + non-empty queue → steer (preserves queue, sends now)")
     func steerIdleNonEmpty() {
         let r = ACPSubmitRoute.resolve(intent: .steer, state: .idle, queueEmpty: false, blocksEmpty: false)
         #expect(r == .steer)

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -423,7 +423,7 @@ struct ACPComposerDraftBridgeTests {
         // Regression: the inversion was previously applied to ALL submits
         // upstream of the composer, including the toolbar send button.
         // With `acpSendOnEnter = false`, a plain ↑ click would have been
-        // converted to `.steer` (cancel + discard) instead of `.auto`
+        // converted to `.steer` (cancel + immediate send) instead of `.auto`
         // (queue/send). The fix moves the keyboard inversion INTO the
         // coordinator's `doCommandBy`; `submit(_:intent:)` (which the
         // button calls via `actions.submitWithIntent`) emits the intent


### PR DESCRIPTION
## Summary

Composer steering now cancels the active turn without deleting pending queued prompts. The explicit queued-item “Send Now” action retains its existing queue-replacement behavior.

## Changes

- Preserve pending queue entries during normal `.steer` submission.
- Remove only a cancelled `.sending` queue head.
- Keep destructive queue replacement and undo for queued-item Send Now.
- Add regression coverage for both paths and update steering copy.

## Where to start

- `Alas/Sources/ACP/Session/ACPSessionRunner.swift` — routing behavior
- `AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift` — regression cases

## Verification

- `xcodegen`
- `xcodebuild … build`
- Focused ACP queue suite: 29 tests passed