### PR TITLE
feat(sidebar): Add new run sidebar

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -23,11 +23,13 @@
 		01CBEF6793755D3D9B000BC1 /* CodeLanguageDetailViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */; };
 		01D2A32A3366C5CF6A225004 /* GhosttyConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */; };
 		01F51F05BA5DD24D4FBC4B4B /* ShortcutActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00057A43DD2D53F8F79FAC43 /* ShortcutActionTests.swift */; };
+		02057616EE02B05DE778C99E /* RunTabPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E00B5DC5B34A5FCF2935BF /* RunTabPresentation.swift */; };
 		022BF67765AB1906AF7BB156 /* ReviewSessionSelectionPersisterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772D5EBDD036102D88C9B8B3 /* ReviewSessionSelectionPersisterTests.swift */; };
 		0237F9775763E3C43D2D849A /* InstallNudgeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25CBAF6618B6D11EC3B9CC76 /* InstallNudgeResolver.swift */; };
 		02425EBF61592A01B1FCC7D0 /* DiffParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1703FC5CD7DF16F4450E274 /* DiffParser.swift */; };
 		026C8FB815E41D31C8E9421B /* AlasCLICommandRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */; };
 		027A326E7DAB6C6E133E5FD3 /* ACPSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0E1BF90CB3BE5BFDFA2EC7C /* ACPSessionStore.swift */; };
+		02821E3FE8E67B2D162A4BC8 /* RunRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C45DAE186532566BD5CCA79 /* RunRecord.swift */; };
 		0294BEA9FB3A117314ED0C48 /* WarningCharacterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0005D9107053886C37A3AC /* WarningCharacterTests.swift */; };
 		02B055E21896C1C14D2D980D /* SectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934BCC470703CF2DF2303357 /* SectionHeader.swift */; };
 		02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */; };
@@ -67,6 +69,7 @@
 		095A19B85DFA5EBA5A24786D /* AdvancedPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16C4F54FB3E390F80208DA1 /* AdvancedPane.swift */; };
 		095E7D98616FB77A9F8BDFD9 /* ACPSessionManagerRetentionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */; };
 		096304FB0EA9B5EC04D76C49 /* ReviewLoopHandoffBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC688020FD7B6A2A4393B72 /* ReviewLoopHandoffBuilderTests.swift */; };
+		0A2377A64E08F89400F08E68 /* AppStateRunRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89441B078E6782A1395A34CB /* AppStateRunRecordTests.swift */; };
 		0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F90D03073708AA01531533 /* GitService+Staging.swift */; };
 		0A98E7EDC11BF68EAEEFED29 /* ReviewTargetPaletteEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0D0F48B60A75972D3A8DBED /* ReviewTargetPaletteEnvironment.swift */; };
 		0AF3143BA962E031E6A21657 /* GGFollowEntrySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F28FA9BC3F5FC98D0A64747 /* GGFollowEntrySheet.swift */; };
@@ -337,6 +340,7 @@
 		31A3E28F0B49F85D2F58AF8E /* GGConfigReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A2D492EE89A160CD404985 /* GGConfigReader.swift */; };
 		31CB9FBE16CECDE2C6D94EC6 /* RemoteStatusFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191BAF20EAD2D227D9E7B418 /* RemoteStatusFingerprint.swift */; };
 		32324CCE247B8B4784674453 /* RemoteContentSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8249F7BF5F86B0AFD5CAB8 /* RemoteContentSearchTests.swift */; };
+		324E539462E078CED452D311 /* RunRecordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB695F22D0C756A00CEFCA72 /* RunRecordStoreTests.swift */; };
 		32660CEE9955165AE3CCDFBE /* InstallerHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364507D55CD5D73CD44819E7 /* InstallerHostTests.swift */; };
 		32674DB95F2B62C00FC0AAA2 /* RemoteProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A54DD8080E3395C8E7049E /* RemoteProtocol.swift */; };
 		3285F4B6AB6DB5A59AE66CF5 /* SearchScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6CCD7F7273667B5D67F821 /* SearchScope.swift */; };
@@ -726,6 +730,7 @@
 		6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFC9539E615699AC90A7412 /* ProjectsManager.swift */; };
 		6EA7BCF9318AC459144B47FB /* ReviewChangesModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C7D51D781D8191004C6C90 /* ReviewChangesModels.swift */; };
 		6ED129AC9B6798F76F7D3A51 /* FileTypeIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */; };
+		6EDBC8B0F9284ABF9796A4F0 /* RunEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 184A8668BB2C00AB8D1BB1C4 /* RunEndpointTests.swift */; };
 		6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */; };
 		6F0EA54CB15AB5507C84B4A7 /* RemoteAppStateAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B72D621D704CB5B2CCA82C6 /* RemoteAppStateAccessTests.swift */; };
 		6FA1659F464BE9C03C90F787 /* GitService+CommitEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4A17C42833BE6190A45AF3 /* GitService+CommitEditing.swift */; };
@@ -1235,6 +1240,7 @@
 		BF776A9CE2409594D67DE4BF /* AlasSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C8F14A2CEAE4B8404213C73 /* AlasSegmentedControl.swift */; };
 		BF887495CBAAA98792FBF74D /* DiffReviewRenderEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A723CF5BB46FABA23D8C9543 /* DiffReviewRenderEligibilityTests.swift */; };
 		BF9C16C33DF0BBAF2946AFC3 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88379ACE40F42BE4A3257659 /* ThemeTests.swift */; };
+		BF9F7D24CA25F467B5A86810 /* RunTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB198FBD900842FAC632F6E /* RunTabView.swift */; };
 		BFADE15EC5D60235EF2ACBE1 /* ImageDiffPairLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB8043A52927E5E935E2F9B /* ImageDiffPairLoaderTests.swift */; };
 		BFB0E1885389D75F93C98BCF /* EditorLSPStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D99E47A1F0E3C85A34EABBE6 /* EditorLSPStatus.swift */; };
 		BFB452EE7A29CF81F7A4BD8A /* RightPaneTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */; };
@@ -1348,6 +1354,7 @@
 		D034E719261C62047659AD68 /* PairedDelimiterFenceBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B40A20BB651C706C9C6FAAA /* PairedDelimiterFenceBoxTests.swift */; };
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
 		D063240A6A5B8C4766B36F7B /* ACPToolCallCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 869F008CBAF90B11A48EFD46 /* ACPToolCallCardTests.swift */; };
+		D0E7182835E93329C89FCD06 /* RunEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273E6EC520E3FE03DC9068C7 /* RunEndpoint.swift */; };
 		D0E9985350ECD64F1D042345 /* MermaidModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33AEF4AA4C36DBC1B912F25 /* MermaidModelsTests.swift */; };
 		D0F370E528AA4D07814AEB15 /* ACPMCPStatusPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C051018EB105E225122750C /* ACPMCPStatusPolicy.swift */; };
 		D0F4A4F5BF5F1C3C625F11D9 /* Clipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6600436B01C75D85C01FFA /* Clipboard.swift */; };
@@ -1402,6 +1409,7 @@
 		D7C0F02B7A62097E3EF21160 /* FileSearchRanker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FABF9037326B7EE23FCC040 /* FileSearchRanker.swift */; };
 		D7D45D387EEF0436834DF7AD /* ThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EE713DD3CACF29F206553C /* ThemeStore.swift */; };
 		D8254D678C89FC54678A1A88 /* RemoteHelperInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB9832AA15DF6888553C7E /* RemoteHelperInstallerTests.swift */; };
+		D84D5F836F828349114F2D3C /* RightPaneTabTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1352DFCDFF4769EAF89B75CF /* RightPaneTabTests.swift */; };
 		D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */; };
 		D86A62438175F76CFC7DCFAD /* RunScriptCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730E9629FD89AA4BDCB3C57F /* RunScriptCreation.swift */; };
 		D8741FB38F9FB2C180FE37E3 /* AppStateCreateWorktreeLaunchSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8A5932B664C88F20BF00CA /* AppStateCreateWorktreeLaunchSurfaceTests.swift */; };
@@ -1577,6 +1585,7 @@
 		F2385B8730E9D1F47C7FA423 /* ReviewChangesRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C9EEDB5A71C5FAE2D0E42B /* ReviewChangesRail.swift */; };
 		F24D9A50F61692958ABCB4F1 /* TrackedRevisionCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3552BE48184E15F0BE6084C /* TrackedRevisionCodingTests.swift */; };
 		F269D59E1E21AD57EF3EE909 /* ACPQueueHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10602801D3FA990E60CB072D /* ACPQueueHeader.swift */; };
+		F270FBA34858518AD8B97894 /* RunTabPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B982F5063B516804E4321F08 /* RunTabPresentationTests.swift */; };
 		F2983AF4C5674B906BEF2E88 /* RemoteWorktreePoll.swift in Sources */ = {isa = PBXBuildFile; fileRef = D837246E56472EBA3993F515 /* RemoteWorktreePoll.swift */; };
 		F2F75C44CD5042F209299FB9 /* InstallSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E7E61C3BD4AD4AE3828A6F0 /* InstallSource.swift */; };
 		F3249EE6574B3C7FC9FED0B1 /* ACPTranscriptChangeLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5027B783605BE1C0189308CC /* ACPTranscriptChangeLogTests.swift */; };
@@ -1796,6 +1805,7 @@
 		12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreviewTabView.swift; sourceTree = "<group>"; };
 		12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFamilyPicker.swift; sourceTree = "<group>"; };
 		134EE8D2BC31085A504D27D8 /* InstallNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallNudgeResolverTests.swift; sourceTree = "<group>"; };
+		1352DFCDFF4769EAF89B75CF /* RightPaneTabTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneTabTests.swift; sourceTree = "<group>"; };
 		136BDA12046FB352E183D6A4 /* AgentHookEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookEvent.swift; sourceTree = "<group>"; };
 		137E9C84D7F32E747F0AF4C0 /* GatekeeperAssessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperAssessorTests.swift; sourceTree = "<group>"; };
 		137F79BD0DEB96B6F756ABD4 /* JSONHookSettingsFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONHookSettingsFile.swift; sourceTree = "<group>"; };
@@ -1826,6 +1836,7 @@
 		17C2AC0F8B3A1B75239995AC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		17F7DB6F391F1AAA9FED1A86 /* ReviewLoopHandoffBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopHandoffBuilder.swift; sourceTree = "<group>"; };
 		1841997CCBDB9611576B930C /* AlasToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasToggle.swift; sourceTree = "<group>"; };
+		184A8668BB2C00AB8D1BB1C4 /* RunEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunEndpointTests.swift; sourceTree = "<group>"; };
 		1854EA4072F4F45DA70854D0 /* RemoteHostRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHostRegistryTests.swift; sourceTree = "<group>"; };
 		1874031C788ADB4398151FF1 /* StageChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StageChip.swift; sourceTree = "<group>"; };
 		1892610460CE642A24A4F322 /* RunScriptDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptDialog.swift; sourceTree = "<group>"; };
@@ -1912,6 +1923,7 @@
 		270C700882ACFBBC59F931D2 /* ProjectIconImageStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectIconImageStagingTests.swift; sourceTree = "<group>"; };
 		27192411BB5CB8F8F7AD09B2 /* RemoteRepoValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteRepoValidatorTests.swift; sourceTree = "<group>"; };
 		271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypesTests.swift; sourceTree = "<group>"; };
+		273E6EC520E3FE03DC9068C7 /* RunEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunEndpoint.swift; sourceTree = "<group>"; };
 		274681651A972F6771B1930C /* session-update-tool-call-update-meta.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-tool-call-update-meta.json"; sourceTree = "<group>"; };
 		2763F93ADFDCDF6B31D16475 /* UpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateController.swift; sourceTree = "<group>"; };
 		2777D1596E51D8DCA8E7ABA3 /* ACPSessionToolCallTruncationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionToolCallTruncationTests.swift; sourceTree = "<group>"; };
@@ -2194,6 +2206,7 @@
 		5027B783605BE1C0189308CC /* ACPTranscriptChangeLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptChangeLogTests.swift; sourceTree = "<group>"; };
 		50737099AA490FAC6BD9F612 /* TextEditCoordinatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinatesTests.swift; sourceTree = "<group>"; };
 		50B0831638833C386E5CC9E8 /* CompletionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionEngine.swift; sourceTree = "<group>"; };
+		50E00B5DC5B34A5FCF2935BF /* RunTabPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunTabPresentation.swift; sourceTree = "<group>"; };
 		50F0FBAC37A6C6A46C8D426E /* ACPMarkdownInlineRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownInlineRendererTests.swift; sourceTree = "<group>"; };
 		515AFF3BF580DA12B16CD4BE /* MermaidRenderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidRenderService.swift; sourceTree = "<group>"; };
 		515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavView.swift; sourceTree = "<group>"; };
@@ -2359,6 +2372,7 @@
 		6C09F563CF8F2EC4EF2B42BC /* GGStackGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackGateTests.swift; sourceTree = "<group>"; };
 		6C1C02F995A1A770255E98C2 /* WorkspaceDialogs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDialogs.swift; sourceTree = "<group>"; };
 		6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModelTests.swift; sourceTree = "<group>"; };
+		6C45DAE186532566BD5CCA79 /* RunRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunRecord.swift; sourceTree = "<group>"; };
 		6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeService.swift; sourceTree = "<group>"; };
 		6C4E2F83F9EAB77B96EBA152 /* GitLabCLIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLabCLIProvider.swift; sourceTree = "<group>"; };
 		6CA51D49B1AE4C4E10D450C6 /* ACPFileWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileWriterTests.swift; sourceTree = "<group>"; };
@@ -2547,6 +2561,7 @@
 		89034A1968C6BC371826314D /* ACPSessionOrchestrationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionOrchestrationCoordinatorTests.swift; sourceTree = "<group>"; };
 		891879D5E86331F0BC092ACC /* ACPUserScrollEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPUserScrollEvent.swift; sourceTree = "<group>"; };
 		8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservations.swift; sourceTree = "<group>"; };
+		89441B078E6782A1395A34CB /* AppStateRunRecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateRunRecordTests.swift; sourceTree = "<group>"; };
 		89B23F35BE6FD53B74DD84ED /* ZmxSessionName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSessionName.swift; sourceTree = "<group>"; };
 		89B2725002A4349D9E5D1432 /* AppKitDiffTilingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffTilingController.swift; sourceTree = "<group>"; };
 		89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowControllerTests.swift; sourceTree = "<group>"; };
@@ -2746,6 +2761,7 @@
 		AB260B63A88AF852906E2D2D /* MermaidRenderCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidRenderCache.swift; sourceTree = "<group>"; };
 		AB3DAB779A962AC2092A2879 /* CommitTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabViewTests.swift; sourceTree = "<group>"; };
 		AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLSPManagerStatusTests.swift; sourceTree = "<group>"; };
+		AB695F22D0C756A00CEFCA72 /* RunRecordStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunRecordStoreTests.swift; sourceTree = "<group>"; };
 		AB7344582814CCAF81B0E354 /* ReviewDraftCommentAgentModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDraftCommentAgentModelTests.swift; sourceTree = "<group>"; };
 		AB8CA584A5F9F1BDE903E8D2 /* ReviewSessionModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionModelsTests.swift; sourceTree = "<group>"; };
 		AB9D4FBF08CBAB59C08BBF1D /* ACPQuestionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionRequest.swift; sourceTree = "<group>"; };
@@ -2839,6 +2855,7 @@
 		B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDraftBridgeTests.swift; sourceTree = "<group>"; };
 		B96B454EC8216FFF50B92C1D /* SSHHostSuggestionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHHostSuggestionsTests.swift; sourceTree = "<group>"; };
 		B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceMergeTests.swift; sourceTree = "<group>"; };
+		B982F5063B516804E4321F08 /* RunTabPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunTabPresentationTests.swift; sourceTree = "<group>"; };
 		B9830BAAE86AA0A20A77731D /* ProcessMemoryProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMemoryProbeTests.swift; sourceTree = "<group>"; };
 		B98658E85103DE518E9A5561 /* GGSplitCommitModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGSplitCommitModel.swift; sourceTree = "<group>"; };
 		B98E7424CBFF07A59BCB703A /* DiffPaneDocumentCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffPaneDocumentCacheTests.swift; sourceTree = "<group>"; };
@@ -3198,6 +3215,7 @@
 		EC6FA61556FA530605C9FE81 /* RemoteNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNetwork.swift; sourceTree = "<group>"; };
 		EC7FA2ABE27A4CC2EB0BCA18 /* ACPTranscriptCurrentPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptCurrentPlanTests.swift; sourceTree = "<group>"; };
 		EC9F12CC9A1AA0A56CF7BA3A /* AppConfigTerminalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigTerminalTests.swift; sourceTree = "<group>"; };
+		ECB198FBD900842FAC632F6E /* RunTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunTabView.swift; sourceTree = "<group>"; };
 		ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewIndentationTests.swift; sourceTree = "<group>"; };
 		ECD9419E685AD7EED286006B /* ACPContextRingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextRingTests.swift; sourceTree = "<group>"; };
 		ECFB48AF581F74C564ACBCF5 /* CompletionDocumentationRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDocumentationRenderer.swift; sourceTree = "<group>"; };
@@ -3470,6 +3488,8 @@
 			isa = PBXGroup;
 			children = (
 				DB3A201BB87075FB20E88FBC /* NewRunScriptDialog.swift */,
+				273E6EC520E3FE03DC9068C7 /* RunEndpoint.swift */,
+				6C45DAE186532566BD5CCA79 /* RunRecord.swift */,
 				E3AF2511A18895DBE494798E /* RunScript.swift */,
 				B65DC03DDA5885AA19DEC00E /* RunScriptCompletionMonitor.swift */,
 				730E9629FD89AA4BDCB3C57F /* RunScriptCreation.swift */,
@@ -3611,6 +3631,7 @@
 				69FCCEC91C40EBC896CF9089 /* AppStateOverlayTests.swift */,
 				8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */,
 				FED0AAD3FE0E143D409A3E8B /* AppStateRemoteWorktreePathTests.swift */,
+				89441B078E6782A1395A34CB /* AppStateRunRecordTests.swift */,
 				23190FA641E518CAFA0A8177 /* AppStateRunScriptCreationTests.swift */,
 				EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */,
 				279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */,
@@ -3857,7 +3878,10 @@
 				1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */,
 				0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */,
 				8451C5BCEE50F118F07CDD83 /* RightPaneStoreBaseBranchTests.swift */,
+				1352DFCDFF4769EAF89B75CF /* RightPaneTabTests.swift */,
 				B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */,
+				184A8668BB2C00AB8D1BB1C4 /* RunEndpointTests.swift */,
+				AB695F22D0C756A00CEFCA72 /* RunRecordStoreTests.swift */,
 				C0856147C5DC7F10944420ED /* RunScriptCompletionMonitorTests.swift */,
 				D6128B044F59DB08F2383F7B /* RunScriptCreationTests.swift */,
 				200B570859DFA8572F150B85 /* RunScriptFailurePresentationTests.swift */,
@@ -3867,6 +3891,7 @@
 				ACAF0D9BAB4658B356FBBBAA /* RunScriptPaletteModelTests.swift */,
 				F15CFDEF63A656129A3EFEEB /* RunScriptStoreTests.swift */,
 				200C4E9E9FBD356C8B051746 /* RunScriptTemplateTests.swift */,
+				B982F5063B516804E4321F08 /* RunTabPresentationTests.swift */,
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
 				B56D60E58F278AC97579937E /* SectionHeaderTests.swift */,
 				4BF2EE8A6AAA7F9B45DACC0C /* SemanticVersionTests.swift */,
@@ -4339,6 +4364,8 @@
 				4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */,
 				9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */,
 				FE66950F2226F1182DCDD39A /* RightPaneView.swift */,
+				50E00B5DC5B34A5FCF2935BF /* RunTabPresentation.swift */,
+				ECB198FBD900842FAC632F6E /* RunTabView.swift */,
 				934BCC470703CF2DF2303357 /* SectionHeader.swift */,
 				11281859D3CDA9DB8AF34D33 /* StashChangesSheet.swift */,
 				2FE3A300CA2284FF5EEEF102 /* StashRows.swift */,
@@ -7065,6 +7092,8 @@
 				6117C4AD7519BCD82EA0CF56 /* RightPaneTransitionalView.swift in Sources */,
 				E4E04048352D9CBC77D954C5 /* RightPaneView.swift in Sources */,
 				7B85B033B476943E77867BA3 /* RootView.swift in Sources */,
+				D0E7182835E93329C89FCD06 /* RunEndpoint.swift in Sources */,
+				02821E3FE8E67B2D162A4BC8 /* RunRecord.swift in Sources */,
 				B14D567062F568BBA1631562 /* RunScript.swift in Sources */,
 				8C5CD5BD5188B5C8DB1592CD /* RunScriptCompletionMonitor.swift in Sources */,
 				D86A62438175F76CFC7DCFAD /* RunScriptCreation.swift in Sources */,
@@ -7075,6 +7104,8 @@
 				96EC9BEE1A4467683D0F6808 /* RunScriptPaletteModel.swift in Sources */,
 				35B9709D0B74BA6B5E3FC0EF /* RunScriptStore.swift in Sources */,
 				FAC502C668FED52BEE4D32BD /* RunScriptTemplate.swift in Sources */,
+				02057616EE02B05DE778C99E /* RunTabPresentation.swift in Sources */,
+				BF9F7D24CA25F467B5A86810 /* RunTabView.swift in Sources */,
 				175D0A77579A022F3AB81E48 /* SQLiteDatabase.swift in Sources */,
 				102686FD795DE94337B3A030 /* SQLiteError.swift in Sources */,
 				C82A2082E6E61069068B8FAB /* SQLiteStatement.swift in Sources */,
@@ -7439,6 +7470,7 @@
 				51E0500756DC8DD5238F4D19 /* AppStateOverlayTests.swift in Sources */,
 				25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */,
 				996B67B45E7247CDED5F98EF /* AppStateRemoteWorktreePathTests.swift in Sources */,
+				0A2377A64E08F89400F08E68 /* AppStateRunRecordTests.swift in Sources */,
 				F8C643420F6CF51D3B74164D /* AppStateRunScriptCreationTests.swift in Sources */,
 				07385C7266A0694AB7F4E872 /* AppStateSpacesTests.swift in Sources */,
 				956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */,
@@ -7846,7 +7878,10 @@
 				DCACB5B624BFFE7C50DA6C61 /* RightPaneStateSyncStatusTests.swift in Sources */,
 				57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */,
 				4186372EBF16A9C7CB38F558 /* RightPaneStoreBaseBranchTests.swift in Sources */,
+				D84D5F836F828349114F2D3C /* RightPaneTabTests.swift in Sources */,
 				4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */,
+				6EDBC8B0F9284ABF9796A4F0 /* RunEndpointTests.swift in Sources */,
+				324E539462E078CED452D311 /* RunRecordStoreTests.swift in Sources */,
 				0E17E7251EC6EAB4B50B10D6 /* RunScriptCompletionMonitorTests.swift in Sources */,
 				80AEF86E91561F880A3A0376 /* RunScriptCreationTests.swift in Sources */,
 				D70B9B1A92771F7E71A092B7 /* RunScriptFailurePresentationTests.swift in Sources */,
@@ -7856,6 +7891,7 @@
 				AC286DF7EDE24F24BAD146AF /* RunScriptPaletteModelTests.swift in Sources */,
 				F09324E122712405CCB0389A /* RunScriptStoreTests.swift in Sources */,
 				26265A75CED42D3C490DF8C2 /* RunScriptTemplateTests.swift in Sources */,
+				F270FBA34858518AD8B97894 /* RunTabPresentationTests.swift in Sources */,
 				B05D6011E0FDB7AA1B016844 /* SQLiteDatabaseTests.swift in Sources */,
 				AA6F188E5E31B83D45380279 /* SSHCommandTests.swift in Sources */,
 				4C3DFB4EDC26169A6D63E05E /* SSHConfigParserTests.swift in Sources */,

