### PR TITLE
fix(mcp): improve MCP registration retries

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMCPStatusControl.swift
+++ b/Alas/Sources/ACP/UI/ACPMCPStatusControl.swift
@@ -184,7 +184,7 @@ private struct ACPMCPStatusPopover: View {
             }
 
             if status.hasBuiltInWarning, let onReconnect {
-                AlasButton(title: "Reconnect session", style: .subtle) {
+                AlasButton(title: "Reconnect session", icon: "arrow.clockwise", style: .normal) {
                     onReconnect()
                 }
                 .padding(.horizontal, 12)

--- a/AlasCLI/crates/alas-client/src/lib.rs
+++ b/AlasCLI/crates/alas-client/src/lib.rs
@@ -625,7 +625,7 @@ pub fn send_hello(socket: &Path, session_id: &str, transport: &str) {
                     return;
                 }
                 if attempt < 2 {
-                    std::thread::sleep(Duration::from_secs(1));
+                    std::thread::sleep(Duration::from_secs(4));
                 }
             }
         });
@@ -788,7 +788,7 @@ mod tests {
     }
 
     #[test]
-    fn send_hello_retries_until_socket_is_available() {
+    fn send_hello_retries_across_registration_grace_period() {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -799,7 +799,7 @@ mod tests {
         ));
         let server_socket = socket.clone();
         let server = thread::spawn(move || {
-            thread::sleep(Duration::from_millis(100));
+            thread::sleep(Duration::from_millis(2_500));
             let listener = UnixListener::bind(&server_socket).unwrap();
             listener.set_nonblocking(true).unwrap();
             let deadline = Instant::now() + Duration::from_millis(2_500);


### PR DESCRIPTION
## Summary

MCP hello attempts were exhausted well before the ACP registration grace period, leaving the warning affordance visible even when the server became available shortly afterward.

- Retry at roughly 0, 4, and 8 seconds, within the existing 12-second grace period.
- Cover a delayed socket registration that would have failed under the old schedule.
- Present reconnect as an outlined button with a refresh icon.

## Validation

- `cargo test -p alas-client`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- Full app suite ran 8,954 tests; 23 unrelated pre-existing failures remain.