--- a/Alas/Sources/App/AppState+RunScripts.swift
+++ b/Alas/Sources/App/AppState+RunScripts.swift
@@ -288,9 +288,9 @@ extension AppState {
     /// can't relabel a deliberate stop as a lost process.
     func stopScript(_ script: RunScript, in worktree: Worktree) {
         let launchKey = "\(worktree.id):\(script.key)"
-        if let pendingLaunchID = pendingScriptLaunches.removeValue(forKey: launchKey) {
+        if let pending = pendingScriptLaunches.removeValue(forKey: launchKey) {
             runRecords.markStopped(worktreeID: worktree.id, scriptKey: script.key, at: Date())
-            pendingScriptLaunchTasks.removeValue(forKey: pendingLaunchID)?.cancel()
+            pendingScriptLaunchTasks.removeValue(forKey: pending.id)?.cancel()
             return
         }
         guard let existing = scriptTab(for: script, in: worktree) else {
@@ -430,10 +430,14 @@ extension AppState {
         ))
 
         let launchID = UUID()
-        pendingScriptLaunches[launchKey] = launchID
+        pendingScriptLaunches[launchKey] = PendingRunScriptLaunch(
+            id: launchID,
+            worktreeID: worktree.id,
+            scriptKey: script.key
+        )
         let launchTask = Task { @MainActor in
             defer {
-                if pendingScriptLaunches[launchKey] == launchID {
+                if pendingScriptLaunches[launchKey]?.id == launchID {
                     pendingScriptLaunches.removeValue(forKey: launchKey)
                 }
                 pendingScriptLaunchTasks.removeValue(forKey: launchID)
@@ -700,12 +704,9 @@ extension AppState {
             return key.hasPrefix("\(worktreeID):")
         }
         for key in pendingKeys {
-            guard let launchID = pendingScriptLaunches.removeValue(forKey: key) else { continue }
-            pendingScriptLaunchTasks.removeValue(forKey: launchID)?.cancel()
-            guard let separator = key.firstIndex(of: ":") else { continue }
-            let keyWorktreeID = String(key[..<separator])
-            let scriptKey = String(key[key.index(after: separator)...])
-            runRecords.markStopped(worktreeID: keyWorktreeID, scriptKey: scriptKey, at: now)
+            guard let pending = pendingScriptLaunches.removeValue(forKey: key) else { continue }
+            pendingScriptLaunchTasks.removeValue(forKey: pending.id)?.cancel()
+            runRecords.markStopped(worktreeID: pending.worktreeID, scriptKey: pending.scriptKey, at: now)
         }
     }
 
@@ -808,6 +809,7 @@ extension AppState {
             )
         }
         pendingRunScriptCreation = nil
+        runScriptCatalogGeneration += 1
     }
 
     func cancelPendingRunScriptCreation() {

--- a/Alas/Sources/App/AppState+RunScripts.swift
+++ b/Alas/Sources/App/AppState+RunScripts.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import os
 
@@ -234,6 +235,19 @@ extension AppState {
         return "\"$HOME/\(path.dropFirst(2).doubleQuotedShellEscaped)\""
     }
 
+    /// The tab hosting this script in this worktree, live session or not.
+    /// Stopping or restarting has to reach a stale tab too — otherwise a
+    /// relaunch would leave the old one stranded beside the new one.
+    func scriptTab(for script: RunScript, in worktree: Worktree) -> Tab? {
+        tabs.tabs(forWorktree: worktree.id).first { tab in
+            guard case .terminal(let state) = tab else { return false }
+            return state.runScriptKey == script.key
+        }
+    }
+
+    /// The script's tab *with a live shell behind it*. Used to decide whether
+    /// there is a terminal worth jumping to — never to decide whether the
+    /// command itself is still running; `runRecords` owns that.
     func runningScriptTab(for script: RunScript, in worktree: Worktree) -> Tab? {
         tabs.tabs(forWorktree: worktree.id).first { tab in
             guard case .terminal(let state) = tab,
@@ -256,10 +270,91 @@ extension AppState {
     }
 
     func restartScript(_ script: RunScript, in worktree: Worktree) {
-        if let existing = runningScriptTab(for: script, in: worktree) {
+        if let existing = scriptTab(for: script, in: worktree) {
+            runRecords.markStopped(worktreeID: worktree.id, scriptKey: script.key, at: Date())
             closeTab(worktreeId: worktree.id, tabId: existing.id)
         }
         launchScript(script, in: worktree)
+    }
+
+    /// Stop an in-flight run by closing the terminal that hosts it. The record
+    /// is marked stopped *before* the close so the monitor-cancellation path
+    /// can't relabel a deliberate stop as a lost process.
+    func stopScript(_ script: RunScript, in worktree: Worktree) {
+        guard let existing = scriptTab(for: script, in: worktree) else {
+            // Nothing left to stop: whatever we thought was running is gone,
+            // and we never saw it exit.
+            runRecords.markLostObservation(worktreeID: worktree.id, scriptKey: script.key, at: Date())
+            return
+        }
+        runRecords.markStopped(worktreeID: worktree.id, scriptKey: script.key, at: Date())
+        closeTab(worktreeId: worktree.id, tabId: existing.id)
+    }
+
+    /// Reveal the terminal a run is (or was) hosted in. Scoped to `worktree`
+    /// so a same-named script in another worktree is never focused.
+    func focusScriptTerminal(_ script: RunScript, in worktree: Worktree) {
+        guard let existing = runningScriptTab(for: script, in: worktree) else { return }
+        activateWorktreeCenterTab(worktreeId: worktree.id, tabId: existing.id)
+    }
+
+    /// Re-check active records whose terminal has gone away. Called when the
+    /// Run tab appears, so reconnecting to a worktree settles uncertain runs
+    /// instead of leaving them stuck on "Running".
+    func reconcileRunRecords(worktreeID: String) {
+        let now = Date()
+        for record in runRecords.records(worktreeID: worktreeID) where record.status.isActive {
+            guard let sessionID = record.sessionID else { continue }
+            guard terminal.registry.session(for: sessionID) == nil else { continue }
+            // A monitor may still be waiting on a completion file that outlives
+            // the shell; only give up once nothing is observing the run.
+            guard !runScriptCompletionTasks.values.contains(where: { $0.sessionID == sessionID }) else { continue }
+            runRecords.markLostObservation(runID: record.id, at: now)
+        }
+    }
+
+    func runExecutionTarget(for script: RunScript, in worktree: Worktree) -> RunExecutionTarget {
+        RunExecutionTarget(
+            host: projects.first(where: { $0.id == worktree.projectId })?.host,
+            workingDirectory: script.cwd.map { worktree.path.appendingPathComponent($0).path }
+                ?? worktree.path.path
+        )
+    }
+
+    /// Opens a run's declared endpoint. A remote run whose URL points at
+    /// loopback is refused rather than silently opening whatever serves that
+    /// port on this Mac.
+    func openRunEndpoint(_ script: RunScript, in worktree: Worktree) {
+        guard let endpoint = script.endpoint else { return }
+        switch RunEndpointPolicy.action(for: endpoint, target: runExecutionTarget(for: script, in: worktree)) {
+        case .open(let url):
+            NSWorkspace.shared.open(url)
+        case let .blockedRemoteLoopback(host, url):
+            showFileActionError(
+                title: "Can't Open Endpoint",
+                message: "\(script.displayName) runs on \(host), but \(url.absoluteString) points at this Mac. Set `# alas-url:` to a URL reachable from here, or forward the port over SSH."
+            )
+        }
+    }
+
+    /// Who else holds the run's endpoint port right now. Reported, never acted
+    /// on — Alas does not terminate a process it does not own.
+    private func detectPortConflict(
+        endpoint: URL?,
+        target: RunExecutionTarget,
+        excludingRunID: String
+    ) -> RunPortConflict? {
+        guard let port = endpoint?.runEndpointPort else { return nil }
+        if let owner = runRecords.activeRunOwningPort(port, host: target.host, excludingRunID: excludingRunID) {
+            return .ownedByRun(
+                worktreeID: owner.worktreeID,
+                branch: owner.branch,
+                scriptName: owner.scriptName
+            )
+        }
+        // A bind probe only means something for ports on this machine.
+        guard !target.isRemote, RunPortProbe.isLocalPortInUse(port) else { return nil }
+        return .externalProcess
     }
 
     private func launchScript(_ script: RunScript, in worktree: Worktree) {
@@ -304,9 +399,28 @@ extension AppState {
         }
         guard let project = projects.first(where: { $0.id == worktree.projectId }) else { return }
         pendingScriptLaunches.insert(launchKey)
+
+        // Claim the slot synchronously, alongside `pendingScriptLaunches`, so
+        // the row flips to "Starting" on the same turn the user clicked and a
+        // second click can't open a second run behind the first one's back.
+        let runID = UUID().uuidString
+        let target = runExecutionTarget(for: script, in: worktree)
+        let conflict = detectPortConflict(endpoint: script.endpoint, target: target, excludingRunID: runID)
+        let displacedRecord = runRecords.begin(RunRecord(
+            id: runID,
+            scriptKey: script.key,
+            scriptName: script.displayName,
+            worktreeID: worktree.id,
+            branch: worktree.branch,
+            target: target,
+            endpoint: script.endpoint,
+            status: .starting,
+            startedAt: Date(),
+            portConflict: conflict
+        ))
+
         Task { @MainActor in
             defer { pendingScriptLaunches.remove(launchKey) }
-            let runID = UUID().uuidString
             let captureLocation: RunScriptCaptureLocation
             do {
                 captureLocation = try RunScriptCompletionMonitor.paths(runID: runID, host: project.host)
@@ -328,7 +442,13 @@ extension AppState {
                     )
                     guard case .terminal(let terminalState) = tab,
                           let sessionID = terminalState.runScriptLeafId
-                    else { return }
+                    else {
+                        // A terminal with no run leaf gives us nothing to
+                        // observe; say so instead of leaving the row starting.
+                        cancelRunScriptCompletionTask(runID: runID, location: captureLocation)
+                        runRecords.markLostObservation(runID: runID, at: Date())
+                        return
+                    }
                     startRunScriptCompletionMonitor(
                         runID: runID,
                         sessionID: sessionID,
@@ -336,6 +456,7 @@ extension AppState {
                         script: script,
                         worktree: worktree
                     )
+                    runRecords.markRunning(runID: runID, sessionID: sessionID)
                     if runScriptSessionForegroundPidIsMissing(sessionID: sessionID) {
                         cancelRunScriptCompletionTasksIfSessionStillExited(sessionID: sessionID, after: .seconds(2), includeRemote: false)
                         cancelRunScriptCompletionTasksIfSessionStillExited(sessionID: sessionID, after: .seconds(30))
@@ -345,6 +466,9 @@ extension AppState {
                     throw error
                 }
             } catch {
+                // The command never started, so the previous outcome is still
+                // the most recent thing we actually observed — put it back.
+                runRecords.rollback(runID: runID, to: displacedRecord)
                 showFileActionError(title: "Run Script Failed", message: error.localizedDescription)
             }
         }
@@ -400,7 +524,10 @@ extension AppState {
                         sessionId: sessionID,
                         runID: runID
                     )
-                    guard completion.exitCode != 0 else { return }
+                    guard completion.exitCode != 0 else {
+                        runRecords.finish(runID: runID, outcome: .succeeded, at: completion.completedAt)
+                        return
+                    }
                     let capturedOutput: RunScriptCapturedOutput
                     if let transcript = completion.transcript {
                         let snapshot = ANSIPlainTextSnapshot.tail(
@@ -415,8 +542,15 @@ extension AppState {
                     } else {
                         capturedOutput = .unavailable
                     }
+                    let failureID = UUID().uuidString
+                    runRecords.finish(
+                        runID: runID,
+                        outcome: .failed(exitCode: completion.exitCode),
+                        at: completion.completedAt,
+                        failureID: failureID
+                    )
                     runScriptFailureQueue.append(RunScriptFailure(
-                        id: UUID().uuidString,
+                        id: failureID,
                         runID: runID,
                         scriptKey: script.key,
                         scriptName: script.displayName,
@@ -427,7 +561,12 @@ extension AppState {
                         capturedOutput: capturedOutput
                     ))
                 } catch is CancellationError {
+                    // `cancelRunScriptCompletionTask` already recorded the
+                    // lost observation; it owns that transition.
                 } catch {
+                    // The waiter failed (dropped SSH, unreadable completion
+                    // file). We never saw an exit status, so we can't claim one.
+                    runRecords.markLostObservation(runID: runID, at: Date())
                     runScriptLogger.error(
                         "Run script completion monitor failed for run \(runID, privacy: .public) at \(String(describing: location), privacy: .public): \(String(describing: error), privacy: .public)"
                     )
@@ -441,10 +580,14 @@ extension AppState {
         cleanupCaptureLocation(location)
     }
 
+    /// Gives up on observing a run. Every caller reaches here because the run's
+    /// shell went away before the command reported an exit status, so the
+    /// record settles on `unknown` — never on success.
     private func cancelRunScriptCompletionTask(runID: String) {
         guard let entry = runScriptCompletionTasks.removeValue(forKey: runID) else { return }
         entry.task.cancel()
         cleanupCaptureLocation(entry.location)
+        runRecords.markLostObservation(runID: runID, at: Date())
     }
 
     func cancelRunScriptCompletionTasks(
@@ -506,7 +649,15 @@ extension AppState {
             cleanupCaptureLocation(entry.location)
         }
         if purgeFailures {
+            // The worktree itself is going away, so its run history goes with
+            // it rather than leaking into a future worktree that reuses the id.
+            runRecords.purge(worktreeID: worktreeID)
             runScriptFailureQueue.purge(worktreeID: worktreeID)
+        } else {
+            let now = Date()
+            for record in runRecords.records(worktreeID: worktreeID) where record.status.isActive {
+                runRecords.markLostObservation(runID: record.id, at: now)
+            }
         }
         if purgeFailures, selectedRunScriptFailure?.worktreeID == worktreeID {
             selectedRunScriptFailure = nil
@@ -514,9 +665,11 @@ extension AppState {
     }
 
     func cancelAllRunScriptCompletionTasks() {
-        for entry in runScriptCompletionTasks.values {
+        let now = Date()
+        for (runID, entry) in runScriptCompletionTasks {
             entry.task.cancel()
             cleanupCaptureLocation(entry.location)
+            runRecords.markLostObservation(runID: runID, at: now)
         }
         runScriptCompletionTasks.removeAll()
     }

--- a/Alas/Sources/App/AppState+RunScripts.swift
+++ b/Alas/Sources/App/AppState+RunScripts.swift
@@ -539,6 +539,11 @@ extension AppState {
                 defer { runScriptCompletionTasks.removeValue(forKey: runID) }
                 do {
                     let completion = try await runScriptCompletionWaiter(location)
+                    guard runRecords.isCurrentActiveRun(
+                        runID: runID,
+                        worktreeID: worktree.id,
+                        scriptKey: script.key
+                    ) else { return }
                     harness.notifications.notifyRunScriptFinished(
                         scriptName: script.displayName,
                         exitCode: completion.exitCode,

--- a/Alas/Sources/App/AppState+RunScripts.swift
+++ b/Alas/Sources/App/AppState+RunScripts.swift
@@ -545,6 +545,7 @@ extension AppState {
                 defer { runScriptCompletionTasks.removeValue(forKey: runID) }
                 do {
                     let completion = try await runScriptCompletionWaiter(location)
+                    let observedAt = Date()
                     guard runRecords.isCurrentActiveRun(
                         runID: runID,
                         worktreeID: worktree.id,
@@ -559,7 +560,7 @@ extension AppState {
                         runID: runID
                     )
                     guard completion.exitCode != 0 else {
-                        runRecords.finish(runID: runID, outcome: .succeeded, at: completion.completedAt)
+                        runRecords.finish(runID: runID, outcome: .succeeded, at: observedAt)
                         return
                     }
                     let capturedOutput: RunScriptCapturedOutput
@@ -580,7 +581,7 @@ extension AppState {
                     runRecords.finish(
                         runID: runID,
                         outcome: .failed(exitCode: completion.exitCode),
-                        at: completion.completedAt,
+                        at: observedAt,
                         failureID: failureID
                     )
                     runScriptFailureQueue.append(RunScriptFailure(
@@ -591,7 +592,7 @@ extension AppState {
                         worktreeID: worktree.id,
                         branch: worktree.branch,
                         exitCode: completion.exitCode,
-                        completedAt: completion.completedAt,
+                        completedAt: observedAt,
                         capturedOutput: capturedOutput
                     ))
                 } catch is CancellationError {

--- a/Alas/Sources/App/AppState+RunScripts.swift
+++ b/Alas/Sources/App/AppState+RunScripts.swift
@@ -381,8 +381,9 @@ extension AppState {
         // Global scripts live in local Application Support and are read by
         // path, not content — launching one into a remote worktree would ship
         // a Mac-only path into the SSH-launched remote shell, which can't see
-        // it. Repo scripts aren't affected: RunScriptStore only discovers them
-        // from a locally-reachable worktree root in the first place.
+        // it. Remote repo scripts are discovered through the remote file layer,
+        // so their absolute path is intentionally not local-file-system
+        // reachable here.
         if script.scope == .global, worktree.path.isRemoteAlasPath {
             showFileActionError(
                 title: "Run Script Failed",
@@ -390,7 +391,8 @@ extension AppState {
             )
             return
         }
-        guard FileManager.default.fileExists(atPath: script.fileURL.path) else {
+        let requiresLocalScriptPath = !(script.scope == .repo && worktree.path.isRemoteAlasPath)
+        guard !requiresLocalScriptPath || FileManager.default.fileExists(atPath: script.fileURL.path) else {
             showFileActionError(
                 title: "Run Script Failed",
                 message: "\(script.fileName) no longer exists on disk."

--- a/Alas/Sources/App/AppState+RunScripts.swift
+++ b/Alas/Sources/App/AppState+RunScripts.swift
@@ -270,6 +270,12 @@ extension AppState {
     }
 
     func restartScript(_ script: RunScript, in worktree: Worktree) {
+        let launchKey = "\(worktree.id):\(script.key)"
+        if pendingScriptLaunches[launchKey] != nil {
+            stopScript(script, in: worktree)
+            launchScript(script, in: worktree)
+            return
+        }
         if let existing = scriptTab(for: script, in: worktree) {
             runRecords.markStopped(worktreeID: worktree.id, scriptKey: script.key, at: Date())
             closeTab(worktreeId: worktree.id, tabId: existing.id)
@@ -282,9 +288,9 @@ extension AppState {
     /// can't relabel a deliberate stop as a lost process.
     func stopScript(_ script: RunScript, in worktree: Worktree) {
         let launchKey = "\(worktree.id):\(script.key)"
-        if let pendingLaunch = pendingScriptLaunches.removeValue(forKey: launchKey) {
+        if let pendingLaunchID = pendingScriptLaunches.removeValue(forKey: launchKey) {
             runRecords.markStopped(worktreeID: worktree.id, scriptKey: script.key, at: Date())
-            pendingLaunch.cancel()
+            pendingScriptLaunchTasks.removeValue(forKey: pendingLaunchID)?.cancel()
             return
         }
         guard let existing = scriptTab(for: script, in: worktree) else {
@@ -423,8 +429,15 @@ extension AppState {
             portConflict: conflict
         ))
 
+        let launchID = UUID()
+        pendingScriptLaunches[launchKey] = launchID
         let launchTask = Task { @MainActor in
-            defer { pendingScriptLaunches.removeValue(forKey: launchKey) }
+            defer {
+                if pendingScriptLaunches[launchKey] == launchID {
+                    pendingScriptLaunches.removeValue(forKey: launchKey)
+                }
+                pendingScriptLaunchTasks.removeValue(forKey: launchID)
+            }
             let captureLocation: RunScriptCaptureLocation
             do {
                 captureLocation = try RunScriptCompletionMonitor.paths(runID: runID, host: project.host)
@@ -481,7 +494,7 @@ extension AppState {
                 showFileActionError(title: "Run Script Failed", message: error.localizedDescription)
             }
         }
-        pendingScriptLaunches[launchKey] = launchTask
+        pendingScriptLaunchTasks[launchID] = launchTask
     }
 
     func runScriptFailures(in worktreeID: String) -> [RunScriptFailure] {
@@ -654,6 +667,11 @@ extension AppState {
     }
 
     func cleanupRunScriptState(worktreeID: String, purgeFailures: Bool = true) {
+        let pendingKeys = pendingScriptLaunches.keys.filter { $0.hasPrefix("\(worktreeID):") }
+        for key in pendingKeys {
+            guard let launchID = pendingScriptLaunches.removeValue(forKey: key) else { continue }
+            pendingScriptLaunchTasks.removeValue(forKey: launchID)?.cancel()
+        }
         for (runID, entry) in runScriptCompletionTasks where entry.worktreeID == worktreeID {
             runScriptCompletionTasks.removeValue(forKey: runID)?.task.cancel()
             cleanupCaptureLocation(entry.location)

--- a/Alas/Sources/App/AppState+RunScripts.swift
+++ b/Alas/Sources/App/AppState+RunScripts.swift
@@ -281,6 +281,12 @@ extension AppState {
     /// is marked stopped *before* the close so the monitor-cancellation path
     /// can't relabel a deliberate stop as a lost process.
     func stopScript(_ script: RunScript, in worktree: Worktree) {
+        let launchKey = "\(worktree.id):\(script.key)"
+        if let pendingLaunch = pendingScriptLaunches.removeValue(forKey: launchKey) {
+            runRecords.markStopped(worktreeID: worktree.id, scriptKey: script.key, at: Date())
+            pendingLaunch.cancel()
+            return
+        }
         guard let existing = scriptTab(for: script, in: worktree) else {
             // Nothing left to stop: whatever we thought was running is gone,
             // and we never saw it exit.
@@ -364,7 +370,7 @@ extension AppState {
         // and both launch. Close that window with a synchronous in-flight
         // guard instead.
         let launchKey = "\(worktree.id):\(script.key)"
-        guard !pendingScriptLaunches.contains(launchKey) else { return }
+        guard pendingScriptLaunches[launchKey] == nil else { return }
 
         // Global scripts live in local Application Support and are read by
         // path, not content — launching one into a remote worktree would ship
@@ -398,8 +404,6 @@ extension AppState {
             return
         }
         guard let project = projects.first(where: { $0.id == worktree.projectId }) else { return }
-        pendingScriptLaunches.insert(launchKey)
-
         // Claim the slot synchronously, alongside `pendingScriptLaunches`, so
         // the row flips to "Starting" on the same turn the user clicked and a
         // second click can't open a second run behind the first one's back.
@@ -419,8 +423,8 @@ extension AppState {
             portConflict: conflict
         ))
 
-        Task { @MainActor in
-            defer { pendingScriptLaunches.remove(launchKey) }
+        let launchTask = Task { @MainActor in
+            defer { pendingScriptLaunches.removeValue(forKey: launchKey) }
             let captureLocation: RunScriptCaptureLocation
             do {
                 captureLocation = try RunScriptCompletionMonitor.paths(runID: runID, host: project.host)
@@ -440,6 +444,10 @@ extension AppState {
                         titleOverride: script.displayName,
                         runScriptKey: script.key
                     )
+                    if Task.isCancelled {
+                        closeTab(worktreeId: worktree.id, tabId: tab.id)
+                        return
+                    }
                     guard case .terminal(let terminalState) = tab,
                           let sessionID = terminalState.runScriptLeafId
                     else {
@@ -466,12 +474,14 @@ extension AppState {
                     throw error
                 }
             } catch {
+                if Task.isCancelled { return }
                 // The command never started, so the previous outcome is still
                 // the most recent thing we actually observed — put it back.
                 runRecords.rollback(runID: runID, to: displacedRecord)
                 showFileActionError(title: "Run Script Failed", message: error.localizedDescription)
             }
         }
+        pendingScriptLaunches[launchKey] = launchTask
     }
 
     func runScriptFailures(in worktreeID: String) -> [RunScriptFailure] {

--- a/Alas/Sources/App/AppState+RunScripts.swift
+++ b/Alas/Sources/App/AppState+RunScripts.swift
@@ -667,11 +667,7 @@ extension AppState {
     }
 
     func cleanupRunScriptState(worktreeID: String, purgeFailures: Bool = true) {
-        let pendingKeys = pendingScriptLaunches.keys.filter { $0.hasPrefix("\(worktreeID):") }
-        for key in pendingKeys {
-            guard let launchID = pendingScriptLaunches.removeValue(forKey: key) else { continue }
-            pendingScriptLaunchTasks.removeValue(forKey: launchID)?.cancel()
-        }
+        cancelPendingRunScriptLaunches(worktreeID: worktreeID)
         for (runID, entry) in runScriptCompletionTasks where entry.worktreeID == worktreeID {
             runScriptCompletionTasks.removeValue(forKey: runID)?.task.cancel()
             cleanupCaptureLocation(entry.location)
@@ -689,6 +685,22 @@ extension AppState {
         }
         if purgeFailures, selectedRunScriptFailure?.worktreeID == worktreeID {
             selectedRunScriptFailure = nil
+        }
+    }
+
+    func cancelPendingRunScriptLaunches(worktreeID: String? = nil) {
+        let now = Date()
+        let pendingKeys = pendingScriptLaunches.keys.filter { key in
+            guard let worktreeID else { return true }
+            return key.hasPrefix("\(worktreeID):")
+        }
+        for key in pendingKeys {
+            guard let launchID = pendingScriptLaunches.removeValue(forKey: key) else { continue }
+            pendingScriptLaunchTasks.removeValue(forKey: launchID)?.cancel()
+            guard let separator = key.firstIndex(of: ":") else { continue }
+            let keyWorktreeID = String(key[..<separator])
+            let scriptKey = String(key[key.index(after: separator)...])
+            runRecords.markStopped(worktreeID: keyWorktreeID, scriptKey: scriptKey, at: now)
         }
     }
 

--- a/Alas/Sources/App/AppState+RunScripts.swift
+++ b/Alas/Sources/App/AppState+RunScripts.swift
@@ -270,7 +270,7 @@ extension AppState {
     }
 
     func restartScript(_ script: RunScript, in worktree: Worktree) {
-        let launchKey = "\(worktree.id):\(script.key)"
+        let launchKey = PendingRunScriptLaunchKey(worktreeID: worktree.id, scriptKey: script.key)
         if pendingScriptLaunches[launchKey] != nil {
             stopScript(script, in: worktree)
             launchScript(script, in: worktree)
@@ -287,7 +287,7 @@ extension AppState {
     /// is marked stopped *before* the close so the monitor-cancellation path
     /// can't relabel a deliberate stop as a lost process.
     func stopScript(_ script: RunScript, in worktree: Worktree) {
-        let launchKey = "\(worktree.id):\(script.key)"
+        let launchKey = PendingRunScriptLaunchKey(worktreeID: worktree.id, scriptKey: script.key)
         if let pending = pendingScriptLaunches.removeValue(forKey: launchKey) {
             runRecords.markStopped(worktreeID: worktree.id, scriptKey: script.key, at: Date())
             pendingScriptLaunchTasks.removeValue(forKey: pending.id)?.cancel()
@@ -375,7 +375,7 @@ extension AppState {
         // that (double-click, repeated Enter) would both see "not running"
         // and both launch. Close that window with a synchronous in-flight
         // guard instead.
-        let launchKey = "\(worktree.id):\(script.key)"
+        let launchKey = PendingRunScriptLaunchKey(worktreeID: worktree.id, scriptKey: script.key)
         guard pendingScriptLaunches[launchKey] == nil else { return }
 
         // Global scripts live in local Application Support and are read by
@@ -701,7 +701,7 @@ extension AppState {
 
     func cancelPendingRunScriptLaunches(worktreeID: String? = nil) {
         let now = Date()
-        let pendingKeys = pendingScriptLaunches.compactMap { key, pending -> String? in
+        let pendingKeys = pendingScriptLaunches.compactMap { key, pending -> PendingRunScriptLaunchKey? in
             guard let worktreeID else { return key }
             return pending.worktreeID == worktreeID ? key : nil
         }

--- a/Alas/Sources/App/AppState+RunScripts.swift
+++ b/Alas/Sources/App/AppState+RunScripts.swift
@@ -699,9 +699,9 @@ extension AppState {
 
     func cancelPendingRunScriptLaunches(worktreeID: String? = nil) {
         let now = Date()
-        let pendingKeys = pendingScriptLaunches.keys.filter { key in
-            guard let worktreeID else { return true }
-            return key.hasPrefix("\(worktreeID):")
+        let pendingKeys = pendingScriptLaunches.compactMap { key, pending -> String? in
+            guard let worktreeID else { return key }
+            return pending.worktreeID == worktreeID ? key : nil
         }
         for key in pendingKeys {
             guard let pending = pendingScriptLaunches.removeValue(forKey: key) else { continue }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -5413,6 +5413,7 @@ final class AppState {
     }
 
     private func terminateAllTerminalSessionsAfterConfirmation(snapshot: TerminalTerminationSnapshot) {
+        cancelPendingRunScriptLaunches()
         for (worktreeId, tabId) in snapshot.terminalTabs {
             closeTab(worktreeId: worktreeId, tabId: tabId)
         }
@@ -6677,7 +6678,11 @@ final class AppState {
     /// touching git or persistence. Shared between Close-All, archive, and
     /// delete so the bookkeeping stays in one place.
     private func cleanupWorktreeState(worktreeId: String, purgeRunScriptFailures: Bool = true) {
-        cleanupRunScriptState(worktreeID: worktreeId, purgeFailures: purgeRunScriptFailures)
+        if purgeRunScriptFailures {
+            cleanupRunScriptState(worktreeID: worktreeId, purgeFailures: true)
+        } else {
+            cancelPendingRunScriptLaunches(worktreeID: worktreeId)
+        }
         closedTabHistory.purge(worktreeID: worktreeId)
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = tabs.closeAll(worktreeId: worktreeId)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -71,6 +71,10 @@ final class AppState {
     var projectsManager: ProjectsManager
     private(set) var closedTabHistory = ClosedTabHistory()
     var runScriptFailureQueue = RunScriptFailureQueue()
+    /// Observed command lifecycles, keyed by worktree then script. Deliberately
+    /// separate from `tabs`: a run's outcome outlives its terminal shell, and a
+    /// live shell never implies a live command.
+    var runRecords = RunRecordStore()
     var selectedRunScriptFailure: RunScriptFailure?
     @ObservationIgnored var runScriptCompletionTasks: [String: (worktreeID: String, sessionID: String, location: RunScriptCaptureLocation, task: Task<Void, Never>)] = [:]
     @ObservationIgnored let runScriptCompletionWaiter: RunScriptCompletionWaiter

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -167,7 +167,7 @@ final class AppState {
     /// rapid invocations (double-click, repeated Enter) would both see no
     /// registered tab yet and both launch — see `AppState+RunScripts.swift`.
     @ObservationIgnored
-    var pendingScriptLaunches: Set<String> = []
+    var pendingScriptLaunches: [String: Task<Void, Never>] = [:]
     let rightPaneStore = RightPaneStore()
     let harness = HarnessService()
     let mcpRegistrationRegistry = MCPRegistrationRegistry()

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4989,7 +4989,9 @@ final class AppState {
         guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
             throw NSError(domain: "AppState", code: 2)
         }
+        try Task.checkCancellation()
         await prepareRemoteAccelerationIfNeeded(for: project)
+        try Task.checkCancellation()
         return try openTerminalTab(
             for: worktree,
             startupScriptSuffix: startupScriptSuffix,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -167,7 +167,9 @@ final class AppState {
     /// rapid invocations (double-click, repeated Enter) would both see no
     /// registered tab yet and both launch — see `AppState+RunScripts.swift`.
     @ObservationIgnored
-    var pendingScriptLaunches: [String: Task<Void, Never>] = [:]
+    var pendingScriptLaunches: [String: UUID] = [:]
+    @ObservationIgnored
+    var pendingScriptLaunchTasks: [UUID: Task<Void, Never>] = [:]
     let rightPaneStore = RightPaneStore()
     let harness = HarnessService()
     let mcpRegistrationRegistry = MCPRegistrationRegistry()

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -59,6 +59,11 @@ struct PendingRunScriptLaunch: Equatable {
     let scriptKey: String
 }
 
+struct PendingRunScriptLaunchKey: Hashable {
+    let worktreeID: String
+    let scriptKey: String
+}
+
 @Observable
 @MainActor
 final class AppState {
@@ -167,15 +172,15 @@ final class AppState {
     @ObservationIgnored
     private var remoteAccelerationTasks: [String: Task<Void, Never>] = [:]
     private let remoteAccelerationProbeRetryDelay: TimeInterval = 30
-    /// Keys of in-flight run-script launches (`"<worktreeId>:<scriptKey>"`).
+    /// Keys of in-flight run-script launches.
     /// `RunScript.launchScript` inserts synchronously before starting its
     /// async `Task` and removes on completion, closing the window where two
     /// rapid invocations (double-click, repeated Enter) would both see no
     /// registered tab yet and both launch — see `AppState+RunScripts.swift`.
-    /// The value carries structured identity because worktree ids can contain
-    /// `:`, so cancellation must not recover identities by splitting the key.
+    /// Worktree ids and script keys can contain `:`, so the dictionary key
+    /// must remain structured rather than serialized.
     @ObservationIgnored
-    var pendingScriptLaunches: [String: PendingRunScriptLaunch] = [:]
+    var pendingScriptLaunches: [PendingRunScriptLaunchKey: PendingRunScriptLaunch] = [:]
     @ObservationIgnored
     var pendingScriptLaunchTasks: [UUID: Task<Void, Never>] = [:]
     var runScriptCatalogGeneration = 0

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -53,6 +53,12 @@ enum WorkspaceDefinitionSaveError: LocalizedError {
     }
 }
 
+struct PendingRunScriptLaunch: Equatable {
+    let id: UUID
+    let worktreeID: String
+    let scriptKey: String
+}
+
 @Observable
 @MainActor
 final class AppState {
@@ -166,10 +172,13 @@ final class AppState {
     /// async `Task` and removes on completion, closing the window where two
     /// rapid invocations (double-click, repeated Enter) would both see no
     /// registered tab yet and both launch — see `AppState+RunScripts.swift`.
+    /// The value carries structured identity because worktree ids can contain
+    /// `:`, so cancellation must not recover identities by splitting the key.
     @ObservationIgnored
-    var pendingScriptLaunches: [String: UUID] = [:]
+    var pendingScriptLaunches: [String: PendingRunScriptLaunch] = [:]
     @ObservationIgnored
     var pendingScriptLaunchTasks: [UUID: Task<Void, Never>] = [:]
+    var runScriptCatalogGeneration = 0
     let rightPaneStore = RightPaneStore()
     let harness = HarnessService()
     let mcpRegistrationRegistry = MCPRegistrationRegistry()

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6677,9 +6677,7 @@ final class AppState {
     /// touching git or persistence. Shared between Close-All, archive, and
     /// delete so the bookkeeping stays in one place.
     private func cleanupWorktreeState(worktreeId: String, purgeRunScriptFailures: Bool = true) {
-        if purgeRunScriptFailures {
-            cleanupRunScriptState(worktreeID: worktreeId, purgeFailures: true)
-        }
+        cleanupRunScriptState(worktreeID: worktreeId, purgeFailures: purgeRunScriptFailures)
         closedTabHistory.purge(worktreeID: worktreeId)
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = tabs.closeAll(worktreeId: worktreeId)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -5375,6 +5375,15 @@ final class AppState {
     func terminateAllTerminalSessionsAfterConfirmationForTesting() {
         terminateAllTerminalSessionsAfterConfirmation(snapshot: terminalTerminationSnapshot())
     }
+
+    func terminateAllTerminalSessionsAfterConfirmationWithStaleEmptySnapshotForTesting() {
+        terminateAllTerminalSessionsAfterConfirmation(snapshot: TerminalTerminationSnapshot(
+            terminalTabs: [],
+            checkoutTerminalTabs: [],
+            persistedSessions: [],
+            sessionCount: 0
+        ))
+    }
 #endif
 
     private struct TerminalTerminationSnapshot {
@@ -5422,11 +5431,21 @@ final class AppState {
     }
 
     private func terminateAllTerminalSessionsAfterConfirmation(snapshot: TerminalTerminationSnapshot) {
+        let confirmedSnapshot = terminalTerminationSnapshot()
         cancelPendingRunScriptLaunches()
-        for (worktreeId, tabId) in snapshot.terminalTabs {
+        var seenTerminalTabs = Set<String>()
+        let terminalTabs = (snapshot.terminalTabs + confirmedSnapshot.terminalTabs).filter {
+            seenTerminalTabs.insert("\($0.worktreeId):\($0.tabId)").inserted
+        }
+        var seenCheckoutTerminalTabs = Set<String>()
+        let checkoutTerminalTabs = (snapshot.checkoutTerminalTabs + confirmedSnapshot.checkoutTerminalTabs).filter {
+            seenCheckoutTerminalTabs.insert("\($0.owner.storageKey):\($0.tabId)").inserted
+        }
+        let persistedSessions = Array(Set(snapshot.persistedSessions).union(confirmedSnapshot.persistedSessions))
+        for (worktreeId, tabId) in terminalTabs {
             closeTab(worktreeId: worktreeId, tabId: tabId)
         }
-        for (owner, tabId) in snapshot.checkoutTerminalTabs {
+        for (owner, tabId) in checkoutTerminalTabs {
             closeSharedSessionTab(owner: owner, tabID: tabId)
         }
         // Also kill persisted leaves whose tab the user never displayed
@@ -5434,7 +5453,7 @@ final class AppState {
         // own those persisted leaves too. Scoped to OUR instance's known
         // leaves so we don't trample sessions owned by a concurrently-
         // running Alas process under the same ZMX_DIR.
-        terminal.terminateAll(additionalSessions: snapshot.persistedSessions)
+        terminal.terminateAll(additionalSessions: persistedSessions)
     }
 
     /// All terminal sessions persisted under this Alas instance's projects.

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -44,6 +44,9 @@ struct AppConfig: Codable, Equatable {
     /// Preview gate for persistent multi-repository Workspaces. This remains
     /// off until the feature has completed its preview acceptance matrix.
     var workspacesEnabled: Bool = false
+    /// Preview gate for the worktree Run tab. This remains off until the
+    /// command lifecycle UI has completed preview testing.
+    var runTabEnabled: Bool = false
     var recentProjectIds: [String] = []
     var recentWorktreeIdsByProject: [String: [String]] = [:]
     var recentWorktreeRefs: [RepoSelectorRecents.RecentWorktreeRef] = []
@@ -500,6 +503,7 @@ struct AppConfig: Codable, Equatable {
         ),
         files: Files(showIgnored: true),
         workspacesEnabled: false,
+        runTabEnabled: false,
         recentProjectIds: [],
         recentWorktreeIdsByProject: [:],
         recentWorktreeRefs: [],
@@ -592,6 +596,7 @@ extension AppConfig {
              files,
              remote,
              workspacesEnabled,
+             runTabEnabled,
              recentProjectIds, recentWorktreeIdsByProject, recentWorktreeRefs,
              collapsedProjectIds,
              sidebarChromeOverrides,
@@ -827,6 +832,9 @@ extension AppConfig {
         // Workspace preview is opt-in. Configs written before the preview
         // must continue to load with the feature disabled.
         workspacesEnabled = (try? c.decode(Bool.self, forKey: .workspacesEnabled)) ?? false
+        // The Run tab preview is opt-in. Configs written before it existed
+        // continue to load without exposing unfinished command controls.
+        runTabEnabled = (try? c.decode(Bool.self, forKey: .runTabEnabled)) ?? false
         recentProjectIds = (try? c.decode([String].self, forKey: .recentProjectIds)) ?? []
         recentWorktreeIdsByProject =
             (try? c.decode([String: [String]].self, forKey: .recentWorktreeIdsByProject)) ?? [:]

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -3,7 +3,17 @@ import Foundation
 import Observation
 import os
 
-enum RightPaneTab: String { case changes, files }
+enum RightPaneTab: String {
+    case changes, files, run
+
+    static func available(runTabEnabled: Bool) -> [Self] {
+        runTabEnabled ? [.changes, .files, .run] : [.changes, .files]
+    }
+
+    static func visible(_ tab: Self, runTabEnabled: Bool) -> Self {
+        tab == .run && !runTabEnabled ? .changes : tab
+    }
+}
 
 enum GGStackLoadState: Equatable {
     case inactive
@@ -975,7 +985,9 @@ final class RightPaneState: GGSplitCommitServicing {
             // ahead commits should stay on Changes so the Commits section
             // is visible. Applied exactly once; user toggles win thereafter.
             if !didInitDefaultTab {
-                if entries.isEmpty && commits.isEmpty && !tree.isEmpty {
+                // The tab bar is live before this first refresh lands, so only
+                // claim the default when the user hasn't already picked a tab.
+                if activeTab == .changes, entries.isEmpty, commits.isEmpty, !tree.isEmpty {
                     activeTab = .files
                 }
                 didInitDefaultTab = true

--- a/Alas/Sources/Right/RightPaneTabBar.swift
+++ b/Alas/Sources/Right/RightPaneTabBar.swift
@@ -8,28 +8,22 @@ struct RightPaneTabBar: View {
     let onHidePane: () -> Void
     let showIgnored: Bool
     let onToggleShowIgnored: () -> Void
+    var showRunTab: Bool = false
+    /// Number of commands currently starting or running in this worktree.
+    var activeRunCount: Int = 0
 
     @Environment(\.theme) private var theme
 
     var body: some View {
         HStack(spacing: 8) {
-            HStack(spacing: 2) {
-                segment(.changes, icon: "diff", label: "Changes", count: changesCount)
-                segment(.files,   icon: "folder", label: "Files",  count: nil)
-                    .contextMenu {
-                        Toggle("Show ignored or excluded files", isOn: Binding(
-                            get: { showIgnored },
-                            set: { _ in onToggleShowIgnored() }
-                        ))
-                    }
+            // Three segments no longer fit beside the summary and hide button
+            // at the pane's 240pt minimum, so fall back to icon-only rather
+            // than truncating every label to an ellipsis.
+            ViewThatFits(in: .horizontal) {
+                segments(compact: false)
+                segments(compact: true)
             }
-            .padding(2)
-            .background(theme.color("seg-container-bg"))
-            .overlay(
-                RoundedRectangle(cornerRadius: 6)
-                    .strokeBorder(theme.color("line"), lineWidth: 0.5)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .fixedSize()
 
             Spacer(minLength: 8)
             trailing
@@ -40,16 +34,53 @@ struct RightPaneTabBar: View {
         .windowDragHandle()
     }
 
-    private func segment(_ tab: RightPaneTab, icon: String, label: String, count: Int?) -> some View {
+    private func segments(compact: Bool) -> some View {
+        HStack(spacing: 2) {
+            segment(.changes, icon: "diff", label: "Changes", count: changesCount, compact: compact)
+            segment(.files, icon: "folder", label: "Files", count: nil, compact: compact)
+                .contextMenu {
+                    Toggle("Show ignored or excluded files", isOn: Binding(
+                        get: { showIgnored },
+                        set: { _ in onToggleShowIgnored() }
+                    ))
+                }
+            if RightPaneTab.available(runTabEnabled: showRunTab).contains(.run) {
+                segment(
+                    .run,
+                    icon: "play",
+                    label: "Run",
+                    count: activeRunCount > 0 ? activeRunCount : nil,
+                    compact: compact
+                )
+            }
+        }
+        .padding(2)
+        .background(theme.color("seg-container-bg"))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(theme.color("line"), lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func segment(
+        _ tab: RightPaneTab,
+        icon: String,
+        label: String,
+        count: Int?,
+        compact: Bool = false
+    ) -> some View {
         let isOn = activeTab == tab
         return Button {
             activeTab = tab
         } label: {
             HStack(spacing: 5) {
                 Icon(name: icon, size: 11, color: isOn ? theme.color("fg") : theme.color("fg-muted"))
-                Text(label)
-                    .font(.system(size: 11.5, weight: isOn ? .semibold : .medium))
-                    .foregroundColor(isOn ? theme.color("fg") : theme.color("fg-muted"))
+                if !compact {
+                    Text(label)
+                        .font(.system(size: 11.5, weight: isOn ? .semibold : .medium))
+                        .foregroundColor(isOn ? theme.color("fg") : theme.color("fg-muted"))
+                }
                 if let count {
                     Text("\(count)")
                         .font(.system(size: 10, weight: .semibold))
@@ -78,6 +109,8 @@ struct RightPaneTabBar: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .help(label)
+        .accessibilityLabel(label)
     }
 
     @ViewBuilder
@@ -92,7 +125,7 @@ struct RightPaneTabBar: View {
                 .font(.system(size: 11, design: .monospaced))
                 .padding(.trailing, 4)
             }
-        case .files:
+        case .files, .run:
             EmptyView()
         }
     }

--- a/Alas/Sources/Right/RightPaneTabBar.swift
+++ b/Alas/Sources/Right/RightPaneTabBar.swift
@@ -23,7 +23,6 @@ struct RightPaneTabBar: View {
                 segments(compact: false)
                 segments(compact: true)
             }
-            .fixedSize()
 
             Spacer(minLength: 8)
             trailing

--- a/Alas/Sources/Right/RightPaneTransitionalView.swift
+++ b/Alas/Sources/Right/RightPaneTransitionalView.swift
@@ -100,7 +100,7 @@ struct RightPaneLoadingSkeletonView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
-        case .files:
+        case .files, .run:
             VStack(alignment: .leading, spacing: 6) {
                 SkeletonRow(widthFraction: 0.6,  leadingInset: 0)
                 SkeletonRow(widthFraction: 0.5,  leadingInset: 16)

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -30,7 +30,12 @@ struct RightPaneView: View {
         // Resolve without activating: the cached state (if any) gives us
         // something to render immediately, and `.task` handles the mutating
         // activation + refresh off the view-update path.
-        _rps = State(initialValue: state.rightPaneStore.activeState(worktreeId: worktree.id))
+        let initialState = state.rightPaneStore.activeState(worktreeId: worktree.id)
+        initialState?.activeTab = RightPaneTab.visible(
+            initialState?.activeTab ?? .changes,
+            runTabEnabled: state.config.runTabEnabled
+        )
+        _rps = State(initialValue: initialState)
     }
 
     var body: some View {

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -58,7 +58,11 @@ struct RightPaneView: View {
                         onToggleShowIgnored: {
                             state.config.files.showIgnored.toggle()
                             state.saveConfig()
-                        }
+                        },
+                        showRunTab: state.config.runTabEnabled,
+                        activeRunCount: state.runRecords
+                            .records(worktreeID: worktree.id)
+                            .count { $0.status.isActive }
                     )
 
                     if rps.hasLoadedSnapshot {
@@ -105,12 +109,20 @@ struct RightPaneView: View {
                                 onClearReveal: { rps.clearReveal() },
                                 worktreeRoot: rps.worktree.path
                             )
+                        case .run:
+                            RunTabView(state: state, worktree: worktree)
                         }
                     } else {
                         RightPaneLoadingSkeletonView(activeTab: rps.activeTab)
                     }
                 }
                 .sidebarChromeTheme(textContrast: override.textContrast)
+                .onChange(of: state.config.runTabEnabled) {
+                    rps.activeTab = RightPaneTab.visible(
+                        rps.activeTab,
+                        runTabEnabled: state.config.runTabEnabled
+                    )
+                }
                 // Host the discard confirmation here (not on ChangesTabView) so
                 // diff-tab Discard actions still present the alert when the right
                 // pane is on the Files tab — `requestDiscardFile` sets pending state

--- a/Alas/Sources/Right/RunTabPresentation.swift
+++ b/Alas/Sources/Right/RunTabPresentation.swift
@@ -1,0 +1,201 @@
+import Foundation
+
+enum RunStatusTone: Equatable {
+    case idle
+    case active
+    case success
+    case failure
+    case warning
+}
+
+/// One button offered by a Run row. Modelled as data so the rules about which
+/// actions a state allows are testable without touching SwiftUI.
+enum RunRowAction: Equatable {
+    /// "Run" the first time, "Rerun" once the script has an outcome.
+    case start(label: String)
+    case stop
+    case restart
+    case openTerminal
+    case openEndpoint(URL)
+    case showOutput(failureID: String)
+    case edit
+}
+
+struct RunRowInput {
+    let script: RunScript
+    let record: RunRecord?
+    /// A live terminal tab for this script exists in this worktree. An open
+    /// shell is not evidence the command is still running — it only decides
+    /// whether "jump to terminal" has anywhere to go.
+    let hasTerminal: Bool
+    let target: RunExecutionTarget
+}
+
+struct RunRowPresentation: Equatable, Identifiable {
+    let id: String
+    let name: String
+    let scope: RunScriptScope
+    let statusLabel: String
+    let tone: RunStatusTone
+    let isActive: Bool
+    /// "exit 42 · 12s · 3m ago". Nil until the script has been run.
+    let detail: String?
+    /// Compact execution context, nil when it's the plain local worktree root.
+    let locationLabel: String?
+    /// Always-complete host and working directory, for the row's tooltip.
+    let locationDetail: String
+    let conflictLabel: String?
+    let actions: [RunRowAction]
+}
+
+enum RunTabPresentation {
+    static func rows(_ inputs: [RunRowInput], now: Date) -> [RunRowPresentation] {
+        inputs.map { row($0, now: now) }
+    }
+
+    static func row(_ input: RunRowInput, now: Date) -> RunRowPresentation {
+        let status = input.record?.status ?? .notRun
+        return RunRowPresentation(
+            id: input.script.key,
+            name: input.script.displayName,
+            scope: input.script.scope,
+            statusLabel: statusLabel(status),
+            tone: tone(status),
+            isActive: status.isActive,
+            detail: detail(record: input.record, now: now),
+            locationLabel: locationLabel(script: input.script, target: input.target),
+            locationDetail: locationDetail(target: input.target),
+            conflictLabel: input.record?.portConflict.map(conflictLabel),
+            actions: actions(input: input, status: status)
+        )
+    }
+
+    // MARK: - Status
+
+    static func statusLabel(_ status: RunStatus) -> String {
+        switch status {
+        case .notRun:                     "Not run"
+        case .starting:                   "Starting"
+        case .running:                    "Running"
+        case .finished(.succeeded):       "Succeeded"
+        case .finished(.failed):          "Failed"
+        case .finished(.stopped):         "Stopped"
+        case .finished(.unknown):         "Unknown"
+        }
+    }
+
+    static func tone(_ status: RunStatus) -> RunStatusTone {
+        switch status {
+        case .notRun:                     .idle
+        case .starting, .running:         .active
+        case .finished(.succeeded):       .success
+        case .finished(.failed):          .failure
+        case .finished(.stopped):         .warning
+        case .finished(.unknown):         .warning
+        }
+    }
+
+    // MARK: - Detail
+
+    private static func detail(record: RunRecord?, now: Date) -> String? {
+        guard let record else { return nil }
+        switch record.status {
+        case .notRun:
+            return nil
+        case .starting:
+            return "Launching terminal"
+        case .running:
+            return "Started \(relative(from: record.startedAt, to: now))"
+        case .finished(let outcome):
+            var parts: [String] = []
+            switch outcome {
+            case .succeeded:
+                break
+            case .failed(let exitCode):
+                parts.append("exit \(exitCode)")
+            case .stopped:
+                parts.append("stopped before it finished")
+            case .unknown:
+                // Never claim an outcome we did not observe.
+                parts.append("no exit status observed")
+            }
+            if let duration = record.duration {
+                parts.append(format(duration: duration))
+            }
+            if let finishedAt = record.finishedAt {
+                parts.append(relative(from: finishedAt, to: now))
+            }
+            return parts.isEmpty ? nil : parts.joined(separator: " · ")
+        }
+    }
+
+    static func format(duration: TimeInterval) -> String {
+        let total = Int(duration.rounded())
+        guard total >= 60 else { return "\(max(0, total))s" }
+        let minutes = total / 60
+        guard minutes >= 60 else { return "\(minutes)m \(total % 60)s" }
+        return "\(minutes / 60)h \(minutes % 60)m"
+    }
+
+    static func relative(from date: Date, to now: Date) -> String {
+        let seconds = Int(now.timeIntervalSince(date).rounded())
+        guard seconds >= 60 else { return "just now" }
+        let minutes = seconds / 60
+        guard minutes >= 60 else { return "\(minutes)m ago" }
+        let hours = minutes / 60
+        guard hours >= 24 else { return "\(hours)h ago" }
+        return "\(hours / 24)d ago"
+    }
+
+    // MARK: - Location
+
+    private static func locationLabel(script: RunScript, target: RunExecutionTarget) -> String? {
+        let cwd = script.cwd?.trimmingCharacters(in: .whitespaces)
+        let subdirectory = (cwd?.isEmpty == false && cwd != ".") ? cwd : nil
+        switch (target.host, subdirectory) {
+        case (nil, nil):                       return nil
+        case (nil, let subdirectory?):         return subdirectory
+        case (let host?, nil):                 return host
+        case (let host?, let subdirectory?):   return "\(host) · \(subdirectory)"
+        }
+    }
+
+    private static func locationDetail(target: RunExecutionTarget) -> String {
+        "\(target.hostLabel) · \(target.workingDirectory)"
+    }
+
+    static func conflictLabel(_ conflict: RunPortConflict) -> String {
+        switch conflict {
+        case let .ownedByRun(_, branch, scriptName):
+            return "Port already served by \(scriptName) on \(branch)"
+        case .externalProcess:
+            return "Port already in use by another process"
+        }
+    }
+
+    // MARK: - Actions
+
+    private static func actions(input: RunRowInput, status: RunStatus) -> [RunRowAction] {
+        var actions: [RunRowAction] = []
+        if status.isActive {
+            actions.append(.stop)
+            actions.append(.restart)
+            // The endpoint only appears once the command is actually up;
+            // offering it mid-launch would just hand the user a dead link.
+            if status == .running, let endpoint = input.script.endpoint {
+                actions.append(.openEndpoint(endpoint))
+            }
+        } else {
+            let hasOutcome = if case .finished = status { true } else { false }
+            actions.append(.start(label: hasOutcome ? "Rerun" : "Run"))
+            if let failureID = input.record?.failureID {
+                actions.append(.showOutput(failureID: failureID))
+            }
+        }
+        if input.hasTerminal {
+            actions.append(.openTerminal)
+        }
+        actions.append(.edit)
+        return actions
+    }
+}

--- a/Alas/Sources/Right/RunTabPresentation.swift
+++ b/Alas/Sources/Right/RunTabPresentation.swift
@@ -28,6 +28,8 @@ struct RunRowInput {
     /// shell is not evidence the command is still running — it only decides
     /// whether "jump to terminal" has anywhere to go.
     let hasTerminal: Bool
+    /// Whether the record's captured failure is still retained and can be opened.
+    let hasCapturedOutput: Bool
     let target: RunExecutionTarget
 }
 
@@ -188,7 +190,7 @@ enum RunTabPresentation {
         } else {
             let hasOutcome = if case .finished = status { true } else { false }
             actions.append(.start(label: hasOutcome ? "Rerun" : "Run"))
-            if let failureID = input.record?.failureID {
+            if input.hasCapturedOutput, let failureID = input.record?.failureID {
                 actions.append(.showOutput(failureID: failureID))
             }
         }

--- a/Alas/Sources/Right/RunTabView.swift
+++ b/Alas/Sources/Right/RunTabView.swift
@@ -1,0 +1,275 @@
+import SwiftUI
+
+/// Commands, their observed state, and their endpoints for one worktree.
+///
+/// Scripts are rescanned on appear (the palette does the same — the directory
+/// holds a handful of small files), while run state comes from
+/// `AppState.runRecords`, which outlives this view. Hiding or switching the
+/// panel therefore never touches a running command.
+struct RunTabView: View {
+    @Bindable var state: AppState
+    let worktree: Worktree
+
+    @Environment(\.theme) private var theme
+    @State private var scripts: [RunScript] = []
+    /// Keeps the "no scripts yet" copy from flashing before the first scan.
+    @State private var hasScanned = false
+    /// Drives the relative timestamps ("3m ago") without re-scanning anything.
+    @State private var now = Date()
+    /// Held in `@State` so `onReceive` keeps one stable subscription instead
+    /// of restarting the interval on every body pass.
+    @State private var ticker = Timer.publish(every: 15, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        Group {
+            if !hasScanned {
+                Color.clear
+            } else if scripts.isEmpty {
+                emptyState
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(RunScriptScope.allCases, id: \.self) { scope in
+                            let scoped = scripts.filter { $0.scope == scope }
+                            if !scoped.isEmpty {
+                                RunScopeHeader(title: scope.sectionTitle, count: scoped.count)
+                                ForEach(scoped) { script in
+                                    RunRowView(
+                                        presentation: presentation(for: script),
+                                        onAction: { perform($0, script: script) }
+                                    )
+                                }
+                            }
+                        }
+                        newScriptFooter
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .task(id: worktree.id) {
+            scripts = RunScriptStore.scripts(worktreeRoot: worktree.path)
+            hasScanned = true
+            // Reconnecting to a worktree is the moment to settle runs whose
+            // terminal disappeared while nothing was watching them.
+            state.reconcileRunRecords(worktreeID: worktree.id)
+            now = Date()
+        }
+        .onReceive(ticker) { now = $0 }
+    }
+
+    private func presentation(for script: RunScript) -> RunRowPresentation {
+        RunTabPresentation.row(
+            RunRowInput(
+                script: script,
+                record: state.runRecords.record(worktreeID: worktree.id, scriptKey: script.key),
+                hasTerminal: state.runningScriptTab(for: script, in: worktree) != nil,
+                target: state.runExecutionTarget(for: script, in: worktree)
+            ),
+            now: now
+        )
+    }
+
+    private func perform(_ action: RunRowAction, script: RunScript) {
+        switch action {
+        case .start:
+            state.runOrFocusScript(script, in: worktree)
+        case .stop:
+            state.stopScript(script, in: worktree)
+        case .restart:
+            state.restartScript(script, in: worktree)
+        case .openTerminal:
+            state.focusScriptTerminal(script, in: worktree)
+        case .openEndpoint:
+            state.openRunEndpoint(script, in: worktree)
+        case .showOutput(let failureID):
+            guard let failure = state.runScriptFailures(in: worktree.id).first(where: { $0.id == failureID })
+            else { return }
+            state.presentRunScriptFailure(failure)
+        case .edit:
+            state.editScript(script, in: worktree)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Icon(name: "play", size: 22, color: theme.color("fg-faint"))
+            Text("No run scripts yet")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.color("fg-muted"))
+            Text("Add a script to \(RunScriptStore.repoScriptsRelativeDir) to build, test, or serve this worktree.")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-faint"))
+                .multilineTextAlignment(.center)
+            HStack(spacing: 8) {
+                Button("New Repo Script") { state.newRunScript(scope: .repo, in: worktree) }
+                Button("New Global Script") { state.newRunScript(scope: .global, in: worktree) }
+            }
+            .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 20)
+        .accessibilityIdentifier("run-tab-empty-state")
+    }
+
+    private var newScriptFooter: some View {
+        HStack(spacing: 8) {
+            Button("New Repo Script") { state.newRunScript(scope: .repo, in: worktree) }
+            Button("New Global Script") { state.newRunScript(scope: .global, in: worktree) }
+            Spacer(minLength: 0)
+        }
+        .controlSize(.small)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+    }
+}
+
+private struct RunScopeHeader: View {
+    let title: String
+    let count: Int
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(title.uppercased())
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.5)
+                .foregroundColor(theme.color("fg-muted"))
+            Text("\(count)")
+                .font(.system(size: 9.5, weight: .semibold))
+                .padding(.horizontal, 5).padding(.vertical, 1)
+                .background(theme.color("seg-pill-bg"))
+                .clipShape(Capsule())
+                .foregroundColor(theme.color("fg-muted"))
+            Spacer(minLength: 8)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 7)
+        .background(theme.color("section-head-bg"))
+    }
+}
+
+private struct RunRowView: View {
+    let presentation: RunRowPresentation
+    let onAction: (RunRowAction) -> Void
+
+    @Environment(\.theme) private var theme
+    @State private var hovering = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                RunStatusDot(tone: presentation.tone, isActive: presentation.isActive)
+                Text(presentation.name)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                Spacer(minLength: 8)
+                Text(presentation.statusLabel)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(toneColor)
+            }
+
+            if let detail = presentation.detail {
+                Text(detail)
+                    .font(.system(size: 10.5))
+                    .foregroundColor(theme.color("fg-faint"))
+                    .lineLimit(1)
+            }
+
+            if let location = presentation.locationLabel {
+                HStack(spacing: 4) {
+                    Icon(name: "terminal", size: 9, color: theme.color("fg-faint"))
+                    Text(location)
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundColor(theme.color("fg-faint"))
+                        .lineLimit(1)
+                }
+            }
+
+            if let conflict = presentation.conflictLabel {
+                HStack(spacing: 4) {
+                    Icon(name: "exclamationmark.triangle", size: 9, color: theme.color("warn"))
+                    Text(conflict)
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.color("warn"))
+                        .lineLimit(2)
+                }
+            }
+
+            HStack(spacing: 6) {
+                ForEach(Array(presentation.actions.enumerated()), id: \.offset) { _, action in
+                    Button(label(for: action)) { onAction(action) }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 10.5, weight: .medium))
+                        .foregroundColor(theme.color("accent"))
+                        .accessibilityLabel("\(label(for: action)) \(presentation.name)")
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.top, 2)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(hovering ? theme.color("bg-3") : .clear)
+        .overlay(Divider().opacity(0.4), alignment: .bottom)
+        .contentShape(Rectangle())
+        .onHover { hovering = $0 }
+        .help(presentation.locationDetail)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("run-row-\(presentation.id)")
+    }
+
+    private var toneColor: Color {
+        switch presentation.tone {
+        case .idle:    theme.color("fg-faint")
+        case .active:  theme.color("accent")
+        case .success: theme.color("add")
+        case .failure: theme.color("del")
+        case .warning: theme.color("warn")
+        }
+    }
+
+    private func label(for action: RunRowAction) -> String {
+        switch action {
+        case .start(let label): label
+        case .stop:             "Stop"
+        case .restart:          "Restart"
+        case .openTerminal:     "Terminal"
+        case .openEndpoint:     "Open"
+        case .showOutput:       "Output"
+        case .edit:             "Edit"
+        }
+    }
+}
+
+private struct RunStatusDot: View {
+    let tone: RunStatusTone
+    let isActive: Bool
+
+    @Environment(\.theme) private var theme
+    @State private var pulsing = false
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: 7, height: 7)
+            .opacity(isActive && pulsing ? 0.35 : 1)
+            .animation(
+                isActive ? .easeInOut(duration: 0.9).repeatForever(autoreverses: true) : .default,
+                value: pulsing
+            )
+            .onAppear { pulsing = isActive }
+            .onChange(of: isActive) { _, active in pulsing = active }
+            .accessibilityHidden(true)
+    }
+
+    private var color: Color {
+        switch tone {
+        case .idle:    theme.color("fg-faint")
+        case .active:  theme.color("accent")
+        case .success: theme.color("add")
+        case .failure: theme.color("del")
+        case .warning: theme.color("warn")
+        }
+    }
+}

--- a/Alas/Sources/Right/RunTabView.swift
+++ b/Alas/Sources/Right/RunTabView.swift
@@ -72,9 +72,8 @@ struct RunTabView: View {
     }
 
     private var activeOrAllScripts: [RunScript] {
-        guard scriptCatalogError != nil else { return scripts }
         let scriptsByKey = Dictionary(uniqueKeysWithValues: scripts.map { ($0.key, $0) })
-        return state.runRecords.records(worktreeID: worktree.id)
+        let activeScripts = state.runRecords.records(worktreeID: worktree.id)
             .filter(\.status.isActive)
             .compactMap { record in
                 scriptsByKey[record.scriptKey] ?? script(from: record)
@@ -83,6 +82,9 @@ struct RunTabView: View {
                 if $0.scope != $1.scope { return $0.scope.rawValue < $1.scope.rawValue }
                 return $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending
             }
+        guard scriptCatalogError == nil else { return activeScripts }
+        let catalogKeys = Set(scripts.map(\.key))
+        return scripts + activeScripts.filter { !catalogKeys.contains($0.key) }
     }
 
     private func script(from record: RunRecord) -> RunScript? {

--- a/Alas/Sources/Right/RunTabView.swift
+++ b/Alas/Sources/Right/RunTabView.swift
@@ -12,6 +12,7 @@ struct RunTabView: View {
 
     @Environment(\.theme) private var theme
     @State private var scripts: [RunScript] = []
+    @State private var scriptCatalogError: String?
     /// Keeps the "no scripts yet" copy from flashing before the first scan.
     @State private var hasScanned = false
     /// Drives the relative timestamps ("3m ago") without re-scanning anything.
@@ -24,6 +25,8 @@ struct RunTabView: View {
         Group {
             if !hasScanned {
                 Color.clear
+            } else if let scriptCatalogError {
+                errorState(scriptCatalogError)
             } else if scripts.isEmpty {
                 emptyState
             } else {
@@ -119,10 +122,17 @@ struct RunTabView: View {
     @discardableResult
     private func refreshScripts() async -> [RunScript] {
         let host = RemoteHostRegistry.shared.host(forPath: worktree.path.path)
-        let fresh = await RunScriptStore.scripts(worktreeRoot: worktree.path, remoteHost: host)
+        let result = await RunScriptStore.discoverScripts(worktreeRoot: worktree.path, remoteHost: host)
         guard !Task.isCancelled else { return scripts }
-        scripts = fresh
-        return fresh
+        switch result {
+        case .scripts(let fresh):
+            scriptCatalogError = nil
+            scripts = fresh
+            return fresh
+        case .failed(let message):
+            scriptCatalogError = message
+            return scripts
+        }
     }
 
     private func freshScript(matching script: RunScript) async -> RunScript? {
@@ -149,6 +159,29 @@ struct RunTabView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.horizontal, 20)
         .accessibilityIdentifier("run-tab-empty-state")
+    }
+
+    private func errorState(_ message: String) -> some View {
+        VStack(spacing: 10) {
+            Icon(name: "exclamationmark.triangle", size: 22, color: theme.color("warn"))
+            Text("Couldn’t Load Run Scripts")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.color("fg-muted"))
+            Text(message)
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-faint"))
+                .multilineTextAlignment(.center)
+            Button("Retry") {
+                Task {
+                    await refreshScripts()
+                    hasScanned = true
+                }
+            }
+            .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 20)
+        .accessibilityIdentifier("run-tab-error-state")
     }
 
     private var newScriptFooter: some View {

--- a/Alas/Sources/Right/RunTabView.swift
+++ b/Alas/Sources/Right/RunTabView.swift
@@ -64,6 +64,12 @@ struct RunTabView: View {
                 script: script,
                 record: state.runRecords.record(worktreeID: worktree.id, scriptKey: script.key),
                 hasTerminal: state.runningScriptTab(for: script, in: worktree) != nil,
+                hasCapturedOutput: state.runRecords.record(worktreeID: worktree.id, scriptKey: script.key)
+                    .flatMap { record in
+                        record.failureID.map { failureID in
+                            state.runScriptFailures(in: worktree.id).contains { $0.id == failureID }
+                        }
+                    } ?? false,
                 target: state.runExecutionTarget(for: script, in: worktree)
             ),
             now: now
@@ -73,7 +79,11 @@ struct RunTabView: View {
     private func perform(_ action: RunRowAction, script: RunScript) {
         switch action {
         case .start:
-            state.runOrFocusScript(script, in: worktree)
+            if case .finished? = state.runRecords.record(worktreeID: worktree.id, scriptKey: script.key)?.status {
+                state.restartScript(script, in: worktree)
+            } else {
+                state.runOrFocusScript(script, in: worktree)
+            }
         case .stop:
             state.stopScript(script, in: worktree)
         case .restart:

--- a/Alas/Sources/Right/RunTabView.swift
+++ b/Alas/Sources/Right/RunTabView.swift
@@ -56,6 +56,10 @@ struct RunTabView: View {
             now = Date()
         }
         .onReceive(ticker) { now = $0 }
+        .onChange(of: state.runScriptCatalogGeneration) {
+            refreshScripts()
+            hasScanned = true
+        }
     }
 
     private func presentation(for script: RunScript) -> RunRowPresentation {
@@ -81,6 +85,8 @@ struct RunTabView: View {
         switch action {
         case .start:
             if case .finished? = state.runRecords.record(worktreeID: worktree.id, scriptKey: script.key)?.status {
+                state.restartScript(script, in: worktree)
+            } else if state.scriptTab(for: script, in: worktree) != nil {
                 state.restartScript(script, in: worktree)
             } else {
                 state.runOrFocusScript(script, in: worktree)

--- a/Alas/Sources/Right/RunTabView.swift
+++ b/Alas/Sources/Right/RunTabView.swift
@@ -92,9 +92,9 @@ struct RunTabView: View {
     }
 
     private func perform(_ action: RunRowAction, matching staleScript: RunScript) async {
-        let script = await freshScript(matching: staleScript) ?? staleScript
         switch action {
         case .start:
+            let script = await freshScript(matching: staleScript) ?? staleScript
             if case .finished? = state.runRecords.record(worktreeID: worktree.id, scriptKey: script.key)?.status {
                 state.restartScript(script, in: worktree)
             } else if state.scriptTab(for: script, in: worktree) != nil {
@@ -103,19 +103,22 @@ struct RunTabView: View {
                 state.runOrFocusScript(script, in: worktree)
             }
         case .stop:
-            state.stopScript(script, in: worktree)
+            state.stopScript(staleScript, in: worktree)
         case .restart:
+            state.stopScript(staleScript, in: worktree)
+            let script = await freshScript(matching: staleScript) ?? staleScript
             state.restartScript(script, in: worktree)
         case .openTerminal:
-            state.focusScriptTerminal(script, in: worktree)
+            state.focusScriptTerminal(staleScript, in: worktree)
         case .openEndpoint:
+            let script = await freshScript(matching: staleScript) ?? staleScript
             state.openRunEndpoint(script, in: worktree)
         case .showOutput(let failureID):
             guard let failure = state.runScriptFailures(in: worktree.id).first(where: { $0.id == failureID })
             else { return }
             state.presentRunScriptFailure(failure)
         case .edit:
-            state.editScript(script, in: worktree)
+            state.editScript(staleScript, in: worktree)
         }
     }
 

--- a/Alas/Sources/Right/RunTabView.swift
+++ b/Alas/Sources/Right/RunTabView.swift
@@ -48,7 +48,7 @@ struct RunTabView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .task(id: worktree.id) {
-            scripts = RunScriptStore.scripts(worktreeRoot: worktree.path)
+            refreshScripts()
             hasScanned = true
             // Reconnecting to a worktree is the moment to settle runs whose
             // terminal disappeared while nothing was watching them.
@@ -77,6 +77,7 @@ struct RunTabView: View {
     }
 
     private func perform(_ action: RunRowAction, script: RunScript) {
+        let script = freshScript(matching: script) ?? script
         switch action {
         case .start:
             if case .finished? = state.runRecords.record(worktreeID: worktree.id, scriptKey: script.key)?.status {
@@ -99,6 +100,16 @@ struct RunTabView: View {
         case .edit:
             state.editScript(script, in: worktree)
         }
+    }
+
+    private func refreshScripts() {
+        scripts = RunScriptStore.scripts(worktreeRoot: worktree.path)
+    }
+
+    private func freshScript(matching script: RunScript) -> RunScript? {
+        let fresh = RunScriptStore.scripts(worktreeRoot: worktree.path)
+        scripts = fresh
+        return fresh.first { $0.key == script.key }
     }
 
     private var emptyState: some View {

--- a/Alas/Sources/Right/RunTabView.swift
+++ b/Alas/Sources/Right/RunTabView.swift
@@ -94,7 +94,7 @@ struct RunTabView: View {
     private func perform(_ action: RunRowAction, matching staleScript: RunScript) async {
         switch action {
         case .start:
-            let script = await freshScript(matching: staleScript) ?? staleScript
+            guard let script = await freshScript(matching: staleScript) else { return }
             if case .finished? = state.runRecords.record(worktreeID: worktree.id, scriptKey: script.key)?.status {
                 state.restartScript(script, in: worktree)
             } else if state.scriptTab(for: script, in: worktree) != nil {
@@ -107,7 +107,7 @@ struct RunTabView: View {
         case .restart:
             let stoppedRunID = state.runRecords.record(worktreeID: worktree.id, scriptKey: staleScript.key)?.id
             state.stopScript(staleScript, in: worktree)
-            let script = await freshScript(matching: staleScript) ?? staleScript
+            guard let script = await freshScript(matching: staleScript) else { return }
             if let stoppedRunID,
                state.runRecords.record(worktreeID: worktree.id, scriptKey: staleScript.key)?.id != stoppedRunID {
                 return
@@ -116,7 +116,7 @@ struct RunTabView: View {
         case .openTerminal:
             state.focusScriptTerminal(staleScript, in: worktree)
         case .openEndpoint:
-            let script = await freshScript(matching: staleScript) ?? staleScript
+            guard let script = await freshScript(matching: staleScript) else { return }
             state.openRunEndpoint(script, in: worktree)
         case .showOutput(let failureID):
             guard let failure = state.runScriptFailures(in: worktree.id).first(where: { $0.id == failureID })
@@ -128,10 +128,10 @@ struct RunTabView: View {
     }
 
     @discardableResult
-    private func refreshScripts() async -> [RunScript] {
+    private func refreshScripts() async -> [RunScript]? {
         let host = RemoteHostRegistry.shared.host(forPath: worktree.path.path)
         let result = await RunScriptStore.discoverScripts(worktreeRoot: worktree.path, remoteHost: host)
-        guard !Task.isCancelled else { return scripts }
+        guard !Task.isCancelled else { return nil }
         switch result {
         case .scripts(let fresh):
             scriptCatalogError = nil
@@ -139,12 +139,12 @@ struct RunTabView: View {
             return fresh
         case .failed(let message):
             scriptCatalogError = message
-            return scripts
+            return nil
         }
     }
 
     private func freshScript(matching script: RunScript) async -> RunScript? {
-        let fresh = await refreshScripts()
+        guard let fresh = await refreshScripts() else { return nil }
         return fresh.first { $0.key == script.key }
     }
 

--- a/Alas/Sources/Right/RunTabView.swift
+++ b/Alas/Sources/Right/RunTabView.swift
@@ -23,17 +23,21 @@ struct RunTabView: View {
 
     var body: some View {
         Group {
+            let displayedScripts = activeOrAllScripts
             if !hasScanned {
                 Color.clear
-            } else if let scriptCatalogError {
+            } else if displayedScripts.isEmpty, let scriptCatalogError {
                 errorState(scriptCatalogError)
-            } else if scripts.isEmpty {
+            } else if displayedScripts.isEmpty {
                 emptyState
             } else {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
+                        if let scriptCatalogError {
+                            catalogErrorBanner(scriptCatalogError)
+                        }
                         ForEach(RunScriptScope.allCases, id: \.self) { scope in
-                            let scoped = scripts.filter { $0.scope == scope }
+                            let scoped = displayedScripts.filter { $0.scope == scope }
                             if !scoped.isEmpty {
                                 RunScopeHeader(title: scope.sectionTitle, count: scoped.count)
                                 ForEach(scoped) { script in
@@ -64,6 +68,13 @@ struct RunTabView: View {
                 await refreshScripts()
                 hasScanned = true
             }
+        }
+    }
+
+    private var activeOrAllScripts: [RunScript] {
+        guard scriptCatalogError != nil else { return scripts }
+        return scripts.filter { script in
+            state.runRecords.record(worktreeID: worktree.id, scriptKey: script.key)?.status.isActive == true
         }
     }
 
@@ -167,6 +178,38 @@ struct RunTabView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.horizontal, 20)
         .accessibilityIdentifier("run-tab-empty-state")
+    }
+
+    private func catalogErrorBanner(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Icon(name: "exclamationmark.triangle", size: 13, color: theme.color("warn"))
+                .padding(.top, 1)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Couldn’t refresh run scripts")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(theme.color("fg-muted"))
+                Text(message)
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.color("fg-faint"))
+                    .lineLimit(2)
+            }
+            Spacer(minLength: 8)
+            Button("Retry") {
+                Task {
+                    await refreshScripts()
+                    hasScanned = true
+                }
+            }
+            .controlSize(.small)
+        }
+        .padding(10)
+        .background(theme.color("warn").opacity(0.10), in: RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(theme.color("warn").opacity(0.25), lineWidth: 1)
+        )
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
     }
 
     private func errorState(_ message: String) -> some View {

--- a/Alas/Sources/Right/RunTabView.swift
+++ b/Alas/Sources/Right/RunTabView.swift
@@ -73,24 +73,56 @@ struct RunTabView: View {
 
     private var activeOrAllScripts: [RunScript] {
         guard scriptCatalogError != nil else { return scripts }
-        return scripts.filter { script in
-            state.runRecords.record(worktreeID: worktree.id, scriptKey: script.key)?.status.isActive == true
+        let scriptsByKey = Dictionary(uniqueKeysWithValues: scripts.map { ($0.key, $0) })
+        return state.runRecords.records(worktreeID: worktree.id)
+            .filter(\.status.isActive)
+            .compactMap { record in
+                scriptsByKey[record.scriptKey] ?? script(from: record)
+            }
+            .sorted {
+                if $0.scope != $1.scope { return $0.scope.rawValue < $1.scope.rawValue }
+                return $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending
+            }
+    }
+
+    private func script(from record: RunRecord) -> RunScript? {
+        let parts = record.scriptKey.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              let scope = RunScriptScope(rawValue: String(parts[0]))
+        else { return nil }
+        let fileName = String(parts[1])
+        let fileURL = switch scope {
+        case .repo:
+            RunScriptStore.repoScriptsDir(worktreeRoot: worktree.path).appendingPathComponent(fileName)
+        case .global:
+            Paths.runScriptsGlobalDir.appendingPathComponent(fileName)
         }
+        return RunScript(
+            scope: scope,
+            fileName: fileName,
+            fileURL: fileURL,
+            displayName: record.scriptName,
+            onExit: .keep,
+            cwd: nil,
+            isExecutable: false,
+            endpoint: record.endpoint
+        )
     }
 
     private func presentation(for script: RunScript) -> RunRowPresentation {
-        RunTabPresentation.row(
+        let record = state.runRecords.record(worktreeID: worktree.id, scriptKey: script.key)
+        return RunTabPresentation.row(
             RunRowInput(
                 script: script,
-                record: state.runRecords.record(worktreeID: worktree.id, scriptKey: script.key),
+                record: record,
                 hasTerminal: state.runningScriptTab(for: script, in: worktree) != nil,
-                hasCapturedOutput: state.runRecords.record(worktreeID: worktree.id, scriptKey: script.key)
-                    .flatMap { record in
-                        record.failureID.map { failureID in
+                hasCapturedOutput: record
+                    .flatMap { current in
+                        current.failureID.map { failureID in
                             state.runScriptFailures(in: worktree.id).contains { $0.id == failureID }
                         }
                     } ?? false,
-                target: state.runExecutionTarget(for: script, in: worktree)
+                target: record?.target ?? state.runExecutionTarget(for: script, in: worktree)
             ),
             now: now
         )
@@ -105,7 +137,11 @@ struct RunTabView: View {
     private func perform(_ action: RunRowAction, matching staleScript: RunScript) async {
         switch action {
         case .start:
+            let preRefreshRunID = state.runRecords.record(worktreeID: worktree.id, scriptKey: staleScript.key)?.id
             guard let script = await freshScript(matching: staleScript) else { return }
+            guard state.runRecords.record(worktreeID: worktree.id, scriptKey: staleScript.key)?.id == preRefreshRunID else {
+                return
+            }
             if case .finished? = state.runRecords.record(worktreeID: worktree.id, scriptKey: script.key)?.status {
                 state.restartScript(script, in: worktree)
             } else if state.scriptTab(for: script, in: worktree) != nil {

--- a/Alas/Sources/Right/RunTabView.swift
+++ b/Alas/Sources/Right/RunTabView.swift
@@ -105,8 +105,13 @@ struct RunTabView: View {
         case .stop:
             state.stopScript(staleScript, in: worktree)
         case .restart:
+            let stoppedRunID = state.runRecords.record(worktreeID: worktree.id, scriptKey: staleScript.key)?.id
             state.stopScript(staleScript, in: worktree)
             let script = await freshScript(matching: staleScript) ?? staleScript
+            if let stoppedRunID,
+               state.runRecords.record(worktreeID: worktree.id, scriptKey: staleScript.key)?.id != stoppedRunID {
+                return
+            }
             state.restartScript(script, in: worktree)
         case .openTerminal:
             state.focusScriptTerminal(staleScript, in: worktree)

--- a/Alas/Sources/Right/RunTabView.swift
+++ b/Alas/Sources/Right/RunTabView.swift
@@ -48,7 +48,7 @@ struct RunTabView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .task(id: worktree.id) {
-            refreshScripts()
+            await refreshScripts()
             hasScanned = true
             // Reconnecting to a worktree is the moment to settle runs whose
             // terminal disappeared while nothing was watching them.
@@ -57,8 +57,10 @@ struct RunTabView: View {
         }
         .onReceive(ticker) { now = $0 }
         .onChange(of: state.runScriptCatalogGeneration) {
-            refreshScripts()
-            hasScanned = true
+            Task {
+                await refreshScripts()
+                hasScanned = true
+            }
         }
     }
 
@@ -81,7 +83,13 @@ struct RunTabView: View {
     }
 
     private func perform(_ action: RunRowAction, script: RunScript) {
-        let script = freshScript(matching: script) ?? script
+        Task {
+            await perform(action, matching: script)
+        }
+    }
+
+    private func perform(_ action: RunRowAction, matching staleScript: RunScript) async {
+        let script = await freshScript(matching: staleScript) ?? staleScript
         switch action {
         case .start:
             if case .finished? = state.runRecords.record(worktreeID: worktree.id, scriptKey: script.key)?.status {
@@ -108,13 +116,17 @@ struct RunTabView: View {
         }
     }
 
-    private func refreshScripts() {
-        scripts = RunScriptStore.scripts(worktreeRoot: worktree.path)
+    @discardableResult
+    private func refreshScripts() async -> [RunScript] {
+        let host = RemoteHostRegistry.shared.host(forPath: worktree.path.path)
+        let fresh = await RunScriptStore.scripts(worktreeRoot: worktree.path, remoteHost: host)
+        guard !Task.isCancelled else { return scripts }
+        scripts = fresh
+        return fresh
     }
 
-    private func freshScript(matching script: RunScript) -> RunScript? {
-        let fresh = RunScriptStore.scripts(worktreeRoot: worktree.path)
-        scripts = fresh
+    private func freshScript(matching script: RunScript) async -> RunScript? {
+        let fresh = await refreshScripts()
         return fresh.first { $0.key == script.key }
     }
 

--- a/Alas/Sources/RunScripts/RunEndpoint.swift
+++ b/Alas/Sources/RunScripts/RunEndpoint.swift
@@ -17,7 +17,10 @@ enum RunEndpointPolicy {
 
     static func isLoopback(_ url: URL) -> Bool {
         guard let host = url.host?.lowercased() else { return false }
-        let normalized = host.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+        var normalized = host.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+        if normalized.hasSuffix(".") {
+            normalized.removeLast()
+        }
         if isIPv4LoopbackLiteral(normalized) { return true }
         return loopbackHosts.contains(normalized)
     }

--- a/Alas/Sources/RunScripts/RunEndpoint.swift
+++ b/Alas/Sources/RunScripts/RunEndpoint.swift
@@ -41,14 +41,10 @@ enum RunEndpointPolicy {
     }
 
     private static func isIPv4LoopbackLiteral(_ host: String) -> Bool {
-        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
-        guard parts.count == 4 else { return false }
-        var octets: [Int] = []
-        for part in parts {
-            guard let value = Int(part), (0...255).contains(value) else { return false }
-            octets.append(value)
-        }
-        return octets.first == 127
+        var address = in_addr()
+        guard inet_aton(host, &address) == 1 else { return false }
+        let ipv4 = UInt32(bigEndian: address.s_addr)
+        return (ipv4 >> 24) == 127
     }
 
     static func action(for url: URL, target: RunExecutionTarget) -> RunEndpointAction {

--- a/Alas/Sources/RunScripts/RunEndpoint.swift
+++ b/Alas/Sources/RunScripts/RunEndpoint.swift
@@ -27,11 +27,17 @@ enum RunEndpointPolicy {
     }
 
     private static func isIPv4MappedIPv6LoopbackLiteral(_ host: String) -> Bool {
-        for prefix in ["::ffff:", "0:0:0:0:0:ffff:"] where host.hasPrefix(prefix) {
-            let mappedIPv4 = String(host.dropFirst(prefix.count))
-            return isIPv4LoopbackLiteral(mappedIPv4)
+        var address = in6_addr()
+        guard inet_pton(AF_INET6, host, &address) == 1 else {
+            return false
         }
-        return false
+        let bytes = withUnsafeBytes(of: &address) { Array($0) }
+        guard bytes.count == 16,
+              bytes[0..<10].allSatisfy({ $0 == 0 }),
+              bytes[10] == 0xff,
+              bytes[11] == 0xff
+        else { return false }
+        return bytes[12] == 127
     }
 
     private static func isIPv4LoopbackLiteral(_ host: String) -> Bool {

--- a/Alas/Sources/RunScripts/RunEndpoint.swift
+++ b/Alas/Sources/RunScripts/RunEndpoint.swift
@@ -18,8 +18,19 @@ enum RunEndpointPolicy {
     static func isLoopback(_ url: URL) -> Bool {
         guard let host = url.host?.lowercased() else { return false }
         let normalized = host.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
-        if normalized.split(separator: ".").first == "127" { return true }
+        if isIPv4LoopbackLiteral(normalized) { return true }
         return loopbackHosts.contains(normalized)
+    }
+
+    private static func isIPv4LoopbackLiteral(_ host: String) -> Bool {
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return false }
+        var octets: [Int] = []
+        for part in parts {
+            guard let value = Int(part), (0...255).contains(value) else { return false }
+            octets.append(value)
+        }
+        return octets.first == 127
     }
 
     static func action(for url: URL, target: RunExecutionTarget) -> RunEndpointAction {

--- a/Alas/Sources/RunScripts/RunEndpoint.swift
+++ b/Alas/Sources/RunScripts/RunEndpoint.swift
@@ -24,12 +24,18 @@ enum RunEndpointPolicy {
         if let zoneSeparator = normalized.firstIndex(of: "%") {
             normalized = String(normalized[..<zoneSeparator])
         }
+        if isLocalhostName(normalized) { return true }
         if isIPv6LoopbackLiteral(normalized) { return true }
         if isIPv6UnspecifiedLiteral(normalized) { return true }
         if isIPv4MappedIPv6LoopbackLiteral(normalized) { return true }
+        if isIPv4MappedIPv6UnspecifiedLiteral(normalized) { return true }
         if isIPv4LoopbackLiteral(normalized) { return true }
         if isIPv4UnspecifiedLiteral(normalized) { return true }
         return loopbackHosts.contains(normalized)
+    }
+
+    private static func isLocalhostName(_ host: String) -> Bool {
+        host == "localhost" || host.hasSuffix(".localhost")
     }
 
     private static func isIPv6LoopbackLiteral(_ host: String) -> Bool {
@@ -64,6 +70,20 @@ enum RunEndpointPolicy {
               bytes[11] == 0xff
         else { return false }
         return bytes[12] == 127
+    }
+
+    private static func isIPv4MappedIPv6UnspecifiedLiteral(_ host: String) -> Bool {
+        var address = in6_addr()
+        guard inet_pton(AF_INET6, host, &address) == 1 else {
+            return false
+        }
+        let bytes = withUnsafeBytes(of: &address) { Array($0) }
+        guard bytes.count == 16,
+              bytes[0..<10].allSatisfy({ $0 == 0 }),
+              bytes[10] == 0xff,
+              bytes[11] == 0xff
+        else { return false }
+        return bytes[12..<16].allSatisfy { $0 == 0 }
     }
 
     private static func isIPv4LoopbackLiteral(_ host: String) -> Bool {

--- a/Alas/Sources/RunScripts/RunEndpoint.swift
+++ b/Alas/Sources/RunScripts/RunEndpoint.swift
@@ -21,6 +21,9 @@ enum RunEndpointPolicy {
         if normalized.hasSuffix(".") {
             normalized.removeLast()
         }
+        if let zoneSeparator = normalized.firstIndex(of: "%") {
+            normalized = String(normalized[..<zoneSeparator])
+        }
         if isIPv4MappedIPv6LoopbackLiteral(normalized) { return true }
         if isIPv4LoopbackLiteral(normalized) { return true }
         return loopbackHosts.contains(normalized)

--- a/Alas/Sources/RunScripts/RunEndpoint.swift
+++ b/Alas/Sources/RunScripts/RunEndpoint.swift
@@ -21,8 +21,17 @@ enum RunEndpointPolicy {
         if normalized.hasSuffix(".") {
             normalized.removeLast()
         }
+        if isIPv4MappedIPv6LoopbackLiteral(normalized) { return true }
         if isIPv4LoopbackLiteral(normalized) { return true }
         return loopbackHosts.contains(normalized)
+    }
+
+    private static func isIPv4MappedIPv6LoopbackLiteral(_ host: String) -> Bool {
+        for prefix in ["::ffff:", "0:0:0:0:0:ffff:"] where host.hasPrefix(prefix) {
+            let mappedIPv4 = String(host.dropFirst(prefix.count))
+            return isIPv4LoopbackLiteral(mappedIPv4)
+        }
+        return false
     }
 
     private static func isIPv4LoopbackLiteral(_ host: String) -> Bool {

--- a/Alas/Sources/RunScripts/RunEndpoint.swift
+++ b/Alas/Sources/RunScripts/RunEndpoint.swift
@@ -17,7 +17,9 @@ enum RunEndpointPolicy {
 
     static func isLoopback(_ url: URL) -> Bool {
         guard let host = url.host?.lowercased() else { return false }
-        return loopbackHosts.contains(host.trimmingCharacters(in: CharacterSet(charactersIn: "[]")))
+        let normalized = host.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+        if normalized.split(separator: ".").first == "127" { return true }
+        return loopbackHosts.contains(normalized)
     }
 
     static func action(for url: URL, target: RunExecutionTarget) -> RunEndpointAction {

--- a/Alas/Sources/RunScripts/RunEndpoint.swift
+++ b/Alas/Sources/RunScripts/RunEndpoint.swift
@@ -1,0 +1,63 @@
+import Darwin
+import Foundation
+
+/// What clicking a run's endpoint should do. Resolved before anything is
+/// opened so a remote run can never quietly hand the user a local service.
+enum RunEndpointAction: Equatable {
+    case open(URL)
+    /// The command runs on another machine but its URL points at loopback —
+    /// opening it would hit whatever happens to listen on this Mac.
+    case blockedRemoteLoopback(host: String, url: URL)
+}
+
+enum RunEndpointPolicy {
+    private static let loopbackHosts: Set<String> = [
+        "localhost", "127.0.0.1", "0.0.0.0", "::1", "0:0:0:0:0:0:0:1", "::",
+    ]
+
+    static func isLoopback(_ url: URL) -> Bool {
+        guard let host = url.host?.lowercased() else { return false }
+        return loopbackHosts.contains(host.trimmingCharacters(in: CharacterSet(charactersIn: "[]")))
+    }
+
+    static func action(for url: URL, target: RunExecutionTarget) -> RunEndpointAction {
+        guard let host = target.host else { return .open(url) }
+        guard isLoopback(url) else { return .open(url) }
+        return .blockedRemoteLoopback(host: host, url: url)
+    }
+
+    /// Only absolute http(s) URLs are treated as endpoints. A malformed
+    /// `alas-url` header is ignored rather than hiding the script.
+    static func endpoint(from value: String) -> URL? {
+        let trimmed = value.trimmingCharacters(in: .whitespaces)
+        guard let url = URL(string: trimmed),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              url.host?.isEmpty == false
+        else { return nil }
+        return url
+    }
+}
+
+enum RunPortProbe {
+    /// True when something on this Mac already holds `port`. Implemented as a
+    /// bind attempt: it observes the collision without touching whatever owns
+    /// the port.
+    static func isLocalPortInUse(_ port: Int) -> Bool {
+        guard (1...65_535).contains(port) else { return false }
+        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { return false }
+        defer { Darwin.close(descriptor) }
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = UInt16(port).bigEndian
+        address.sin_addr.s_addr = INADDR_ANY
+        let result = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        return result != 0 && errno == EADDRINUSE
+    }
+}

--- a/Alas/Sources/RunScripts/RunEndpoint.swift
+++ b/Alas/Sources/RunScripts/RunEndpoint.swift
@@ -24,9 +24,21 @@ enum RunEndpointPolicy {
         if let zoneSeparator = normalized.firstIndex(of: "%") {
             normalized = String(normalized[..<zoneSeparator])
         }
+        if isIPv6LoopbackLiteral(normalized) { return true }
         if isIPv4MappedIPv6LoopbackLiteral(normalized) { return true }
         if isIPv4LoopbackLiteral(normalized) { return true }
         return loopbackHosts.contains(normalized)
+    }
+
+    private static func isIPv6LoopbackLiteral(_ host: String) -> Bool {
+        var address = in6_addr()
+        guard inet_pton(AF_INET6, host, &address) == 1 else {
+            return false
+        }
+        let bytes = withUnsafeBytes(of: &address) { Array($0) }
+        return bytes.count == 16
+            && bytes[0..<15].allSatisfy { $0 == 0 }
+            && bytes[15] == 1
     }
 
     private static func isIPv4MappedIPv6LoopbackLiteral(_ host: String) -> Bool {

--- a/Alas/Sources/RunScripts/RunEndpoint.swift
+++ b/Alas/Sources/RunScripts/RunEndpoint.swift
@@ -25,8 +25,10 @@ enum RunEndpointPolicy {
             normalized = String(normalized[..<zoneSeparator])
         }
         if isIPv6LoopbackLiteral(normalized) { return true }
+        if isIPv6UnspecifiedLiteral(normalized) { return true }
         if isIPv4MappedIPv6LoopbackLiteral(normalized) { return true }
         if isIPv4LoopbackLiteral(normalized) { return true }
+        if isIPv4UnspecifiedLiteral(normalized) { return true }
         return loopbackHosts.contains(normalized)
     }
 
@@ -39,6 +41,15 @@ enum RunEndpointPolicy {
         return bytes.count == 16
             && bytes[0..<15].allSatisfy { $0 == 0 }
             && bytes[15] == 1
+    }
+
+    private static func isIPv6UnspecifiedLiteral(_ host: String) -> Bool {
+        var address = in6_addr()
+        guard inet_pton(AF_INET6, host, &address) == 1 else {
+            return false
+        }
+        let bytes = withUnsafeBytes(of: &address) { Array($0) }
+        return bytes.count == 16 && bytes.allSatisfy { $0 == 0 }
     }
 
     private static func isIPv4MappedIPv6LoopbackLiteral(_ host: String) -> Bool {
@@ -60,6 +71,12 @@ enum RunEndpointPolicy {
         guard inet_aton(host, &address) == 1 else { return false }
         let ipv4 = UInt32(bigEndian: address.s_addr)
         return (ipv4 >> 24) == 127
+    }
+
+    private static func isIPv4UnspecifiedLiteral(_ host: String) -> Bool {
+        var address = in_addr()
+        guard inet_aton(host, &address) == 1 else { return false }
+        return UInt32(bigEndian: address.s_addr) == 0
     }
 
     static func action(for url: URL, target: RunExecutionTarget) -> RunEndpointAction {

--- a/Alas/Sources/RunScripts/RunEndpoint.swift
+++ b/Alas/Sources/RunScripts/RunEndpoint.swift
@@ -72,6 +72,10 @@ enum RunPortProbe {
     /// the port.
     static func isLocalPortInUse(_ port: Int) -> Bool {
         guard (1...65_535).contains(port) else { return false }
+        return isIPv4PortInUse(port) || isIPv6PortInUse(port)
+    }
+
+    private static func isIPv4PortInUse(_ port: Int) -> Bool {
         let descriptor = socket(AF_INET, SOCK_STREAM, 0)
         guard descriptor >= 0 else { return false }
         defer { Darwin.close(descriptor) }
@@ -83,6 +87,23 @@ enum RunPortProbe {
         let result = withUnsafePointer(to: &address) { pointer in
             pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
                 bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        return result != 0 && errno == EADDRINUSE
+    }
+
+    private static func isIPv6PortInUse(_ port: Int) -> Bool {
+        let descriptor = socket(AF_INET6, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { return false }
+        defer { Darwin.close(descriptor) }
+        var address = sockaddr_in6()
+        address.sin6_len = UInt8(MemoryLayout<sockaddr_in6>.size)
+        address.sin6_family = sa_family_t(AF_INET6)
+        address.sin6_port = UInt16(port).bigEndian
+        address.sin6_addr = in6addr_any
+        let result = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in6>.size))
             }
         }
         return result != 0 && errno == EADDRINUSE

--- a/Alas/Sources/RunScripts/RunRecord.swift
+++ b/Alas/Sources/RunScripts/RunRecord.swift
@@ -1,0 +1,237 @@
+import Foundation
+
+/// How a run ended. `unknown` exists so losing sight of a process is never
+/// laundered into success: an interrupted run reports only what we observed.
+enum RunOutcome: Equatable, Sendable {
+    case succeeded
+    case failed(exitCode: Int32)
+    /// The user stopped the run (or its terminal) while it was still going.
+    case stopped
+    /// Observation ended before the command reported an exit status.
+    case unknown
+}
+
+/// Lifecycle of a single command, tracked independently of the terminal shell
+/// hosting it — an `alas-on-exit: keep` script leaves its shell at a prompt
+/// long after the command itself finished, and closing that shell later says
+/// nothing about the command's outcome.
+enum RunStatus: Equatable, Sendable {
+    case notRun
+    case starting
+    case running
+    case finished(RunOutcome)
+
+    var isActive: Bool {
+        switch self {
+        case .starting, .running: true
+        case .notRun, .finished:  false
+        }
+    }
+}
+
+/// Where a run executes. Rows surface this so a local run and an SSH run of
+/// the same script are never mistaken for each other.
+struct RunExecutionTarget: Equatable, Sendable {
+    /// SSH destination, or nil when the command runs on this Mac.
+    let host: String?
+    /// Absolute working directory on `host`.
+    let workingDirectory: String
+
+    var isRemote: Bool { host != nil }
+    var hostLabel: String { host ?? "This Mac" }
+}
+
+/// Another owner of a run's endpoint port, detected when the run starts.
+/// Alas reports the collision and never terminates the process holding it.
+enum RunPortConflict: Equatable, Sendable {
+    /// Another run Alas owns already serves the port.
+    case ownedByRun(worktreeID: String, branch: String, scriptName: String)
+    /// Something outside Alas is listening on it.
+    case externalProcess
+}
+
+/// The observed history of one launch of one script in one worktree.
+struct RunRecord: Identifiable, Equatable, Sendable {
+    /// Fresh per launch. Completion monitors carry it so a late callback from
+    /// a superseded run is dropped instead of clobbering the run that
+    /// replaced it.
+    let id: String
+    let scriptKey: String
+    let scriptName: String
+    let worktreeID: String
+    let branch: String
+    let target: RunExecutionTarget
+    let endpoint: URL?
+    var status: RunStatus
+    var startedAt: Date
+    var finishedAt: Date?
+    /// Terminal leaf hosting the run, once one exists.
+    var sessionID: String?
+    /// `RunScriptFailure.id` holding the captured output of a failed run.
+    var failureID: String?
+    var portConflict: RunPortConflict?
+
+    init(
+        id: String,
+        scriptKey: String,
+        scriptName: String,
+        worktreeID: String,
+        branch: String,
+        target: RunExecutionTarget,
+        endpoint: URL? = nil,
+        status: RunStatus,
+        startedAt: Date,
+        finishedAt: Date? = nil,
+        sessionID: String? = nil,
+        failureID: String? = nil,
+        portConflict: RunPortConflict? = nil
+    ) {
+        self.id = id
+        self.scriptKey = scriptKey
+        self.scriptName = scriptName
+        self.worktreeID = worktreeID
+        self.branch = branch
+        self.target = target
+        self.endpoint = endpoint
+        self.status = status
+        self.startedAt = startedAt
+        self.finishedAt = finishedAt
+        self.sessionID = sessionID
+        self.failureID = failureID
+        self.portConflict = portConflict
+    }
+
+    var duration: TimeInterval? {
+        finishedAt.map { $0.timeIntervalSince(startedAt) }
+    }
+}
+
+/// The latest run per (worktree, script). Keyed by worktree first so tearing
+/// a worktree down is one removal and no lookup can reach across worktrees.
+///
+/// Deliberately a plain value type with no knowledge of terminals: the Run
+/// tab, and any future local-checks surface, can share it.
+struct RunRecordStore: Equatable {
+    private(set) var byWorktree: [String: [String: RunRecord]] = [:]
+
+    func record(worktreeID: String, scriptKey: String) -> RunRecord? {
+        byWorktree[worktreeID]?[scriptKey]
+    }
+
+    func records(worktreeID: String) -> [RunRecord] {
+        Array(byWorktree[worktreeID, default: [:]].values)
+    }
+
+    var activeRecords: [RunRecord] {
+        byWorktree.values.flatMap(\.values).filter(\.status.isActive)
+    }
+
+    /// Starts a run, returning the record it displaced so a launch that fails
+    /// before the command exists can put the previous outcome back.
+    @discardableResult
+    mutating func begin(_ record: RunRecord) -> RunRecord? {
+        let previous = byWorktree[record.worktreeID]?[record.scriptKey]
+        byWorktree[record.worktreeID, default: [:]][record.scriptKey] = record
+        return previous
+    }
+
+    /// Undoes a `begin` whose launch never produced a command. A no-op once
+    /// something else has taken the slot, so a stale rollback can't resurrect
+    /// an old record over a newer run.
+    mutating func rollback(runID: String, to previous: RunRecord?) {
+        guard let location = locate(runID: runID) else { return }
+        byWorktree[location.worktreeID]?[location.scriptKey] = previous
+        if byWorktree[location.worktreeID]?.isEmpty == true {
+            byWorktree[location.worktreeID] = nil
+        }
+    }
+
+    mutating func markRunning(runID: String, sessionID: String) {
+        mutateActive(runID: runID) {
+            $0.status = .running
+            $0.sessionID = sessionID
+        }
+    }
+
+    mutating func finish(runID: String, outcome: RunOutcome, at date: Date, failureID: String? = nil) {
+        mutateActive(runID: runID) {
+            $0.status = .finished(outcome)
+            $0.finishedAt = date
+            $0.failureID = failureID
+        }
+    }
+
+    /// User-initiated stop. Only an in-flight run can be stopped: a command
+    /// that already reported an exit status keeps that outcome even when its
+    /// shell is closed afterwards.
+    mutating func markStopped(worktreeID: String, scriptKey: String, at date: Date) {
+        guard let record = record(worktreeID: worktreeID, scriptKey: scriptKey), record.status.isActive else { return }
+        mutateActive(runID: record.id) {
+            $0.status = .finished(.stopped)
+            $0.finishedAt = date
+        }
+    }
+
+    /// Observation ended without an exit status (terminal killed, SSH dropped,
+    /// monitor cancelled). Never resolves to success.
+    mutating func markLostObservation(runID: String, at date: Date) {
+        mutateActive(runID: runID) {
+            $0.status = .finished(.unknown)
+            $0.finishedAt = date
+        }
+    }
+
+    mutating func markLostObservation(worktreeID: String, scriptKey: String, at date: Date) {
+        guard let record = record(worktreeID: worktreeID, scriptKey: scriptKey) else { return }
+        markLostObservation(runID: record.id, at: date)
+    }
+
+    mutating func setPortConflict(_ conflict: RunPortConflict?, runID: String) {
+        mutateActive(runID: runID) { $0.portConflict = conflict }
+    }
+
+    mutating func purge(worktreeID: String) {
+        byWorktree[worktreeID] = nil
+    }
+
+    /// The run Alas already owns on `port` at `host`, if any. Used to name the
+    /// other side of a port collision instead of guessing.
+    func activeRunOwningPort(_ port: Int, host: String?, excludingRunID: String? = nil) -> RunRecord? {
+        activeRecords.first { record in
+            record.id != excludingRunID
+                && record.target.host == host
+                && record.endpoint?.runEndpointPort == port
+        }
+    }
+
+    private func locate(runID: String) -> (worktreeID: String, scriptKey: String)? {
+        for (worktreeID, records) in byWorktree {
+            for (scriptKey, record) in records where record.id == runID {
+                return (worktreeID, scriptKey)
+            }
+        }
+        return nil
+    }
+
+    private mutating func mutateActive(runID: String, _ body: (inout RunRecord) -> Void) {
+        guard let location = locate(runID: runID),
+              var record = byWorktree[location.worktreeID]?[location.scriptKey],
+              record.status.isActive
+        else { return }
+        body(&record)
+        byWorktree[location.worktreeID]?[location.scriptKey] = record
+    }
+}
+
+extension URL {
+    /// Explicit port, else the scheme's default. `nil` when neither applies,
+    /// which is exactly when a port collision can't be reasoned about.
+    var runEndpointPort: Int? {
+        if let port { return port }
+        switch scheme?.lowercased() {
+        case "http":  return 80
+        case "https": return 443
+        default:      return nil
+        }
+    }
+}

--- a/Alas/Sources/RunScripts/RunRecord.swift
+++ b/Alas/Sources/RunScripts/RunRecord.swift
@@ -122,6 +122,11 @@ struct RunRecordStore: Equatable {
         Array(byWorktree[worktreeID, default: [:]].values)
     }
 
+    func isCurrentActiveRun(runID: String, worktreeID: String, scriptKey: String) -> Bool {
+        guard let record = record(worktreeID: worktreeID, scriptKey: scriptKey) else { return false }
+        return record.id == runID && record.status.isActive
+    }
+
     var activeRecords: [RunRecord] {
         byWorktree.values.flatMap(\.values).filter(\.status.isActive)
     }

--- a/Alas/Sources/RunScripts/RunScript.swift
+++ b/Alas/Sources/RunScripts/RunScript.swift
@@ -30,6 +30,9 @@ struct RunScript: Equatable, Identifiable, Sendable {
     /// Working directory relative to the worktree root. Nil = worktree root.
     let cwd: String?
     let isExecutable: Bool
+    /// Declared service endpoint (`# alas-url:`), when the script serves one.
+    /// Optional by design — build/test/lint commands stay useful without it.
+    var endpoint: URL?
 
     var key: String { "\(scope.rawValue):\(fileName)" }
     var id: String { key }
@@ -40,15 +43,16 @@ struct RunScript: Equatable, Identifiable, Sendable {
 /// never hides a script from the list.
 enum RunScriptMetadata {
     private static let headerLineLimit = 20
-    private static let pattern = /^#\s*alas-(name|on-exit|cwd):\s*(.+?)\s*$/
+    private static let pattern = /^#\s*alas-(name|on-exit|cwd|url):\s*(.+?)\s*$/
 
     static func parse(
         fileName: String,
         contents: String
-    ) -> (displayName: String, onExit: RunScriptOnExit, cwd: String?) {
+    ) -> (displayName: String, onExit: RunScriptOnExit, cwd: String?, endpoint: URL?) {
         var name: String?
         var onExit = RunScriptOnExit.keep
         var cwd: String?
+        var endpoint: URL?
         for line in contents.split(separator: "\n", omittingEmptySubsequences: false).prefix(headerLineLimit) {
             guard let match = line.firstMatch(of: pattern) else { continue }
             let value = String(match.2)
@@ -56,10 +60,11 @@ enum RunScriptMetadata {
             case "name":    name = value
             case "on-exit": onExit = RunScriptOnExit(rawValue: value) ?? .keep
             case "cwd":     cwd = value
+            case "url":     endpoint = RunEndpointPolicy.endpoint(from: value)
             default:        break
             }
         }
         let fallback = (fileName as NSString).deletingPathExtension
-        return (name ?? (fallback.isEmpty ? fileName : fallback), onExit, cwd)
+        return (name ?? (fallback.isEmpty ? fileName : fallback), onExit, cwd, endpoint)
     }
 }

--- a/Alas/Sources/RunScripts/RunScriptStore.swift
+++ b/Alas/Sources/RunScripts/RunScriptStore.swift
@@ -13,6 +13,17 @@ enum RunScriptStore {
         case failed(String)
     }
 
+    enum RemoteProbeError: LocalizedError {
+        case executableProbeFailed(path: String, status: Int32)
+
+        var errorDescription: String? {
+            switch self {
+            case let .executableProbeFailed(path, status):
+                "Could not determine whether remote script is executable: \(path) (exit \(status))"
+            }
+        }
+    }
+
     static func repoScriptsDir(worktreeRoot: URL) -> URL {
         worktreeRoot.appendingPathComponent(repoScriptsRelativeDir, isDirectory: true)
     }
@@ -91,7 +102,7 @@ enum RunScriptStore {
         var scripts: [RunScript] = []
         for entry in entries where !entry.isDirectory && !entry.name.hasPrefix(".") {
             let url = directory.appendingPathComponent(entry.name)
-            guard let data = try? await RemoteFileAccess.readPrefix(
+            guard let data = try await RemoteFileAccess.readPrefix(
                 host: host,
                 path: url.path,
                 maxBytes: headerReadLimit
@@ -99,7 +110,7 @@ enum RunScriptStore {
                 continue
             }
             let header = String(decoding: data, as: UTF8.self)
-            let isExecutable = await isRemoteExecutable(host: host, path: url.path)
+            let isExecutable = try await isRemoteExecutable(host: host, path: url.path)
             scripts.append(script(
                 scope: .repo,
                 fileName: entry.name,
@@ -132,12 +143,17 @@ enum RunScriptStore {
         }
     }
 
-    private static func isRemoteExecutable(host: String, path: String) async -> Bool {
+    private static func isRemoteExecutable(host: String, path: String) async throws -> Bool {
         let command = "test -x \(SSHCommand.shellQuote(path))"
-        guard let result = try? await RemoteExec.run(host: host, cwd: nil, command: command, timeout: 5) else {
+        let result = try await RemoteExec.run(host: host, cwd: nil, command: command, timeout: 5)
+        switch result.exitCode {
+        case 0:
+            return true
+        case 1:
             return false
+        default:
+            throw RemoteProbeError.executableProbeFailed(path: path, status: result.exitCode)
         }
-        return result.exitCode == 0
     }
 
     static func script(

--- a/Alas/Sources/RunScripts/RunScriptStore.swift
+++ b/Alas/Sources/RunScripts/RunScriptStore.swift
@@ -21,6 +21,20 @@ enum RunScriptStore {
             + discover(in: globalDir, scope: .global)
     }
 
+    /// Host-aware discovery for UI surfaces attached to a concrete worktree.
+    /// Local worktrees keep the synchronous FileManager path; remote worktrees
+    /// scan repository scripts through SSH so the list matches what launches.
+    static func scripts(
+        worktreeRoot: URL,
+        remoteHost: String?,
+        globalDir: URL = Paths.runScriptsGlobalDir
+    ) async -> [RunScript] {
+        guard let remoteHost else {
+            return scripts(worktreeRoot: worktreeRoot, globalDir: globalDir)
+        }
+        return await remoteRepoScripts(worktreeRoot: worktreeRoot, host: remoteHost)
+    }
+
     private static func discover(in dir: URL, scope: RunScriptScope) -> [RunScript] {
         let fm = FileManager.default
         guard let entries = try? fm.contentsOfDirectory(
@@ -31,16 +45,12 @@ enum RunScriptStore {
         return entries
             .filter { (try? $0.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true }
             .map { url in
-                let meta = RunScriptMetadata.parse(fileName: url.lastPathComponent, contents: headText(of: url))
-                return RunScript(
+                script(
                     scope: scope,
                     fileName: url.lastPathComponent,
                     fileURL: url,
-                    displayName: meta.displayName,
-                    onExit: meta.onExit,
-                    cwd: meta.cwd,
-                    isExecutable: fm.isExecutableFile(atPath: url.path),
-                    endpoint: meta.endpoint
+                    contents: headText(of: url),
+                    isExecutable: fm.isExecutableFile(atPath: url.path)
                 )
             }
             .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
@@ -52,5 +62,60 @@ enum RunScriptStore {
         let data = (try? handle.read(upToCount: headerReadLimit)) ?? nil
         guard let data else { return "" }
         return String(decoding: data, as: UTF8.self)
+    }
+
+    private static func remoteRepoScripts(worktreeRoot: URL, host: String) async -> [RunScript] {
+        let directory = repoScriptsDir(worktreeRoot: worktreeRoot)
+        guard let entries = try? await RemoteFileStats.directoryEntries(
+            host: host,
+            worktreeRoot: worktreeRoot.path,
+            path: directory.path
+        ) else { return [] }
+
+        var scripts: [RunScript] = []
+        for entry in entries where !entry.isDirectory && !entry.name.hasPrefix(".") {
+            let url = directory.appendingPathComponent(entry.name)
+            guard case .file(let data, _) = try? await RemoteFileAccess.read(host: host, path: url.path) else {
+                continue
+            }
+            let header = String(decoding: data.prefix(headerReadLimit), as: UTF8.self)
+            let isExecutable = await isRemoteExecutable(host: host, path: url.path)
+            scripts.append(script(
+                scope: .repo,
+                fileName: entry.name,
+                fileURL: url,
+                contents: header,
+                isExecutable: isExecutable
+            ))
+        }
+        return scripts.sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
+    }
+
+    private static func isRemoteExecutable(host: String, path: String) async -> Bool {
+        let command = "test -x \(SSHCommand.shellQuote(path))"
+        guard let result = try? await RemoteExec.run(host: host, cwd: nil, command: command, timeout: 5) else {
+            return false
+        }
+        return result.exitCode == 0
+    }
+
+    static func script(
+        scope: RunScriptScope,
+        fileName: String,
+        fileURL: URL,
+        contents: String,
+        isExecutable: Bool
+    ) -> RunScript {
+        let meta = RunScriptMetadata.parse(fileName: fileName, contents: contents)
+        return RunScript(
+            scope: scope,
+            fileName: fileName,
+            fileURL: fileURL,
+            displayName: meta.displayName,
+            onExit: meta.onExit,
+            cwd: meta.cwd,
+            isExecutable: isExecutable,
+            endpoint: meta.endpoint
+        )
     }
 }

--- a/Alas/Sources/RunScripts/RunScriptStore.swift
+++ b/Alas/Sources/RunScripts/RunScriptStore.swift
@@ -39,7 +39,8 @@ enum RunScriptStore {
                     displayName: meta.displayName,
                     onExit: meta.onExit,
                     cwd: meta.cwd,
-                    isExecutable: fm.isExecutableFile(atPath: url.path)
+                    isExecutable: fm.isExecutableFile(atPath: url.path),
+                    endpoint: meta.endpoint
                 )
             }
             .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }

--- a/Alas/Sources/RunScripts/RunScriptStore.swift
+++ b/Alas/Sources/RunScripts/RunScriptStore.swift
@@ -8,6 +8,11 @@ enum RunScriptStore {
     /// Only this many leading bytes are read for metadata parsing.
     private static let headerReadLimit = 4096
 
+    enum DiscoveryResult {
+        case scripts([RunScript])
+        case failed(String)
+    }
+
     static func repoScriptsDir(worktreeRoot: URL) -> URL {
         worktreeRoot.appendingPathComponent(repoScriptsRelativeDir, isDirectory: true)
     }
@@ -29,10 +34,25 @@ enum RunScriptStore {
         remoteHost: String?,
         globalDir: URL = Paths.runScriptsGlobalDir
     ) async -> [RunScript] {
-        guard let remoteHost else {
-            return scripts(worktreeRoot: worktreeRoot, globalDir: globalDir)
+        switch await discoverScripts(worktreeRoot: worktreeRoot, remoteHost: remoteHost, globalDir: globalDir) {
+        case .scripts(let scripts): scripts
+        case .failed: []
         }
-        return await remoteRepoScripts(worktreeRoot: worktreeRoot, host: remoteHost)
+    }
+
+    static func discoverScripts(
+        worktreeRoot: URL,
+        remoteHost: String?,
+        globalDir: URL = Paths.runScriptsGlobalDir
+    ) async -> DiscoveryResult {
+        guard let remoteHost else {
+            return .scripts(scripts(worktreeRoot: worktreeRoot, globalDir: globalDir))
+        }
+        do {
+            return .scripts(try await remoteRepoScripts(worktreeRoot: worktreeRoot, host: remoteHost))
+        } catch {
+            return .failed(error.localizedDescription)
+        }
     }
 
     private static func discover(in dir: URL, scope: RunScriptScope) -> [RunScript] {
@@ -64,13 +84,9 @@ enum RunScriptStore {
         return String(decoding: data, as: UTF8.self)
     }
 
-    private static func remoteRepoScripts(worktreeRoot: URL, host: String) async -> [RunScript] {
+    private static func remoteRepoScripts(worktreeRoot: URL, host: String) async throws -> [RunScript] {
         let directory = repoScriptsDir(worktreeRoot: worktreeRoot)
-        guard let entries = try? await RemoteFileStats.directoryEntries(
-            host: host,
-            worktreeRoot: worktreeRoot.path,
-            path: directory.path
-        ) else { return [] }
+        let entries = try await remoteRepoScriptEntries(host: host, worktreeRoot: worktreeRoot, directory: directory)
 
         var scripts: [RunScript] = []
         for entry in entries where !entry.isDirectory && !entry.name.hasPrefix(".") {
@@ -93,6 +109,27 @@ enum RunScriptStore {
             ))
         }
         return scripts.sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
+    }
+
+    private static func remoteRepoScriptEntries(
+        host: String,
+        worktreeRoot: URL,
+        directory: URL
+    ) async throws -> [(name: String, isDirectory: Bool)] {
+        switch try await RemotePathContainment.containedList(
+            host: host,
+            path: directory.path,
+            worktreeRoot: worktreeRoot.path
+        ) {
+        case .ok(let entries):
+            return entries
+        case .notADirectory:
+            return []
+        case .outsideWorktree:
+            throw RemotePathContainment.ContainmentError.outsideWorktree(directory.path)
+        case .unreadable:
+            throw RemoteFileStatsError.directoryListingFailed(path: directory.path)
+        }
     }
 
     private static func isRemoteExecutable(host: String, path: String) async -> Bool {

--- a/Alas/Sources/RunScripts/RunScriptStore.swift
+++ b/Alas/Sources/RunScripts/RunScriptStore.swift
@@ -75,10 +75,14 @@ enum RunScriptStore {
         var scripts: [RunScript] = []
         for entry in entries where !entry.isDirectory && !entry.name.hasPrefix(".") {
             let url = directory.appendingPathComponent(entry.name)
-            guard case .file(let data, _) = try? await RemoteFileAccess.read(host: host, path: url.path) else {
+            guard let data = try? await RemoteFileAccess.readPrefix(
+                host: host,
+                path: url.path,
+                maxBytes: headerReadLimit
+            ) else {
                 continue
             }
-            let header = String(decoding: data.prefix(headerReadLimit), as: UTF8.self)
+            let header = String(decoding: data, as: UTF8.self)
             let isExecutable = await isRemoteExecutable(host: host, path: url.path)
             scripts.append(script(
                 scope: .repo,

--- a/Alas/Sources/Settings/AdvancedPane.swift
+++ b/Alas/Sources/Settings/AdvancedPane.swift
@@ -29,6 +29,18 @@ struct AdvancedPane: View {
                             }
                         ))
                     }
+                    SettingsRow(
+                        name: "Run tab preview",
+                        desc: "Shows the worktree Run tab for preview testing."
+                    ) {
+                        AlasToggle(on: Binding(
+                            get: { state.config.runTabEnabled },
+                            set: { enabled in
+                                state.config.runTabEnabled = enabled
+                                state.saveConfig()
+                            }
+                        ))
+                    }
                     if let recovery = state.workspaceRecoveryError {
                         VStack(alignment: .leading, spacing: 8) {
                             Text("Workspace recovery required: \(recovery.message)")

--- a/AlasTests/AppConfigTests.swift
+++ b/AlasTests/AppConfigTests.swift
@@ -30,6 +30,7 @@ struct AppConfigTests {
         #expect(cfg.worktrees.rootPath == "~/.alas/worktrees")
         #expect(cfg.worktrees.branchPrefix == "feature/")
         #expect(cfg.workspacesEnabled == false)
+        #expect(cfg.runTabEnabled == false)
     }
 
     @Test func decodeOldConfigDefaultsWorkspacesDisabled() throws {
@@ -41,6 +42,17 @@ struct AppConfigTests {
         let decoded = try JSONDecoder().decode(AppConfig.self, from: oldConfig)
 
         #expect(decoded.workspacesEnabled == false)
+    }
+
+    @Test func decodeOldConfigDefaultsRunTabDisabled() throws {
+        let data = try JSONEncoder().encode(AppConfig.defaults)
+        var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        object.removeValue(forKey: "runTabEnabled")
+
+        let oldConfig = try JSONSerialization.data(withJSONObject: object)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: oldConfig)
+
+        #expect(decoded.runTabEnabled == false)
     }
 
     @Test func decodeOldHarnessConfigDefaultsAwaitingPingOn() throws {

--- a/AlasTests/AppStateRunRecordTests.swift
+++ b/AlasTests/AppStateRunRecordTests.swift
@@ -72,10 +72,12 @@ struct AppStateRunRecordTests {
             runScriptCompletionWaiter: waiter
         )
         state.projectsManager = ProjectsManager(persistedProjects: [project])
+        let primaryWorktree = worktree(id: "wt-1", branch: "main")
+        state.projectsManager.insertOptimisticWorktree(primaryWorktree)
         return Fixture(
             state: state,
             script: script,
-            worktree: worktree(id: "wt-1", branch: "main"),
+            worktree: primaryWorktree,
             directory: directory,
             errors: { errors.values }
         )
@@ -366,6 +368,20 @@ struct AppStateRunRecordTests {
         #expect(fixture.state.pendingScriptLaunchTasks.isEmpty)
         #expect(task.isCancelled)
         #expect(runRecord(fixture)?.status == .finished(.stopped))
+    }
+
+    @Test func terminateAllTerminalSessionsClosesTabsOpenedAfterInitialSnapshot() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        _ = fixture.state.tabs.appendTerminal(
+            worktreeId: fixture.worktree.id,
+            title: "Late Terminal",
+            sessionId: "late-leaf"
+        )
+
+        fixture.state.terminateAllTerminalSessionsAfterConfirmationWithStaleEmptySnapshotForTesting()
+
+        #expect(fixture.state.tabs.tabs(forWorktree: fixture.worktree.id).isEmpty)
     }
 
     @Test func pendingLaunchCancellationDoesNotParseWorktreeIDFromKey() throws {

--- a/AlasTests/AppStateRunRecordTests.swift
+++ b/AlasTests/AppStateRunRecordTests.swift
@@ -245,6 +245,40 @@ struct AppStateRunRecordTests {
         #expect(runRecord(fixture)?.status == .finished(.stopped))
     }
 
+    @Test func closeAllTabsCancelsPendingLaunchesWithoutPurgingRunHistory() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let previous = RunRecord(
+            id: UUID().uuidString,
+            scriptKey: fixture.script.key,
+            scriptName: fixture.script.displayName,
+            worktreeID: fixture.worktree.id,
+            branch: fixture.worktree.branch,
+            target: fixture.state.runExecutionTarget(for: fixture.script, in: fixture.worktree),
+            status: .starting,
+            startedAt: Date()
+        )
+        fixture.state.runRecords.begin(previous)
+        fixture.state.runRecords.finish(
+            runID: previous.id,
+            outcome: .succeeded,
+            at: Date()
+        )
+        let launchID = UUID()
+        let task = Task<Void, Never> {
+            try? await Task.sleep(for: .seconds(30))
+        }
+        fixture.state.pendingScriptLaunches["\(fixture.worktree.id):\(fixture.script.key)"] = launchID
+        fixture.state.pendingScriptLaunchTasks[launchID] = task
+
+        fixture.state.closeAllTabs(worktreeId: fixture.worktree.id)
+
+        #expect(fixture.state.pendingScriptLaunches.isEmpty)
+        #expect(fixture.state.pendingScriptLaunchTasks.isEmpty)
+        #expect(task.isCancelled)
+        #expect(runRecord(fixture)?.status == .finished(.succeeded))
+    }
+
     @Test func interruptedRunBecomesUnknownRatherThanSucceeded() async throws {
         let fixture = try makeFixture(waiter: { _ in
             try await Task.sleep(for: .seconds(5))

--- a/AlasTests/AppStateRunRecordTests.swift
+++ b/AlasTests/AppStateRunRecordTests.swift
@@ -301,7 +301,11 @@ struct AppStateRunRecordTests {
         let task = Task<Void, Never> {
             try? await Task.sleep(for: .seconds(30))
         }
-        fixture.state.pendingScriptLaunches["\(fixture.worktree.id):\(fixture.script.key)"] = launchID
+        fixture.state.pendingScriptLaunches["\(fixture.worktree.id):\(fixture.script.key)"] = PendingRunScriptLaunch(
+            id: launchID,
+            worktreeID: fixture.worktree.id,
+            scriptKey: fixture.script.key
+        )
         fixture.state.pendingScriptLaunchTasks[launchID] = task
 
         fixture.state.closeAllTabs(worktreeId: fixture.worktree.id)
@@ -330,7 +334,11 @@ struct AppStateRunRecordTests {
         let task = Task<Void, Never> {
             try? await Task.sleep(for: .seconds(30))
         }
-        fixture.state.pendingScriptLaunches["\(fixture.worktree.id):\(fixture.script.key)"] = launchID
+        fixture.state.pendingScriptLaunches["\(fixture.worktree.id):\(fixture.script.key)"] = PendingRunScriptLaunch(
+            id: launchID,
+            worktreeID: fixture.worktree.id,
+            scriptKey: fixture.script.key
+        )
         fixture.state.pendingScriptLaunchTasks[launchID] = task
 
         fixture.state.terminateAllTerminalSessionsAfterConfirmationForTesting()
@@ -339,6 +347,38 @@ struct AppStateRunRecordTests {
         #expect(fixture.state.pendingScriptLaunchTasks.isEmpty)
         #expect(task.isCancelled)
         #expect(runRecord(fixture)?.status == .finished(.stopped))
+    }
+
+    @Test func pendingLaunchCancellationDoesNotParseWorktreeIDFromKey() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let worktreeID = "repo:path:with:colons"
+        let record = RunRecord(
+            id: UUID().uuidString,
+            scriptKey: fixture.script.key,
+            scriptName: fixture.script.displayName,
+            worktreeID: worktreeID,
+            branch: fixture.worktree.branch,
+            target: fixture.state.runExecutionTarget(for: fixture.script, in: fixture.worktree),
+            status: .starting,
+            startedAt: Date()
+        )
+        fixture.state.runRecords.begin(record)
+        let launchID = UUID()
+        let task = Task<Void, Never> {
+            try? await Task.sleep(for: .seconds(30))
+        }
+        fixture.state.pendingScriptLaunches["\(worktreeID):\(fixture.script.key)"] = PendingRunScriptLaunch(
+            id: launchID,
+            worktreeID: worktreeID,
+            scriptKey: fixture.script.key
+        )
+        fixture.state.pendingScriptLaunchTasks[launchID] = task
+
+        fixture.state.cancelPendingRunScriptLaunches(worktreeID: worktreeID)
+
+        #expect(task.isCancelled)
+        #expect(fixture.state.runRecords.record(worktreeID: worktreeID, scriptKey: fixture.script.key)?.status == .finished(.stopped))
     }
 
     @Test func interruptedRunBecomesUnknownRatherThanSucceeded() async throws {

--- a/AlasTests/AppStateRunRecordTests.swift
+++ b/AlasTests/AppStateRunRecordTests.swift
@@ -220,6 +220,39 @@ struct AppStateRunRecordTests {
         #expect(current.status == .running)
     }
 
+    @Test func supersededFailureDoesNotEnqueueCapturedOutput() async throws {
+        let calls = LockedCounter()
+        let fixture = try makeFixture(waiter: { _ in
+            let call = calls.incrementAndGet()
+            if call == 1 {
+                try await Task.sleep(for: .milliseconds(150))
+                return RunScriptCompletion(exitCode: 42, transcript: Data("old failed\n".utf8), truncated: false)
+            }
+            try await Task.sleep(for: .seconds(5))
+            return RunScriptCompletion(exitCode: 0, transcript: nil, truncated: false)
+        })
+        defer {
+            fixture.state.cancelAllRunScriptCompletionTasks()
+            try? FileManager.default.removeItem(at: fixture.directory)
+        }
+
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        try await Task.sleep(for: .milliseconds(50))
+        let firstRunID = try #require(runRecord(fixture)?.id)
+
+        fixture.state.restartScript(fixture.script, in: fixture.worktree)
+        try await Task.sleep(for: .milliseconds(50))
+        let secondRunID = try #require(runRecord(fixture)?.id)
+        #expect(secondRunID != firstRunID)
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        let current = try #require(runRecord(fixture))
+        #expect(current.id == secondRunID)
+        #expect(current.status == .running)
+        #expect(fixture.state.runScriptFailures(in: fixture.worktree.id).isEmpty)
+    }
+
     // MARK: - Stop and interruption
 
     @Test func stoppingARunReportsStoppedNotFailed() async throws {

--- a/AlasTests/AppStateRunRecordTests.swift
+++ b/AlasTests/AppStateRunRecordTests.swift
@@ -130,6 +130,24 @@ struct AppStateRunRecordTests {
         #expect(scriptTabCount(fixture) == 1)
     }
 
+    @Test func completionUsesLocalObservationTimeForRunRecord() async throws {
+        let remoteClock = Date(timeIntervalSince1970: 1)
+        let fixture = try makeFixture(waiter: { _ in
+            RunScriptCompletion(exitCode: 0, completedAt: remoteClock, transcript: nil, truncated: false)
+        })
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        let beforeLaunch = Date()
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        try await Task.sleep(for: .milliseconds(50))
+        await fixture.state.waitForRunScriptCompletionTasksForTesting()
+
+        let record = try #require(runRecord(fixture))
+        let finishedAt = try #require(record.finishedAt)
+        #expect(finishedAt >= beforeLaunch)
+        #expect(finishedAt != remoteClock)
+    }
+
     @Test func remoteRepoScriptLaunchDoesNotRequireLocalScriptPath() throws {
         let fixture = try makeFixture(waiter: { _ in
             try await Task.sleep(for: .seconds(5))

--- a/AlasTests/AppStateRunRecordTests.swift
+++ b/AlasTests/AppStateRunRecordTests.swift
@@ -128,6 +128,25 @@ struct AppStateRunRecordTests {
         #expect(scriptTabCount(fixture) == 1)
     }
 
+    @Test func remoteRepoScriptLaunchDoesNotRequireLocalScriptPath() throws {
+        let fixture = try makeFixture(waiter: { _ in
+            try await Task.sleep(for: .seconds(5))
+            return RunScriptCompletion(exitCode: 0, transcript: nil, truncated: false)
+        })
+        defer {
+            fixture.state.cancelPendingRunScriptLaunches()
+            RemoteHostRegistry.shared.unregister(root: fixture.worktree.path.path)
+            try? FileManager.default.removeItem(at: fixture.directory)
+        }
+        try FileManager.default.removeItem(at: fixture.script.fileURL)
+        RemoteHostRegistry.shared.register(root: fixture.worktree.path.path, host: "devbox")
+
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+
+        #expect(fixture.errors().isEmpty)
+        #expect(runRecord(fixture)?.status == .starting)
+    }
+
     @Test func failedRunLinksTheCapturedOutput() async throws {
         let fixture = try makeFixture(waiter: { _ in
             RunScriptCompletion(exitCode: 42, transcript: Data("boom\n".utf8), truncated: false)

--- a/AlasTests/AppStateRunRecordTests.swift
+++ b/AlasTests/AppStateRunRecordTests.swift
@@ -322,7 +322,7 @@ struct AppStateRunRecordTests {
         let task = Task<Void, Never> {
             try? await Task.sleep(for: .seconds(30))
         }
-        fixture.state.pendingScriptLaunches["\(fixture.worktree.id):\(fixture.script.key)"] = PendingRunScriptLaunch(
+        fixture.state.pendingScriptLaunches[PendingRunScriptLaunchKey(worktreeID: fixture.worktree.id, scriptKey: fixture.script.key)] = PendingRunScriptLaunch(
             id: launchID,
             worktreeID: fixture.worktree.id,
             scriptKey: fixture.script.key
@@ -355,7 +355,7 @@ struct AppStateRunRecordTests {
         let task = Task<Void, Never> {
             try? await Task.sleep(for: .seconds(30))
         }
-        fixture.state.pendingScriptLaunches["\(fixture.worktree.id):\(fixture.script.key)"] = PendingRunScriptLaunch(
+        fixture.state.pendingScriptLaunches[PendingRunScriptLaunchKey(worktreeID: fixture.worktree.id, scriptKey: fixture.script.key)] = PendingRunScriptLaunch(
             id: launchID,
             worktreeID: fixture.worktree.id,
             scriptKey: fixture.script.key
@@ -403,7 +403,7 @@ struct AppStateRunRecordTests {
         let task = Task<Void, Never> {
             try? await Task.sleep(for: .seconds(30))
         }
-        fixture.state.pendingScriptLaunches["\(worktreeID):\(fixture.script.key)"] = PendingRunScriptLaunch(
+        fixture.state.pendingScriptLaunches[PendingRunScriptLaunchKey(worktreeID: worktreeID, scriptKey: fixture.script.key)] = PendingRunScriptLaunch(
             id: launchID,
             worktreeID: worktreeID,
             scriptKey: fixture.script.key
@@ -436,7 +436,7 @@ struct AppStateRunRecordTests {
             let task = Task<Void, Never> {
                 try? await Task.sleep(for: .seconds(30))
             }
-            fixture.state.pendingScriptLaunches["\(worktreeID):\(fixture.script.key)"] = PendingRunScriptLaunch(
+            fixture.state.pendingScriptLaunches[PendingRunScriptLaunchKey(worktreeID: worktreeID, scriptKey: fixture.script.key)] = PendingRunScriptLaunch(
                 id: launchID,
                 worktreeID: worktreeID,
                 scriptKey: fixture.script.key
@@ -450,6 +450,47 @@ struct AppStateRunRecordTests {
         #expect(fixture.state.pendingScriptLaunches.values.first?.worktreeID == secondWorktreeID)
         #expect(fixture.state.runRecords.record(worktreeID: firstWorktreeID, scriptKey: fixture.script.key)?.status == .finished(.stopped))
         #expect(fixture.state.runRecords.record(worktreeID: secondWorktreeID, scriptKey: fixture.script.key)?.status == .starting)
+        fixture.state.cancelPendingRunScriptLaunches()
+    }
+
+    @Test func pendingLaunchKeysDoNotCollideWhenIdentitiesContainColons() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let first = (worktreeID: "/tmp/a", scriptKey: "x:repo:y")
+        let second = (worktreeID: "/tmp/a:repo:x", scriptKey: "y")
+        #expect("\(first.worktreeID):repo:\(first.scriptKey)" == "\(second.worktreeID):repo:\(second.scriptKey)")
+
+        for identity in [first, second] {
+            fixture.state.runRecords.begin(RunRecord(
+                id: UUID().uuidString,
+                scriptKey: identity.scriptKey,
+                scriptName: identity.scriptKey,
+                worktreeID: identity.worktreeID,
+                branch: fixture.worktree.branch,
+                target: fixture.state.runExecutionTarget(for: fixture.script, in: fixture.worktree),
+                status: .starting,
+                startedAt: Date()
+            ))
+            let launchID = UUID()
+            fixture.state.pendingScriptLaunches[PendingRunScriptLaunchKey(
+                worktreeID: identity.worktreeID,
+                scriptKey: identity.scriptKey
+            )] = PendingRunScriptLaunch(
+                id: launchID,
+                worktreeID: identity.worktreeID,
+                scriptKey: identity.scriptKey
+            )
+            fixture.state.pendingScriptLaunchTasks[launchID] = Task<Void, Never> {
+                try? await Task.sleep(for: .seconds(30))
+            }
+        }
+
+        fixture.state.cancelPendingRunScriptLaunches(worktreeID: first.worktreeID)
+
+        #expect(fixture.state.pendingScriptLaunches.count == 1)
+        #expect(fixture.state.pendingScriptLaunches.values.first?.worktreeID == second.worktreeID)
+        #expect(fixture.state.runRecords.record(worktreeID: first.worktreeID, scriptKey: first.scriptKey)?.status == .finished(.stopped))
+        #expect(fixture.state.runRecords.record(worktreeID: second.worktreeID, scriptKey: second.scriptKey)?.status == .starting)
         fixture.state.cancelPendingRunScriptLaunches()
     }
 

--- a/AlasTests/AppStateRunRecordTests.swift
+++ b/AlasTests/AppStateRunRecordTests.swift
@@ -279,6 +279,35 @@ struct AppStateRunRecordTests {
         #expect(runRecord(fixture)?.status == .finished(.succeeded))
     }
 
+    @Test func terminateAllTerminalSessionsCancelsPendingLaunches() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let record = RunRecord(
+            id: UUID().uuidString,
+            scriptKey: fixture.script.key,
+            scriptName: fixture.script.displayName,
+            worktreeID: fixture.worktree.id,
+            branch: fixture.worktree.branch,
+            target: fixture.state.runExecutionTarget(for: fixture.script, in: fixture.worktree),
+            status: .starting,
+            startedAt: Date()
+        )
+        fixture.state.runRecords.begin(record)
+        let launchID = UUID()
+        let task = Task<Void, Never> {
+            try? await Task.sleep(for: .seconds(30))
+        }
+        fixture.state.pendingScriptLaunches["\(fixture.worktree.id):\(fixture.script.key)"] = launchID
+        fixture.state.pendingScriptLaunchTasks[launchID] = task
+
+        fixture.state.terminateAllTerminalSessionsAfterConfirmationForTesting()
+
+        #expect(fixture.state.pendingScriptLaunches.isEmpty)
+        #expect(fixture.state.pendingScriptLaunchTasks.isEmpty)
+        #expect(task.isCancelled)
+        #expect(runRecord(fixture)?.status == .finished(.stopped))
+    }
+
     @Test func interruptedRunBecomesUnknownRatherThanSucceeded() async throws {
         let fixture = try makeFixture(waiter: { _ in
             try await Task.sleep(for: .seconds(5))

--- a/AlasTests/AppStateRunRecordTests.swift
+++ b/AlasTests/AppStateRunRecordTests.swift
@@ -381,6 +381,43 @@ struct AppStateRunRecordTests {
         #expect(fixture.state.runRecords.record(worktreeID: worktreeID, scriptKey: fixture.script.key)?.status == .finished(.stopped))
     }
 
+    @Test func pendingLaunchCancellationMatchesExactWorktreeID() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let firstWorktreeID = "/tmp/repo"
+        let secondWorktreeID = "/tmp/repo:staging"
+        for worktreeID in [firstWorktreeID, secondWorktreeID] {
+            fixture.state.runRecords.begin(RunRecord(
+                id: UUID().uuidString,
+                scriptKey: fixture.script.key,
+                scriptName: fixture.script.displayName,
+                worktreeID: worktreeID,
+                branch: fixture.worktree.branch,
+                target: fixture.state.runExecutionTarget(for: fixture.script, in: fixture.worktree),
+                status: .starting,
+                startedAt: Date()
+            ))
+            let launchID = UUID()
+            let task = Task<Void, Never> {
+                try? await Task.sleep(for: .seconds(30))
+            }
+            fixture.state.pendingScriptLaunches["\(worktreeID):\(fixture.script.key)"] = PendingRunScriptLaunch(
+                id: launchID,
+                worktreeID: worktreeID,
+                scriptKey: fixture.script.key
+            )
+            fixture.state.pendingScriptLaunchTasks[launchID] = task
+        }
+
+        fixture.state.cancelPendingRunScriptLaunches(worktreeID: firstWorktreeID)
+
+        #expect(fixture.state.pendingScriptLaunches.count == 1)
+        #expect(fixture.state.pendingScriptLaunches.values.first?.worktreeID == secondWorktreeID)
+        #expect(fixture.state.runRecords.record(worktreeID: firstWorktreeID, scriptKey: fixture.script.key)?.status == .finished(.stopped))
+        #expect(fixture.state.runRecords.record(worktreeID: secondWorktreeID, scriptKey: fixture.script.key)?.status == .starting)
+        fixture.state.cancelPendingRunScriptLaunches()
+    }
+
     @Test func interruptedRunBecomesUnknownRatherThanSucceeded() async throws {
         let fixture = try makeFixture(waiter: { _ in
             try await Task.sleep(for: .seconds(5))

--- a/AlasTests/AppStateRunRecordTests.swift
+++ b/AlasTests/AppStateRunRecordTests.swift
@@ -1,0 +1,469 @@
+import Foundation
+import Testing
+@testable import Alas
+
+/// End-to-end coverage of the Run tab's state: launching, completion versus
+/// shell lifetime, worktree isolation, and interrupted execution.
+@MainActor
+struct AppStateRunRecordTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    }
+
+    private struct Fixture {
+        let state: AppState
+        let script: RunScript
+        let worktree: Worktree
+        let directory: URL
+        var errors: () -> [(title: String, message: String)]
+    }
+
+    private func makeFixture(
+        waiter: @escaping AppState.RunScriptCompletionWaiter = { _ in
+            RunScriptCompletion(exitCode: 0, transcript: nil, truncated: false)
+        },
+        endpoint: URL? = nil,
+        host: String? = nil
+    ) throws -> Fixture {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("run-record-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let scriptURL = directory.appendingPathComponent("dev.sh")
+        try "echo hi\n".write(to: scriptURL, atomically: true, encoding: .utf8)
+        let script = RunScript(
+            scope: .repo,
+            fileName: "dev.sh",
+            fileURL: scriptURL,
+            displayName: "Dev",
+            onExit: .keep,
+            cwd: nil,
+            isExecutable: false,
+            endpoint: endpoint
+        )
+        let project = ProjectConfig(
+            id: "project",
+            name: "Project",
+            path: directory.path,
+            color: "blue",
+            addedAt: Date(),
+            host: host
+        )
+        func worktree(id: String, branch: String) -> Worktree {
+            Worktree(
+                id: id,
+                projectId: project.id,
+                name: branch,
+                branch: branch,
+                path: directory,
+                status: .clean,
+                lastActivity: Date()
+            )
+        }
+        let errors = ErrorBox()
+        var openCount = 0
+        let state = AppState(
+            store: MemoryStore(),
+            fileActionErrorHandler: { title, message in errors.append((title, message)) },
+            terminalSessionOpener: { _, _, _, _, _, _, _, _, _ in
+                openCount += 1
+                return AppState.OpenedTerminalSession(id: "session-\(openCount)", foregroundPid: { 123 })
+            },
+            runScriptCompletionWaiter: waiter
+        )
+        state.projectsManager = ProjectsManager(persistedProjects: [project])
+        return Fixture(
+            state: state,
+            script: script,
+            worktree: worktree(id: "wt-1", branch: "main"),
+            directory: directory,
+            errors: { errors.values }
+        )
+    }
+
+    private func secondWorktree(_ fixture: Fixture) -> Worktree {
+        Worktree(
+            id: "wt-2",
+            projectId: fixture.worktree.projectId,
+            name: "feature",
+            branch: "feature",
+            path: fixture.directory,
+            status: .clean,
+            lastActivity: Date()
+        )
+    }
+
+    private func runRecord(_ fixture: Fixture, worktree: Worktree? = nil) -> RunRecord? {
+        fixture.state.runRecords.record(
+            worktreeID: (worktree ?? fixture.worktree).id,
+            scriptKey: fixture.script.key
+        )
+    }
+
+    private func scriptTabCount(_ fixture: Fixture, worktree: Worktree? = nil) -> Int {
+        fixture.state.tabs.tabs(forWorktree: (worktree ?? fixture.worktree).id).count { tab in
+            guard case .terminal(let state) = tab else { return false }
+            return state.runScriptKey == fixture.script.key
+        }
+    }
+
+    // MARK: - Launch and completion
+
+    @Test func successfulRunIsRecordedWithoutClosingItsShell() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        // The row must not sit on "Not run" while the terminal opens.
+        #expect(runRecord(fixture)?.status == .starting)
+        try await Task.sleep(for: .milliseconds(50))
+        await fixture.state.waitForRunScriptCompletionTasksForTesting()
+
+        let record = try #require(runRecord(fixture))
+        #expect(record.status == .finished(.succeeded))
+        #expect(record.finishedAt != nil)
+        #expect(record.sessionID == "session-1")
+        // An `on-exit: keep` script leaves its shell at a prompt; the command
+        // is finished all the same.
+        #expect(scriptTabCount(fixture) == 1)
+    }
+
+    @Test func failedRunLinksTheCapturedOutput() async throws {
+        let fixture = try makeFixture(waiter: { _ in
+            RunScriptCompletion(exitCode: 42, transcript: Data("boom\n".utf8), truncated: false)
+        })
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        try await Task.sleep(for: .milliseconds(50))
+        await fixture.state.waitForRunScriptCompletionTasksForTesting()
+
+        let record = try #require(runRecord(fixture))
+        #expect(record.status == .finished(.failed(exitCode: 42)))
+        let failures = fixture.state.runScriptFailures(in: fixture.worktree.id)
+        #expect(failures.count == 1)
+        #expect(record.failureID == failures.first?.id)
+    }
+
+    @Test func launchFailureRestoresThePreviousObservedOutcome() async throws {
+        let fixture = try makeFixture(waiter: { _ in
+            RunScriptCompletion(exitCode: 7, transcript: nil, truncated: false)
+        })
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        try await Task.sleep(for: .milliseconds(50))
+        await fixture.state.waitForRunScriptCompletionTasksForTesting()
+        #expect(runRecord(fixture)?.status == .finished(.failed(exitCode: 7)))
+
+        // Delete the script out from under the next launch.
+        try FileManager.default.removeItem(at: fixture.script.fileURL)
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(runRecord(fixture)?.status == .finished(.failed(exitCode: 7)))
+        #expect(fixture.errors().contains { $0.title == "Run Script Failed" })
+    }
+
+    // MARK: - Launch races
+
+    @Test func doubleLaunchProducesOneRunRecord() async throws {
+        let fixture = try makeFixture(waiter: { _ in
+            try await Task.sleep(for: .seconds(5))
+            return RunScriptCompletion(exitCode: 0, transcript: nil, truncated: false)
+        })
+        defer {
+            fixture.state.cancelAllRunScriptCompletionTasks()
+            try? FileManager.default.removeItem(at: fixture.directory)
+        }
+
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(runRecord(fixture)?.status == .running)
+        #expect(fixture.state.runScriptCompletionTaskCountForTesting == 1)
+    }
+
+    /// A restart supersedes the previous run. When the old monitor finally
+    /// reports, it must not overwrite the run that replaced it.
+    @Test func supersededMonitorDoesNotOverwriteTheRestartedRun() async throws {
+        let calls = LockedCounter()
+        let fixture = try makeFixture(waiter: { _ in
+            let call = calls.incrementAndGet()
+            if call == 1 {
+                try await Task.sleep(for: .milliseconds(150))
+                return RunScriptCompletion(exitCode: 0, transcript: nil, truncated: false)
+            }
+            try await Task.sleep(for: .seconds(5))
+            return RunScriptCompletion(exitCode: 0, transcript: nil, truncated: false)
+        })
+        defer {
+            fixture.state.cancelAllRunScriptCompletionTasks()
+            try? FileManager.default.removeItem(at: fixture.directory)
+        }
+
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        try await Task.sleep(for: .milliseconds(50))
+        let firstRunID = try #require(runRecord(fixture)?.id)
+
+        fixture.state.restartScript(fixture.script, in: fixture.worktree)
+        try await Task.sleep(for: .milliseconds(50))
+        let secondRunID = try #require(runRecord(fixture)?.id)
+        #expect(secondRunID != firstRunID)
+
+        // Let the superseded monitor resolve with a success it no longer owns.
+        try await Task.sleep(for: .milliseconds(200))
+
+        let current = try #require(runRecord(fixture))
+        #expect(current.id == secondRunID)
+        #expect(current.status == .running)
+    }
+
+    // MARK: - Stop and interruption
+
+    @Test func stoppingARunReportsStoppedNotFailed() async throws {
+        let fixture = try makeFixture(waiter: { _ in
+            try await Task.sleep(for: .seconds(5))
+            return RunScriptCompletion(exitCode: 0, transcript: nil, truncated: false)
+        })
+        defer {
+            fixture.state.cancelAllRunScriptCompletionTasks()
+            try? FileManager.default.removeItem(at: fixture.directory)
+        }
+
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        try await Task.sleep(for: .milliseconds(50))
+        fixture.state.stopScript(fixture.script, in: fixture.worktree)
+
+        #expect(runRecord(fixture)?.status == .finished(.stopped))
+        #expect(scriptTabCount(fixture) == 0)
+
+        // The monitor teardown that follows a close must not relabel a
+        // deliberate stop as a lost process.
+        fixture.state.cancelRunScriptCompletionTasks(sessionID: "session-1")
+        #expect(runRecord(fixture)?.status == .finished(.stopped))
+    }
+
+    @Test func interruptedRunBecomesUnknownRatherThanSucceeded() async throws {
+        let fixture = try makeFixture(waiter: { _ in
+            try await Task.sleep(for: .seconds(5))
+            return RunScriptCompletion(exitCode: 0, transcript: nil, truncated: false)
+        })
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(runRecord(fixture)?.status == .running)
+
+        // The hosting shell died before the command reported anything.
+        fixture.state.cancelRunScriptCompletionTasks(sessionID: "session-1")
+
+        #expect(runRecord(fixture)?.status == .finished(.unknown))
+    }
+
+    @Test func waiterFailureBecomesUnknownRatherThanSucceeded() async throws {
+        struct DroppedConnection: Error {}
+        let fixture = try makeFixture(waiter: { _ in throw DroppedConnection() })
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        try await Task.sleep(for: .milliseconds(50))
+        await fixture.state.waitForRunScriptCompletionTasksForTesting()
+
+        #expect(runRecord(fixture)?.status == .finished(.unknown))
+        #expect(fixture.state.runScriptFailures(in: fixture.worktree.id).isEmpty)
+    }
+
+    /// Reconnecting to a worktree settles runs whose terminal vanished while
+    /// nothing was observing them.
+    @Test func reconcileSettlesRunsWhoseTerminalIsGone() async throws {
+        let fixture = try makeFixture(waiter: { _ in
+            try await Task.sleep(for: .seconds(5))
+            return RunScriptCompletion(exitCode: 0, transcript: nil, truncated: false)
+        })
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        try await Task.sleep(for: .milliseconds(50))
+
+        // A monitor is still watching, so reconciliation must not give up yet.
+        fixture.state.reconcileRunRecords(worktreeID: fixture.worktree.id)
+        #expect(runRecord(fixture)?.status == .running)
+
+        fixture.state.cancelAllRunScriptCompletionTasks()
+        fixture.state.reconcileRunRecords(worktreeID: fixture.worktree.id)
+        #expect(runRecord(fixture)?.status == .finished(.unknown))
+    }
+
+    // MARK: - Worktree isolation
+
+    @Test func runsAreScopedToTheWorktreeThatLaunchedThem() async throws {
+        let fixture = try makeFixture(waiter: { _ in
+            try await Task.sleep(for: .seconds(5))
+            return RunScriptCompletion(exitCode: 0, transcript: nil, truncated: false)
+        })
+        defer {
+            fixture.state.cancelAllRunScriptCompletionTasks()
+            try? FileManager.default.removeItem(at: fixture.directory)
+        }
+        let other = secondWorktree(fixture)
+
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(runRecord(fixture)?.status == .running)
+        #expect(runRecord(fixture, worktree: other) == nil)
+        #expect(scriptTabCount(fixture, worktree: other) == 0)
+
+        // Stopping the other worktree's (nonexistent) run must not reach into
+        // the running one.
+        fixture.state.stopScript(fixture.script, in: other)
+        #expect(runRecord(fixture)?.status == .running)
+    }
+
+    @Test func eachWorktreeKeepsItsOwnRun() async throws {
+        let fixture = try makeFixture(waiter: { _ in
+            try await Task.sleep(for: .seconds(5))
+            return RunScriptCompletion(exitCode: 0, transcript: nil, truncated: false)
+        })
+        defer {
+            fixture.state.cancelAllRunScriptCompletionTasks()
+            try? FileManager.default.removeItem(at: fixture.directory)
+        }
+        let other = secondWorktree(fixture)
+
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        fixture.state.runOrFocusScript(fixture.script, in: other)
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(runRecord(fixture)?.sessionID == "session-1")
+        #expect(runRecord(fixture, worktree: other)?.sessionID == "session-2")
+
+        fixture.state.stopScript(fixture.script, in: fixture.worktree)
+        #expect(runRecord(fixture)?.status == .finished(.stopped))
+        #expect(runRecord(fixture, worktree: other)?.status == .running)
+    }
+
+    // MARK: - Panel independence
+
+    /// The Run panel is a view onto `runRecords`; hiding it or switching the
+    /// right pane away must not touch the run.
+    @Test func hidingTheRightPaneDoesNotStopARun() async throws {
+        let fixture = try makeFixture(waiter: { _ in
+            try await Task.sleep(for: .seconds(5))
+            return RunScriptCompletion(exitCode: 0, transcript: nil, truncated: false)
+        })
+        defer {
+            fixture.state.cancelAllRunScriptCompletionTasks()
+            try? FileManager.default.removeItem(at: fixture.directory)
+        }
+
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        try await Task.sleep(for: .milliseconds(50))
+
+        fixture.state.config.rightPaneVisible = false
+        fixture.state.rightPaneStore.deactivate()
+
+        #expect(runRecord(fixture)?.status == .running)
+        #expect(fixture.state.runScriptCompletionTaskCountForTesting == 1)
+        #expect(scriptTabCount(fixture) == 1)
+    }
+
+    // MARK: - Endpoints
+
+    @Test func remoteRunRefusesToOpenALoopbackEndpoint() throws {
+        let fixture = try makeFixture(
+            endpoint: URL(string: "http://localhost:3000")!,
+            host: "devbox"
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        fixture.state.openRunEndpoint(fixture.script, in: fixture.worktree)
+
+        let error = try #require(fixture.errors().first)
+        #expect(error.title == "Can't Open Endpoint")
+        #expect(error.message.contains("devbox"))
+        #expect(error.message.contains("http://localhost:3000"))
+    }
+
+    @Test func executionTargetReflectsHostAndWorkingDirectory() throws {
+        let fixture = try makeFixture(host: "devbox")
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let nested = RunScript(
+            scope: .repo,
+            fileName: "web.sh",
+            fileURL: fixture.script.fileURL,
+            displayName: "Web",
+            onExit: .keep,
+            cwd: "apps/web",
+            isExecutable: false
+        )
+
+        let target = fixture.state.runExecutionTarget(for: nested, in: fixture.worktree)
+
+        #expect(target.host == "devbox")
+        #expect(target.workingDirectory == fixture.directory.appendingPathComponent("apps/web").path)
+    }
+
+    /// A port already served by another worktree's run is reported, not
+    /// resolved by killing anything.
+    @Test func portCollisionWithAnotherWorktreeIsReported() async throws {
+        let endpoint = URL(string: "http://localhost:3000")!
+        let fixture = try makeFixture(
+            waiter: { _ in
+                try await Task.sleep(for: .seconds(5))
+                return RunScriptCompletion(exitCode: 0, transcript: nil, truncated: false)
+            },
+            endpoint: endpoint
+        )
+        defer {
+            fixture.state.cancelAllRunScriptCompletionTasks()
+            try? FileManager.default.removeItem(at: fixture.directory)
+        }
+        let other = secondWorktree(fixture)
+
+        fixture.state.runOrFocusScript(fixture.script, in: fixture.worktree)
+        try await Task.sleep(for: .milliseconds(50))
+        fixture.state.runOrFocusScript(fixture.script, in: other)
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(runRecord(fixture, worktree: other)?.portConflict == .ownedByRun(
+            worktreeID: fixture.worktree.id,
+            branch: "main",
+            scriptName: "Dev"
+        ))
+        // Both runs keep going; a collision is information, not an eviction.
+        #expect(runRecord(fixture)?.status == .running)
+        #expect(runRecord(fixture, worktree: other)?.status == .running)
+    }
+}
+
+private final class ErrorBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [(title: String, message: String)] = []
+
+    var values: [(title: String, message: String)] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func append(_ entry: (title: String, message: String)) {
+        lock.lock()
+        storage.append(entry)
+        lock.unlock()
+    }
+}
+
+private final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func incrementAndGet() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        count += 1
+        return count
+    }
+}

--- a/AlasTests/AppStateRunScriptCreationTests.swift
+++ b/AlasTests/AppStateRunScriptCreationTests.swift
@@ -55,6 +55,7 @@ struct AppStateRunScriptCreationTests {
         try state.createPendingRunScript(name: " Dev Server ", onExit: .close)
 
         #expect(state.pendingRunScriptCreation == nil)
+        #expect(state.runScriptCatalogGeneration == 1)
         let tab = try #require(state.tabs.activeTab(forWorktree: worktree.id))
         guard case .editor(let editor) = tab else {
             Issue.record("expected repo editor tab")

--- a/AlasTests/RightPaneTabTests.swift
+++ b/AlasTests/RightPaneTabTests.swift
@@ -1,0 +1,14 @@
+import Testing
+@testable import Alas
+
+struct RightPaneTabTests {
+    @Test func runTabIsUnavailableUntilPreviewIsEnabled() {
+        #expect(RightPaneTab.available(runTabEnabled: false) == [.changes, .files])
+        #expect(RightPaneTab.available(runTabEnabled: true) == [.changes, .files, .run])
+    }
+
+    @Test func hidingRunTabMovesItsSelectionToChanges() {
+        #expect(RightPaneTab.visible(.run, runTabEnabled: false) == .changes)
+        #expect(RightPaneTab.visible(.files, runTabEnabled: false) == .files)
+    }
+}

--- a/AlasTests/RunEndpointTests.swift
+++ b/AlasTests/RunEndpointTests.swift
@@ -61,6 +61,11 @@ struct RunEndpointTests {
         #expect(RunEndpointPolicy.action(for: url, target: target(host: "devbox")) == .open(url))
     }
 
+    @Test func remoteRunDoesNotTreatDnsNamesStartingWith127AsLoopback() {
+        let url = URL(string: "https://127.example.internal:8443/app")!
+        #expect(RunEndpointPolicy.action(for: url, target: target(host: "devbox")) == .open(url))
+    }
+
     // MARK: - Port probe
 
     @Test func portProbeDetectsAListenerWithoutTouchingIt() throws {

--- a/AlasTests/RunEndpointTests.swift
+++ b/AlasTests/RunEndpointTests.swift
@@ -1,0 +1,130 @@
+import Darwin
+import Foundation
+import Testing
+@testable import Alas
+
+struct RunEndpointTests {
+    private func target(host: String?) -> RunExecutionTarget {
+        RunExecutionTarget(host: host, workingDirectory: "/wt")
+    }
+
+    // MARK: - Header parsing
+
+    @Test func parsesHttpEndpointHeader() {
+        let meta = RunScriptMetadata.parse(
+            fileName: "web.sh",
+            contents: "# alas-name: Web\n# alas-url: http://localhost:3000/app\n"
+        )
+        #expect(meta.endpoint == URL(string: "http://localhost:3000/app"))
+    }
+
+    @Test func ignoresNonHttpOrMalformedEndpointHeaders() {
+        for value in ["file:///tmp/x", "localhost:3000", "not a url", "ftp://example.test"] {
+            let meta = RunScriptMetadata.parse(fileName: "web.sh", contents: "# alas-url: \(value)\n")
+            #expect(meta.endpoint == nil, "expected \(value) to be rejected")
+        }
+    }
+
+    /// A bad endpoint header must never hide the script from the Run tab.
+    @Test func malformedEndpointStillYieldsAUsableScript() {
+        let meta = RunScriptMetadata.parse(
+            fileName: "web.sh",
+            contents: "# alas-name: Web\n# alas-url: nonsense\n# alas-cwd: apps/web\n"
+        )
+        #expect(meta.displayName == "Web")
+        #expect(meta.cwd == "apps/web")
+        #expect(meta.endpoint == nil)
+    }
+
+    // MARK: - Open policy
+
+    @Test func localRunOpensItsEndpointDirectly() {
+        let url = URL(string: "http://localhost:3000")!
+        #expect(RunEndpointPolicy.action(for: url, target: target(host: nil)) == .open(url))
+    }
+
+    /// The dangerous case: an SSH run whose URL says "localhost" would open a
+    /// completely unrelated service on the user's own machine.
+    @Test func remoteRunRefusesToOpenALoopbackURL() {
+        for host in ["localhost", "127.0.0.1", "0.0.0.0", "[::1]"] {
+            let url = URL(string: "http://\(host):3000")!
+            #expect(
+                RunEndpointPolicy.action(for: url, target: target(host: "devbox"))
+                    == .blockedRemoteLoopback(host: "devbox", url: url),
+                "expected \(host) to be blocked for a remote run"
+            )
+        }
+    }
+
+    @Test func remoteRunOpensAnAddressableURL() {
+        let url = URL(string: "https://devbox.internal:8443/app")!
+        #expect(RunEndpointPolicy.action(for: url, target: target(host: "devbox")) == .open(url))
+    }
+
+    // MARK: - Port probe
+
+    @Test func portProbeDetectsAListenerWithoutTouchingIt() throws {
+        let listener = try Listener()
+        defer { listener.close() }
+        #expect(RunPortProbe.isLocalPortInUse(listener.port))
+        // Observing the collision must leave the other socket alone: it is
+        // still open and still holding the port.
+        #expect(listener.isOpen)
+        #expect(RunPortProbe.isLocalPortInUse(listener.port))
+    }
+
+    @Test func portProbeRejectsPortsOutsideTheValidRange() {
+        #expect(!RunPortProbe.isLocalPortInUse(0))
+        #expect(!RunPortProbe.isLocalPortInUse(-1))
+        #expect(!RunPortProbe.isLocalPortInUse(70_000))
+    }
+}
+
+/// A real listening socket on an OS-assigned port, so the probe is exercised
+/// against the same condition a dev server produces.
+private final class Listener {
+    let descriptor: Int32
+    let port: Int
+
+    init() throws {
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw ListenerError.failed }
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = 0
+        address.sin_addr.s_addr = INADDR_ANY
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bound == 0, listen(fd, 1) == 0 else {
+            Darwin.close(fd)
+            throw ListenerError.failed
+        }
+        var assigned = sockaddr_in()
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let named = withUnsafeMutablePointer(to: &assigned) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(fd, $0, &length)
+            }
+        }
+        guard named == 0 else {
+            Darwin.close(fd)
+            throw ListenerError.failed
+        }
+        descriptor = fd
+        port = Int(UInt16(bigEndian: assigned.sin_port))
+    }
+
+    var isOpen: Bool {
+        fcntl(descriptor, F_GETFL) != -1
+    }
+
+    func close() {
+        Darwin.close(descriptor)
+    }
+
+    enum ListenerError: Error { case failed }
+}

--- a/AlasTests/RunEndpointTests.swift
+++ b/AlasTests/RunEndpointTests.swift
@@ -46,7 +46,7 @@ struct RunEndpointTests {
     /// The dangerous case: an SSH run whose URL says "localhost" would open a
     /// completely unrelated service on the user's own machine.
     @Test func remoteRunRefusesToOpenALoopbackURL() {
-        for host in ["localhost", "127.0.0.1", "127.0.0.2", "0.0.0.0", "[::1]"] {
+        for host in ["localhost", "localhost.", "127.0.0.1", "127.0.0.2", "0.0.0.0", "[::1]"] {
             let url = URL(string: "http://\(host):3000")!
             #expect(
                 RunEndpointPolicy.action(for: url, target: target(host: "devbox"))

--- a/AlasTests/RunEndpointTests.swift
+++ b/AlasTests/RunEndpointTests.swift
@@ -46,7 +46,7 @@ struct RunEndpointTests {
     /// The dangerous case: an SSH run whose URL says "localhost" would open a
     /// completely unrelated service on the user's own machine.
     @Test func remoteRunRefusesToOpenALoopbackURL() {
-        for host in ["localhost", "127.0.0.1", "0.0.0.0", "[::1]"] {
+        for host in ["localhost", "127.0.0.1", "127.0.0.2", "0.0.0.0", "[::1]"] {
             let url = URL(string: "http://\(host):3000")!
             #expect(
                 RunEndpointPolicy.action(for: url, target: target(host: "devbox"))

--- a/AlasTests/RunEndpointTests.swift
+++ b/AlasTests/RunEndpointTests.swift
@@ -46,7 +46,7 @@ struct RunEndpointTests {
     /// The dangerous case: an SSH run whose URL says "localhost" would open a
     /// completely unrelated service on the user's own machine.
     @Test func remoteRunRefusesToOpenALoopbackURL() {
-        for host in ["localhost", "localhost.", "127.0.0.1", "127.0.0.2", "127.1", "2130706433", "0177.0.0.1", "0x7f000001", "0.0.0.0", "[::1]", "[0:0::1]", "[0000::0001]", "[::1%25lo0]", "[::ffff:127.0.0.1]", "[::ffff:7f00:1]"] {
+        for host in ["localhost", "localhost.", "127.0.0.1", "127.0.0.2", "127.1", "2130706433", "0177.0.0.1", "0x7f000001", "0.0.0.0", "0", "[::1]", "[0:0::1]", "[0000::0001]", "[::1%25lo0]", "[::ffff:127.0.0.1]", "[::ffff:7f00:1]", "[::]", "[0:0::]", "[0000:0000:0000:0000:0000:0000:0000:0000]"] {
             let url = URL(string: "http://\(host):3000")!
             #expect(
                 RunEndpointPolicy.action(for: url, target: target(host: "devbox"))

--- a/AlasTests/RunEndpointTests.swift
+++ b/AlasTests/RunEndpointTests.swift
@@ -46,7 +46,7 @@ struct RunEndpointTests {
     /// The dangerous case: an SSH run whose URL says "localhost" would open a
     /// completely unrelated service on the user's own machine.
     @Test func remoteRunRefusesToOpenALoopbackURL() {
-        for host in ["localhost", "localhost.", "127.0.0.1", "127.0.0.2", "127.1", "2130706433", "0177.0.0.1", "0x7f000001", "0.0.0.0", "[::1]", "[::ffff:127.0.0.1]", "[::ffff:7f00:1]"] {
+        for host in ["localhost", "localhost.", "127.0.0.1", "127.0.0.2", "127.1", "2130706433", "0177.0.0.1", "0x7f000001", "0.0.0.0", "[::1]", "[::1%25lo0]", "[::ffff:127.0.0.1]", "[::ffff:7f00:1]"] {
             let url = URL(string: "http://\(host):3000")!
             #expect(
                 RunEndpointPolicy.action(for: url, target: target(host: "devbox"))

--- a/AlasTests/RunEndpointTests.swift
+++ b/AlasTests/RunEndpointTests.swift
@@ -46,7 +46,7 @@ struct RunEndpointTests {
     /// The dangerous case: an SSH run whose URL says "localhost" would open a
     /// completely unrelated service on the user's own machine.
     @Test func remoteRunRefusesToOpenALoopbackURL() {
-        for host in ["localhost", "localhost.", "127.0.0.1", "127.0.0.2", "127.1", "2130706433", "0177.0.0.1", "0x7f000001", "0.0.0.0", "0", "[::1]", "[0:0::1]", "[0000::0001]", "[::1%25lo0]", "[::ffff:127.0.0.1]", "[::ffff:7f00:1]", "[::]", "[0:0::]", "[0000:0000:0000:0000:0000:0000:0000:0000]"] {
+        for host in ["localhost", "localhost.", "service.localhost", "service.localhost.", "127.0.0.1", "127.0.0.2", "127.1", "2130706433", "0177.0.0.1", "0x7f000001", "0.0.0.0", "0", "[::1]", "[0:0::1]", "[0000::0001]", "[::1%25lo0]", "[::ffff:127.0.0.1]", "[::ffff:7f00:1]", "[::ffff:0.0.0.0]", "[::ffff:0:0]", "[::]", "[0:0::]", "[0000:0000:0000:0000:0000:0000:0000:0000]"] {
             let url = URL(string: "http://\(host):3000")!
             #expect(
                 RunEndpointPolicy.action(for: url, target: target(host: "devbox"))

--- a/AlasTests/RunEndpointTests.swift
+++ b/AlasTests/RunEndpointTests.swift
@@ -46,7 +46,7 @@ struct RunEndpointTests {
     /// The dangerous case: an SSH run whose URL says "localhost" would open a
     /// completely unrelated service on the user's own machine.
     @Test func remoteRunRefusesToOpenALoopbackURL() {
-        for host in ["localhost", "localhost.", "127.0.0.1", "127.0.0.2", "0.0.0.0", "[::1]", "[::ffff:127.0.0.1]"] {
+        for host in ["localhost", "localhost.", "127.0.0.1", "127.0.0.2", "0.0.0.0", "[::1]", "[::ffff:127.0.0.1]", "[::ffff:7f00:1]"] {
             let url = URL(string: "http://\(host):3000")!
             #expect(
                 RunEndpointPolicy.action(for: url, target: target(host: "devbox"))

--- a/AlasTests/RunEndpointTests.swift
+++ b/AlasTests/RunEndpointTests.swift
@@ -46,7 +46,7 @@ struct RunEndpointTests {
     /// The dangerous case: an SSH run whose URL says "localhost" would open a
     /// completely unrelated service on the user's own machine.
     @Test func remoteRunRefusesToOpenALoopbackURL() {
-        for host in ["localhost", "localhost.", "127.0.0.1", "127.0.0.2", "127.1", "2130706433", "0177.0.0.1", "0x7f000001", "0.0.0.0", "[::1]", "[::1%25lo0]", "[::ffff:127.0.0.1]", "[::ffff:7f00:1]"] {
+        for host in ["localhost", "localhost.", "127.0.0.1", "127.0.0.2", "127.1", "2130706433", "0177.0.0.1", "0x7f000001", "0.0.0.0", "[::1]", "[0:0::1]", "[0000::0001]", "[::1%25lo0]", "[::ffff:127.0.0.1]", "[::ffff:7f00:1]"] {
             let url = URL(string: "http://\(host):3000")!
             #expect(
                 RunEndpointPolicy.action(for: url, target: target(host: "devbox"))

--- a/AlasTests/RunEndpointTests.swift
+++ b/AlasTests/RunEndpointTests.swift
@@ -46,7 +46,7 @@ struct RunEndpointTests {
     /// The dangerous case: an SSH run whose URL says "localhost" would open a
     /// completely unrelated service on the user's own machine.
     @Test func remoteRunRefusesToOpenALoopbackURL() {
-        for host in ["localhost", "localhost.", "127.0.0.1", "127.0.0.2", "0.0.0.0", "[::1]"] {
+        for host in ["localhost", "localhost.", "127.0.0.1", "127.0.0.2", "0.0.0.0", "[::1]", "[::ffff:127.0.0.1]"] {
             let url = URL(string: "http://\(host):3000")!
             #expect(
                 RunEndpointPolicy.action(for: url, target: target(host: "devbox"))

--- a/AlasTests/RunEndpointTests.swift
+++ b/AlasTests/RunEndpointTests.swift
@@ -46,7 +46,7 @@ struct RunEndpointTests {
     /// The dangerous case: an SSH run whose URL says "localhost" would open a
     /// completely unrelated service on the user's own machine.
     @Test func remoteRunRefusesToOpenALoopbackURL() {
-        for host in ["localhost", "localhost.", "127.0.0.1", "127.0.0.2", "0.0.0.0", "[::1]", "[::ffff:127.0.0.1]", "[::ffff:7f00:1]"] {
+        for host in ["localhost", "localhost.", "127.0.0.1", "127.0.0.2", "127.1", "2130706433", "0177.0.0.1", "0x7f000001", "0.0.0.0", "[::1]", "[::ffff:127.0.0.1]", "[::ffff:7f00:1]"] {
             let url = URL(string: "http://\(host):3000")!
             #expect(
                 RunEndpointPolicy.action(for: url, target: target(host: "devbox"))

--- a/AlasTests/RunEndpointTests.swift
+++ b/AlasTests/RunEndpointTests.swift
@@ -78,6 +78,14 @@ struct RunEndpointTests {
         #expect(RunPortProbe.isLocalPortInUse(listener.port))
     }
 
+    @Test func portProbeDetectsIPv6OnlyListener() throws {
+        let listener = try IPv6OnlyListener()
+        defer { listener.close() }
+
+        #expect(RunPortProbe.isLocalPortInUse(listener.port))
+        #expect(listener.isOpen)
+    }
+
     @Test func portProbeRejectsPortsOutsideTheValidRange() {
         #expect(!RunPortProbe.isLocalPortInUse(0))
         #expect(!RunPortProbe.isLocalPortInUse(-1))
@@ -132,4 +140,54 @@ private final class Listener {
     }
 
     enum ListenerError: Error { case failed }
+}
+
+private final class IPv6OnlyListener {
+    let descriptor: Int32
+    let port: Int
+
+    init() throws {
+        let fd = socket(AF_INET6, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw Listener.ListenerError.failed }
+        var only: Int32 = 1
+        guard setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &only, socklen_t(MemoryLayout<Int32>.size)) == 0 else {
+            Darwin.close(fd)
+            throw Listener.ListenerError.failed
+        }
+        var address = sockaddr_in6()
+        address.sin6_len = UInt8(MemoryLayout<sockaddr_in6>.size)
+        address.sin6_family = sa_family_t(AF_INET6)
+        address.sin6_port = 0
+        address.sin6_addr = in6addr_loopback
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in6>.size))
+            }
+        }
+        guard bound == 0, listen(fd, 1) == 0 else {
+            Darwin.close(fd)
+            throw Listener.ListenerError.failed
+        }
+        var assigned = sockaddr_in6()
+        var length = socklen_t(MemoryLayout<sockaddr_in6>.size)
+        let named = withUnsafeMutablePointer(to: &assigned) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(fd, $0, &length)
+            }
+        }
+        guard named == 0 else {
+            Darwin.close(fd)
+            throw Listener.ListenerError.failed
+        }
+        descriptor = fd
+        port = Int(UInt16(bigEndian: assigned.sin6_port))
+    }
+
+    var isOpen: Bool {
+        fcntl(descriptor, F_GETFL) != -1
+    }
+
+    func close() {
+        Darwin.close(descriptor)
+    }
 }

--- a/AlasTests/RunRecordStoreTests.swift
+++ b/AlasTests/RunRecordStoreTests.swift
@@ -1,0 +1,223 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct RunRecordStoreTests {
+    private let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func target(host: String? = nil, cwd: String = "/wt") -> RunExecutionTarget {
+        RunExecutionTarget(host: host, workingDirectory: cwd)
+    }
+
+    private func record(
+        id: String = "run-1",
+        scriptKey: String = "repo:dev.sh",
+        worktreeID: String = "wt-1",
+        branch: String = "main",
+        host: String? = nil,
+        endpoint: URL? = nil,
+        status: RunStatus = .starting
+    ) -> RunRecord {
+        RunRecord(
+            id: id,
+            scriptKey: scriptKey,
+            scriptName: "Dev",
+            worktreeID: worktreeID,
+            branch: branch,
+            target: target(host: host),
+            endpoint: endpoint,
+            status: status,
+            startedAt: epoch
+        )
+    }
+
+    // MARK: - Lifecycle
+
+    @Test func beginThenRunThenFinishTracksOneRun() {
+        var store = RunRecordStore()
+        #expect(store.begin(record()) == nil)
+        store.markRunning(runID: "run-1", sessionID: "session-1")
+        #expect(store.record(worktreeID: "wt-1", scriptKey: "repo:dev.sh")?.status == .running)
+        #expect(store.record(worktreeID: "wt-1", scriptKey: "repo:dev.sh")?.sessionID == "session-1")
+
+        store.finish(runID: "run-1", outcome: .succeeded, at: epoch.addingTimeInterval(12))
+
+        let finished = store.record(worktreeID: "wt-1", scriptKey: "repo:dev.sh")
+        #expect(finished?.status == .finished(.succeeded))
+        #expect(finished?.duration == 12)
+        #expect(store.activeRecords.isEmpty)
+    }
+
+    @Test func finishRecordsFailureExitCodeAndOutputLink() {
+        var store = RunRecordStore()
+        store.begin(record())
+        store.markRunning(runID: "run-1", sessionID: "session-1")
+
+        store.finish(runID: "run-1", outcome: .failed(exitCode: 42), at: epoch, failureID: "failure-1")
+
+        #expect(store.record(worktreeID: "wt-1", scriptKey: "repo:dev.sh")?.status == .finished(.failed(exitCode: 42)))
+        #expect(store.record(worktreeID: "wt-1", scriptKey: "repo:dev.sh")?.failureID == "failure-1")
+    }
+
+    // MARK: - Launch races
+
+    /// A restart replaces the record; the superseded run's monitor may still
+    /// be in flight and must not write its outcome over the new run.
+    @Test func supersededRunCannotFinishTheRunThatReplacedIt() {
+        var store = RunRecordStore()
+        store.begin(record(id: "run-1"))
+        store.markRunning(runID: "run-1", sessionID: "session-1")
+        store.begin(record(id: "run-2"))
+        store.markRunning(runID: "run-2", sessionID: "session-2")
+
+        store.finish(runID: "run-1", outcome: .succeeded, at: epoch.addingTimeInterval(5))
+
+        let current = store.record(worktreeID: "wt-1", scriptKey: "repo:dev.sh")
+        #expect(current?.id == "run-2")
+        #expect(current?.status == .running)
+    }
+
+    @Test func supersededRunCannotMarkTheReplacementUnknown() {
+        var store = RunRecordStore()
+        store.begin(record(id: "run-1"))
+        store.begin(record(id: "run-2"))
+        store.markRunning(runID: "run-2", sessionID: "session-2")
+
+        store.markLostObservation(runID: "run-1", at: epoch)
+
+        #expect(store.record(worktreeID: "wt-1", scriptKey: "repo:dev.sh")?.status == .running)
+    }
+
+    @Test func rollbackRestoresTheDisplacedOutcome() {
+        var store = RunRecordStore()
+        store.begin(record(id: "run-1"))
+        store.finish(runID: "run-1", outcome: .failed(exitCode: 1), at: epoch)
+        let displaced = store.begin(record(id: "run-2"))
+
+        store.rollback(runID: "run-2", to: displaced)
+
+        let current = store.record(worktreeID: "wt-1", scriptKey: "repo:dev.sh")
+        #expect(current?.id == "run-1")
+        #expect(current?.status == .finished(.failed(exitCode: 1)))
+    }
+
+    @Test func rollbackOfASupersededRunLeavesTheCurrentRunAlone() {
+        var store = RunRecordStore()
+        let displaced = store.begin(record(id: "run-1"))
+        store.begin(record(id: "run-2"))
+
+        store.rollback(runID: "run-1", to: displaced)
+
+        #expect(store.record(worktreeID: "wt-1", scriptKey: "repo:dev.sh")?.id == "run-2")
+    }
+
+    @Test func rollbackWithNoPreviousRunClearsTheSlot() {
+        var store = RunRecordStore()
+        let displaced = store.begin(record(id: "run-1"))
+
+        store.rollback(runID: "run-1", to: displaced)
+
+        #expect(store.record(worktreeID: "wt-1", scriptKey: "repo:dev.sh") == nil)
+        #expect(store.byWorktree["wt-1"] == nil)
+    }
+
+    // MARK: - Honest outcomes
+
+    @Test func lostObservationNeverReportsSuccess() {
+        var store = RunRecordStore()
+        store.begin(record())
+        store.markRunning(runID: "run-1", sessionID: "session-1")
+
+        store.markLostObservation(runID: "run-1", at: epoch.addingTimeInterval(3))
+
+        #expect(store.record(worktreeID: "wt-1", scriptKey: "repo:dev.sh")?.status == .finished(.unknown))
+    }
+
+    /// The command reported an exit status; closing its shell afterwards is
+    /// not new information about the command.
+    @Test func closingTheShellAfterCompletionKeepsTheObservedOutcome() {
+        var store = RunRecordStore()
+        store.begin(record())
+        store.markRunning(runID: "run-1", sessionID: "session-1")
+        store.finish(runID: "run-1", outcome: .succeeded, at: epoch)
+
+        store.markLostObservation(runID: "run-1", at: epoch.addingTimeInterval(60))
+        store.markStopped(worktreeID: "wt-1", scriptKey: "repo:dev.sh", at: epoch.addingTimeInterval(60))
+
+        #expect(store.record(worktreeID: "wt-1", scriptKey: "repo:dev.sh")?.status == .finished(.succeeded))
+    }
+
+    @Test func stopWinsOverLaterLostObservation() {
+        var store = RunRecordStore()
+        store.begin(record())
+        store.markRunning(runID: "run-1", sessionID: "session-1")
+
+        store.markStopped(worktreeID: "wt-1", scriptKey: "repo:dev.sh", at: epoch.addingTimeInterval(4))
+        store.markLostObservation(runID: "run-1", at: epoch.addingTimeInterval(6))
+
+        let current = store.record(worktreeID: "wt-1", scriptKey: "repo:dev.sh")
+        #expect(current?.status == .finished(.stopped))
+        #expect(current?.finishedAt == epoch.addingTimeInterval(4))
+    }
+
+    // MARK: - Worktree isolation
+
+    @Test func recordsDoNotLeakAcrossWorktrees() {
+        var store = RunRecordStore()
+        store.begin(record(id: "run-a", worktreeID: "wt-1"))
+        store.markRunning(runID: "run-a", sessionID: "session-a")
+        store.begin(record(id: "run-b", worktreeID: "wt-2"))
+        store.markRunning(runID: "run-b", sessionID: "session-b")
+
+        store.markStopped(worktreeID: "wt-1", scriptKey: "repo:dev.sh", at: epoch)
+
+        #expect(store.record(worktreeID: "wt-1", scriptKey: "repo:dev.sh")?.status == .finished(.stopped))
+        #expect(store.record(worktreeID: "wt-2", scriptKey: "repo:dev.sh")?.status == .running)
+    }
+
+    @Test func purgingOneWorktreeLeavesTheOthers() {
+        var store = RunRecordStore()
+        store.begin(record(id: "run-a", worktreeID: "wt-1"))
+        store.begin(record(id: "run-b", worktreeID: "wt-2"))
+
+        store.purge(worktreeID: "wt-1")
+
+        #expect(store.records(worktreeID: "wt-1").isEmpty)
+        #expect(store.records(worktreeID: "wt-2").count == 1)
+    }
+
+    // MARK: - Endpoint ownership
+
+    @Test func portOwnerIsMatchedByHostAndPort() {
+        var store = RunRecordStore()
+        store.begin(record(
+            id: "run-a",
+            worktreeID: "wt-1",
+            branch: "feature",
+            endpoint: URL(string: "http://localhost:3000")!
+        ))
+        store.markRunning(runID: "run-a", sessionID: "session-a")
+
+        #expect(store.activeRunOwningPort(3000, host: nil)?.branch == "feature")
+        #expect(store.activeRunOwningPort(3001, host: nil) == nil)
+        // Same port number, different machine — not a collision.
+        #expect(store.activeRunOwningPort(3000, host: "devbox") == nil)
+        #expect(store.activeRunOwningPort(3000, host: nil, excludingRunID: "run-a") == nil)
+    }
+
+    @Test func finishedRunsNoLongerOwnTheirPort() {
+        var store = RunRecordStore()
+        store.begin(record(id: "run-a", endpoint: URL(string: "http://localhost:3000")!))
+        store.markRunning(runID: "run-a", sessionID: "session-a")
+        store.finish(runID: "run-a", outcome: .succeeded, at: epoch)
+
+        #expect(store.activeRunOwningPort(3000, host: nil) == nil)
+    }
+
+    @Test func schemeDefaultPortsCountAsEndpointPorts() {
+        #expect(URL(string: "http://localhost")?.runEndpointPort == 80)
+        #expect(URL(string: "https://example.test")?.runEndpointPort == 443)
+        #expect(URL(string: "http://localhost:8080")?.runEndpointPort == 8080)
+        #expect(URL(string: "file:///tmp/x")?.runEndpointPort == nil)
+    }
+}

--- a/AlasTests/RunScriptLaunchTests.swift
+++ b/AlasTests/RunScriptLaunchTests.swift
@@ -379,6 +379,63 @@ struct RunScriptLaunchTests {
     }
 
     @MainActor
+    @Test func cancelledTerminalPreparationDoesNotOpenTerminal() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let project = ProjectConfig(id: "project", name: "Project", path: dir.path, color: "blue", addedAt: Date())
+        let worktree = Worktree(
+            id: "wt", projectId: project.id, name: "main", branch: "main",
+            path: dir, status: .clean, lastActivity: Date()
+        )
+
+        var openCount = 0
+        let state = AppState(
+            store: MemoryStore(),
+            terminalSessionOpener: { _, _, _, _, _, _, _, _, _ in
+                openCount += 1
+                return AppState.OpenedTerminalSession(id: "session-\(openCount)", foregroundPid: { nil })
+            }
+        )
+        state.projectsManager = ProjectsManager(persistedProjects: [project])
+
+        final class Gate {
+            var continuation: CheckedContinuation<Void, Never>?
+
+            func wait() async {
+                await withCheckedContinuation { continuation in
+                    self.continuation = continuation
+                }
+            }
+
+            func open() {
+                continuation?.resume()
+            }
+        }
+
+        let gate = Gate()
+        let task = Task { @MainActor in
+            await gate.wait()
+            return try await state.openTerminalTabPreparingRemoteZmxIfNeeded(for: worktree)
+        }
+        while gate.continuation == nil {
+            await Task.yield()
+        }
+        task.cancel()
+        gate.open()
+
+        do {
+            _ = try await task.value
+            Issue.record("expected terminal launch to be cancelled")
+        } catch is CancellationError {
+            // Expected: cancellation must be observed before opening a terminal.
+        }
+
+        #expect(openCount == 0)
+        #expect(state.tabs.tabs(forWorktree: worktree.id).isEmpty)
+    }
+
+    @MainActor
     @Test func nonZeroRunCreatesFailureWithSanitizedOutput() async throws {
         let fixture = try makeAppStateFixture(waiter: { _ in
             RunScriptCompletion(

--- a/AlasTests/RunScriptStoreTests.swift
+++ b/AlasTests/RunScriptStoreTests.swift
@@ -59,4 +59,26 @@ struct RunScriptStoreTests {
         )
         #expect(scripts.map(\.fileName) == ["visible.sh"])
     }
+
+    @Test func scriptConstructionPreservesMetadataAndExecutableBit() {
+        let directory = URL(fileURLWithPath: #"/srv/repos/app/.alas/scripts"#, isDirectory: true)
+        let script = RunScriptStore.script(
+            scope: .repo,
+            fileName: "web.sh",
+            fileURL: directory.appendingPathComponent("web.sh"),
+            contents: """
+            # alas-name: Web
+            # alas-cwd: app
+            # alas-url: http://localhost:3000
+            """,
+            isExecutable: true
+        )
+
+        #expect(script.displayName == "Web")
+        #expect(script.scope == .repo)
+        #expect(script.fileURL.path == "/srv/repos/app/.alas/scripts/web.sh")
+        #expect(script.cwd == "app")
+        #expect(script.isExecutable)
+        #expect(script.endpoint?.absoluteString == "http://localhost:3000")
+    }
 }

--- a/AlasTests/RunScriptStoreTests.swift
+++ b/AlasTests/RunScriptStoreTests.swift
@@ -81,4 +81,11 @@ struct RunScriptStoreTests {
         #expect(script.isExecutable)
         #expect(script.endpoint?.absoluteString == "http://localhost:3000")
     }
+
+    @Test func remoteMetadataReadUsesBoundedPrefixCommand() {
+        let script = RemoteFileAccess.readPrefixScript(path: "/repo/.alas/scripts/web.sh", maxBytes: 4096)
+
+        #expect(script.contains("head -c 4096"))
+        #expect(!script.contains("cat "))
+    }
 }

--- a/AlasTests/RunTabPresentationTests.swift
+++ b/AlasTests/RunTabPresentationTests.swift
@@ -1,0 +1,229 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct RunTabPresentationTests {
+    private let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func script(
+        cwd: String? = nil,
+        endpoint: URL? = nil
+    ) -> RunScript {
+        RunScript(
+            scope: .repo,
+            fileName: "dev.sh",
+            fileURL: URL(fileURLWithPath: "/wt/.alas/scripts/dev.sh"),
+            displayName: "Dev Server",
+            onExit: .keep,
+            cwd: cwd,
+            isExecutable: true,
+            endpoint: endpoint
+        )
+    }
+
+    private func record(
+        status: RunStatus,
+        startedAt: Date? = nil,
+        finishedAt: Date? = nil,
+        failureID: String? = nil,
+        endpoint: URL? = nil,
+        portConflict: RunPortConflict? = nil,
+        host: String? = nil
+    ) -> RunRecord {
+        RunRecord(
+            id: "run-1",
+            scriptKey: "repo:dev.sh",
+            scriptName: "Dev Server",
+            worktreeID: "wt-1",
+            branch: "main",
+            target: RunExecutionTarget(host: host, workingDirectory: "/wt"),
+            endpoint: endpoint,
+            status: status,
+            startedAt: startedAt ?? epoch,
+            finishedAt: finishedAt,
+            failureID: failureID,
+            portConflict: portConflict
+        )
+    }
+
+    private func row(
+        script: RunScript? = nil,
+        record: RunRecord? = nil,
+        hasTerminal: Bool = false,
+        host: String? = nil,
+        workingDirectory: String = "/wt",
+        now: Date? = nil
+    ) -> RunRowPresentation {
+        RunTabPresentation.row(
+            RunRowInput(
+                script: script ?? self.script(),
+                record: record,
+                hasTerminal: hasTerminal,
+                target: RunExecutionTarget(host: host, workingDirectory: workingDirectory)
+            ),
+            now: now ?? epoch
+        )
+    }
+
+    // MARK: - States
+
+    @Test func neverRunScriptOffersRunOnly() {
+        let row = row()
+        #expect(row.statusLabel == "Not run")
+        #expect(row.tone == .idle)
+        #expect(row.detail == nil)
+        #expect(row.actions == [.start(label: "Run"), .edit])
+    }
+
+    @Test func runningScriptOffersStopAndRestart() {
+        let row = row(
+            record: record(status: .running),
+            hasTerminal: true,
+            now: epoch.addingTimeInterval(180)
+        )
+        #expect(row.statusLabel == "Running")
+        #expect(row.tone == .active)
+        #expect(row.isActive)
+        #expect(row.detail == "Started 3m ago")
+        #expect(row.actions == [.stop, .restart, .openTerminal, .edit])
+    }
+
+    @Test func runningScriptWithEndpointOffersOpen() {
+        let endpoint = URL(string: "http://localhost:3000")!
+        let row = row(
+            script: script(endpoint: endpoint),
+            record: record(status: .running, endpoint: endpoint)
+        )
+        #expect(row.actions.contains(.openEndpoint(endpoint)))
+    }
+
+    /// Mid-launch there is nothing serving yet, so the endpoint link would
+    /// only produce a connection refused.
+    @Test func startingScriptDoesNotOfferItsEndpointYet() {
+        let endpoint = URL(string: "http://localhost:3000")!
+        let row = row(
+            script: script(endpoint: endpoint),
+            record: record(status: .starting, endpoint: endpoint)
+        )
+        #expect(row.statusLabel == "Starting")
+        #expect(row.detail == "Launching terminal")
+        #expect(!row.actions.contains(.openEndpoint(endpoint)))
+    }
+
+    @Test func failedRunReportsExitCodeDurationAndOutputLink() {
+        let row = row(
+            record: record(
+                status: .finished(.failed(exitCode: 42)),
+                finishedAt: epoch.addingTimeInterval(75),
+                failureID: "failure-1"
+            ),
+            now: epoch.addingTimeInterval(75 + 3_600)
+        )
+        #expect(row.statusLabel == "Failed")
+        #expect(row.tone == .failure)
+        #expect(row.detail == "exit 42 · 1m 15s · 1h ago")
+        #expect(row.actions == [.start(label: "Rerun"), .showOutput(failureID: "failure-1"), .edit])
+    }
+
+    @Test func succeededRunReportsDurationWithoutClaimingVerification() {
+        let row = row(
+            record: record(status: .finished(.succeeded), finishedAt: epoch.addingTimeInterval(9)),
+            now: epoch.addingTimeInterval(9)
+        )
+        #expect(row.statusLabel == "Succeeded")
+        #expect(row.tone == .success)
+        #expect(row.detail == "9s · just now")
+        #expect(row.actions == [.start(label: "Rerun"), .edit])
+    }
+
+    @Test func stoppedRunSaysSoInsteadOfFailing() {
+        let row = row(
+            record: record(status: .finished(.stopped), finishedAt: epoch.addingTimeInterval(30)),
+            now: epoch.addingTimeInterval(30)
+        )
+        #expect(row.statusLabel == "Stopped")
+        #expect(row.tone == .warning)
+        #expect(row.detail == "stopped before it finished · 30s · just now")
+    }
+
+    @Test func interruptedRunIsNeverPresentedAsSuccess() {
+        let row = row(
+            record: record(status: .finished(.unknown), finishedAt: epoch.addingTimeInterval(30)),
+            now: epoch.addingTimeInterval(30)
+        )
+        #expect(row.statusLabel == "Unknown")
+        #expect(row.tone == .warning)
+        #expect(row.detail == "no exit status observed · 30s · just now")
+        #expect(!row.actions.contains(.openEndpoint(URL(string: "http://localhost:3000")!)))
+    }
+
+    // MARK: - Terminal lifetime
+
+    /// An open shell is not evidence a command is running: it only decides
+    /// whether "jump to terminal" has a destination.
+    @Test func liveTerminalDoesNotMakeAFinishedRunLookActive() {
+        let row = row(record: record(status: .finished(.succeeded), finishedAt: epoch), hasTerminal: true)
+        #expect(!row.isActive)
+        #expect(row.statusLabel == "Succeeded")
+        #expect(row.actions == [.start(label: "Rerun"), .openTerminal, .edit])
+    }
+
+    // MARK: - Execution host
+
+    @Test func localWorktreeRootShowsNoExtraLocationChip() {
+        let row = row(workingDirectory: "/wt")
+        #expect(row.locationLabel == nil)
+        #expect(row.locationDetail == "This Mac · /wt")
+    }
+
+    @Test func localSubdirectoryShowsTheRelativeWorkingDirectory() {
+        let row = row(script: script(cwd: "apps/web"), workingDirectory: "/wt/apps/web")
+        #expect(row.locationLabel == "apps/web")
+        #expect(row.locationDetail == "This Mac · /wt/apps/web")
+    }
+
+    @Test func remoteTargetShowsHostAndWorkingDirectory() {
+        let row = row(
+            script: script(cwd: "apps/web"),
+            host: "devbox",
+            workingDirectory: "/srv/wt/apps/web"
+        )
+        #expect(row.locationLabel == "devbox · apps/web")
+        #expect(row.locationDetail == "devbox · /srv/wt/apps/web")
+    }
+
+    // MARK: - Port conflicts
+
+    @Test func portConflictNamesTheOtherOwnerWithoutOfferingToKillIt() {
+        let row = row(record: record(
+            status: .running,
+            portConflict: .ownedByRun(worktreeID: "wt-2", branch: "feature", scriptName: "Web")
+        ))
+        #expect(row.conflictLabel == "Port already served by Web on feature")
+        // Reporting a collision must not turn into an offer to kill anything
+        // but our own run.
+        #expect(row.actions == [.stop, .restart, .edit])
+    }
+
+    @Test func externalPortConflictIsReportedGenerically() {
+        let row = row(record: record(status: .running, portConflict: .externalProcess))
+        #expect(row.conflictLabel == "Port already in use by another process")
+    }
+
+    // MARK: - Formatting
+
+    @Test func durationsFormatByMagnitude() {
+        #expect(RunTabPresentation.format(duration: 0.2) == "0s")
+        #expect(RunTabPresentation.format(duration: 45) == "45s")
+        #expect(RunTabPresentation.format(duration: 90) == "1m 30s")
+        #expect(RunTabPresentation.format(duration: 3_780) == "1h 3m")
+    }
+
+    @Test func relativeTimesFormatByMagnitude() {
+        #expect(RunTabPresentation.relative(from: epoch, to: epoch) == "just now")
+        #expect(RunTabPresentation.relative(from: epoch, to: epoch.addingTimeInterval(59)) == "just now")
+        #expect(RunTabPresentation.relative(from: epoch, to: epoch.addingTimeInterval(600)) == "10m ago")
+        #expect(RunTabPresentation.relative(from: epoch, to: epoch.addingTimeInterval(7_200)) == "2h ago")
+        #expect(RunTabPresentation.relative(from: epoch, to: epoch.addingTimeInterval(3 * 86_400)) == "3d ago")
+    }
+}

--- a/AlasTests/RunTabPresentationTests.swift
+++ b/AlasTests/RunTabPresentationTests.swift
@@ -50,6 +50,7 @@ struct RunTabPresentationTests {
         script: RunScript? = nil,
         record: RunRecord? = nil,
         hasTerminal: Bool = false,
+        hasCapturedOutput: Bool = false,
         host: String? = nil,
         workingDirectory: String = "/wt",
         now: Date? = nil
@@ -59,6 +60,7 @@ struct RunTabPresentationTests {
                 script: script ?? self.script(),
                 record: record,
                 hasTerminal: hasTerminal,
+                hasCapturedOutput: hasCapturedOutput,
                 target: RunExecutionTarget(host: host, workingDirectory: workingDirectory)
             ),
             now: now ?? epoch
@@ -115,14 +117,19 @@ struct RunTabPresentationTests {
             record: record(
                 status: .finished(.failed(exitCode: 42)),
                 finishedAt: epoch.addingTimeInterval(75),
-                failureID: "failure-1"
-            ),
+                failureID: "failure-1"),
+            hasCapturedOutput: true,
             now: epoch.addingTimeInterval(75 + 3_600)
         )
         #expect(row.statusLabel == "Failed")
         #expect(row.tone == .failure)
         #expect(row.detail == "exit 42 · 1m 15s · 1h ago")
         #expect(row.actions == [.start(label: "Rerun"), .showOutput(failureID: "failure-1"), .edit])
+    }
+
+    @Test func failedRunWithoutRetainedOutputDoesNotOfferDeadOutputAction() {
+        let row = row(record: record(status: .finished(.failed(exitCode: 42)), failureID: "gone"))
+        #expect(row.actions == [.start(label: "Rerun"), .edit])
     }
 
     @Test func succeededRunReportsDurationWithoutClaimingVerification() {


### PR DESCRIPTION
## Summary
- add per-worktree command lifecycle records, endpoint safety, and Run controls backed by existing scripts and terminals
- show the Run tab only when Settings > Debug > Run tab preview is enabled
- cover lifecycle isolation, endpoint policy, presentation, and preview-gate config behavior

Closes #1157 

## Testing
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-run-tab-tests-2 -quiet build`\n- focused AppConfig, RightPaneTab, Run record, endpoint, presentation, and right-pane suites\n- Full local suite started but Xcode remained idle after its test child exited, so it is not claimed as passed. CI is the authoritative full-suite check.