### PR TITLE
feat(worktree): Speed up local worktree deletion

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1310,6 +1310,7 @@
 		CA4CE5E97DB02330A1151245 /* ACPSetupCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8E722C16FFBEEEC43337D5 /* ACPSetupCheck.swift */; };
 		CA7269D9237C925D7C1358D7 /* RemoteWorktreePollTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EEB37C08A315D65558B273 /* RemoteWorktreePollTests.swift */; };
 		CA73C930734C839D8EA9088D /* GGStackReadinessModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DCBE3FBD88DC56C81B8FDB /* GGStackReadinessModelTests.swift */; };
+		CA84CE4A7E854E8E034A4F17 /* WorktreeTrashCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0EAD22528F97163977B065A /* WorktreeTrashCleaner.swift */; };
 		CAC084F6260D705CCA5D6FBE /* RemoteQueueProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C782D92A16724E99D824C8A7 /* RemoteQueueProjection.swift */; };
 		CAD36BB3EBF8B31309B7BEFF /* DiffSelectableTextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E87586CA07BA62C84BAD24 /* DiffSelectableTextBuilder.swift */; };
 		CAE149AF78F3A62AC985EA2D /* TerminalIntegrationActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606DD97D8F66AC2B5883F984 /* TerminalIntegrationActionsTests.swift */; };
@@ -2691,6 +2692,7 @@
 		A00CFC045C4BF9C13B4105BF /* ConflictMarkerParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictMarkerParserTests.swift; sourceTree = "<group>"; };
 		A02E6B12C5EC8FAA50202EEA /* GGUnstackSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGUnstackSheet.swift; sourceTree = "<group>"; };
 		A0D27AA18750DEA3843477D9 /* RunScriptFailureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptFailureTests.swift; sourceTree = "<group>"; };
+		A0EAD22528F97163977B065A /* WorktreeTrashCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeTrashCleaner.swift; sourceTree = "<group>"; };
 		A107DA120039DD59C4F5CDD7 /* MermaidRenderServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidRenderServiceTests.swift; sourceTree = "<group>"; };
 		A1503D1CB549B39E499EFAB8 /* DiffInlineAnnotationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineAnnotationCard.swift; sourceTree = "<group>"; };
 		A172B476A5BF7E4016431E6A /* DiffReviewModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewModelsTests.swift; sourceTree = "<group>"; };
@@ -4113,6 +4115,7 @@
 				91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */,
 				6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */,
 				5B270704174889BC7F24E3D4 /* WorktreeTrash.swift */,
+				A0EAD22528F97163977B065A /* WorktreeTrashCleaner.swift */,
 				FCE6979EDAEAE45BC2A49A20 /* CommitAI */,
 			);
 			path = Git;
@@ -7202,6 +7205,7 @@
 				9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */,
 				52E3CDEB14242DB611348EEA /* WorktreeSortMenu.swift in Sources */,
 				92C1EDD306CEEF99DE875C62 /* WorktreeTrash.swift in Sources */,
+				CA84CE4A7E854E8E034A4F17 /* WorktreeTrashCleaner.swift in Sources */,
 				E681EB5B83BAC199B1ED5E24 /* WorktreeWatcher.swift in Sources */,
 				467BA12331DB76C41313BF70 /* WorktreesPane.swift in Sources */,
 				9C73FEDF9B7B93D60FA3B51F /* ZmxClient.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -823,6 +823,7 @@
 		806A8D3076BDF74084FF05AB /* ACPVisibleRowsCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1C663053BAB6A85A664A52 /* ACPVisibleRowsCacheTests.swift */; };
 		806C55C225BA072937201651 /* WorkspaceWorkItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC31E49E6E453B417479C95 /* WorkspaceWorkItemTests.swift */; };
 		809972779548945B012F8B6C /* ACPConnectingPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFBD2A49431277EB68106AAA /* ACPConnectingPlaceholder.swift */; };
+		80AA87265F3F16FF51BAC8F9 /* WorktreeTrashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1506E607B54FBEF4AB79E7F /* WorktreeTrashTests.swift */; };
 		80AEF86E91561F880A3A0376 /* RunScriptCreationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6128B044F59DB08F2383F7B /* RunScriptCreationTests.swift */; };
 		8104F4F1DFD11BC5758545E9 /* RightPaneStateDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */; };
 		81214C5FDACA47C2FFC15E9E /* HoverWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8149AEEF45B05C60E06888E5 /* HoverWindowController.swift */; };
@@ -948,6 +949,7 @@
 		92845FA01F7A57EB8508C2CF /* AppKitDiffScrollerReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3384E5FA341561735906B9EF /* AppKitDiffScrollerReconcilerTests.swift */; };
 		929C2E12D6178FF3728365A2 /* ACPStdioTerminalDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DB2EFD475B2D7D5D75B06A /* ACPStdioTerminalDispatchTests.swift */; };
 		92BDCA81E566BF56CFE87AFB /* NewRunScriptDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3A201BB87075FB20E88FBC /* NewRunScriptDialog.swift */; };
+		92C1EDD306CEEF99DE875C62 /* WorktreeTrash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B270704174889BC7F24E3D4 /* WorktreeTrash.swift */; };
 		92EEAFAEFB3E637FB72174A8 /* BeautifulMermaid in Frameworks */ = {isa = PBXBuildFile; productRef = F1692E6406C1269703621C3B /* BeautifulMermaid */; };
 		93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44D759586280250330A9A04 /* FontSizeCommands.swift */; };
 		93CE39FC58076587CC85F489 /* GGStackModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86CE36A9A7301E6863CEDFCC /* GGStackModels.swift */; };
@@ -2254,6 +2256,7 @@
 		5A43A7D90E591CFD18088C70 /* AgentLauncherModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLauncherModel.swift; sourceTree = "<group>"; };
 		5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateFileTreeTests.swift; sourceTree = "<group>"; };
 		5AA5809066E33EB30E09E0D8 /* RemoteWebAssetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWebAssetTests.swift; sourceTree = "<group>"; };
+		5B270704174889BC7F24E3D4 /* WorktreeTrash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeTrash.swift; sourceTree = "<group>"; };
 		5B2AECB6C5521CD59E44929A /* WorkspaceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStore.swift; sourceTree = "<group>"; };
 		5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigTests.swift; sourceTree = "<group>"; };
 		5B40A20BB651C706C9C6FAAA /* PairedDelimiterFenceBoxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedDelimiterFenceBoxTests.swift; sourceTree = "<group>"; };
@@ -3109,6 +3112,7 @@
 		E0E1BF90CB3BE5BFDFA2EC7C /* ACPSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStore.swift; sourceTree = "<group>"; };
 		E0E5107A10052A150DD8DE02 /* ZmxSunPathBudgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSunPathBudgetTests.swift; sourceTree = "<group>"; };
 		E0F10B6B1311831E53DA45C0 /* DiffReviewStagedMutationActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewStagedMutationActionsTests.swift; sourceTree = "<group>"; };
+		E1506E607B54FBEF4AB79E7F /* WorktreeTrashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeTrashTests.swift; sourceTree = "<group>"; };
 		E15A32659EEBFA80F816CE31 /* SymbolsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeatureTests.swift; sourceTree = "<group>"; };
 		E16C4F54FB3E390F80208DA1 /* AdvancedPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedPane.swift; sourceTree = "<group>"; };
 		E1703FC5CD7DF16F4450E274 /* DiffParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParser.swift; sourceTree = "<group>"; };
@@ -3929,6 +3933,7 @@
 				6BA2F208DBC024A64D0ED065 /* WorktreeServiceCreatedAtTests.swift */,
 				D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */,
 				4C3F4EE1590F6355AF2AD9DA /* WorktreeSortMenuTests.swift */,
+				E1506E607B54FBEF4AB79E7F /* WorktreeTrashTests.swift */,
 				670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */,
 				321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */,
 				4B3300F31455EE1BDF7BDE15 /* ZmxClientTests.swift */,
@@ -4107,6 +4112,7 @@
 				DFEE7C5318AA6D04095403B2 /* ShellEnvResolver.swift */,
 				91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */,
 				6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */,
+				5B270704174889BC7F24E3D4 /* WorktreeTrash.swift */,
 				FCE6979EDAEAE45BC2A49A20 /* CommitAI */,
 			);
 			path = Git;
@@ -7195,6 +7201,7 @@
 				4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */,
 				9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */,
 				52E3CDEB14242DB611348EEA /* WorktreeSortMenu.swift in Sources */,
+				92C1EDD306CEEF99DE875C62 /* WorktreeTrash.swift in Sources */,
 				E681EB5B83BAC199B1ED5E24 /* WorktreeWatcher.swift in Sources */,
 				467BA12331DB76C41313BF70 /* WorktreesPane.swift in Sources */,
 				9C73FEDF9B7B93D60FA3B51F /* ZmxClient.swift in Sources */,
@@ -7954,6 +7961,7 @@
 				2735F19DF0AD717CA3CF3B23 /* WorktreeServiceCreatedAtTests.swift in Sources */,
 				CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */,
 				887B90FE9E87033A31567CC0 /* WorktreeSortMenuTests.swift in Sources */,
+				80AA87265F3F16FF51BAC8F9 /* WorktreeTrashTests.swift in Sources */,
 				E4EAC28F55CBE987E0AB1F85 /* WorktreeWatcherFilterTests.swift in Sources */,
 				98B61C62BB4FEDCDE271FAC1 /* WorktreeWatcherTests.swift in Sources */,
 				2ED82820F76F5032E4339926 /* ZmxClientTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -60,6 +60,7 @@ final class AppState {
     typealias ACPDetachRunner = @MainActor (ACPSessionManager, ACPSession.ID) async -> Void
     typealias RemoteAccelerationPreparer = @MainActor (ProjectConfig) async -> Void
     typealias RunScriptCompletionWaiter = @Sendable (RunScriptCaptureLocation) async throws -> RunScriptCompletion
+    typealias WorktreeCleanupLauncher = @MainActor (WorktreeTrashCleanupTicket) throws -> Void
     static let piMCPGeneratedConfigExcludePath = ".pi/mcp.json"
 
     /// Stable for this process; identifies this app instance to the ACP
@@ -131,6 +132,8 @@ final class AppState {
     private let acpDetachRunner: ACPDetachRunner?
     @ObservationIgnored
     private let remoteAccelerationPreparer: RemoteAccelerationPreparer?
+    @ObservationIgnored
+    private let worktreeCleanupLauncher: WorktreeCleanupLauncher
 
     private struct PendingACPDetach {
         let id: UUID
@@ -637,7 +640,10 @@ final class AppState {
         workspaceSpacePersistenceBridge: WorkspaceSpacePersistenceBridge? = nil,
         workspacesManager: WorkspacesManager? = nil,
         workspaceStore: WorkspaceStore = WorkspaceStore(),
-        workspaceRemoteTransport: WorkspaceRemoteTransport = .init()
+        workspaceRemoteTransport: WorkspaceRemoteTransport = .init(),
+        worktreeCleanupLauncher: @escaping WorktreeCleanupLauncher = {
+            try WorktreeTrashCleaner.launch($0)
+        }
     ) {
         self.store = store
         self.workspaceStore = workspaceStore
@@ -655,6 +661,7 @@ final class AppState {
         self.closeTabConfirmer = closeTabConfirmer
         self.acpDetachRunner = acpDetachRunner
         self.remoteAccelerationPreparer = remoteAccelerationPreparer
+        self.worktreeCleanupLauncher = worktreeCleanupLauncher
         self.projectGitWatcherFactory = projectGitWatcherFactory
         self.runScriptCompletionWaiter = runScriptCompletionWaiter
         let workspaceBridge = workspaceSpacePersistenceBridge ?? WorkspaceSpacePersistenceBridge(workspaceStore: workspaceStore)
@@ -719,6 +726,10 @@ final class AppState {
         }
         Task.detached {
             RunScriptCompletionMonitor.cleanupStaleLocalFiles()
+        }
+        let cleanupProjects = projectsFile.projects
+        Task.detached(priority: .utility) {
+            WorktreeTrashCleaner.sweep(projects: cleanupProjects)
         }
 
         // Kick off a background resolution of the user's login-shell PATH so
@@ -7725,8 +7736,9 @@ final class AppState {
         force: Bool,
         removedIndex: Int
     ) async {
+        let outcome: WorktreeRemovalOutcome
         do {
-            try await Self.performRemoveWorktree(
+            outcome = try await Self.performRemoveWorktree(
                 repoPath: repoPath,
                 worktree: worktree,
                 deleteBranchIfMerged: deleteBranchIfMerged,
@@ -7761,6 +7773,19 @@ final class AppState {
         }
 
         cleanupWorktreeState(worktreeId: worktree.id)
+        if case .staged(let ticket) = outcome {
+            do {
+                try worktreeCleanupLauncher(ticket)
+            } catch {
+                Self.logger.error(
+                    "Could not launch worktree cleanup for \(ticket.stagedPath.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+            }
+            let cleanupProjects = projects
+            Task.detached(priority: .utility) {
+                WorktreeTrashCleaner.sweep(projects: cleanupProjects)
+            }
+        }
         // Always clear the deleting state after a successful remove,
         // even if the subsequent refresh fails.
         projectsManager.setOperationState(id: worktree.id, state: nil)
@@ -7819,10 +7844,19 @@ final class AppState {
         worktree: Worktree,
         deleteBranchIfMerged: Bool,
         force: Bool
-    ) async throws {
+    ) async throws -> WorktreeRemovalOutcome {
         try await ProjectMutationGate.shared.withMutation(projectID: worktree.projectId) {
             try await Task.detached {
-                try await WorktreeService().remove(
+                if worktree.path.isRemoteAlasPath {
+                    try await WorktreeService().remove(
+                        repoPath: repoPath,
+                        worktree: worktree,
+                        deleteBranchIfMerged: deleteBranchIfMerged,
+                        force: force
+                    )
+                    return .synchronous
+                }
+                return try await WorktreeService().removeFastLocal(
                     repoPath: repoPath,
                     worktree: worktree,
                     deleteBranchIfMerged: deleteBranchIfMerged,

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -1025,7 +1025,34 @@ struct WorktreeService {
             try failAfterRollingBack(removeResult.stderr)
         }
 
-        try? WorktreeTrash.markCommitted(ticket)
+        let outcome: WorktreeRemovalOutcome
+        do {
+            try WorktreeTrash.markCommitted(ticket)
+            outcome = .staged(ticket)
+        } catch {
+            let markerFailure = error.localizedDescription
+            let stagedPath = Self.resolvedFileSystemPath(ticket.stagedPath)
+            guard WorktreeTrash.isValid(ticket),
+                  WorktreeTrash.matchesDirectoryIdentity(ticket)
+            else {
+                throw WorktreeError.gitFailed(
+                    "Git removed the worktree registration, but the deletion marker "
+                        + "could not be written and the staged directory changed. "
+                        + "Files remain at \(stagedPath). Marker: \(markerFailure)"
+                )
+            }
+            do {
+                try FileManager.default.removeItem(at: ticket.stagedPath)
+                outcome = .synchronous
+            } catch {
+                throw WorktreeError.gitFailed(
+                    "Git removed the worktree registration, but the deletion marker "
+                        + "could not be written and synchronous cleanup failed; "
+                        + "staged files remain at \(stagedPath). "
+                        + "Marker: \(markerFailure). Cleanup: \(error.localizedDescription)"
+                )
+            }
+        }
 
         if deleteBranchIfMerged && worktree.branch != "(detached)" {
             _ = try? await Process.git(
@@ -1034,7 +1061,7 @@ struct WorktreeService {
                 usesRemoteHostRegistry: false
             )
         }
-        return .staged(ticket)
+        return outcome
     }
 
     func deletePreflight(

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -835,7 +835,7 @@ struct WorktreeService {
         guard let expectedCommonDirectory = Self.localCommonGitDirectory(
             forWorktreeAt: repoPath
         ),
-              let expectedWorktreeIdentity = Self.linkedWorktreeIdentity(
+              let expectedRegistration = Self.linkedWorktreeRegistration(
                   worktree.path,
                   expectedCommonDirectory: expectedCommonDirectory
               )
@@ -901,7 +901,7 @@ struct WorktreeService {
                     "Git common directory no longer matches the registered worktree."
                 )
             }
-            ticket = WorktreeTrash.makeTicket(
+            ticket = try WorktreeTrash.makeTicket(
                 commonGitDirectory: commonDirectory,
                 originalPath: worktree.path
             )
@@ -921,7 +921,9 @@ struct WorktreeService {
             return .synchronous
         }
 
-        guard Self.directoryIdentity(at: worktree.path) == expectedWorktreeIdentity else {
+        guard WorktreeTrash.directoryIdentity(at: worktree.path)
+            == expectedRegistration.directoryIdentity
+        else {
             throw WorktreeError.gitFailed("Worktree changed before it could be staged.")
         }
         do {
@@ -938,19 +940,10 @@ struct WorktreeService {
             return .synchronous
         }
 
-        guard Self.directoryIdentity(at: ticket.stagedPath) == expectedWorktreeIdentity else {
-            do {
-                try moveItem(ticket.stagedPath, worktree.path)
-            } catch {
-                throw WorktreeError.gitFailed(
-                    "Worktree changed while it was being staged; staged files remain at "
-                        + "\(ticket.stagedPath.path). Rollback: \(error.localizedDescription)"
-                )
-            }
-            throw WorktreeError.gitFailed("Worktree changed while it was being staged.")
-        }
-
         func failAfterRollingBack(_ registryMessage: String) throws -> Never {
+            try? FileManager.default.removeItem(
+                at: WorktreeTrash.committedMarkerURL(for: ticket)
+            )
             do {
                 try moveItem(ticket.stagedPath, worktree.path)
             } catch {
@@ -964,6 +957,37 @@ struct WorktreeService {
                 )
             }
             throw WorktreeError.gitFailed(registryMessage)
+        }
+
+        guard WorktreeTrash.matchesDirectoryIdentity(ticket) else {
+            try failAfterRollingBack("Worktree changed while it was being staged.")
+        }
+
+        if !force {
+            let stagedIsClean: Bool
+            do {
+                if auditedMissingLFS {
+                    stagedIsClean = try await canForceRemoveAfterMissingLFS(
+                        ticket.stagedPath,
+                        gitDirectory: expectedRegistration.gitDirectory,
+                        usesRemoteHostRegistry: false
+                    )
+                } else {
+                    stagedIsClean = try await isWorktreeClean(
+                        ticket.stagedPath,
+                        gitDirectory: expectedRegistration.gitDirectory,
+                        usesRemoteHostRegistry: false
+                    )
+                }
+            } catch {
+                try failAfterRollingBack(error.localizedDescription)
+            }
+            guard stagedIsClean else {
+                try failAfterRollingBack("Worktree contains modified or untracked files.")
+            }
+            guard WorktreeTrash.matchesDirectoryIdentity(ticket) else {
+                try failAfterRollingBack("Worktree changed while its contents were audited.")
+            }
         }
 
         var removeArgs = ["worktree", "remove", worktree.path.path]
@@ -1135,37 +1159,19 @@ struct WorktreeService {
         resolvedFileSystemPath(lhs) == resolvedFileSystemPath(rhs)
     }
 
-    private struct FileSystemIdentity: Equatable {
-        let systemNumber: UInt64
-        let fileNumber: UInt64
+    private struct LinkedWorktreeRegistration {
+        let directoryIdentity: WorktreeTrashDirectoryIdentity
+        let gitDirectory: URL
     }
 
-    private static func directoryIdentity(at path: URL) -> FileSystemIdentity? {
-        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path.path),
-              attributes[.type] as? FileAttributeType == .typeDirectory,
-              let systemNumber = attributes[.systemNumber] as? NSNumber,
-              let fileNumber = attributes[.systemFileNumber] as? NSNumber
-        else { return nil }
-        return FileSystemIdentity(
-            systemNumber: systemNumber.uint64Value,
-            fileNumber: fileNumber.uint64Value
-        )
-    }
-
-    private static func linkedWorktreeIdentity(
+    private static func linkedWorktreeRegistration(
         _ worktreePath: URL,
         expectedCommonDirectory: URL
-    ) -> FileSystemIdentity? {
+    ) -> LinkedWorktreeRegistration? {
         let fileManager = FileManager.default
-        guard let rootAttributes = try? fileManager.attributesOfItem(atPath: worktreePath.path),
-              rootAttributes[.type] as? FileAttributeType == .typeDirectory,
-              let systemNumber = rootAttributes[.systemNumber] as? NSNumber,
-              let fileNumber = rootAttributes[.systemFileNumber] as? NSNumber
-        else { return nil }
-        let identity = FileSystemIdentity(
-            systemNumber: systemNumber.uint64Value,
-            fileNumber: fileNumber.uint64Value
-        )
+        guard let directoryIdentity = WorktreeTrash.directoryIdentity(at: worktreePath) else {
+            return nil
+        }
 
         let dotGit = worktreePath.appendingPathComponent(".git", isDirectory: false)
         guard let dotGitAttributes = try? fileManager.attributesOfItem(atPath: dotGit.path),
@@ -1190,7 +1196,11 @@ struct WorktreeService {
         let backlink = (rawBacklink as NSString).isAbsolutePath
             ? URL(fileURLWithPath: rawBacklink)
             : gitDirectory.appendingPathComponent(rawBacklink)
-        return fileSystemPathsEqual(backlink, dotGit) ? identity : nil
+        guard fileSystemPathsEqual(backlink, dotGit) else { return nil }
+        return LinkedWorktreeRegistration(
+            directoryIdentity: directoryIdentity,
+            gitDirectory: gitDirectory
+        )
     }
 
     private static func registrationState(
@@ -1287,12 +1297,22 @@ struct WorktreeService {
             }
     }
 
+    private static func gitContextArguments(
+        worktreePath: URL,
+        gitDirectory: URL?
+    ) -> [String] {
+        guard let gitDirectory else { return [] }
+        return ["--git-dir", gitDirectory.path, "--work-tree", worktreePath.path]
+    }
+
     private func isWorktreeClean(
         _ path: URL,
+        gitDirectory: URL? = nil,
         usesRemoteHostRegistry: Bool = true
     ) async throws -> Bool {
         let result = try await Process.git(
-            ["status", "--porcelain", "--ignore-submodules=none", "--untracked-files=all"],
+            Self.gitContextArguments(worktreePath: path, gitDirectory: gitDirectory)
+                + ["status", "--porcelain", "--ignore-submodules=none", "--untracked-files=all"],
             cwd: path,
             usesRemoteHostRegistry: usesRemoteHostRegistry
         )
@@ -1302,10 +1322,11 @@ struct WorktreeService {
 
     private func areInitializedSubmodulesClean(
         _ path: URL,
+        gitDirectory: URL? = nil,
         usesRemoteHostRegistry: Bool = true
     ) async throws -> Bool {
         let result = try await Process.git(
-            [
+            Self.gitContextArguments(worktreePath: path, gitDirectory: gitDirectory) + [
                 "submodule", "foreach", "--quiet", "--recursive",
                 "git status --porcelain --ignore-submodules=none --untracked-files=all"
             ],
@@ -1319,6 +1340,7 @@ struct WorktreeService {
     private func initializedSubmodulesHaveNoLocalState(
         _ path: URL,
         timeout: TimeInterval = 120,
+        gitDirectory: URL? = nil,
         usesRemoteHostRegistry: Bool = true
     ) async throws -> Bool {
         // Reachability set arithmetic for reflog and notes/stash (the
@@ -1374,7 +1396,8 @@ struct WorktreeService {
         fi
         """
         let result = try await Process.git(
-            ["submodule", "foreach", "--quiet", "--recursive", localStateScript],
+            Self.gitContextArguments(worktreePath: path, gitDirectory: gitDirectory)
+                + ["submodule", "foreach", "--quiet", "--recursive", localStateScript],
             cwd: path,
             usesRemoteHostRegistry: usesRemoteHostRegistry,
             timeout: timeout
@@ -1385,29 +1408,35 @@ struct WorktreeService {
 
     private func canForceRemoveAfterMissingLFS(
         _ path: URL,
+        gitDirectory: URL? = nil,
         usesRemoteHostRegistry: Bool = true
     ) async throws -> Bool {
         guard try await isWorktreeCleanAllowingSmudgedLFS(
             path,
+            gitDirectory: gitDirectory,
             usesRemoteHostRegistry: usesRemoteHostRegistry
         ) else { return false }
         let subsClean = try await areInitializedSubmodulesClean(
             path,
+            gitDirectory: gitDirectory,
             usesRemoteHostRegistry: usesRemoteHostRegistry
         )
         guard subsClean else { return false }
         return try await initializedSubmodulesHaveNoLocalState(
             path,
+            gitDirectory: gitDirectory,
             usesRemoteHostRegistry: usesRemoteHostRegistry
         )
     }
 
     private func isWorktreeCleanAllowingSmudgedLFS(
         _ path: URL,
+        gitDirectory: URL? = nil,
         usesRemoteHostRegistry: Bool = true
     ) async throws -> Bool {
         let result = try await Process.git(
-            Self.lfsFilterOverride + [
+            Self.lfsFilterOverride
+                + Self.gitContextArguments(worktreePath: path, gitDirectory: gitDirectory) + [
                 "status", "--porcelain=v2", "-z",
                 "--ignore-submodules=none", "--untracked-files=all"
             ],
@@ -1434,6 +1463,7 @@ struct WorktreeService {
             guard try await isCleanLFSFile(
                 relativePath,
                 in: path,
+                gitDirectory: gitDirectory,
                 usesRemoteHostRegistry: usesRemoteHostRegistry
             ) else { return false }
         }
@@ -1443,17 +1473,20 @@ struct WorktreeService {
     private func isCleanLFSFile(
         _ relativePath: String,
         in worktreePath: URL,
+        gitDirectory: URL? = nil,
         usesRemoteHostRegistry: Bool = true
     ) async throws -> Bool {
         guard try await usesLFSFilter(
             relativePath,
             in: worktreePath,
+            gitDirectory: gitDirectory,
             usesRemoteHostRegistry: usesRemoteHostRegistry
         ),
               let pointer = try await indexLFSPointer(
-                relativePath,
-                in: worktreePath,
-                usesRemoteHostRegistry: usesRemoteHostRegistry
+                  relativePath,
+                  in: worktreePath,
+                  gitDirectory: gitDirectory,
+                  usesRemoteHostRegistry: usesRemoteHostRegistry
               )
         else { return false }
 
@@ -1475,10 +1508,12 @@ struct WorktreeService {
     private func usesLFSFilter(
         _ relativePath: String,
         in worktreePath: URL,
+        gitDirectory: URL? = nil,
         usesRemoteHostRegistry: Bool = true
     ) async throws -> Bool {
         let result = try await Process.git(
-            ["check-attr", "-z", "filter", "--", relativePath],
+            Self.gitContextArguments(worktreePath: worktreePath, gitDirectory: gitDirectory)
+                + ["check-attr", "-z", "filter", "--", relativePath],
             cwd: worktreePath,
             usesRemoteHostRegistry: usesRemoteHostRegistry
         )
@@ -1490,10 +1525,12 @@ struct WorktreeService {
     private func indexLFSPointer(
         _ relativePath: String,
         in worktreePath: URL,
+        gitDirectory: URL? = nil,
         usesRemoteHostRegistry: Bool = true
     ) async throws -> LFSPointer? {
         let listed = try await Process.git(
-            ["ls-files", "-s", "--", relativePath],
+            Self.gitContextArguments(worktreePath: worktreePath, gitDirectory: gitDirectory)
+                + ["ls-files", "-s", "--", relativePath],
             cwd: worktreePath,
             usesRemoteHostRegistry: usesRemoteHostRegistry
         )
@@ -1503,7 +1540,8 @@ struct WorktreeService {
         }
 
         let blob = try await Process.git(
-            ["cat-file", "-p", String(sha)],
+            Self.gitContextArguments(worktreePath: worktreePath, gitDirectory: gitDirectory)
+                + ["cat-file", "-p", String(sha)],
             cwd: worktreePath,
             usesRemoteHostRegistry: usesRemoteHostRegistry
         )

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -832,6 +832,18 @@ struct WorktreeService {
         guard registration.isPresent else {
             throw WorktreeError.gitFailed("Worktree registration was not found.")
         }
+        guard let expectedCommonDirectory = Self.localCommonGitDirectory(
+            forWorktreeAt: repoPath
+        ),
+              Self.matchesLinkedWorktreeRegistration(
+                  worktree.path,
+                  expectedCommonDirectory: expectedCommonDirectory
+              )
+        else {
+            throw WorktreeError.gitFailed(
+                "Worktree path no longer matches its Git registration."
+            )
+        }
 
         var auditedMissingLFS = false
         if !force {
@@ -883,6 +895,11 @@ struct WorktreeService {
                 commonDirectory = repoPath
                     .appendingPathComponent(commonDirectoryOutput)
                     .standardizedFileURL
+            }
+            guard Self.fileSystemPathsEqual(commonDirectory, expectedCommonDirectory) else {
+                throw WorktreeError.gitFailed(
+                    "Git common directory no longer matches the registered worktree."
+                )
             }
             ticket = WorktreeTrash.makeTicket(
                 commonGitDirectory: commonDirectory,
@@ -955,6 +972,8 @@ struct WorktreeService {
         if removeResult.exitCode != 0 {
             try failAfterRollingBack(removeResult.stderr)
         }
+
+        try? WorktreeTrash.markCommitted(ticket)
 
         if deleteBranchIfMerged && worktree.branch != "(detached)" {
             _ = try? await Process.git(
@@ -1082,6 +1101,45 @@ struct WorktreeService {
             defer { Darwin.free(resolved) }
             return String(cString: resolved)
         }
+    }
+
+    private static func fileSystemPathsEqual(_ lhs: URL, _ rhs: URL) -> Bool {
+        resolvedFileSystemPath(lhs) == resolvedFileSystemPath(rhs)
+    }
+
+    private static func matchesLinkedWorktreeRegistration(
+        _ worktreePath: URL,
+        expectedCommonDirectory: URL
+    ) -> Bool {
+        let fileManager = FileManager.default
+        guard let rootAttributes = try? fileManager.attributesOfItem(atPath: worktreePath.path),
+              rootAttributes[.type] as? FileAttributeType == .typeDirectory
+        else { return false }
+
+        let dotGit = worktreePath.appendingPathComponent(".git", isDirectory: false)
+        guard let dotGitAttributes = try? fileManager.attributesOfItem(atPath: dotGit.path),
+              dotGitAttributes[.type] as? FileAttributeType == .typeRegular,
+              let gitDirectory = localGitDirectory(forWorktreeAt: worktreePath),
+              let commonDirectory = localCommonGitDirectory(forWorktreeAt: worktreePath),
+              fileSystemPathsEqual(commonDirectory, expectedCommonDirectory)
+        else { return false }
+
+        let expectedWorktreesDirectory = expectedCommonDirectory
+            .appendingPathComponent("worktrees", isDirectory: true)
+        guard fileSystemPathsEqual(
+            gitDirectory.deletingLastPathComponent(),
+            expectedWorktreesDirectory
+        ) else { return false }
+
+        let backlinkFile = gitDirectory.appendingPathComponent("gitdir", isDirectory: false)
+        guard let rawBacklink = try? String(contentsOf: backlinkFile, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawBacklink.isEmpty
+        else { return false }
+        let backlink = (rawBacklink as NSString).isAbsolutePath
+            ? URL(fileURLWithPath: rawBacklink)
+            : gitDirectory.appendingPathComponent(rawBacklink)
+        return fileSystemPathsEqual(backlink, dotGit)
     }
 
     private static func registrationState(

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -974,6 +974,22 @@ struct WorktreeService {
             try failAfterRollingBack("Worktree changed while it was being staged.")
         }
 
+        let stagedSubmodulesHaveNoLocalState: Bool
+        do {
+            stagedSubmodulesHaveNoLocalState = try await stagedInitializedSubmodulesHaveNoLocalState(
+                ticket.stagedPath,
+                gitDirectory: expectedRegistration.gitDirectory
+            )
+        } catch {
+            try failAfterRollingBack(error.localizedDescription)
+        }
+        guard stagedSubmodulesHaveNoLocalState else {
+            try failAfterRollingBack("Worktree contains initialized submodule local state.")
+        }
+        guard WorktreeTrash.matchesDirectoryIdentity(ticket) else {
+            try failAfterRollingBack("Worktree changed while its submodules were audited.")
+        }
+
         if !force {
             let stagedIsClean: Bool
             do {
@@ -1295,10 +1311,12 @@ struct WorktreeService {
 
     private func containsInitializedSubmodules(
         _ path: URL,
+        gitDirectory: URL? = nil,
         usesRemoteHostRegistry: Bool = true
     ) async throws -> Bool {
         let result = try await Process.git(
-            ["submodule", "status", "--recursive"],
+            Self.gitContextArguments(worktreePath: path, gitDirectory: gitDirectory)
+                + ["submodule", "status", "--recursive"],
             cwd: path,
             usesRemoteHostRegistry: usesRemoteHostRegistry
         )
@@ -1336,6 +1354,68 @@ struct WorktreeService {
             .compactMap { line in
                 line.split(separator: " ", maxSplits: 1).dropFirst().first.map(String.init)
             }
+    }
+
+    private func stagedInitializedSubmodulesHaveNoLocalState(
+        _ path: URL,
+        gitDirectory: URL
+    ) async throws -> Bool {
+        let submodulePaths = try await submodulePathsFromGitmodules(
+            path,
+            usesRemoteHostRegistry: false
+        )
+        for relativePath in submodulePaths {
+            let submodulePath = path.appendingPathComponent(relativePath)
+            guard FileManager.default.fileExists(
+                atPath: submodulePath.appendingPathComponent(".git").path
+            ) else { continue }
+            guard let submoduleGitDirectory = Self.submoduleGitDirectory(
+                for: submodulePath,
+                relativePath: relativePath,
+                parentGitDirectory: gitDirectory
+            ) else { return false }
+            guard try await isWorktreeClean(
+                submodulePath,
+                gitDirectory: submoduleGitDirectory,
+                usesRemoteHostRegistry: false
+            ) else { return false }
+            guard try await repositoryHasNoLocalState(
+                submodulePath,
+                gitDirectory: submoduleGitDirectory
+            ) else { return false }
+            guard try await stagedInitializedSubmodulesHaveNoLocalState(
+                submodulePath,
+                gitDirectory: submoduleGitDirectory
+            ) else { return false }
+        }
+        return true
+    }
+
+    private static func submoduleGitDirectory(
+        for submodulePath: URL,
+        relativePath: String,
+        parentGitDirectory: URL
+    ) -> URL? {
+        let dotGit = submodulePath.appendingPathComponent(".git")
+        if (try? dotGit.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true {
+            return dotGit
+        }
+        guard let rawGitFile = try? String(contentsOf: dotGit, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              rawGitFile.hasPrefix("gitdir:")
+        else { return nil }
+        let rawPath = rawGitFile.dropFirst("gitdir:".count).trimmingCharacters(in: .whitespaces)
+        let recordedGitDirectory = (rawPath as NSString).isAbsolutePath
+            ? URL(fileURLWithPath: rawPath)
+            : submodulePath.appendingPathComponent(rawPath)
+        if FileManager.default.fileExists(atPath: recordedGitDirectory.path) {
+            return recordedGitDirectory.standardizedFileURL
+        }
+        let fallback = parentGitDirectory
+            .appendingPathComponent("modules", isDirectory: true)
+            .appendingPathComponent(relativePath, isDirectory: true)
+            .standardizedFileURL
+        return FileManager.default.fileExists(atPath: fallback.path) ? fallback : nil
     }
 
     private static func gitContextArguments(
@@ -1445,6 +1525,97 @@ struct WorktreeService {
         )
         guard result.exitCode == 0 else { throw WorktreeError.gitFailed(result.stderr) }
         return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func repositoryHasNoLocalState(
+        _ path: URL,
+        gitDirectory: URL
+    ) async throws -> Bool {
+        let context = Self.gitContextArguments(worktreePath: path, gitDirectory: gitDirectory)
+        let reflog = try await Process.git(
+            context + ["rev-list", "--max-count=1", "--reflog", "--not", "--remotes"],
+            cwd: path,
+            usesRemoteHostRegistry: false
+        )
+        guard reflog.exitCode == 0 else { throw WorktreeError.gitFailed(reflog.stderr) }
+        guard reflog.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return false
+        }
+
+        let extraRefs = try await Process.git(
+            context + ["for-each-ref", "--format=%(refname)", "refs/notes", "refs/stash"],
+            cwd: path,
+            usesRemoteHostRegistry: false
+        )
+        guard extraRefs.exitCode == 0 else { throw WorktreeError.gitFailed(extraRefs.stderr) }
+        let extraRefNames = extraRefs.stdout
+            .split(separator: "\n")
+            .map(String.init)
+        if !extraRefNames.isEmpty {
+            let extraReachability = try await Process.git(
+                context + ["rev-list", "--max-count=1"] + extraRefNames + ["--not", "--remotes"],
+                cwd: path,
+                usesRemoteHostRegistry: false
+            )
+            guard extraReachability.exitCode == 0 else {
+                throw WorktreeError.gitFailed(extraReachability.stderr)
+            }
+            guard extraReachability.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return false
+            }
+        }
+
+        let localBranches = try await Process.git(
+            context + ["for-each-ref", "--format=%(refname)=%(objectname)", "refs/heads"],
+            cwd: path,
+            usesRemoteHostRegistry: false
+        )
+        guard localBranches.exitCode == 0 else { throw WorktreeError.gitFailed(localBranches.stderr) }
+        let remoteBranches = try await Process.git(
+            context + ["for-each-ref", "--format=%(refname)=%(objectname)", "refs/remotes"],
+            cwd: path,
+            usesRemoteHostRegistry: false
+        )
+        guard remoteBranches.exitCode == 0 else { throw WorktreeError.gitFailed(remoteBranches.stderr) }
+        let remoteHeadLines = Set(remoteBranches.stdout
+            .split(separator: "\n")
+            .compactMap { line -> String? in
+                let value = String(line)
+                guard !value.contains("/HEAD=") else { return nil }
+                guard let refsRange = value.range(of: "refs/remotes/") else { return nil }
+                let suffix = value[refsRange.upperBound...]
+                guard let slash = suffix.firstIndex(of: "/") else { return nil }
+                return "refs/heads/" + suffix[suffix.index(after: slash)...]
+            })
+        for branch in localBranches.stdout.split(separator: "\n").map(String.init) {
+            guard remoteHeadLines.contains(branch) else { return false }
+        }
+
+        let localTags = try await Process.git(
+            context + ["for-each-ref", "--format=%(refname)=%(objectname)", "refs/tags"],
+            cwd: path,
+            usesRemoteHostRegistry: false
+        )
+        guard localTags.exitCode == 0 else { throw WorktreeError.gitFailed(localTags.stderr) }
+        let remoteTags = try await Process.git(
+            ["-c", "protocol.file.allow=always"] + context + ["ls-remote", "--tags", "--refs", "origin"],
+            cwd: path,
+            usesRemoteHostRegistry: false
+        )
+        guard remoteTags.exitCode == 0 else {
+            return localTags.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        let remoteTagLines = Set(remoteTags.stdout
+            .split(separator: "\n")
+            .compactMap { line -> String? in
+                let parts = line.split(separator: "\t", maxSplits: 1)
+                guard parts.count == 2 else { return nil }
+                return "\(parts[1])=\(parts[0])"
+            })
+        for tag in localTags.stdout.split(separator: "\n").map(String.init) {
+            guard remoteTagLines.contains(tag) else { return false }
+        }
+        return true
     }
 
     private func canForceRemoveAfterMissingLFS(

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -835,7 +835,7 @@ struct WorktreeService {
         guard let expectedCommonDirectory = Self.localCommonGitDirectory(
             forWorktreeAt: repoPath
         ),
-              Self.matchesLinkedWorktreeRegistration(
+              let expectedWorktreeIdentity = Self.linkedWorktreeIdentity(
                   worktree.path,
                   expectedCommonDirectory: expectedCommonDirectory
               )
@@ -909,6 +909,22 @@ struct WorktreeService {
                 at: ticket.trashRoot,
                 withIntermediateDirectories: true
             )
+        } catch {
+            try await remove(
+                repoPath: repoPath,
+                worktree: worktree,
+                deleteBranchIfMerged: deleteBranchIfMerged,
+                force: force,
+                forceTwice: registration.isLocked && force,
+                usesRemoteHostRegistry: false
+            )
+            return .synchronous
+        }
+
+        guard Self.directoryIdentity(at: worktree.path) == expectedWorktreeIdentity else {
+            throw WorktreeError.gitFailed("Worktree changed before it could be staged.")
+        }
+        do {
             try moveItem(worktree.path, ticket.stagedPath)
         } catch {
             try await remove(
@@ -920,6 +936,18 @@ struct WorktreeService {
                 usesRemoteHostRegistry: false
             )
             return .synchronous
+        }
+
+        guard Self.directoryIdentity(at: ticket.stagedPath) == expectedWorktreeIdentity else {
+            do {
+                try moveItem(ticket.stagedPath, worktree.path)
+            } catch {
+                throw WorktreeError.gitFailed(
+                    "Worktree changed while it was being staged; staged files remain at "
+                        + "\(ticket.stagedPath.path). Rollback: \(error.localizedDescription)"
+                )
+            }
+            throw WorktreeError.gitFailed("Worktree changed while it was being staged.")
         }
 
         func failAfterRollingBack(_ registryMessage: String) throws -> Never {
@@ -1107,14 +1135,37 @@ struct WorktreeService {
         resolvedFileSystemPath(lhs) == resolvedFileSystemPath(rhs)
     }
 
-    private static func matchesLinkedWorktreeRegistration(
+    private struct FileSystemIdentity: Equatable {
+        let systemNumber: UInt64
+        let fileNumber: UInt64
+    }
+
+    private static func directoryIdentity(at path: URL) -> FileSystemIdentity? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path.path),
+              attributes[.type] as? FileAttributeType == .typeDirectory,
+              let systemNumber = attributes[.systemNumber] as? NSNumber,
+              let fileNumber = attributes[.systemFileNumber] as? NSNumber
+        else { return nil }
+        return FileSystemIdentity(
+            systemNumber: systemNumber.uint64Value,
+            fileNumber: fileNumber.uint64Value
+        )
+    }
+
+    private static func linkedWorktreeIdentity(
         _ worktreePath: URL,
         expectedCommonDirectory: URL
-    ) -> Bool {
+    ) -> FileSystemIdentity? {
         let fileManager = FileManager.default
         guard let rootAttributes = try? fileManager.attributesOfItem(atPath: worktreePath.path),
-              rootAttributes[.type] as? FileAttributeType == .typeDirectory
-        else { return false }
+              rootAttributes[.type] as? FileAttributeType == .typeDirectory,
+              let systemNumber = rootAttributes[.systemNumber] as? NSNumber,
+              let fileNumber = rootAttributes[.systemFileNumber] as? NSNumber
+        else { return nil }
+        let identity = FileSystemIdentity(
+            systemNumber: systemNumber.uint64Value,
+            fileNumber: fileNumber.uint64Value
+        )
 
         let dotGit = worktreePath.appendingPathComponent(".git", isDirectory: false)
         guard let dotGitAttributes = try? fileManager.attributesOfItem(atPath: dotGit.path),
@@ -1122,24 +1173,24 @@ struct WorktreeService {
               let gitDirectory = localGitDirectory(forWorktreeAt: worktreePath),
               let commonDirectory = localCommonGitDirectory(forWorktreeAt: worktreePath),
               fileSystemPathsEqual(commonDirectory, expectedCommonDirectory)
-        else { return false }
+        else { return nil }
 
         let expectedWorktreesDirectory = expectedCommonDirectory
             .appendingPathComponent("worktrees", isDirectory: true)
         guard fileSystemPathsEqual(
             gitDirectory.deletingLastPathComponent(),
             expectedWorktreesDirectory
-        ) else { return false }
+        ) else { return nil }
 
         let backlinkFile = gitDirectory.appendingPathComponent("gitdir", isDirectory: false)
         guard let rawBacklink = try? String(contentsOf: backlinkFile, encoding: .utf8)
             .trimmingCharacters(in: .whitespacesAndNewlines),
               !rawBacklink.isEmpty
-        else { return false }
+        else { return nil }
         let backlink = (rawBacklink as NSString).isAbsolutePath
             ? URL(fileURLWithPath: rawBacklink)
             : gitDirectory.appendingPathComponent(rawBacklink)
-        return fileSystemPathsEqual(backlink, dotGit)
+        return fileSystemPathsEqual(backlink, dotGit) ? identity : nil
     }
 
     private static func registrationState(

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -1,4 +1,5 @@
 import CryptoKit
+import Darwin
 import Foundation
 
 struct WorktreeDeletePreflight: Equatable {
@@ -783,6 +784,176 @@ struct WorktreeService {
         }
     }
 
+    func removeFastLocal(
+        repoPath: URL,
+        worktree: Worktree,
+        deleteBranchIfMerged: Bool,
+        force: Bool = false,
+        usesRemoteHostRegistry: Bool = true,
+        moveItem: @Sendable (URL, URL) throws -> Void = {
+            try WorktreeService.renameAtomically(from: $0, to: $1)
+        }
+    ) async throws -> WorktreeRemovalOutcome {
+        if repoPath.isRemoteAlasPath || worktree.path.isRemoteAlasPath {
+            try await remove(
+                repoPath: repoPath,
+                worktree: worktree,
+                deleteBranchIfMerged: deleteBranchIfMerged,
+                force: force,
+                usesRemoteHostRegistry: usesRemoteHostRegistry
+            )
+            return .synchronous
+        }
+
+        let registrations = try await Process.git(
+            ["worktree", "list", "--porcelain"],
+            cwd: repoPath,
+            usesRemoteHostRegistry: false
+        )
+        guard registrations.exitCode == 0 else {
+            throw WorktreeError.gitFailed(registrations.stderr)
+        }
+        let registration = Self.registrationState(
+            in: registrations.stdout,
+            matching: worktree.path
+        )
+        guard registration.isPresent else {
+            throw WorktreeError.gitFailed("Worktree registration was not found.")
+        }
+
+        var auditedMissingLFS = false
+        if !force {
+            do {
+                guard try await isWorktreeClean(
+                    worktree.path,
+                    usesRemoteHostRegistry: false
+                ) else {
+                    throw WorktreeError.gitFailed("Worktree contains modified or untracked files.")
+                }
+            } catch let error as WorktreeError {
+                guard case .gitFailed(let message) = error,
+                      Self.looksLikeMissingLFS(message),
+                      try await canForceRemoveAfterMissingLFS(
+                          worktree.path,
+                          usesRemoteHostRegistry: false
+                      )
+                else { throw error }
+                auditedMissingLFS = true
+            }
+        }
+
+        _ = try? await Process.git(
+            ["fsmonitor--daemon", "stop"],
+            cwd: worktree.path,
+            usesRemoteHostRegistry: false,
+            timeout: 2
+        )
+
+        let ticket: WorktreeTrashCleanupTicket
+        do {
+            let commonDirectoryResult = try await Process.git(
+                ["rev-parse", "--git-common-dir"],
+                cwd: repoPath,
+                usesRemoteHostRegistry: false
+            )
+            guard commonDirectoryResult.exitCode == 0 else {
+                throw WorktreeError.gitFailed(commonDirectoryResult.stderr)
+            }
+            let commonDirectoryOutput = commonDirectoryResult.stdout
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !commonDirectoryOutput.isEmpty else {
+                throw WorktreeError.gitFailed("Git returned an empty common directory.")
+            }
+            let commonDirectory: URL
+            if (commonDirectoryOutput as NSString).isAbsolutePath {
+                commonDirectory = URL(fileURLWithPath: commonDirectoryOutput).standardizedFileURL
+            } else {
+                commonDirectory = repoPath
+                    .appendingPathComponent(commonDirectoryOutput)
+                    .standardizedFileURL
+            }
+            ticket = WorktreeTrash.makeTicket(
+                commonGitDirectory: commonDirectory,
+                originalPath: worktree.path
+            )
+            try FileManager.default.createDirectory(
+                at: ticket.trashRoot,
+                withIntermediateDirectories: true
+            )
+            try moveItem(worktree.path, ticket.stagedPath)
+        } catch {
+            try await remove(
+                repoPath: repoPath,
+                worktree: worktree,
+                deleteBranchIfMerged: deleteBranchIfMerged,
+                force: force,
+                forceTwice: registration.isLocked && force,
+                usesRemoteHostRegistry: false
+            )
+            return .synchronous
+        }
+
+        func failAfterRollingBack(_ registryMessage: String) throws -> Never {
+            do {
+                try moveItem(ticket.stagedPath, worktree.path)
+            } catch {
+                let gitMessage = registryMessage
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                let stagedPath = Self.resolvedFileSystemPath(ticket.stagedPath)
+                throw WorktreeError.gitFailed(
+                    "Failed to remove Git registration for \(worktree.path.path); "
+                        + "staged files remain at \(stagedPath). "
+                        + "Git: \(gitMessage). Rollback: \(error.localizedDescription)"
+                )
+            }
+            throw WorktreeError.gitFailed(registryMessage)
+        }
+
+        var removeArgs = ["worktree", "remove", worktree.path.path]
+        if registration.isLocked && force {
+            removeArgs.append(contentsOf: ["--force", "--force"])
+        } else if force || auditedMissingLFS {
+            removeArgs.append("--force")
+        }
+        let initialRemoveArgs = auditedMissingLFS
+            ? Self.lfsFilterOverride + removeArgs
+            : removeArgs
+        let removeResult: ProcessResult
+        do {
+            var result = try await Process.git(
+                initialRemoveArgs,
+                cwd: repoPath,
+                usesRemoteHostRegistry: false,
+                timeout: 90
+            )
+            if result.exitCode != 0,
+               !auditedMissingLFS,
+               Self.looksLikeMissingLFS(result.stderr) {
+                result = try await Process.git(
+                    Self.lfsFilterOverride + removeArgs,
+                    cwd: repoPath,
+                    usesRemoteHostRegistry: false,
+                    timeout: 90
+                )
+            }
+            removeResult = result
+        } catch {
+            try failAfterRollingBack(error.localizedDescription)
+        }
+        if removeResult.exitCode != 0 {
+            try failAfterRollingBack(removeResult.stderr)
+        }
+
+        if deleteBranchIfMerged && worktree.branch != "(detached)" {
+            _ = try? await Process.git(
+                ["branch", "-d", worktree.branch],
+                cwd: repoPath,
+                usesRemoteHostRegistry: false
+            )
+        }
+        return .staged(ticket)
+    }
+
     func deletePreflight(
         worktreePath: URL,
         usesRemoteHostRegistry: Bool = true
@@ -879,6 +1050,54 @@ struct WorktreeService {
     }
 
     // MARK: - Helpers
+
+    private static func renameAtomically(from source: URL, to destination: URL) throws {
+        let result: (status: Int32, error: Int32) = source.withUnsafeFileSystemRepresentation { sourcePath in
+            destination.withUnsafeFileSystemRepresentation { destinationPath in
+                guard let sourcePath, let destinationPath else { return (-1, EINVAL) }
+                let status = Darwin.rename(sourcePath, destinationPath)
+                return (status, status == 0 ? 0 : errno)
+            }
+        }
+        guard result.status == 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(result.error))
+        }
+    }
+
+    private static func resolvedFileSystemPath(_ url: URL) -> String {
+        url.withUnsafeFileSystemRepresentation { path in
+            guard let path, let resolved = Darwin.realpath(path, nil) else { return url.path }
+            defer { Darwin.free(resolved) }
+            return String(cString: resolved)
+        }
+    }
+
+    private static func registrationState(
+        in porcelain: String,
+        matching worktreePath: URL
+    ) -> (isPresent: Bool, isLocked: Bool) {
+        let target = worktreePath.standardizedFileURL.path
+        var currentPath: String?
+        var currentLocked = false
+
+        func currentMatch() -> (isPresent: Bool, isLocked: Bool)? {
+            guard let currentPath,
+                  URL(fileURLWithPath: currentPath).standardizedFileURL.path == target
+            else { return nil }
+            return (true, currentLocked)
+        }
+
+        for line in porcelain.split(separator: "\n") {
+            if line.hasPrefix("worktree ") {
+                if let match = currentMatch() { return match }
+                currentPath = String(line.dropFirst("worktree ".count))
+                currentLocked = false
+            } else if line.hasPrefix("locked") {
+                currentLocked = true
+            }
+        }
+        return currentMatch() ?? (false, false)
+    }
 
     private static let lfsFilterOverride = [
         "-c", "filter.lfs.process=",

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -990,7 +990,8 @@ struct WorktreeService {
             }
         }
 
-        var removeArgs = ["worktree", "remove", worktree.path.path]
+        let commonGitArguments = ["--git-dir", expectedCommonDirectory.path]
+        var removeArgs = commonGitArguments + ["worktree", "remove", worktree.path.path]
         if registration.isLocked && force {
             removeArgs.append(contentsOf: ["--force", "--force"])
         } else if force || auditedMissingLFS {
@@ -1003,7 +1004,7 @@ struct WorktreeService {
         do {
             var result = try await Process.git(
                 initialRemoveArgs,
-                cwd: repoPath,
+                cwd: expectedCommonDirectory,
                 usesRemoteHostRegistry: false,
                 timeout: 90
             )
@@ -1012,7 +1013,7 @@ struct WorktreeService {
                Self.looksLikeMissingLFS(result.stderr) {
                 result = try await Process.git(
                     Self.lfsFilterOverride + removeArgs,
-                    cwd: repoPath,
+                    cwd: expectedCommonDirectory,
                     usesRemoteHostRegistry: false,
                     timeout: 90
                 )
@@ -1056,8 +1057,8 @@ struct WorktreeService {
 
         if deleteBranchIfMerged && worktree.branch != "(detached)" {
             _ = try? await Process.git(
-                ["branch", "-d", worktree.branch],
-                cwd: repoPath,
+                commonGitArguments + ["branch", "-d", worktree.branch],
+                cwd: expectedCommonDirectory,
                 usesRemoteHostRegistry: false
             )
         }

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -183,7 +183,7 @@ struct WorktreeService {
         }
     }
 
-    private static func localGitDirectory(forWorktreeAt path: URL) -> URL? {
+    static func localGitDirectory(forWorktreeAt path: URL) -> URL? {
         let dotGit = path.appendingPathComponent(".git")
         var isDirectory = ObjCBool(false)
         guard FileManager.default.fileExists(atPath: dotGit.path, isDirectory: &isDirectory) else { return nil }
@@ -197,6 +197,18 @@ struct WorktreeService {
             return URL(fileURLWithPath: rawPath).standardizedFileURL
         }
         return path.appendingPathComponent(rawPath).standardizedFileURL
+    }
+
+    static func localCommonGitDirectory(forWorktreeAt path: URL) -> URL? {
+        guard let gitDirectory = localGitDirectory(forWorktreeAt: path) else { return nil }
+        let marker = gitDirectory.appendingPathComponent("commondir")
+        guard let raw = try? String(contentsOf: marker, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty
+        else { return gitDirectory.standardizedFileURL }
+        return (raw as NSString).isAbsolutePath
+            ? URL(fileURLWithPath: raw).standardizedFileURL
+            : gitDirectory.appendingPathComponent(raw).standardizedFileURL
     }
 
     static func remoteLineageIDCommand(path: String, candidateID: String = UUID().uuidString.lowercased()) -> String {

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -844,6 +844,9 @@ struct WorktreeService {
                 "Worktree path no longer matches its Git registration."
             )
         }
+        let branchDeletionGitDirectory = repoPath.standardizedFileURL == worktree.path.standardizedFileURL
+            ? nil
+            : Self.localGitDirectory(forWorktreeAt: repoPath)
 
         var auditedMissingLFS = false
         if !force {
@@ -927,6 +930,11 @@ struct WorktreeService {
             throw WorktreeError.gitFailed("Worktree changed before it could be staged.")
         }
         do {
+            try WorktreeTrash.markPending(
+                ticket,
+                originalPath: worktree.path,
+                linkedGitDirectory: expectedRegistration.gitDirectory
+            )
             try moveItem(worktree.path, ticket.stagedPath)
         } catch {
             try await remove(
@@ -943,6 +951,9 @@ struct WorktreeService {
         func failAfterRollingBack(_ registryMessage: String) throws -> Never {
             try? FileManager.default.removeItem(
                 at: WorktreeTrash.committedMarkerURL(for: ticket)
+            )
+            try? FileManager.default.removeItem(
+                at: WorktreeTrash.pendingMarkerURL(for: ticket)
             )
             do {
                 try moveItem(ticket.stagedPath, worktree.path)
@@ -1029,6 +1040,7 @@ struct WorktreeService {
         let outcome: WorktreeRemovalOutcome
         do {
             try WorktreeTrash.markCommitted(ticket)
+            try? FileManager.default.removeItem(at: WorktreeTrash.pendingMarkerURL(for: ticket))
             outcome = .staged(ticket)
         } catch {
             let markerFailure = error.localizedDescription
@@ -1056,8 +1068,9 @@ struct WorktreeService {
         }
 
         if deleteBranchIfMerged && worktree.branch != "(detached)" {
+            let branchGitDirectory = branchDeletionGitDirectory ?? expectedCommonDirectory
             _ = try? await Process.git(
-                commonGitArguments + ["branch", "-d", worktree.branch],
+                ["--git-dir", branchGitDirectory.path, "branch", "-d", worktree.branch],
                 cwd: expectedCommonDirectory,
                 usesRemoteHostRegistry: false
             )

--- a/Alas/Sources/Git/WorktreeTrash.swift
+++ b/Alas/Sources/Git/WorktreeTrash.swift
@@ -23,6 +23,7 @@ enum WorktreeTrash {
     private static let committedMarkerVersion = "1"
     private static let pendingMarkerName = ".alas-worktree-deletion-pending"
     private static let pendingMarkerVersion = "1"
+    private static let maximumPendingMarkerBytes: UInt64 = 4_096
 
     private struct CommittedMetadata {
         let date: Date
@@ -113,6 +114,9 @@ enum WorktreeTrash {
             Data(linkedGitDirectory.lastPathComponent.utf8).base64EncodedString(),
             "",
         ].joined(separator: "\n")
+        guard metadata.utf8.count <= maximumPendingMarkerBytes else {
+            throw CocoaError(.fileWriteOutOfSpace)
+        }
         try Data(metadata.utf8).write(
             to: pendingMarkerURL(for: ticket),
             options: .atomic
@@ -374,7 +378,7 @@ enum WorktreeTrash {
         guard let attributes = try? fileManager.attributesOfItem(atPath: markerURL.path),
               attributes[.type] as? FileAttributeType == .typeRegular,
               let size = attributes[.size] as? NSNumber,
-              size.uint64Value <= 1_024,
+              size.uint64Value <= maximumPendingMarkerBytes,
               let data = fileManager.contents(atPath: markerURL.path),
               let raw = String(data: data, encoding: .utf8),
               raw.utf8.count == data.count

--- a/Alas/Sources/Git/WorktreeTrash.swift
+++ b/Alas/Sources/Git/WorktreeTrash.swift
@@ -1,8 +1,14 @@
 import Foundation
 
+struct WorktreeTrashDirectoryIdentity: Equatable, Sendable {
+    let systemNumber: UInt64
+    let fileNumber: UInt64
+}
+
 struct WorktreeTrashCleanupTicket: Equatable, Sendable {
     let trashRoot: URL
     let stagedPath: URL
+    let directoryIdentity: WorktreeTrashDirectoryIdentity
 }
 
 enum WorktreeRemovalOutcome: Equatable, Sendable {
@@ -28,7 +34,10 @@ enum WorktreeTrash {
         originalPath: URL,
         now: Date = Date(),
         id: UUID = UUID()
-    ) -> WorktreeTrashCleanupTicket {
+    ) throws -> WorktreeTrashCleanupTicket {
+        guard let directoryIdentity = directoryIdentity(at: originalPath) else {
+            throw CocoaError(.fileReadNoSuchFile)
+        }
         let trashRoot = root(commonGitDirectory: commonGitDirectory)
         let safeBase = sanitizedBaseName(originalPath.lastPathComponent)
         let name = "\(safeBase).\(marker).\(Int(now.timeIntervalSince1970)).\(id.uuidString.lowercased())"
@@ -37,7 +46,8 @@ enum WorktreeTrash {
             stagedPath: URL(
                 fileURLWithPath: trashRoot.appendingPathComponent(name).path,
                 isDirectory: false
-            )
+            ),
+            directoryIdentity: directoryIdentity
         )
     }
 
@@ -87,12 +97,17 @@ enum WorktreeTrash {
                 options: [.skipsHiddenFiles]
             ) else { continue }
             for entry in entries {
+                guard let directoryIdentity = directoryIdentity(
+                    at: entry,
+                    fileManager: fileManager
+                ) else { continue }
                 let ticket = WorktreeTrashCleanupTicket(
                     trashRoot: trashRoot,
                     stagedPath: URL(
                         fileURLWithPath: trashRoot.path + "/" + entry.lastPathComponent,
                         isDirectory: false
-                    )
+                    ),
+                    directoryIdentity: directoryIdentity
                 )
                 guard isValid(ticket),
                       let values = try? entry.resourceValues(forKeys: keys),
@@ -105,6 +120,29 @@ enum WorktreeTrash {
             }
         }
         return tickets.sorted { $0.stagedPath.path < $1.stagedPath.path }
+    }
+
+    static func directoryIdentity(
+        at path: URL,
+        fileManager: FileManager = .default
+    ) -> WorktreeTrashDirectoryIdentity? {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: path.path),
+              attributes[.type] as? FileAttributeType == .typeDirectory,
+              let systemNumber = attributes[.systemNumber] as? NSNumber,
+              let fileNumber = attributes[.systemFileNumber] as? NSNumber
+        else { return nil }
+        return WorktreeTrashDirectoryIdentity(
+            systemNumber: systemNumber.uint64Value,
+            fileNumber: fileNumber.uint64Value
+        )
+    }
+
+    static func matchesDirectoryIdentity(
+        _ ticket: WorktreeTrashCleanupTicket,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        directoryIdentity(at: ticket.stagedPath, fileManager: fileManager)
+            == ticket.directoryIdentity
     }
 
     private static func sanitizedBaseName(_ value: String) -> String {

--- a/Alas/Sources/Git/WorktreeTrash.swift
+++ b/Alas/Sources/Git/WorktreeTrash.swift
@@ -248,18 +248,82 @@ enum WorktreeTrash {
               let pending = pendingMetadata(ticket, fileManager: fileManager),
               pending.directoryIdentity == ticket.directoryIdentity,
               pending.stagedName == ticket.stagedPath.lastPathComponent,
-              !fileManager.fileExists(atPath: pending.originalPath.path),
-              !fileManager.fileExists(atPath: commonGitDirectory
-                .appendingPathComponent("worktrees", isDirectory: true)
-                .appendingPathComponent(pending.linkedGitDirectoryName, isDirectory: true)
-                .path)
+              !fileManager.fileExists(atPath: pending.originalPath.path)
         else { return }
+        let registrationDirectory = commonGitDirectory
+            .appendingPathComponent("worktrees", isDirectory: true)
+            .appendingPathComponent(pending.linkedGitDirectoryName, isDirectory: true)
+        if fileManager.fileExists(atPath: registrationDirectory.path) {
+            restorePendingTicket(
+                ticket,
+                pending: pending,
+                registrationDirectory: registrationDirectory,
+                fileManager: fileManager
+            )
+            return
+        }
         do {
             try markCommitted(ticket, at: pending.date)
             try fileManager.removeItem(at: pendingMarkerURL(for: ticket))
         } catch {
             return
         }
+    }
+
+    private static func restorePendingTicket(
+        _ ticket: WorktreeTrashCleanupTicket,
+        pending: PendingMetadata,
+        registrationDirectory: URL,
+        fileManager: FileManager
+    ) {
+        guard registrationGitFilePointsToOriginalPath(
+            registrationDirectory: registrationDirectory,
+            originalPath: pending.originalPath,
+            fileManager: fileManager
+        ) else { return }
+        do {
+            try fileManager.moveItem(at: ticket.stagedPath, to: pending.originalPath)
+            try fileManager.removeItem(at: pendingMarkerURL(for: ticket))
+        } catch {
+            return
+        }
+    }
+
+    private static func registrationGitFilePointsToOriginalPath(
+        registrationDirectory: URL,
+        originalPath: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        let gitdirFile = registrationDirectory.appendingPathComponent("gitdir", isDirectory: false)
+        guard let data = fileManager.contents(atPath: gitdirFile.path),
+              let raw = String(data: data, encoding: .utf8),
+              raw.utf8.count == data.count
+        else { return false }
+        let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return false }
+        let gitdir = (value as NSString).isAbsolutePath
+            ? URL(fileURLWithPath: value)
+            : registrationDirectory.appendingPathComponent(value)
+        let expected = originalPath.appendingPathComponent(".git", isDirectory: false)
+        return pathsReferToSameFile(gitdir, expected)
+            || gitdir.standardizedFileURL.path == expected.standardizedFileURL.path
+    }
+
+    private static func pathsReferToSameFile(_ lhs: URL, _ rhs: URL) -> Bool {
+        let lhsPath = lhs.resolvingSymlinksInPath().standardizedFileURL.path
+        let rhsPath = rhs.resolvingSymlinksInPath().standardizedFileURL.path
+        return lhsPath == rhsPath
+            || normalizedDarwinPath(lhsPath) == normalizedDarwinPath(rhsPath)
+    }
+
+    private static func normalizedDarwinPath(_ path: String) -> String {
+        if path.hasPrefix("/private/var/") {
+            return String(path.dropFirst("/private".count))
+        }
+        if path == "/private/var" {
+            return "/var"
+        }
+        return path
     }
 
     private static func committedMetadata(

--- a/Alas/Sources/Git/WorktreeTrash.swift
+++ b/Alas/Sources/Git/WorktreeTrash.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+struct WorktreeTrashCleanupTicket: Equatable, Sendable {
+    let trashRoot: URL
+    let stagedPath: URL
+}
+
+enum WorktreeRemovalOutcome: Equatable, Sendable {
+    case synchronous
+    case staged(WorktreeTrashCleanupTicket)
+}
+
+enum WorktreeTrash {
+    static let relativeDirectory = "alas/trash"
+    private static let marker = "alas-worktree"
+
+    static func root(commonGitDirectory: URL) -> URL {
+        let path = commonGitDirectory
+            .appendingPathComponent(relativeDirectory)
+            .standardizedFileURL
+            .path
+        return URL(fileURLWithPath: path, isDirectory: false).standardizedFileURL
+    }
+
+    static func makeTicket(
+        commonGitDirectory: URL,
+        originalPath: URL,
+        now: Date = Date(),
+        id: UUID = UUID()
+    ) -> WorktreeTrashCleanupTicket {
+        let trashRoot = root(commonGitDirectory: commonGitDirectory)
+        let safeBase = sanitizedBaseName(originalPath.lastPathComponent)
+        let name = "\(safeBase).\(marker).\(Int(now.timeIntervalSince1970)).\(id.uuidString.lowercased())"
+        return WorktreeTrashCleanupTicket(
+            trashRoot: trashRoot,
+            stagedPath: URL(
+                fileURLWithPath: trashRoot.appendingPathComponent(name).path,
+                isDirectory: false
+            )
+        )
+    }
+
+    static func isValid(_ ticket: WorktreeTrashCleanupTicket) -> Bool {
+        let root = ticket.trashRoot.standardizedFileURL
+        let target = ticket.stagedPath.standardizedFileURL
+        return root.lastPathComponent == "trash"
+            && root.deletingLastPathComponent().lastPathComponent == "alas"
+            && target.deletingLastPathComponent().path == root.path
+            && isRecognizedEntryName(target.lastPathComponent)
+    }
+
+    static func staleTickets(
+        commonGitDirectories: [URL],
+        olderThan cutoff: Date,
+        fileManager: FileManager = .default
+    ) -> [WorktreeTrashCleanupTicket] {
+        let keys: Set<URLResourceKey> = [
+            .contentModificationDateKey,
+            .isDirectoryKey,
+            .isSymbolicLinkKey,
+        ]
+        let commonDirectories = Dictionary(
+            commonGitDirectories.map { ($0.standardizedFileURL.path, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        var tickets: [WorktreeTrashCleanupTicket] = []
+        for commonPath in commonDirectories.keys.sorted() {
+            guard let commonGitDirectory = commonDirectories[commonPath] else { continue }
+            let trashRoot = root(commonGitDirectory: commonGitDirectory)
+            guard let entries = try? fileManager.contentsOfDirectory(
+                at: trashRoot,
+                includingPropertiesForKeys: Array(keys),
+                options: [.skipsHiddenFiles]
+            ) else { continue }
+            for entry in entries {
+                let ticket = WorktreeTrashCleanupTicket(
+                    trashRoot: trashRoot,
+                    stagedPath: URL(
+                        fileURLWithPath: trashRoot.path + "/" + entry.lastPathComponent,
+                        isDirectory: false
+                    )
+                )
+                guard isValid(ticket),
+                      let values = try? entry.resourceValues(forKeys: keys),
+                      values.isDirectory == true,
+                      values.isSymbolicLink != true,
+                      let modified = values.contentModificationDate,
+                      modified < cutoff
+                else { continue }
+                tickets.append(ticket)
+            }
+        }
+        return tickets.sorted { $0.stagedPath.path < $1.stagedPath.path }
+    }
+
+    private static func sanitizedBaseName(_ value: String) -> String {
+        var result = ""
+        var needsSeparator = false
+        for scalar in value.unicodeScalars {
+            let byte = scalar.value
+            let allowed = (48...57).contains(byte)
+                || (65...90).contains(byte)
+                || (97...122).contains(byte)
+                || byte == 45
+                || byte == 95
+            if allowed {
+                if needsSeparator, !result.isEmpty { result.append("-") }
+                result.unicodeScalars.append(scalar)
+                needsSeparator = false
+            } else {
+                needsSeparator = true
+            }
+        }
+        let trimmed = result.trimmingCharacters(in: CharacterSet(charactersIn: "-_"))
+        let limited = String(trimmed.prefix(48))
+        return limited.isEmpty ? "worktree" : limited
+    }
+
+    private static func isRecognizedEntryName(_ value: String) -> Bool {
+        let fields = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard fields.count == 4,
+              fields[1] == Substring(marker),
+              let epoch = Int(fields[2]),
+              epoch >= 0,
+              UUID(uuidString: String(fields[3])) != nil
+        else { return false }
+        return !fields[0].isEmpty
+    }
+}

--- a/Alas/Sources/Git/WorktreeTrash.swift
+++ b/Alas/Sources/Git/WorktreeTrash.swift
@@ -13,6 +13,7 @@ enum WorktreeRemovalOutcome: Equatable, Sendable {
 enum WorktreeTrash {
     static let relativeDirectory = "alas/trash"
     private static let marker = "alas-worktree"
+    private static let committedMarkerName = ".alas-worktree-deletion-committed"
 
     static func root(commonGitDirectory: URL) -> URL {
         let path = commonGitDirectory
@@ -49,16 +50,29 @@ enum WorktreeTrash {
             && isRecognizedEntryName(target.lastPathComponent)
     }
 
+    static func markCommitted(
+        _ ticket: WorktreeTrashCleanupTicket,
+        at date: Date = Date()
+    ) throws {
+        guard isValid(ticket) else {
+            throw CocoaError(.fileWriteInvalidFileName)
+        }
+        let seconds = date.timeIntervalSince1970
+        guard seconds.isFinite, seconds >= 0 else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        try Data("\(seconds)\n".utf8).write(
+            to: committedMarkerURL(for: ticket),
+            options: .atomic
+        )
+    }
+
     static func staleTickets(
         commonGitDirectories: [URL],
         olderThan cutoff: Date,
         fileManager: FileManager = .default
     ) -> [WorktreeTrashCleanupTicket] {
-        let keys: Set<URLResourceKey> = [
-            .contentModificationDateKey,
-            .isDirectoryKey,
-            .isSymbolicLinkKey,
-        ]
+        let keys: Set<URLResourceKey> = [.isDirectoryKey, .isSymbolicLinkKey]
         let commonDirectories = Dictionary(
             commonGitDirectories.map { ($0.standardizedFileURL.path, $0) },
             uniquingKeysWith: { first, _ in first }
@@ -84,8 +98,8 @@ enum WorktreeTrash {
                       let values = try? entry.resourceValues(forKeys: keys),
                       values.isDirectory == true,
                       values.isSymbolicLink != true,
-                      let modified = values.contentModificationDate,
-                      modified < cutoff
+                      let committedAt = committedAt(ticket, fileManager: fileManager),
+                      committedAt < cutoff
                 else { continue }
                 tickets.append(ticket)
             }
@@ -114,6 +128,33 @@ enum WorktreeTrash {
         let trimmed = result.trimmingCharacters(in: CharacterSet(charactersIn: "-_"))
         let limited = String(trimmed.prefix(48))
         return limited.isEmpty ? "worktree" : limited
+    }
+
+    static func committedMarkerURL(for ticket: WorktreeTrashCleanupTicket) -> URL {
+        let identifier = ticket.stagedPath.lastPathComponent
+            .split(separator: ".", omittingEmptySubsequences: false)
+            .last
+            .map(String.init) ?? "invalid"
+        return ticket.trashRoot.appendingPathComponent(
+            "\(committedMarkerName).\(identifier)",
+            isDirectory: false
+        )
+    }
+
+    private static func committedAt(
+        _ ticket: WorktreeTrashCleanupTicket,
+        fileManager: FileManager
+    ) -> Date? {
+        let markerURL = committedMarkerURL(for: ticket)
+        guard let attributes = try? fileManager.attributesOfItem(atPath: markerURL.path),
+              attributes[.type] as? FileAttributeType == .typeRegular,
+              let data = fileManager.contents(atPath: markerURL.path),
+              let raw = String(data: data, encoding: .utf8),
+              let seconds = TimeInterval(raw.trimmingCharacters(in: .whitespacesAndNewlines)),
+              seconds.isFinite,
+              seconds >= 0
+        else { return nil }
+        return Date(timeIntervalSince1970: seconds)
     }
 
     private static func isRecognizedEntryName(_ value: String) -> Bool {

--- a/Alas/Sources/Git/WorktreeTrash.swift
+++ b/Alas/Sources/Git/WorktreeTrash.swift
@@ -20,6 +20,12 @@ enum WorktreeTrash {
     static let relativeDirectory = "alas/trash"
     private static let marker = "alas-worktree"
     private static let committedMarkerName = ".alas-worktree-deletion-committed"
+    private static let committedMarkerVersion = "1"
+
+    private struct CommittedMetadata {
+        let date: Date
+        let directoryIdentity: WorktreeTrashDirectoryIdentity
+    }
 
     static func root(commonGitDirectory: URL) -> URL {
         let path = commonGitDirectory
@@ -71,7 +77,14 @@ enum WorktreeTrash {
         guard seconds.isFinite, seconds >= 0 else {
             throw CocoaError(.fileWriteUnknown)
         }
-        try Data("\(seconds)\n".utf8).write(
+        let metadata = [
+            committedMarkerVersion,
+            String(seconds),
+            String(ticket.directoryIdentity.systemNumber),
+            String(ticket.directoryIdentity.fileNumber),
+            "",
+        ].joined(separator: "\n")
+        try Data(metadata.utf8).write(
             to: committedMarkerURL(for: ticket),
             options: .atomic
         )
@@ -113,8 +126,9 @@ enum WorktreeTrash {
                       let values = try? entry.resourceValues(forKeys: keys),
                       values.isDirectory == true,
                       values.isSymbolicLink != true,
-                      let committedAt = committedAt(ticket, fileManager: fileManager),
-                      committedAt < cutoff
+                      let committed = committedMetadata(ticket, fileManager: fileManager),
+                      committed.directoryIdentity == directoryIdentity,
+                      committed.date < cutoff
                 else { continue }
                 tickets.append(ticket)
             }
@@ -179,20 +193,36 @@ enum WorktreeTrash {
         )
     }
 
-    private static func committedAt(
+    private static func committedMetadata(
         _ ticket: WorktreeTrashCleanupTicket,
         fileManager: FileManager
-    ) -> Date? {
+    ) -> CommittedMetadata? {
         let markerURL = committedMarkerURL(for: ticket)
         guard let attributes = try? fileManager.attributesOfItem(atPath: markerURL.path),
               attributes[.type] as? FileAttributeType == .typeRegular,
+              let size = attributes[.size] as? NSNumber,
+              size.uint64Value <= 256,
               let data = fileManager.contents(atPath: markerURL.path),
               let raw = String(data: data, encoding: .utf8),
-              let seconds = TimeInterval(raw.trimmingCharacters(in: .whitespacesAndNewlines)),
-              seconds.isFinite,
-              seconds >= 0
+              raw.utf8.count == data.count
         else { return nil }
-        return Date(timeIntervalSince1970: seconds)
+        let fields = raw.components(separatedBy: "\n")
+        guard fields.count == 5,
+              fields[0] == committedMarkerVersion,
+              fields[4].isEmpty,
+              let seconds = TimeInterval(fields[1]),
+              seconds.isFinite,
+              seconds >= 0,
+              let systemNumber = UInt64(fields[2]),
+              let fileNumber = UInt64(fields[3])
+        else { return nil }
+        return CommittedMetadata(
+            date: Date(timeIntervalSince1970: seconds),
+            directoryIdentity: WorktreeTrashDirectoryIdentity(
+                systemNumber: systemNumber,
+                fileNumber: fileNumber
+            )
+        )
     }
 
     private static func isRecognizedEntryName(_ value: String) -> Bool {

--- a/Alas/Sources/Git/WorktreeTrash.swift
+++ b/Alas/Sources/Git/WorktreeTrash.swift
@@ -21,6 +21,8 @@ enum WorktreeTrash {
     private static let marker = "alas-worktree"
     private static let committedMarkerName = ".alas-worktree-deletion-committed"
     private static let committedMarkerVersion = "1"
+    private static let pendingMarkerName = ".alas-worktree-deletion-pending"
+    private static let pendingMarkerVersion = "1"
 
     private struct CommittedMetadata {
         let date: Date
@@ -90,6 +92,33 @@ enum WorktreeTrash {
         )
     }
 
+    static func markPending(
+        _ ticket: WorktreeTrashCleanupTicket,
+        originalPath: URL,
+        linkedGitDirectory: URL,
+        at date: Date = Date()
+    ) throws {
+        guard isValid(ticket) else { throw CocoaError(.fileWriteInvalidFileName) }
+        let seconds = date.timeIntervalSince1970
+        guard seconds.isFinite, seconds >= 0,
+              !linkedGitDirectory.lastPathComponent.isEmpty
+        else { throw CocoaError(.fileWriteUnknown) }
+        let metadata = [
+            pendingMarkerVersion,
+            String(seconds),
+            String(ticket.directoryIdentity.systemNumber),
+            String(ticket.directoryIdentity.fileNumber),
+            ticket.stagedPath.lastPathComponent,
+            Data(originalPath.standardizedFileURL.path.utf8).base64EncodedString(),
+            Data(linkedGitDirectory.lastPathComponent.utf8).base64EncodedString(),
+            "",
+        ].joined(separator: "\n")
+        try Data(metadata.utf8).write(
+            to: pendingMarkerURL(for: ticket),
+            options: .atomic
+        )
+    }
+
     static func staleTickets(
         commonGitDirectories: [URL],
         olderThan cutoff: Date,
@@ -121,6 +150,11 @@ enum WorktreeTrash {
                         isDirectory: false
                     ),
                     directoryIdentity: directoryIdentity
+                )
+                reconcilePendingTicket(
+                    ticket,
+                    commonGitDirectory: commonGitDirectory,
+                    fileManager: fileManager
                 )
                 guard isValid(ticket),
                       let values = try? entry.resourceValues(forKeys: keys),
@@ -193,6 +227,41 @@ enum WorktreeTrash {
         )
     }
 
+    static func pendingMarkerURL(for ticket: WorktreeTrashCleanupTicket) -> URL {
+        let identifier = ticket.stagedPath.lastPathComponent
+            .split(separator: ".", omittingEmptySubsequences: false)
+            .last
+            .map(String.init) ?? "invalid"
+        return ticket.trashRoot.appendingPathComponent(
+            "\(pendingMarkerName).\(identifier)",
+            isDirectory: false
+        )
+    }
+
+    private static func reconcilePendingTicket(
+        _ ticket: WorktreeTrashCleanupTicket,
+        commonGitDirectory: URL,
+        fileManager: FileManager
+    ) {
+        guard isValid(ticket),
+              matchesDirectoryIdentity(ticket, fileManager: fileManager),
+              let pending = pendingMetadata(ticket, fileManager: fileManager),
+              pending.directoryIdentity == ticket.directoryIdentity,
+              pending.stagedName == ticket.stagedPath.lastPathComponent,
+              !fileManager.fileExists(atPath: pending.originalPath.path),
+              !fileManager.fileExists(atPath: commonGitDirectory
+                .appendingPathComponent("worktrees", isDirectory: true)
+                .appendingPathComponent(pending.linkedGitDirectoryName, isDirectory: true)
+                .path)
+        else { return }
+        do {
+            try markCommitted(ticket, at: pending.date)
+            try fileManager.removeItem(at: pendingMarkerURL(for: ticket))
+        } catch {
+            return
+        }
+    }
+
     private static func committedMetadata(
         _ ticket: WorktreeTrashCleanupTicket,
         fileManager: FileManager
@@ -222,6 +291,57 @@ enum WorktreeTrash {
                 systemNumber: systemNumber,
                 fileNumber: fileNumber
             )
+        )
+    }
+
+    private struct PendingMetadata {
+        let date: Date
+        let directoryIdentity: WorktreeTrashDirectoryIdentity
+        let stagedName: String
+        let originalPath: URL
+        let linkedGitDirectoryName: String
+    }
+
+    private static func pendingMetadata(
+        _ ticket: WorktreeTrashCleanupTicket,
+        fileManager: FileManager
+    ) -> PendingMetadata? {
+        let markerURL = pendingMarkerURL(for: ticket)
+        guard let attributes = try? fileManager.attributesOfItem(atPath: markerURL.path),
+              attributes[.type] as? FileAttributeType == .typeRegular,
+              let size = attributes[.size] as? NSNumber,
+              size.uint64Value <= 1_024,
+              let data = fileManager.contents(atPath: markerURL.path),
+              let raw = String(data: data, encoding: .utf8),
+              raw.utf8.count == data.count
+        else { return nil }
+        let fields = raw.components(separatedBy: "\n")
+        guard fields.count == 8,
+              fields[0] == pendingMarkerVersion,
+              fields[7].isEmpty,
+              let seconds = TimeInterval(fields[1]), seconds.isFinite, seconds >= 0,
+              let systemNumber = UInt64(fields[2]),
+              let fileNumber = UInt64(fields[3]),
+              isRecognizedEntryName(fields[4]),
+              let originalData = Data(base64Encoded: fields[5]),
+              let original = String(data: originalData, encoding: .utf8),
+              original.utf8.count == originalData.count,
+              original.hasPrefix("/"),
+              let linkedGitDirectoryNameData = Data(base64Encoded: fields[6]),
+              let linkedGitDirectoryName = String(data: linkedGitDirectoryNameData, encoding: .utf8),
+              linkedGitDirectoryName.utf8.count == linkedGitDirectoryNameData.count,
+              !linkedGitDirectoryName.isEmpty,
+              !linkedGitDirectoryName.contains("/")
+        else { return nil }
+        return PendingMetadata(
+            date: Date(timeIntervalSince1970: seconds),
+            directoryIdentity: WorktreeTrashDirectoryIdentity(
+                systemNumber: systemNumber,
+                fileNumber: fileNumber
+            ),
+            stagedName: fields[4],
+            originalPath: URL(fileURLWithPath: original).standardizedFileURL,
+            linkedGitDirectoryName: linkedGitDirectoryName
         )
     }
 

--- a/Alas/Sources/Git/WorktreeTrashCleaner.swift
+++ b/Alas/Sources/Git/WorktreeTrashCleaner.swift
@@ -43,11 +43,29 @@ enum WorktreeTrashCleaner {
             import time
             import uuid
 
-            def open_directory(name, dirfd):
+            REMOVABLE_FLAGS = sum(
+                getattr(stat_module, name, 0)
+                for name in ("UF_IMMUTABLE", "UF_APPEND")
+            )
+
+            def clear_removable_flags(name, directory):
+                if REMOVABLE_FLAGS == 0:
+                    return
+                path = os.path.join(directory, name)
+                try:
+                    entry_stat = os.stat(path, follow_symlinks=False)
+                    flags = getattr(entry_stat, "st_flags", 0)
+                    if flags & REMOVABLE_FLAGS:
+                        os.chflags(path, flags & ~REMOVABLE_FLAGS, follow_symlinks=False)
+                except (AttributeError, FileNotFoundError):
+                    pass
+
+            def open_directory(name, dirfd, directory):
                 flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
                 try:
                     fd = os.open(name, flags, dir_fd=dirfd)
                 except PermissionError:
+                    clear_removable_flags(name, directory)
                     os.chmod(name, 0o700, dir_fd=dirfd, follow_symlinks=False)
                     fd = os.open(name, flags, dir_fd=dirfd)
                 mode = stat_module.S_IMODE(os.fstat(fd).st_mode)
@@ -55,13 +73,14 @@ enum WorktreeTrashCleaner {
                     os.fchmod(fd, mode | 0o700)
                 return fd
 
-            def remove_contents(dirfd):
+            def remove_contents(dirfd, directory):
                 for name in os.listdir(dirfd):
                     try:
-                        childfd = open_directory(name, dirfd)
+                        childfd = open_directory(name, dirfd, directory)
                     except OSError as error:
                         if error.errno in (errno.ENOTDIR, errno.ELOOP):
                             try:
+                                clear_removable_flags(name, directory)
                                 os.unlink(name, dir_fd=dirfd)
                             except FileNotFoundError:
                                 pass
@@ -70,10 +89,11 @@ enum WorktreeTrashCleaner {
                             continue
                         raise
                     try:
-                        remove_contents(childfd)
+                        remove_contents(childfd, os.path.join(directory, name))
                     finally:
                         os.close(childfd)
                     try:
+                        clear_removable_flags(name, directory)
                         os.rmdir(name, dir_fd=dirfd)
                     except FileNotFoundError:
                         pass
@@ -85,18 +105,19 @@ enum WorktreeTrashCleaner {
             expected_inode = int(sys.argv[5])
             parent, name = os.path.split(staged)
             private_name = f".{name}.deleting.{os.getpid()}.{uuid.uuid4().hex}"
+            private_path = os.path.join(parent, private_name)
             parentfd = os.open(parent, os.O_RDONLY | os.O_DIRECTORY)
             stagedfd = None
             renamedfd = None
             renamed = False
             try:
-                stagedfd = open_directory(name, parentfd)
+                stagedfd = open_directory(name, parentfd, parent)
                 staged_stat = os.fstat(stagedfd)
                 if (staged_stat.st_dev, staged_stat.st_ino) != (expected_device, expected_inode):
                     sys.exit(0)
                 os.rename(name, private_name, src_dir_fd=parentfd, dst_dir_fd=parentfd)
                 renamed = True
-                renamedfd = open_directory(private_name, parentfd)
+                renamedfd = open_directory(private_name, parentfd, parent)
                 renamed_stat = os.fstat(renamedfd)
                 if (renamed_stat.st_dev, renamed_stat.st_ino) != (expected_device, expected_inode):
                     try:
@@ -104,8 +125,9 @@ enum WorktreeTrashCleaner {
                     except OSError:
                         pass
                     sys.exit(0)
-                remove_contents(renamedfd)
+                remove_contents(renamedfd, private_path)
                 try:
+                    clear_removable_flags(private_name, parent)
                     os.rmdir(private_name, dir_fd=parentfd)
                 except FileNotFoundError:
                     pass

--- a/Alas/Sources/Git/WorktreeTrashCleaner.swift
+++ b/Alas/Sources/Git/WorktreeTrashCleaner.swift
@@ -12,9 +12,15 @@ enum WorktreeTrashCleaner {
 
     enum CleanerError: LocalizedError {
         case invalidTicket
+        case replacedDirectory
 
         var errorDescription: String? {
-            "Refusing to clean a path outside the Alas worktree trash directory."
+            switch self {
+            case .invalidTicket:
+                "Refusing to clean a path outside the Alas worktree trash directory."
+            case .replacedDirectory:
+                "Refusing to clean a replaced worktree trash directory."
+            }
         }
     }
 
@@ -24,13 +30,23 @@ enum WorktreeTrashCleaner {
         spawn: Spawn = spawnDetached
     ) throws {
         guard WorktreeTrash.isValid(ticket) else { throw CleanerError.invalidTicket }
+        guard WorktreeTrash.matchesDirectoryIdentity(ticket) else {
+            throw CleanerError.replacedDirectory
+        }
         try spawn(URL(fileURLWithPath: "/usr/bin/nice"), [
             "-n", "10", "/bin/sh", "-c",
-            "/bin/sleep \"$1\"; /bin/rm -rf -- \"$3\" && exec /bin/rm -f -- \"$2\"",
+            """
+            /bin/sleep "$1"
+            current=$(/usr/bin/stat -f '%d:%i' "$3" 2>/dev/null) || exit 0
+            test "$current" = "$4:$5" || exit 0
+            /bin/rm -rf -- "$3" && exec /bin/rm -f -- "$2"
+            """,
             "alas-worktree-cleaner",
             String(max(0, delaySeconds)),
             WorktreeTrash.committedMarkerURL(for: ticket).path,
             ticket.stagedPath.path,
+            String(ticket.directoryIdentity.systemNumber),
+            String(ticket.directoryIdentity.fileNumber),
         ])
     }
 

--- a/Alas/Sources/Git/WorktreeTrashCleaner.swift
+++ b/Alas/Sources/Git/WorktreeTrashCleaner.swift
@@ -26,9 +26,10 @@ enum WorktreeTrashCleaner {
         guard WorktreeTrash.isValid(ticket) else { throw CleanerError.invalidTicket }
         try spawn(URL(fileURLWithPath: "/usr/bin/nice"), [
             "-n", "10", "/bin/sh", "-c",
-            "/bin/sleep \"$1\"; exec /bin/rm -rf -- \"$2\"",
+            "/bin/sleep \"$1\"; /bin/rm -rf -- \"$3\" && exec /bin/rm -f -- \"$2\"",
             "alas-worktree-cleaner",
             String(max(0, delaySeconds)),
+            WorktreeTrash.committedMarkerURL(for: ticket).path,
             ticket.stagedPath.path,
         ])
     }

--- a/Alas/Sources/Git/WorktreeTrashCleaner.swift
+++ b/Alas/Sources/Git/WorktreeTrashCleaner.swift
@@ -1,0 +1,72 @@
+import Foundation
+import os
+
+enum WorktreeTrashCleaner {
+    typealias Launcher = (WorktreeTrashCleanupTicket) throws -> Void
+    typealias Spawn = (URL, [String]) throws -> Void
+
+    private static let logger = Logger(
+        subsystem: "io.nlopez.alas",
+        category: "worktree-trash"
+    )
+
+    enum CleanerError: LocalizedError {
+        case invalidTicket
+
+        var errorDescription: String? {
+            "Refusing to clean a path outside the Alas worktree trash directory."
+        }
+    }
+
+    static func launch(
+        _ ticket: WorktreeTrashCleanupTicket,
+        delaySeconds: Int = 1,
+        spawn: Spawn = spawnDetached
+    ) throws {
+        guard WorktreeTrash.isValid(ticket) else { throw CleanerError.invalidTicket }
+        try spawn(URL(fileURLWithPath: "/usr/bin/nice"), [
+            "-n", "10", "/bin/sh", "-c",
+            "/bin/sleep \"$1\"; exec /bin/rm -rf -- \"$2\"",
+            "alas-worktree-cleaner",
+            String(max(0, delaySeconds)),
+            ticket.stagedPath.path,
+        ])
+    }
+
+    static func sweep(
+        projects: [ProjectConfig],
+        now: Date = Date(),
+        launcher: Launcher = { try launch($0) }
+    ) {
+        let commonDirectories = projects.compactMap { project -> URL? in
+            guard project.host == nil else { return nil }
+            let path = URL(fileURLWithPath: project.path)
+            guard !path.isRemoteAlasPath else { return nil }
+            return WorktreeService.localCommonGitDirectory(forWorktreeAt: path)
+        }
+        let cutoff = now.addingTimeInterval(-24 * 60 * 60)
+        for ticket in WorktreeTrash.staleTickets(
+            commonGitDirectories: commonDirectories,
+            olderThan: cutoff
+        ) {
+            do {
+                try launcher(ticket)
+            } catch {
+                logger.error(
+                    "Could not launch stale worktree cleanup for \(ticket.stagedPath.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+    }
+
+    private static func spawnDetached(executable: URL, arguments: [String]) throws {
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = arguments
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        process.qualityOfService = .utility
+        try process.run()
+    }
+}

--- a/Alas/Sources/Git/WorktreeTrashCleaner.swift
+++ b/Alas/Sources/Git/WorktreeTrashCleaner.swift
@@ -34,14 +34,91 @@ enum WorktreeTrashCleaner {
             throw CleanerError.replacedDirectory
         }
         try spawn(URL(fileURLWithPath: "/usr/bin/nice"), [
-            "-n", "10", "/bin/sh", "-c",
+            "-n", "10", "/usr/bin/python3", "-c",
             """
-            /bin/sleep "$1"
-            current=$(/usr/bin/stat -f '%d:%i' "$3" 2>/dev/null) || exit 0
-            test "$current" = "$4:$5" || exit 0
-            /bin/rm -rf -- "$3" && exec /bin/rm -f -- "$2"
+            import errno
+            import os
+            import sys
+            import time
+            import uuid
+
+            def remove_contents(dirfd):
+                for name in os.listdir(dirfd):
+                    try:
+                        childfd = os.open(
+                            name,
+                            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                            dir_fd=dirfd,
+                        )
+                    except OSError as error:
+                        if error.errno in (errno.ENOTDIR, errno.ELOOP):
+                            try:
+                                os.unlink(name, dir_fd=dirfd)
+                            except FileNotFoundError:
+                                pass
+                            continue
+                        if error.errno == errno.ENOENT:
+                            continue
+                        raise
+                    try:
+                        remove_contents(childfd)
+                    finally:
+                        os.close(childfd)
+                    try:
+                        os.rmdir(name, dir_fd=dirfd)
+                    except FileNotFoundError:
+                        pass
+
+            time.sleep(max(0, int(sys.argv[1])))
+            marker = sys.argv[2]
+            staged = sys.argv[3]
+            expected_device = int(sys.argv[4])
+            expected_inode = int(sys.argv[5])
+            parent, name = os.path.split(staged)
+            private_name = f".{name}.deleting.{os.getpid()}.{uuid.uuid4().hex}"
+            parentfd = os.open(parent, os.O_RDONLY | os.O_DIRECTORY)
+            stagedfd = None
+            renamedfd = None
+            try:
+                stagedfd = os.open(
+                    name,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                    dir_fd=parentfd,
+                )
+                stat = os.fstat(stagedfd)
+                if (stat.st_dev, stat.st_ino) != (expected_device, expected_inode):
+                    sys.exit(0)
+                os.rename(name, private_name, src_dir_fd=parentfd, dst_dir_fd=parentfd)
+                renamedfd = os.open(
+                    private_name,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                    dir_fd=parentfd,
+                )
+                renamed_stat = os.fstat(renamedfd)
+                if (renamed_stat.st_dev, renamed_stat.st_ino) != (expected_device, expected_inode):
+                    try:
+                        os.rename(private_name, name, src_dir_fd=parentfd, dst_dir_fd=parentfd)
+                    except OSError:
+                        pass
+                    sys.exit(0)
+                remove_contents(renamedfd)
+                try:
+                    os.rmdir(private_name, dir_fd=parentfd)
+                except FileNotFoundError:
+                    pass
+                try:
+                    os.unlink(marker)
+                except FileNotFoundError:
+                    pass
+            except FileNotFoundError:
+                pass
+            finally:
+                if renamedfd is not None:
+                    os.close(renamedfd)
+                if stagedfd is not None:
+                    os.close(stagedfd)
+                os.close(parentfd)
             """,
-            "alas-worktree-cleaner",
             String(max(0, delaySeconds)),
             WorktreeTrash.committedMarkerURL(for: ticket).path,
             ticket.stagedPath.path,

--- a/Alas/Sources/Git/WorktreeTrashCleaner.swift
+++ b/Alas/Sources/Git/WorktreeTrashCleaner.swift
@@ -38,6 +38,7 @@ enum WorktreeTrashCleaner {
             """
             import errno
             import os
+            import stat as stat_module
             import sys
             import time
             import uuid
@@ -45,10 +46,14 @@ enum WorktreeTrashCleaner {
             def open_directory(name, dirfd):
                 flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
                 try:
-                    return os.open(name, flags, dir_fd=dirfd)
+                    fd = os.open(name, flags, dir_fd=dirfd)
                 except PermissionError:
                     os.chmod(name, 0o700, dir_fd=dirfd, follow_symlinks=False)
-                    return os.open(name, flags, dir_fd=dirfd)
+                    fd = os.open(name, flags, dir_fd=dirfd)
+                mode = stat_module.S_IMODE(os.fstat(fd).st_mode)
+                if (mode & 0o700) != 0o700:
+                    os.fchmod(fd, mode | 0o700)
+                return fd
 
             def remove_contents(dirfd):
                 for name in os.listdir(dirfd):
@@ -83,12 +88,14 @@ enum WorktreeTrashCleaner {
             parentfd = os.open(parent, os.O_RDONLY | os.O_DIRECTORY)
             stagedfd = None
             renamedfd = None
+            renamed = False
             try:
                 stagedfd = open_directory(name, parentfd)
-                stat = os.fstat(stagedfd)
-                if (stat.st_dev, stat.st_ino) != (expected_device, expected_inode):
+                staged_stat = os.fstat(stagedfd)
+                if (staged_stat.st_dev, staged_stat.st_ino) != (expected_device, expected_inode):
                     sys.exit(0)
                 os.rename(name, private_name, src_dir_fd=parentfd, dst_dir_fd=parentfd)
+                renamed = True
                 renamedfd = open_directory(private_name, parentfd)
                 renamed_stat = os.fstat(renamedfd)
                 if (renamed_stat.st_dev, renamed_stat.st_ino) != (expected_device, expected_inode):
@@ -102,12 +109,23 @@ enum WorktreeTrashCleaner {
                     os.rmdir(private_name, dir_fd=parentfd)
                 except FileNotFoundError:
                     pass
+                renamed = False
                 try:
                     os.unlink(marker)
                 except FileNotFoundError:
                     pass
             except FileNotFoundError:
                 pass
+            except Exception:
+                if renamed:
+                    if renamedfd is not None:
+                        os.close(renamedfd)
+                        renamedfd = None
+                    try:
+                        os.rename(private_name, name, src_dir_fd=parentfd, dst_dir_fd=parentfd)
+                    except OSError:
+                        pass
+                raise
             finally:
                 if renamedfd is not None:
                     os.close(renamedfd)

--- a/Alas/Sources/Git/WorktreeTrashCleaner.swift
+++ b/Alas/Sources/Git/WorktreeTrashCleaner.swift
@@ -39,11 +39,14 @@ enum WorktreeTrashCleaner {
         now: Date = Date(),
         launcher: Launcher = { try launch($0) }
     ) {
-        let commonDirectories = projects.compactMap { project -> URL? in
-            guard project.host == nil else { return nil }
-            let path = URL(fileURLWithPath: project.path)
-            guard !path.isRemoteAlasPath else { return nil }
-            return WorktreeService.localCommonGitDirectory(forWorktreeAt: path)
+        let commonDirectories = projects.flatMap { project -> [URL] in
+            guard project.host == nil else { return [] }
+            let paths = [URL(fileURLWithPath: project.path)]
+                + project.cachedWorktrees.map(\.path)
+            return paths.compactMap { path in
+                guard !path.isRemoteAlasPath else { return nil }
+                return WorktreeService.localCommonGitDirectory(forWorktreeAt: path)
+            }
         }
         let cutoff = now.addingTimeInterval(-24 * 60 * 60)
         for ticket in WorktreeTrash.staleTickets(

--- a/Alas/Sources/Git/WorktreeTrashCleaner.swift
+++ b/Alas/Sources/Git/WorktreeTrashCleaner.swift
@@ -42,14 +42,18 @@ enum WorktreeTrashCleaner {
             import time
             import uuid
 
+            def open_directory(name, dirfd):
+                flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+                try:
+                    return os.open(name, flags, dir_fd=dirfd)
+                except PermissionError:
+                    os.chmod(name, 0o700, dir_fd=dirfd, follow_symlinks=False)
+                    return os.open(name, flags, dir_fd=dirfd)
+
             def remove_contents(dirfd):
                 for name in os.listdir(dirfd):
                     try:
-                        childfd = os.open(
-                            name,
-                            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
-                            dir_fd=dirfd,
-                        )
+                        childfd = open_directory(name, dirfd)
                     except OSError as error:
                         if error.errno in (errno.ENOTDIR, errno.ELOOP):
                             try:
@@ -80,20 +84,12 @@ enum WorktreeTrashCleaner {
             stagedfd = None
             renamedfd = None
             try:
-                stagedfd = os.open(
-                    name,
-                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
-                    dir_fd=parentfd,
-                )
+                stagedfd = open_directory(name, parentfd)
                 stat = os.fstat(stagedfd)
                 if (stat.st_dev, stat.st_ino) != (expected_device, expected_inode):
                     sys.exit(0)
                 os.rename(name, private_name, src_dir_fd=parentfd, dst_dir_fd=parentfd)
-                renamedfd = os.open(
-                    private_name,
-                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
-                    dir_fd=parentfd,
-                )
+                renamedfd = open_directory(private_name, parentfd)
                 renamed_stat = os.fstat(renamedfd)
                 if (renamed_stat.st_dev, renamed_stat.st_ino) != (expected_device, expected_inode):
                     try:

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -2,6 +2,14 @@ import Testing
 import Foundation
 @testable import Alas
 
+@MainActor
+private final class WorktreeCleanupProbe {
+    weak var state: AppState?
+    var worktreeID = ""
+    var launchedTickets: [WorktreeTrashCleanupTicket] = []
+    var tabsWereEmptyAtLaunch = false
+}
+
 @Suite(.serialized)
 @MainActor
 struct AppStateCleanupTests {
@@ -892,6 +900,93 @@ struct AppStateCleanupTests {
 
         state.projectsManager.setOperationState(id: wt.id, state: .deleting)
         #expect(state.projectsManager.operationState(for: wt.id) == .deleting)
+    }
+
+    @Test func deleteWorktreeCleansAppStateBeforeLaunchingFileCleanup() async throws {
+        let repo = try await makeRepo(name: "delete-staged")
+        let linked = repo.deletingLastPathComponent()
+            .appendingPathComponent("delete-staged-linked-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: linked)
+            try? FileManager.default.removeItem(at: repo)
+        }
+        let probe = WorktreeCleanupProbe()
+        let state = AppState(
+            worktreeCleanupLauncher: { ticket in
+                probe.launchedTickets.append(ticket)
+                probe.tabsWereEmptyAtLaunch = probe.state?.tabs
+                    .tabs(forWorktree: probe.worktreeID)
+                    .isEmpty == true
+            }
+        )
+        probe.state = state
+        let project = try await state.projectsManager.addProject(
+            path: repo,
+            displayName: "delete-staged",
+            color: "#5fb7c4"
+        )
+        let worktree = try await WorktreeService().add(
+            repoPath: repo,
+            base: "main",
+            branch: "feature/staged",
+            destination: linked,
+            projectId: project.id
+        )
+        probe.worktreeID = worktree.id
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        state.tabs.appendTerminal(worktreeId: worktree.id, title: "term", sessionId: "session")
+        state.selectWorktree(id: worktree.id)
+
+        #expect(await state.cliDeleteWorktree(worktree, force: true, keepBranch: true) == .ok)
+        try await waitForOperationState(state.projectsManager, id: worktree.id, equals: nil)
+
+        let ticket = try #require(probe.launchedTickets.first)
+        defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+        #expect(probe.launchedTickets.count == 1)
+        #expect(probe.tabsWereEmptyAtLaunch)
+        #expect(FileManager.default.fileExists(atPath: ticket.stagedPath.path))
+        #expect(!state.projectsManager.worktrees(projectId: project.id).contains { $0.id == worktree.id })
+        #expect(state.selectedWorktreeId == Worktree.makeId(path: repo))
+    }
+
+    @Test func cleanupLaunchFailureLeavesWorktreeDeletedForStaleRecovery() async throws {
+        let repo = try await makeRepo(name: "delete-cleanup-launch-failure")
+        let linked = repo.deletingLastPathComponent()
+            .appendingPathComponent("delete-cleanup-launch-failure-linked-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: linked)
+            try? FileManager.default.removeItem(at: repo)
+        }
+        let probe = WorktreeCleanupProbe()
+        let state = AppState(
+            worktreeCleanupLauncher: { ticket in
+                probe.launchedTickets.append(ticket)
+                throw CocoaError(.fileWriteUnknown)
+            }
+        )
+        let project = try await state.projectsManager.addProject(
+            path: repo,
+            displayName: "delete-cleanup-launch-failure",
+            color: "#5fb7c4"
+        )
+        let worktree = try await WorktreeService().add(
+            repoPath: repo,
+            base: "main",
+            branch: "feature/cleanup-launch-failure",
+            destination: linked,
+            projectId: project.id
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        #expect(await state.cliDeleteWorktree(worktree, force: true, keepBranch: true) == .ok)
+        try await waitForOperationState(state.projectsManager, id: worktree.id, equals: nil)
+
+        let ticket = try #require(probe.launchedTickets.first)
+        defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+        #expect(probe.launchedTickets.count == 1)
+        #expect(FileManager.default.fileExists(atPath: ticket.stagedPath.path))
+        #expect(!state.projectsManager.worktrees(projectId: project.id).contains { $0.id == worktree.id })
+        #expect(state.projectsManager.operationState(for: worktree.id) == nil)
     }
 
     // MARK: - Dirty-worktree force-delete state

--- a/AlasTests/WorktreeServiceTests.swift
+++ b/AlasTests/WorktreeServiceTests.swift
@@ -688,6 +688,49 @@ extension WorktreeServiceTests {
         #expect(try await service.list(repoPath: repo, projectId: "p").count == 1)
     }
 
+    @Test func fastLocalRemoveDeletesStagedFilesSynchronouslyWhenCommitMarkerCannotBeWritten() async throws {
+        let fixture = try await makeLinkedWorktree(suffix: "marker-write-failure")
+        let trashRoot = WorktreeTrash.root(
+            commonGitDirectory: fixture.repo.appendingPathComponent(".git")
+        )
+        defer {
+            try? FileManager.default.removeItem(at: trashRoot)
+            fixture.removeFiles()
+        }
+
+        let outcome = try await fixture.service.removeFastLocal(
+            repoPath: fixture.repo,
+            worktree: fixture.worktree,
+            deleteBranchIfMerged: false,
+            force: false,
+            moveItem: { source, destination in
+                try FileManager.default.moveItem(at: source, to: destination)
+                guard let directoryIdentity = WorktreeTrash.directoryIdentity(at: destination) else {
+                    throw CocoaError(.fileReadUnknown)
+                }
+                let ticket = WorktreeTrashCleanupTicket(
+                    trashRoot: destination.deletingLastPathComponent(),
+                    stagedPath: destination,
+                    directoryIdentity: directoryIdentity
+                )
+                try FileManager.default.createDirectory(
+                    at: WorktreeTrash.committedMarkerURL(for: ticket),
+                    withIntermediateDirectories: false
+                )
+            }
+        )
+
+        #expect(outcome == .synchronous)
+        #expect(!FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+        let stagedDirectories = try FileManager.default.contentsOfDirectory(
+            at: trashRoot,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        #expect(stagedDirectories.isEmpty)
+        #expect(try await fixture.service.list(repoPath: fixture.repo, projectId: "p").count == 1)
+    }
+
     @Test func fastLocalRemoveFailsClosedWhenWorktreeBecameDirty() async throws {
         let fixture = try await makeLinkedWorktree(suffix: "became-dirty")
         defer { fixture.removeFiles() }

--- a/AlasTests/WorktreeServiceTests.swift
+++ b/AlasTests/WorktreeServiceTests.swift
@@ -737,6 +737,59 @@ extension WorktreeServiceTests {
         #expect(FileManager.default.fileExists(atPath: unrelatedMarker.path))
     }
 
+    @Test func fastLocalRemoveRestoresReplacementStagedDuringRenameWithoutRemovingRegistration() async throws {
+        let fixture = try await makeLinkedWorktree(suffix: "replaced-during-stage")
+        let originalPath = fixture.worktree.path.standardizedFileURL
+        let displaced = originalPath.deletingLastPathComponent()
+            .appendingPathComponent("\(originalPath.lastPathComponent)-displaced")
+        let unrelatedMarker = originalPath.appendingPathComponent("unrelated.txt")
+        defer {
+            try? FileManager.default.removeItem(at: originalPath)
+            try? FileManager.default.removeItem(at: displaced)
+            try? FileManager.default.removeItem(at: fixture.repo)
+        }
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await fixture.service.removeFastLocal(
+                repoPath: fixture.repo,
+                worktree: fixture.worktree,
+                deleteBranchIfMerged: false,
+                force: true,
+                moveItem: { source, destination in
+                    if source.standardizedFileURL == originalPath {
+                        try FileManager.default.moveItem(at: source, to: displaced)
+                        try FileManager.default.createDirectory(
+                            at: source,
+                            withIntermediateDirectories: true
+                        )
+                        try "do not delete".write(
+                            to: unrelatedMarker,
+                            atomically: true,
+                            encoding: .utf8
+                        )
+                    }
+                    try FileManager.default.moveItem(at: source, to: destination)
+                }
+            )
+        }
+
+        #expect(FileManager.default.fileExists(atPath: unrelatedMarker.path))
+        #expect(FileManager.default.fileExists(atPath: displaced.appendingPathComponent(".git").path))
+        let registrations = try await Process.git(
+            ["worktree", "list", "--porcelain"],
+            cwd: fixture.repo
+        )
+        let registeredPaths = registrations.stdout
+            .split(separator: "\n")
+            .compactMap { line -> String? in
+                guard line.hasPrefix("worktree ") else { return nil }
+                return URL(fileURLWithPath: String(line.dropFirst("worktree ".count)))
+                    .resolvingSymlinksInPath()
+                    .path
+            }
+        #expect(registeredPaths.contains(originalPath.resolvingSymlinksInPath().path))
+    }
+
     @Test func fastLocalRemoveFallsBackWhenRenameFails() async throws {
         let fixture = try await makeLinkedWorktree(suffix: "rename-fallback")
         defer { fixture.removeFiles() }

--- a/AlasTests/WorktreeServiceTests.swift
+++ b/AlasTests/WorktreeServiceTests.swift
@@ -688,6 +688,33 @@ extension WorktreeServiceTests {
         #expect(try await service.list(repoPath: repo, projectId: "p").count == 1)
     }
 
+    @Test func fastLocalRemoveSurvivesWhenProjectPathIsTheRemovedWorktree() async throws {
+        let fixture = try await makeLinkedWorktree(suffix: "project-path-target")
+        defer { fixture.removeFiles() }
+
+        let outcome = try await fixture.service.removeFastLocal(
+            repoPath: fixture.worktree.path,
+            worktree: fixture.worktree,
+            deleteBranchIfMerged: true,
+            force: false
+        )
+        guard case .staged(let ticket) = outcome else {
+            Issue.record("Expected staged removal")
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+
+        #expect(!FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+        let worktrees = try await fixture.service.list(repoPath: fixture.repo, projectId: "p")
+        #expect(worktrees.count == 1)
+        #expect(!worktrees.contains { $0.path.standardizedFileURL == fixture.worktree.path.standardizedFileURL })
+        let branches = try await Process.git(
+            ["branch", "--list", fixture.worktree.branch],
+            cwd: fixture.repo
+        )
+        #expect(branches.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
     @Test func fastLocalRemoveDeletesStagedFilesSynchronouslyWhenCommitMarkerCannotBeWritten() async throws {
         let fixture = try await makeLinkedWorktree(suffix: "marker-write-failure")
         let trashRoot = WorktreeTrash.root(

--- a/AlasTests/WorktreeServiceTests.swift
+++ b/AlasTests/WorktreeServiceTests.swift
@@ -708,6 +708,42 @@ extension WorktreeServiceTests {
         #expect(FileManager.default.fileExists(atPath: fixture.worktree.path.path))
     }
 
+    @Test func fastLocalRemoveRestoresWorktreeMadeDirtyDuringStaging() async throws {
+        let fixture = try await makeLinkedWorktree(suffix: "dirty-during-stage")
+        let dirtyFile = fixture.worktree.path.appendingPathComponent("new-during-stage.txt")
+        let trashRoot = WorktreeTrash.root(
+            commonGitDirectory: fixture.repo.appendingPathComponent(".git")
+        )
+        defer {
+            try? FileManager.default.removeItem(at: trashRoot)
+            fixture.removeFiles()
+        }
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await fixture.service.removeFastLocal(
+                repoPath: fixture.repo,
+                worktree: fixture.worktree,
+                deleteBranchIfMerged: false,
+                force: false,
+                moveItem: { source, destination in
+                    try FileManager.default.moveItem(at: source, to: destination)
+                    try "do not discard".write(
+                        to: destination.appendingPathComponent(dirtyFile.lastPathComponent),
+                        atomically: true,
+                        encoding: .utf8
+                    )
+                }
+            )
+        }
+
+        #expect(FileManager.default.fileExists(atPath: dirtyFile.path))
+        let registrations = try await Process.git(
+            ["worktree", "list", "--porcelain"],
+            cwd: fixture.repo
+        )
+        #expect(registrations.stdout.contains(fixture.worktree.path.path))
+    }
+
     @Test func fastLocalRemoveDoesNotStageReplacementDirectoryEvenWithForce() async throws {
         let fixture = try await makeLinkedWorktree(suffix: "replaced-before-stage")
         let displaced = fixture.worktree.path.deletingLastPathComponent()

--- a/AlasTests/WorktreeServiceTests.swift
+++ b/AlasTests/WorktreeServiceTests.swift
@@ -1530,6 +1530,53 @@ extension WorktreeServiceTests {
         #expect(listed.count == 1)
     }
 
+    @Test func fastLocalRemoveRestoresWhenSubmoduleLocalStateAppearsAfterApproval() async throws {
+        let fixture = try await makeRepoWithInitializedSubmodule(
+            suffix: "fast-submodule-local-state-race"
+        )
+        let trashRoot = WorktreeTrash.root(
+            commonGitDirectory: fixture.repo.appendingPathComponent(".git")
+        )
+        defer {
+            try? FileManager.default.removeItem(at: trashRoot)
+            fixture.removeFiles()
+        }
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await fixture.service.removeFastLocal(
+                repoPath: fixture.repo,
+                worktree: fixture.worktree,
+                deleteBranchIfMerged: false,
+                force: true,
+                moveItem: { source, destination in
+                    if source.standardizedFileURL == fixture.worktree.path.standardizedFileURL {
+                        let submodule = source.appendingPathComponent("Deps/Submodule")
+                        let process = Foundation.Process()
+                        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+                        process.arguments = ["tag", "local-after-approval"]
+                        process.currentDirectoryURL = submodule
+                        try process.run()
+                        process.waitUntilExit()
+                        guard process.terminationStatus == 0 else {
+                            throw CocoaError(.fileWriteUnknown)
+                        }
+                    }
+                    try FileManager.default.moveItem(at: source, to: destination)
+                }
+            )
+        }
+
+        #expect(FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+        #expect(FileManager.default.fileExists(
+            atPath: fixture.worktree.path.appendingPathComponent("Deps/Submodule").path
+        ))
+        let registrations = try await Process.git(
+            ["worktree", "list", "--porcelain"],
+            cwd: fixture.repo
+        )
+        #expect(registrations.stdout.contains(fixture.worktree.path.path))
+    }
+
     @Test func removeDoesNotForceDeleteIgnoredDirtySubmodule() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/WorktreeServiceTests.swift
+++ b/AlasTests/WorktreeServiceTests.swift
@@ -715,6 +715,56 @@ extension WorktreeServiceTests {
         #expect(branches.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
     }
 
+    @Test func fastLocalRemoveDeletesBranchMergedIntoSurvivingLinkedProject() async throws {
+        let fixture = try await makeLinkedWorktree(suffix: "linked-project-merge")
+        let project = fixture.repo.deletingLastPathComponent()
+            .appendingPathComponent("\(fixture.repo.lastPathComponent)-project")
+        defer {
+            try? FileManager.default.removeItem(at: project)
+            fixture.removeFiles()
+        }
+        let commit = try await Process.git(
+            ["commit", "--allow-empty", "-m", "only merged into project"],
+            cwd: fixture.worktree.path
+        )
+        try #require(commit.exitCode == 0)
+        _ = try await fixture.service.add(
+            repoPath: fixture.repo,
+            base: fixture.worktree.branch,
+            branch: "project",
+            destination: project,
+            projectId: "p"
+        )
+
+        _ = try await fixture.service.removeFastLocal(
+            repoPath: project,
+            worktree: fixture.worktree,
+            deleteBranchIfMerged: true
+        )
+
+        let branches = try await Process.git(
+            ["branch", "--list", fixture.worktree.branch], cwd: project
+        )
+        #expect(branches.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    @Test func fastLocalRemovePersistsRecoveryJournalBeforeMovingFiles() async throws {
+        let fixture = try await makeLinkedWorktree(suffix: "pending-before-rename")
+        defer { fixture.removeFiles() }
+        _ = try await fixture.service.removeFastLocal(
+            repoPath: fixture.repo,
+            worktree: fixture.worktree,
+            deleteBranchIfMerged: false,
+            moveItem: { source, destination in
+                let identifier = destination.lastPathComponent.split(separator: ".").last!
+                let pending = destination.deletingLastPathComponent()
+                    .appendingPathComponent(".alas-worktree-deletion-pending.\(identifier)")
+                #expect(FileManager.default.fileExists(atPath: pending.path))
+                try FileManager.default.moveItem(at: source, to: destination)
+            }
+        )
+    }
+
     @Test func fastLocalRemoveDeletesStagedFilesSynchronouslyWhenCommitMarkerCannotBeWritten() async throws {
         let fixture = try await makeLinkedWorktree(suffix: "marker-write-failure")
         let trashRoot = WorktreeTrash.root(

--- a/AlasTests/WorktreeServiceTests.swift
+++ b/AlasTests/WorktreeServiceTests.swift
@@ -708,6 +708,35 @@ extension WorktreeServiceTests {
         #expect(FileManager.default.fileExists(atPath: fixture.worktree.path.path))
     }
 
+    @Test func fastLocalRemoveDoesNotStageReplacementDirectoryEvenWithForce() async throws {
+        let fixture = try await makeLinkedWorktree(suffix: "replaced-before-stage")
+        let displaced = fixture.worktree.path.deletingLastPathComponent()
+            .appendingPathComponent("\(fixture.worktree.path.lastPathComponent)-displaced")
+        defer {
+            try? FileManager.default.removeItem(at: fixture.worktree.path)
+            try? FileManager.default.removeItem(at: displaced)
+            try? FileManager.default.removeItem(at: fixture.repo)
+        }
+        try FileManager.default.moveItem(at: fixture.worktree.path, to: displaced)
+        try FileManager.default.createDirectory(
+            at: fixture.worktree.path,
+            withIntermediateDirectories: true
+        )
+        let unrelatedMarker = fixture.worktree.path.appendingPathComponent("unrelated.txt")
+        try "do not delete".write(to: unrelatedMarker, atomically: true, encoding: .utf8)
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await fixture.service.removeFastLocal(
+                repoPath: fixture.repo,
+                worktree: fixture.worktree,
+                deleteBranchIfMerged: false,
+                force: true
+            )
+        }
+
+        #expect(FileManager.default.fileExists(atPath: unrelatedMarker.path))
+    }
+
     @Test func fastLocalRemoveFallsBackWhenRenameFails() async throws {
         let fixture = try await makeLinkedWorktree(suffix: "rename-fallback")
         defer { fixture.removeFiles() }
@@ -846,6 +875,82 @@ extension WorktreeServiceTests {
             #expect(FileManager.default.fileExists(atPath: staged.appendingPathComponent(".git").path))
             try? FileManager.default.removeItem(at: trash)
         }
+    }
+
+    @Test func fastLocalRemoveRollbackFailureIsNotSweepEligible() async throws {
+        let fixture = try await makeLinkedWorktree(suffix: "rollback-not-committed")
+        defer { fixture.removeFiles() }
+        _ = try await Process.git(["worktree", "lock", fixture.worktree.path.path], cwd: fixture.repo)
+        let originalPath = fixture.worktree.path.standardizedFileURL
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await fixture.service.removeFastLocal(
+                repoPath: fixture.repo,
+                worktree: fixture.worktree,
+                deleteBranchIfMerged: false,
+                force: false,
+                moveItem: { source, destination in
+                    if source.standardizedFileURL == originalPath {
+                        try FileManager.default.moveItem(at: source, to: destination)
+                        try "collision".write(to: source, atomically: true, encoding: .utf8)
+                    } else {
+                        throw CocoaError(.fileWriteFileExists)
+                    }
+                }
+            )
+        }
+
+        let common = fixture.repo.appendingPathComponent(".git")
+        let staged = try #require(
+            FileManager.default.contentsOfDirectory(
+                at: WorktreeTrash.root(commonGitDirectory: common),
+                includingPropertiesForKeys: nil
+            ).first
+        )
+        #expect(FileManager.default.fileExists(atPath: staged.appendingPathComponent(".git").path))
+        #expect(WorktreeTrash.staleTickets(
+            commonGitDirectories: [common],
+            olderThan: .distantFuture
+        ).isEmpty)
+    }
+
+    @Test func rollbackFailureIgnoresCommitMarkerLookalikeInsideWorktree() async throws {
+        let fixture = try await makeLinkedWorktree(suffix: "rollback-marker-lookalike")
+        defer { fixture.removeFiles() }
+        try ".alas-worktree-deletion-committed\n".write(
+            to: fixture.repo.appendingPathComponent(".git/info/exclude"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "1\n".write(
+            to: fixture.worktree.path.appendingPathComponent(".alas-worktree-deletion-committed"),
+            atomically: true,
+            encoding: .utf8
+        )
+        _ = try await Process.git(["worktree", "lock", fixture.worktree.path.path], cwd: fixture.repo)
+        let originalPath = fixture.worktree.path.standardizedFileURL
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await fixture.service.removeFastLocal(
+                repoPath: fixture.repo,
+                worktree: fixture.worktree,
+                deleteBranchIfMerged: false,
+                force: false,
+                moveItem: { source, destination in
+                    if source.standardizedFileURL == originalPath {
+                        try FileManager.default.moveItem(at: source, to: destination)
+                        try "collision".write(to: source, atomically: true, encoding: .utf8)
+                    } else {
+                        throw CocoaError(.fileWriteFileExists)
+                    }
+                }
+            )
+        }
+
+        #expect(WorktreeTrash.staleTickets(
+            commonGitDirectories: [fixture.repo.appendingPathComponent(".git")],
+            olderThan: .distantFuture
+        ).isEmpty)
     }
 
     @Test func removeWithForceSucceedsOnDirtyWorktree() async throws {

--- a/AlasTests/WorktreeServiceTests.swift
+++ b/AlasTests/WorktreeServiceTests.swift
@@ -478,6 +478,32 @@ private actor ThrowingFrozenRemoteRunner {
 }
 
 extension WorktreeServiceTests {
+    private struct LinkedWorktreeFixture {
+        let repo: URL
+        let service: WorktreeService
+        let worktree: Worktree
+
+        func removeFiles() {
+            try? FileManager.default.removeItem(at: worktree.path)
+            try? FileManager.default.removeItem(at: repo)
+        }
+    }
+
+    private func makeLinkedWorktree(suffix: String) async throws -> LinkedWorktreeFixture {
+        let repo = try await makeRepo()
+        let destination = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-\(suffix)")
+        let service = WorktreeService()
+        let worktree = try await service.add(
+            repoPath: repo,
+            base: "main",
+            branch: "feature/\(suffix)",
+            destination: destination,
+            projectId: "p"
+        )
+        return LinkedWorktreeFixture(repo: repo, service: service, worktree: worktree)
+    }
+
     @Test func deletePreflightReportsCleanForCleanWorktree() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }
@@ -621,6 +647,207 @@ extension WorktreeServiceTests {
         }
     }
 
+    @Test func fastLocalRemoveReturnsStagedTicketBeforeFilesAreDeleted() async throws {
+        let repo = try await makeRepo()
+        let destination = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-fast")
+        defer {
+            try? FileManager.default.removeItem(at: destination)
+            try? FileManager.default.removeItem(at: repo)
+        }
+        let service = WorktreeService()
+        let worktree = try await service.add(
+            repoPath: repo,
+            base: "main",
+            branch: "feature/fast",
+            destination: destination,
+            projectId: "p"
+        )
+        try "keep until cleaner".write(
+            to: destination.appendingPathComponent("marker.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let outcome = try await service.removeFastLocal(
+            repoPath: repo,
+            worktree: worktree,
+            deleteBranchIfMerged: false,
+            force: true
+        )
+        guard case .staged(let ticket) = outcome else {
+            Issue.record("Expected staged removal")
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+
+        #expect(!FileManager.default.fileExists(atPath: destination.path))
+        #expect(FileManager.default.fileExists(
+            atPath: ticket.stagedPath.appendingPathComponent("marker.txt").path
+        ))
+        #expect(try await service.list(repoPath: repo, projectId: "p").count == 1)
+    }
+
+    @Test func fastLocalRemoveFailsClosedWhenWorktreeBecameDirty() async throws {
+        let fixture = try await makeLinkedWorktree(suffix: "became-dirty")
+        defer { fixture.removeFiles() }
+        try "dirty".write(
+            to: fixture.worktree.path.appendingPathComponent("new.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await fixture.service.removeFastLocal(
+                repoPath: fixture.repo,
+                worktree: fixture.worktree,
+                deleteBranchIfMerged: false,
+                force: false
+            )
+        }
+        #expect(FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+    }
+
+    @Test func fastLocalRemoveFallsBackWhenRenameFails() async throws {
+        let fixture = try await makeLinkedWorktree(suffix: "rename-fallback")
+        defer { fixture.removeFiles() }
+
+        let outcome = try await fixture.service.removeFastLocal(
+            repoPath: fixture.repo,
+            worktree: fixture.worktree,
+            deleteBranchIfMerged: false,
+            force: false,
+            moveItem: { _, _ in throw CocoaError(.fileWriteNoPermission) }
+        )
+
+        #expect(outcome == .synchronous)
+        #expect(!FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+    }
+
+    @Test func fastLocalRemoveRestoresPathWhenRegistryRemovalFails() async throws {
+        let fixture = try await makeLinkedWorktree(suffix: "rollback")
+        defer { fixture.removeFiles() }
+        _ = try await Process.git(["worktree", "lock", fixture.worktree.path.path], cwd: fixture.repo)
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await fixture.service.removeFastLocal(
+                repoPath: fixture.repo,
+                worktree: fixture.worktree,
+                deleteBranchIfMerged: false,
+                force: false
+            )
+        }
+
+        #expect(FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+    }
+
+    @Test func fastLocalRemoveUsesDoubleForceForApprovedLockedWorktree() async throws {
+        let fixture = try await makeLinkedWorktree(suffix: "locked-fast")
+        defer { fixture.removeFiles() }
+        _ = try await Process.git(["worktree", "lock", fixture.worktree.path.path], cwd: fixture.repo)
+
+        let outcome = try await fixture.service.removeFastLocal(
+            repoPath: fixture.repo,
+            worktree: fixture.worktree,
+            deleteBranchIfMerged: false,
+            force: true
+        )
+        guard case .staged(let ticket) = outcome else {
+            Issue.record("Expected staged removal")
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+        #expect(!FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+    }
+
+    @Test func fastLocalRemoveNeverStagesARegisteredRemotePath() async throws {
+        let fixture = try await makeLinkedWorktree(suffix: "remote-fallback")
+        defer { fixture.removeFiles() }
+        RemoteHostRegistry.shared.register(root: fixture.worktree.path.path, host: "test-host")
+        defer { RemoteHostRegistry.shared.unregister(root: fixture.worktree.path.path) }
+
+        let outcome = try await fixture.service.removeFastLocal(
+            repoPath: fixture.repo,
+            worktree: fixture.worktree,
+            deleteBranchIfMerged: false,
+            force: false,
+            usesRemoteHostRegistry: false
+        )
+
+        #expect(outcome == .synchronous)
+        #expect(!FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+    }
+
+    @Test func fastLocalRemoveWithDeleteBranchUsesRealBranchName() async throws {
+        let repo = try await makeRepo()
+        let destination = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-feature-name")
+        defer {
+            try? FileManager.default.removeItem(at: destination)
+            try? FileManager.default.removeItem(at: repo)
+        }
+        let service = WorktreeService()
+        let worktree = try await service.add(
+            repoPath: repo,
+            base: "main",
+            branch: "feature/name",
+            destination: destination,
+            projectId: "p"
+        )
+
+        let outcome = try await service.removeFastLocal(
+            repoPath: repo,
+            worktree: worktree,
+            deleteBranchIfMerged: true,
+            force: false
+        )
+        guard case .staged(let ticket) = outcome else {
+            Issue.record("Expected staged removal")
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+
+        let branches = try await Process.git(["branch", "--list", "feature/name"], cwd: repo)
+        #expect(branches.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    @Test func fastLocalRemoveReportsBothPathsWhenRollbackFails() async throws {
+        let fixture = try await makeLinkedWorktree(suffix: "rollback-fails")
+        defer { fixture.removeFiles() }
+        _ = try await Process.git(["worktree", "lock", fixture.worktree.path.path], cwd: fixture.repo)
+        let originalPath = fixture.worktree.path.standardizedFileURL
+
+        do {
+            _ = try await fixture.service.removeFastLocal(
+                repoPath: fixture.repo,
+                worktree: fixture.worktree,
+                deleteBranchIfMerged: false,
+                force: false,
+                moveItem: { source, destination in
+                    if source.standardizedFileURL == originalPath {
+                        try FileManager.default.moveItem(at: source, to: destination)
+                        try "collision".write(to: source, atomically: true, encoding: .utf8)
+                    } else {
+                        throw CocoaError(.fileWriteFileExists)
+                    }
+                }
+            )
+            Issue.record("Expected registry and rollback failure")
+        } catch {
+            let message = error.localizedDescription
+            #expect(message.contains(fixture.worktree.path.path))
+            let trash = WorktreeTrash.root(
+                commonGitDirectory: fixture.repo.appendingPathComponent(".git")
+            )
+            let staged = try #require(
+                FileManager.default.contentsOfDirectory(at: trash, includingPropertiesForKeys: nil).first
+            )
+            #expect(message.contains(staged.path))
+            #expect(FileManager.default.fileExists(atPath: staged.appendingPathComponent(".git").path))
+            try? FileManager.default.removeItem(at: trash)
+        }
+    }
+
     @Test func removeWithForceSucceedsOnDirtyWorktree() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }
@@ -641,10 +868,20 @@ extension WorktreeServiceTests {
         #expect(listed.count == 1) // only main remains
     }
 
-    @Test func removeRetriesWithoutLFSFiltersWhenGitStatusRequiresMissingLFS() async throws {
-        let repo = try await makeRepo()
-        defer { try? FileManager.default.removeItem(at: repo) }
+    private struct MissingLFSFixture {
+        let repo: URL
+        let destination: URL
+        let worktree: Worktree
+        let marker: URL
 
+        func removeFiles() {
+            try? FileManager.default.removeItem(at: destination)
+            try? FileManager.default.removeItem(at: repo)
+        }
+    }
+
+    private func makeMissingLFSFixture(suffix: String) async throws -> MissingLFSFixture {
+        let repo = try await makeRepo()
         let lfsOverride = [
             "-c", "filter.lfs.process=",
             "-c", "filter.lfs.smudge=",
@@ -671,8 +908,8 @@ extension WorktreeServiceTests {
         _ = try await Process.git(lfsOverride + ["commit", "-q", "-m", "add lfs pointer"], cwd: repo)
 
         let dest = repo.deletingLastPathComponent()
-            .appendingPathComponent("\(repo.lastPathComponent)-missing-lfs-remove")
-        let branch = "feat/missing-lfs-remove"
+            .appendingPathComponent("\(repo.lastPathComponent)-\(suffix)")
+        let branch = "feat/\(suffix)"
         _ = try await Process.git(
             lfsOverride + ["worktree", "add", "-q", dest.path, "-b", branch],
             cwd: repo
@@ -691,9 +928,46 @@ extension WorktreeServiceTests {
             status: .clean,
             lastActivity: Date()
         )
-        try await WorktreeService().remove(repoPath: repo, worktree: wt, deleteBranchIfMerged: false)
+        return MissingLFSFixture(
+            repo: repo,
+            destination: dest,
+            worktree: wt,
+            marker: dest.appendingPathComponent("data.bin")
+        )
+    }
 
-        #expect(!FileManager.default.fileExists(atPath: dest.path))
+    @Test func removeRetriesWithoutLFSFiltersWhenGitStatusRequiresMissingLFS() async throws {
+        let fixture = try await makeMissingLFSFixture(suffix: "missing-lfs-remove")
+        defer { fixture.removeFiles() }
+
+        try await WorktreeService().remove(
+            repoPath: fixture.repo,
+            worktree: fixture.worktree,
+            deleteBranchIfMerged: false
+        )
+
+        #expect(!FileManager.default.fileExists(atPath: fixture.destination.path))
+    }
+
+    @Test func fastLocalRemovePreservesMissingLFSCleanSemantics() async throws {
+        let fixture = try await makeMissingLFSFixture(suffix: "fast-missing-lfs")
+        defer { fixture.removeFiles() }
+
+        let outcome = try await WorktreeService().removeFastLocal(
+            repoPath: fixture.repo,
+            worktree: fixture.worktree,
+            deleteBranchIfMerged: false
+        )
+        guard case .staged(let ticket) = outcome else {
+            Issue.record("Expected staged removal")
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+
+        #expect(!FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+        #expect(FileManager.default.fileExists(
+            atPath: ticket.stagedPath.appendingPathComponent(fixture.marker.lastPathComponent).path
+        ))
     }
 
     @Test func removePreservesSmudgedLFSCleanSemanticsWhenGitLFSIsMissing() async throws {
@@ -839,6 +1113,12 @@ extension WorktreeServiceTests {
         let submoduleRepo: URL
         let service: WorktreeService
         let worktree: Worktree
+
+        func removeFiles() {
+            try? FileManager.default.removeItem(at: worktree.path)
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: submoduleRepo)
+        }
     }
 
     private func makeRepoWithInitializedSubmodule(suffix: String) async throws -> InitializedSubmoduleFixture {
@@ -914,6 +1194,26 @@ extension WorktreeServiceTests {
         let listed = try await fixture.service.list(repoPath: fixture.repo, projectId: "p")
         #expect(listed.count == 1)
         #expect(!FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+    }
+
+    @Test func fastLocalRemoveSupportsInitializedSubmodulesAfterForceApproval() async throws {
+        let fixture = try await makeRepoWithInitializedSubmodule(suffix: "fast-submodule")
+        defer { fixture.removeFiles() }
+
+        let outcome = try await fixture.service.removeFastLocal(
+            repoPath: fixture.repo,
+            worktree: fixture.worktree,
+            deleteBranchIfMerged: false,
+            force: true
+        )
+        guard case .staged(let ticket) = outcome else {
+            Issue.record("Expected staged removal")
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+
+        let listed = try await fixture.service.list(repoPath: fixture.repo, projectId: "p")
+        #expect(listed.count == 1)
     }
 
     @Test func removeDoesNotForceDeleteIgnoredDirtySubmodule() async throws {

--- a/AlasTests/WorktreeTrashTests.swift
+++ b/AlasTests/WorktreeTrashTests.swift
@@ -68,4 +68,102 @@ struct WorktreeTrashTests {
 
         #expect(tickets == [old])
     }
+
+    @Test func cleanerPassesTheValidatedPathAsAnArgument() throws {
+        let ticket = WorktreeTrash.makeTicket(
+            commonGitDirectory: URL(fileURLWithPath: "/tmp/repo/.git"),
+            originalPath: URL(fileURLWithPath: "/tmp/a name; touch nope")
+        )
+        var capturedExecutable: URL?
+        var capturedArguments: [String] = []
+
+        try WorktreeTrashCleaner.launch(ticket, delaySeconds: 1) { executable, arguments in
+            capturedExecutable = executable
+            capturedArguments = arguments
+        }
+
+        #expect(capturedExecutable?.path == "/usr/bin/nice")
+        #expect(capturedArguments.last == ticket.stagedPath.path)
+        #expect(capturedArguments.dropLast().allSatisfy { !$0.contains(ticket.stagedPath.path) })
+    }
+
+    @Test func sweepLaunchesOnlyOldTicketsFromUniqueLocalProjects() async throws {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-sweep-\(UUID().uuidString)")
+        let linked = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-linked")
+        defer {
+            try? FileManager.default.removeItem(at: linked)
+            try? FileManager.default.removeItem(at: repo)
+        }
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: repo)
+        _ = try await Process.git(["worktree", "add", "-q", "-b", "linked", linked.path], cwd: repo)
+
+        let common = repo.appendingPathComponent(".git")
+        let old = WorktreeTrash.makeTicket(
+            commonGitDirectory: common,
+            originalPath: linked,
+            now: Date(timeIntervalSince1970: 100),
+            id: UUID()
+        )
+        let young = WorktreeTrash.makeTicket(
+            commonGitDirectory: common,
+            originalPath: linked,
+            now: Date(timeIntervalSince1970: 250),
+            id: UUID()
+        )
+        try FileManager.default.createDirectory(at: old.stagedPath, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: young.stagedPath, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 100)],
+            ofItemAtPath: old.stagedPath.path
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 99_990)],
+            ofItemAtPath: young.stagedPath.path
+        )
+
+        let addedAt = Date(timeIntervalSince1970: 1)
+        let projects = [
+            ProjectConfig(id: "main", name: "main", path: repo.path, color: "#000000", addedAt: addedAt),
+            ProjectConfig(id: "linked", name: "linked", path: linked.path, color: "#000000", addedAt: addedAt),
+            ProjectConfig(id: "remote", name: "remote", path: "/repo", color: "#000000", addedAt: addedAt, host: "host"),
+            ProjectConfig(id: "missing", name: "missing", path: "/missing", color: "#000000", addedAt: addedAt),
+        ]
+        var launched: [WorktreeTrashCleanupTicket] = []
+
+        WorktreeTrashCleaner.sweep(
+            projects: projects,
+            now: Date(timeIntervalSince1970: 100_000),
+            launcher: { launched.append($0) }
+        )
+
+        #expect(launched == [old])
+    }
+
+    @Test func liveCleanerEventuallyDeletesTheTicketDirectory() async throws {
+        let common = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-cleaner-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: common) }
+        let ticket = WorktreeTrash.makeTicket(
+            commonGitDirectory: common,
+            originalPath: URL(fileURLWithPath: "/tmp/clean-me")
+        )
+        try FileManager.default.createDirectory(at: ticket.stagedPath, withIntermediateDirectories: true)
+        try "marker".write(
+            to: ticket.stagedPath.appendingPathComponent("marker.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        try WorktreeTrashCleaner.launch(ticket, delaySeconds: 0)
+        let deadline = Date().addingTimeInterval(5)
+        while FileManager.default.fileExists(atPath: ticket.stagedPath.path), Date() < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: ticket.stagedPath.path))
+    }
 }

--- a/AlasTests/WorktreeTrashTests.swift
+++ b/AlasTests/WorktreeTrashTests.swift
@@ -395,7 +395,12 @@ struct WorktreeTrashTests {
         var recovered: [WorktreeTrashCleanupTicket] = []
         WorktreeTrashCleaner.sweep(projects: [project], launcher: { recovered.append($0) })
         #expect(recovered == (registrationRemoved ? [ticket] : []))
-        #expect(FileManager.default.fileExists(atPath: ticket.stagedPath.path))
+        #expect(FileManager.default.fileExists(
+            atPath: (registrationRemoved ? ticket.stagedPath : original).path
+        ))
+        #expect(!FileManager.default.fileExists(
+            atPath: (registrationRemoved ? original : ticket.stagedPath).path
+        ))
     }
 
     @Test func liveCleanerEventuallyDeletesTheTicketDirectory() async throws {

--- a/AlasTests/WorktreeTrashTests.swift
+++ b/AlasTests/WorktreeTrashTests.swift
@@ -259,6 +259,35 @@ struct WorktreeTrashTests {
         #expect(!FileManager.default.fileExists(atPath: committedMarker.path))
     }
 
+    @Test func liveCleanerDeletesUserImmutableFiles() async throws {
+        let common = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-cleaner-immutable-\(UUID().uuidString)")
+        defer { try? chflags("nouchg", at: common, recursive: true) }
+        defer { try? FileManager.default.removeItem(at: common) }
+        let ticket = try makeStagedTicket(
+            commonGitDirectory: common,
+            originalBaseName: "clean-me"
+        )
+        let lockedFile = ticket.stagedPath.appendingPathComponent("locked.txt")
+        try "trash".write(to: lockedFile, atomically: true, encoding: .utf8)
+        try chflags("uchg", at: lockedFile)
+        defer { try? chflags("nouchg", at: lockedFile) }
+        try WorktreeTrash.markCommitted(ticket)
+        let committedMarker = WorktreeTrash.committedMarkerURL(for: ticket)
+
+        try WorktreeTrashCleaner.launch(ticket, delaySeconds: 0)
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            let stagedExists = FileManager.default.fileExists(atPath: ticket.stagedPath.path)
+            let markerExists = FileManager.default.fileExists(atPath: committedMarker.path)
+            if !stagedExists && !markerExists { break }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: ticket.stagedPath.path))
+        #expect(!FileManager.default.fileExists(atPath: committedMarker.path))
+    }
+
     @Test func staleSweepDoesNotSpawnCleanerForReplacementDirectory() async throws {
         let repo = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-stale-cleaner-swap-\(UUID().uuidString)")
@@ -595,5 +624,17 @@ struct WorktreeTrashTests {
             withIntermediateDirectories: true
         )
         return path
+    }
+
+    private func chflags(_ flags: String, at url: URL, recursive: Bool = false) throws {
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        let process = Foundation.Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/chflags")
+        process.arguments = recursive ? ["-R", flags, url.path] : [flags, url.path]
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw CocoaError(.fileWriteUnknown)
+        }
     }
 }

--- a/AlasTests/WorktreeTrashTests.swift
+++ b/AlasTests/WorktreeTrashTests.swift
@@ -188,6 +188,67 @@ struct WorktreeTrashTests {
         #expect(launched == [old])
     }
 
+    @Test func sweepRecoversCommittedTicketWhenConfiguredLinkedWorktreeWasDeleted() async throws {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-sweep-deleted-anchor-\(UUID().uuidString)")
+        let linked = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-linked")
+        defer {
+            try? FileManager.default.removeItem(at: linked)
+            try? FileManager.default.removeItem(at: repo)
+        }
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: repo)
+        let service = WorktreeService()
+        let linkedWorktree = try await service.add(
+            repoPath: repo,
+            base: "main",
+            branch: "linked",
+            destination: linked,
+            projectId: "linked-project"
+        )
+        let cachedWorktrees = try await service.list(repoPath: repo, projectId: "linked-project")
+        let project = ProjectConfig(
+            id: "linked-project",
+            name: "linked",
+            path: linked.path,
+            color: "#000000",
+            addedAt: .now,
+            cachedWorktrees: cachedWorktrees
+        )
+
+        let outcome = try await service.removeFastLocal(
+            repoPath: repo,
+            worktree: linkedWorktree,
+            deleteBranchIfMerged: false,
+            force: true
+        )
+        let ticket: WorktreeTrashCleanupTicket
+        switch outcome {
+        case .staged(let stagedTicket):
+            ticket = stagedTicket
+        case .synchronous:
+            Issue.record("Expected staged removal")
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+        #expect(throws: CocoaError.self) {
+            try WorktreeTrashCleaner.launch(ticket, delaySeconds: 0) { _, _ in
+                throw CocoaError(.fileWriteUnknown)
+            }
+        }
+
+        var recovered: [WorktreeTrashCleanupTicket] = []
+        WorktreeTrashCleaner.sweep(
+            projects: [project],
+            now: Date().addingTimeInterval(48 * 60 * 60),
+            launcher: { recovered.append($0) }
+        )
+
+        #expect(recovered == [ticket])
+    }
+
     @Test func liveCleanerEventuallyDeletesTheTicketDirectory() async throws {
         let common = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-cleaner-\(UUID().uuidString)")

--- a/AlasTests/WorktreeTrashTests.swift
+++ b/AlasTests/WorktreeTrashTests.swift
@@ -5,28 +5,31 @@ import Testing
 @Suite(.serialized)
 struct WorktreeTrashTests {
     @Test func ticketIsAnImmediateRecognizableChildOfTrashRoot() throws {
-        let common = URL(fileURLWithPath: "/tmp/repo/.git")
-        let original = URL(fileURLWithPath: "/tmp/feature/odd name")
+        let common = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ticket-test-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: common) }
         let id = try #require(UUID(uuidString: "12345678-1234-1234-1234-123456789abc"))
 
-        let ticket = WorktreeTrash.makeTicket(
+        let ticket = try makeStagedTicket(
             commonGitDirectory: common,
-            originalPath: original,
+            originalBaseName: "odd name",
             now: Date(timeIntervalSince1970: 1_789_041_600),
             id: id
         )
 
-        #expect(ticket.trashRoot == common.appendingPathComponent("alas/trash").standardizedFileURL)
+        #expect(ticket.trashRoot.path == common.appendingPathComponent("alas/trash").standardizedFileURL.path)
         #expect(ticket.stagedPath.deletingLastPathComponent().path == ticket.trashRoot.path)
         #expect(ticket.stagedPath.lastPathComponent.hasSuffix(".1789041600.12345678-1234-1234-1234-123456789abc"))
         #expect(WorktreeTrash.isValid(ticket))
         #expect(!WorktreeTrash.isValid(.init(
             trashRoot: ticket.trashRoot,
-            stagedPath: ticket.trashRoot.appendingPathComponent("nested/entry")
+            stagedPath: ticket.trashRoot.appendingPathComponent("nested/entry"),
+            directoryIdentity: ticket.directoryIdentity
         )))
         #expect(!WorktreeTrash.isValid(.init(
             trashRoot: URL(fileURLWithPath: "/tmp"),
-            stagedPath: URL(fileURLWithPath: "/tmp/worktree.alas-worktree.1.12345678-1234-1234-1234-123456789abc")
+            stagedPath: URL(fileURLWithPath: "/tmp/worktree.alas-worktree.1.12345678-1234-1234-1234-123456789abc"),
+            directoryIdentity: ticket.directoryIdentity
         )))
     }
 
@@ -34,20 +37,18 @@ struct WorktreeTrashTests {
         let common = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-trash-test-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: common) }
-        let old = WorktreeTrash.makeTicket(
+        let old = try makeStagedTicket(
             commonGitDirectory: common,
-            originalPath: URL(fileURLWithPath: "/tmp/old"),
+            originalBaseName: "old",
             now: Date(timeIntervalSince1970: 100),
             id: UUID()
         )
-        let young = WorktreeTrash.makeTicket(
+        let young = try makeStagedTicket(
             commonGitDirectory: common,
-            originalPath: URL(fileURLWithPath: "/tmp/young"),
+            originalBaseName: "young",
             now: Date(timeIntervalSince1970: 200),
             id: UUID()
         )
-        try FileManager.default.createDirectory(at: old.stagedPath, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: young.stagedPath, withIntermediateDirectories: true)
         try WorktreeTrash.markCommitted(old, at: Date(timeIntervalSince1970: 100))
         try WorktreeTrash.markCommitted(young, at: Date(timeIntervalSince1970: 200))
         try FileManager.default.createDirectory(
@@ -75,26 +76,25 @@ struct WorktreeTrashTests {
         let common = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-trash-commit-test-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: common) }
-        let oldCommitted = WorktreeTrash.makeTicket(
+        let oldCommitted = try makeStagedTicket(
             commonGitDirectory: common,
-            originalPath: URL(fileURLWithPath: "/tmp/old-committed"),
+            originalBaseName: "old-committed",
             now: Date(timeIntervalSince1970: 10),
             id: UUID()
         )
-        let newlyCommitted = WorktreeTrash.makeTicket(
+        let newlyCommitted = try makeStagedTicket(
             commonGitDirectory: common,
-            originalPath: URL(fileURLWithPath: "/tmp/newly-committed"),
+            originalBaseName: "newly-committed",
             now: Date(timeIntervalSince1970: 20),
             id: UUID()
         )
-        let uncommitted = WorktreeTrash.makeTicket(
+        let uncommitted = try makeStagedTicket(
             commonGitDirectory: common,
-            originalPath: URL(fileURLWithPath: "/tmp/uncommitted"),
+            originalBaseName: "uncommitted",
             now: Date(timeIntervalSince1970: 30),
             id: UUID()
         )
         for ticket in [oldCommitted, newlyCommitted, uncommitted] {
-            try FileManager.default.createDirectory(at: ticket.stagedPath, withIntermediateDirectories: true)
             try FileManager.default.setAttributes(
                 [.modificationDate: Date(timeIntervalSince1970: 1)],
                 ofItemAtPath: ticket.stagedPath.path
@@ -112,9 +112,12 @@ struct WorktreeTrashTests {
     }
 
     @Test func cleanerPassesTheValidatedPathAsAnArgument() throws {
-        let ticket = WorktreeTrash.makeTicket(
-            commonGitDirectory: URL(fileURLWithPath: "/tmp/repo/.git"),
-            originalPath: URL(fileURLWithPath: "/tmp/a name; touch nope")
+        let common = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-cleaner-args-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: common) }
+        let ticket = try makeStagedTicket(
+            commonGitDirectory: common,
+            originalBaseName: "a name; touch nope"
         )
         var capturedExecutable: URL?
         var capturedArguments: [String] = []
@@ -125,9 +128,107 @@ struct WorktreeTrashTests {
         }
 
         #expect(capturedExecutable?.path == "/usr/bin/nice")
-        #expect(capturedArguments.last == ticket.stagedPath.path)
-        #expect(capturedArguments.dropLast().last == WorktreeTrash.committedMarkerURL(for: ticket).path)
-        #expect(capturedArguments.dropLast().allSatisfy { !$0.contains(ticket.stagedPath.path) })
+        #expect(capturedArguments[8] == ticket.stagedPath.path)
+        #expect(capturedArguments[7] == WorktreeTrash.committedMarkerURL(for: ticket).path)
+        #expect(!capturedArguments[4].contains(ticket.stagedPath.path))
+    }
+
+    @Test func cleanerShellLeavesReplacementInsertedAfterLaunchValidation() throws {
+        let common = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-cleaner-swap-\(UUID().uuidString)")
+        let original = common.appendingPathComponent("original")
+        let displaced = common.appendingPathComponent("displaced")
+        defer { try? FileManager.default.removeItem(at: common) }
+        try FileManager.default.createDirectory(at: original, withIntermediateDirectories: true)
+        let ticket = try WorktreeTrash.makeTicket(
+            commonGitDirectory: common,
+            originalPath: original
+        )
+        try FileManager.default.createDirectory(
+            at: ticket.trashRoot,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.moveItem(at: original, to: ticket.stagedPath)
+        try WorktreeTrash.markCommitted(ticket)
+        let replacementMarker = ticket.stagedPath.appendingPathComponent("replacement.txt")
+
+        try WorktreeTrashCleaner.launch(ticket, delaySeconds: 0) { executable, arguments in
+            try FileManager.default.moveItem(at: ticket.stagedPath, to: displaced)
+            try FileManager.default.createDirectory(
+                at: ticket.stagedPath,
+                withIntermediateDirectories: true
+            )
+            try "keep".write(to: replacementMarker, atomically: true, encoding: .utf8)
+            let process = Foundation.Process()
+            process.executableURL = executable
+            process.arguments = arguments
+            try process.run()
+            process.waitUntilExit()
+        }
+
+        #expect(FileManager.default.fileExists(atPath: replacementMarker.path))
+        #expect(FileManager.default.fileExists(
+            atPath: WorktreeTrash.committedMarkerURL(for: ticket).path
+        ))
+    }
+
+    @Test func staleSweepDoesNotSpawnCleanerForReplacementDirectory() async throws {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-stale-cleaner-swap-\(UUID().uuidString)")
+        let original = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-original")
+        let displaced = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-displaced")
+        defer {
+            try? FileManager.default.removeItem(at: original)
+            try? FileManager.default.removeItem(at: displaced)
+            try? FileManager.default.removeItem(at: repo)
+        }
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: repo)
+        try FileManager.default.createDirectory(at: original, withIntermediateDirectories: true)
+        let ticket = try WorktreeTrash.makeTicket(
+            commonGitDirectory: repo.appendingPathComponent(".git"),
+            originalPath: original,
+            now: Date(timeIntervalSince1970: 100)
+        )
+        try FileManager.default.createDirectory(
+            at: ticket.trashRoot,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.moveItem(at: original, to: ticket.stagedPath)
+        try WorktreeTrash.markCommitted(ticket, at: Date(timeIntervalSince1970: 100))
+        let replacementMarker = ticket.stagedPath.appendingPathComponent("replacement.txt")
+        var cleanerSpawned = false
+        var sweepLaunched = false
+
+        WorktreeTrashCleaner.sweep(
+            projects: [ProjectConfig(
+                id: "main",
+                name: "main",
+                path: repo.path,
+                color: "#000000",
+                addedAt: Date(timeIntervalSince1970: 1)
+            )],
+            now: Date(timeIntervalSince1970: 100_000),
+            launcher: { discoveredTicket in
+                sweepLaunched = true
+                try FileManager.default.moveItem(at: discoveredTicket.stagedPath, to: displaced)
+                try FileManager.default.createDirectory(
+                    at: discoveredTicket.stagedPath,
+                    withIntermediateDirectories: true
+                )
+                try "keep".write(to: replacementMarker, atomically: true, encoding: .utf8)
+                try WorktreeTrashCleaner.launch(discoveredTicket, delaySeconds: 0) { _, _ in
+                    cleanerSpawned = true
+                }
+            }
+        )
+
+        #expect(sweepLaunched)
+        #expect(!cleanerSpawned)
+        #expect(FileManager.default.fileExists(atPath: replacementMarker.path))
     }
 
     @Test func sweepLaunchesOnlyOldTicketsFromUniqueLocalProjects() async throws {
@@ -145,20 +246,18 @@ struct WorktreeTrashTests {
         _ = try await Process.git(["worktree", "add", "-q", "-b", "linked", linked.path], cwd: repo)
 
         let common = repo.appendingPathComponent(".git")
-        let old = WorktreeTrash.makeTicket(
+        let old = try makeStagedTicket(
             commonGitDirectory: common,
-            originalPath: linked,
+            originalBaseName: "old",
             now: Date(timeIntervalSince1970: 100),
             id: UUID()
         )
-        let young = WorktreeTrash.makeTicket(
+        let young = try makeStagedTicket(
             commonGitDirectory: common,
-            originalPath: linked,
+            originalBaseName: "young",
             now: Date(timeIntervalSince1970: 250),
             id: UUID()
         )
-        try FileManager.default.createDirectory(at: old.stagedPath, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: young.stagedPath, withIntermediateDirectories: true)
         try WorktreeTrash.markCommitted(old, at: Date(timeIntervalSince1970: 100))
         try WorktreeTrash.markCommitted(young, at: Date(timeIntervalSince1970: 99_990))
         try FileManager.default.setAttributes(
@@ -253,11 +352,10 @@ struct WorktreeTrashTests {
         let common = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-cleaner-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: common) }
-        let ticket = WorktreeTrash.makeTicket(
+        let ticket = try makeStagedTicket(
             commonGitDirectory: common,
-            originalPath: URL(fileURLWithPath: "/tmp/clean-me")
+            originalBaseName: "clean-me"
         )
-        try FileManager.default.createDirectory(at: ticket.stagedPath, withIntermediateDirectories: true)
         try "marker".write(
             to: ticket.stagedPath.appendingPathComponent("marker.txt"),
             atomically: true,
@@ -277,5 +375,29 @@ struct WorktreeTrashTests {
 
         #expect(!FileManager.default.fileExists(atPath: ticket.stagedPath.path))
         #expect(!FileManager.default.fileExists(atPath: committedMarker.path))
+    }
+
+    private func makeStagedTicket(
+        commonGitDirectory: URL,
+        originalBaseName: String,
+        now: Date = Date(),
+        id: UUID = UUID()
+    ) throws -> WorktreeTrashCleanupTicket {
+        let source = commonGitDirectory
+            .appendingPathComponent("alas/test-sources/\(UUID().uuidString)")
+            .appendingPathComponent(originalBaseName)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        let ticket = try WorktreeTrash.makeTicket(
+            commonGitDirectory: commonGitDirectory,
+            originalPath: source,
+            now: now,
+            id: id
+        )
+        try FileManager.default.createDirectory(
+            at: ticket.trashRoot,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.moveItem(at: source, to: ticket.stagedPath)
+        return ticket
     }
 }

--- a/AlasTests/WorktreeTrashTests.swift
+++ b/AlasTests/WorktreeTrashTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+struct WorktreeTrashTests {
+    @Test func ticketIsAnImmediateRecognizableChildOfTrashRoot() throws {
+        let common = URL(fileURLWithPath: "/tmp/repo/.git")
+        let original = URL(fileURLWithPath: "/tmp/feature/odd name")
+        let id = try #require(UUID(uuidString: "12345678-1234-1234-1234-123456789abc"))
+
+        let ticket = WorktreeTrash.makeTicket(
+            commonGitDirectory: common,
+            originalPath: original,
+            now: Date(timeIntervalSince1970: 1_789_041_600),
+            id: id
+        )
+
+        #expect(ticket.trashRoot == common.appendingPathComponent("alas/trash").standardizedFileURL)
+        #expect(ticket.stagedPath.deletingLastPathComponent().path == ticket.trashRoot.path)
+        #expect(ticket.stagedPath.lastPathComponent.hasSuffix(".1789041600.12345678-1234-1234-1234-123456789abc"))
+        #expect(WorktreeTrash.isValid(ticket))
+        #expect(!WorktreeTrash.isValid(.init(
+            trashRoot: ticket.trashRoot,
+            stagedPath: ticket.trashRoot.appendingPathComponent("nested/entry")
+        )))
+        #expect(!WorktreeTrash.isValid(.init(
+            trashRoot: URL(fileURLWithPath: "/tmp"),
+            stagedPath: URL(fileURLWithPath: "/tmp/worktree.alas-worktree.1.12345678-1234-1234-1234-123456789abc")
+        )))
+    }
+
+    @Test func staleTicketsKeepOnlyOldValidDirectoriesAndDeduplicateRoots() throws {
+        let common = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-trash-test-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: common) }
+        let old = WorktreeTrash.makeTicket(
+            commonGitDirectory: common,
+            originalPath: URL(fileURLWithPath: "/tmp/old"),
+            now: Date(timeIntervalSince1970: 100),
+            id: UUID()
+        )
+        let young = WorktreeTrash.makeTicket(
+            commonGitDirectory: common,
+            originalPath: URL(fileURLWithPath: "/tmp/young"),
+            now: Date(timeIntervalSince1970: 200),
+            id: UUID()
+        )
+        try FileManager.default.createDirectory(at: old.stagedPath, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: young.stagedPath, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: old.trashRoot.appendingPathComponent("unrecognized"),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 100)],
+            ofItemAtPath: old.stagedPath.path
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 200)],
+            ofItemAtPath: young.stagedPath.path
+        )
+
+        let tickets = WorktreeTrash.staleTickets(
+            commonGitDirectories: [common, common],
+            olderThan: Date(timeIntervalSince1970: 150)
+        )
+
+        #expect(tickets == [old])
+    }
+}

--- a/AlasTests/WorktreeTrashTests.swift
+++ b/AlasTests/WorktreeTrashTests.swift
@@ -131,12 +131,13 @@ struct WorktreeTrashTests {
         }
 
         #expect(capturedExecutable?.path == "/usr/bin/nice")
-        #expect(capturedArguments[8] == ticket.stagedPath.path)
-        #expect(capturedArguments[7] == WorktreeTrash.committedMarkerURL(for: ticket).path)
+        #expect(capturedArguments[2] == "/usr/bin/python3")
+        #expect(capturedArguments[7] == ticket.stagedPath.path)
+        #expect(capturedArguments[6] == WorktreeTrash.committedMarkerURL(for: ticket).path)
         #expect(!capturedArguments[4].contains(ticket.stagedPath.path))
     }
 
-    @Test func cleanerReplacementSurvivesAndNeverBecomesStaleCandidate() throws {
+    @Test func cleanerReplacementSurvivesWhenSwappedBeforeCleanerLaunch() throws {
         let common = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-cleaner-swap-\(UUID().uuidString)")
         let original = common.appendingPathComponent("original")
@@ -178,6 +179,38 @@ struct WorktreeTrashTests {
             olderThan: Date(timeIntervalSince1970: 200)
         )
         #expect(staleTickets.isEmpty)
+    }
+
+    @Test func liveCleanerDoesNotDeleteReplacementSwappedInAfterLaunch() async throws {
+        let common = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-cleaner-live-swap-\(UUID().uuidString)")
+        let displaced = common.appendingPathComponent("displaced")
+        defer { try? FileManager.default.removeItem(at: common) }
+        let ticket = try makeStagedTicket(
+            commonGitDirectory: common,
+            originalBaseName: "clean-me"
+        )
+        try "trash".write(
+            to: ticket.stagedPath.appendingPathComponent("trash.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try WorktreeTrash.markCommitted(ticket)
+        let replacementMarker = ticket.stagedPath.appendingPathComponent("replacement.txt")
+        let committedMarker = WorktreeTrash.committedMarkerURL(for: ticket)
+
+        try WorktreeTrashCleaner.launch(ticket, delaySeconds: 1)
+        try FileManager.default.moveItem(at: ticket.stagedPath, to: displaced)
+        try FileManager.default.createDirectory(
+            at: ticket.stagedPath,
+            withIntermediateDirectories: true
+        )
+        try "keep".write(to: replacementMarker, atomically: true, encoding: .utf8)
+        try await Task.sleep(for: .milliseconds(1_500))
+
+        #expect(FileManager.default.fileExists(atPath: replacementMarker.path))
+        #expect(FileManager.default.fileExists(atPath: displaced.path))
+        #expect(FileManager.default.fileExists(atPath: committedMarker.path))
     }
 
     @Test func staleSweepDoesNotSpawnCleanerForReplacementDirectory() async throws {
@@ -403,6 +436,54 @@ struct WorktreeTrashTests {
         ))
     }
 
+    @Test func sweepReconcilesPendingDeletionWithLongOriginalPath() async throws {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-pending-long-recovery-\(UUID().uuidString)")
+        let original = try longWorktreePath(
+            root: repo.deletingLastPathComponent(),
+            prefix: "\(repo.lastPathComponent)-linked"
+        )
+        defer {
+            try? FileManager.default.removeItem(at: original)
+            try? FileManager.default.removeItem(at: repo)
+        }
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: repo)
+        _ = try await WorktreeService().add(
+            repoPath: repo, base: "main", branch: "linked", destination: original, projectId: "p"
+        )
+        let gitDirectory = try #require(WorktreeService.localGitDirectory(forWorktreeAt: original))
+        let ticket = try WorktreeTrash.makeTicket(
+            commonGitDirectory: repo.appendingPathComponent(".git"), originalPath: original
+        )
+        try FileManager.default.createDirectory(at: ticket.trashRoot, withIntermediateDirectories: true)
+        try WorktreeTrash.markPending(
+            ticket,
+            originalPath: original,
+            linkedGitDirectory: gitDirectory,
+            at: Date(timeIntervalSince1970: 100)
+        )
+        let pendingSize = try #require(
+            FileManager.default.attributesOfItem(
+                atPath: WorktreeTrash.pendingMarkerURL(for: ticket).path
+            )[.size] as? NSNumber
+        )
+        #expect(pendingSize.uint64Value > 1_024)
+        try FileManager.default.moveItem(at: original, to: ticket.stagedPath)
+        try FileManager.default.removeItem(at: gitDirectory)
+        let project = ProjectConfig(id: "p", name: "repo", path: repo.path, color: "#000000", addedAt: .now)
+        var recovered: [WorktreeTrashCleanupTicket] = []
+
+        WorktreeTrashCleaner.sweep(
+            projects: [project],
+            now: Date(timeIntervalSince1970: 100_000),
+            launcher: { recovered.append($0) }
+        )
+
+        #expect(recovered == [ticket])
+    }
+
     @Test func liveCleanerEventuallyDeletesTheTicketDirectory() async throws {
         let common = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-cleaner-\(UUID().uuidString)")
@@ -454,5 +535,19 @@ struct WorktreeTrashTests {
         )
         try FileManager.default.moveItem(at: source, to: ticket.stagedPath)
         return ticket
+    }
+
+    private func longWorktreePath(root: URL, prefix: String) throws -> URL {
+        var path = root.appendingPathComponent(prefix)
+        var index = 0
+        while path.standardizedFileURL.path.utf8.count < 780 {
+            path.appendPathComponent("segment-\(index)-abcdefghijklmnopqrstuvwxyz")
+            index += 1
+        }
+        try FileManager.default.createDirectory(
+            at: path.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        return path
     }
 }

--- a/AlasTests/WorktreeTrashTests.swift
+++ b/AlasTests/WorktreeTrashTests.swift
@@ -213,6 +213,47 @@ struct WorktreeTrashTests {
         #expect(FileManager.default.fileExists(atPath: committedMarker.path))
     }
 
+    @Test func liveCleanerDeletesUnreadableDirectories() async throws {
+        let common = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-cleaner-unreadable-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: common) }
+        let ticket = try makeStagedTicket(
+            commonGitDirectory: common,
+            originalBaseName: "clean-me"
+        )
+        let unreadable = ticket.stagedPath.appendingPathComponent("unreadable")
+        try FileManager.default.createDirectory(at: unreadable, withIntermediateDirectories: true)
+        try "trash".write(
+            to: unreadable.appendingPathComponent("trash.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o000],
+            ofItemAtPath: unreadable.path
+        )
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o700],
+                ofItemAtPath: unreadable.path
+            )
+        }
+        try WorktreeTrash.markCommitted(ticket)
+        let committedMarker = WorktreeTrash.committedMarkerURL(for: ticket)
+
+        try WorktreeTrashCleaner.launch(ticket, delaySeconds: 0)
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            let stagedExists = FileManager.default.fileExists(atPath: ticket.stagedPath.path)
+            let markerExists = FileManager.default.fileExists(atPath: committedMarker.path)
+            if !stagedExists && !markerExists { break }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: ticket.stagedPath.path))
+        #expect(!FileManager.default.fileExists(atPath: committedMarker.path))
+    }
+
     @Test func staleSweepDoesNotSpawnCleanerForReplacementDirectory() async throws {
         let repo = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-stale-cleaner-swap-\(UUID().uuidString)")

--- a/AlasTests/WorktreeTrashTests.swift
+++ b/AlasTests/WorktreeTrashTests.swift
@@ -356,6 +356,48 @@ struct WorktreeTrashTests {
         #expect(recovered == [ticket])
     }
 
+    @Test(arguments: [true, false])
+    func sweepReconcilesPendingDeletionWithGitRegistration(registrationRemoved: Bool) async throws {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-pending-recovery-\(UUID().uuidString)")
+        let original = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-linked")
+        defer {
+            try? FileManager.default.removeItem(at: original)
+            try? FileManager.default.removeItem(at: repo)
+        }
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: repo)
+        _ = try await WorktreeService().add(
+            repoPath: repo, base: "main", branch: "linked", destination: original, projectId: "p"
+        )
+        let gitDirectory = try #require(WorktreeService.localGitDirectory(forWorktreeAt: original))
+        let ticket = try WorktreeTrash.makeTicket(
+            commonGitDirectory: repo.appendingPathComponent(".git"), originalPath: original
+        )
+        try FileManager.default.createDirectory(at: ticket.trashRoot, withIntermediateDirectories: true)
+        let identifier = ticket.stagedPath.lastPathComponent.split(separator: ".").last!
+        let pending = ticket.trashRoot.appendingPathComponent(".alas-worktree-deletion-pending.\(identifier)")
+        let metadata = [
+            "1", "100", String(ticket.directoryIdentity.systemNumber),
+            String(ticket.directoryIdentity.fileNumber), ticket.stagedPath.lastPathComponent,
+            Data(original.standardizedFileURL.path.utf8).base64EncodedString(),
+            Data(gitDirectory.lastPathComponent.utf8).base64EncodedString(), "",
+        ].joined(separator: "\n")
+        try Data(metadata.utf8).write(to: pending, options: .atomic)
+        try FileManager.default.moveItem(at: original, to: ticket.stagedPath)
+        if registrationRemoved {
+            let removal = try await Process.git(["worktree", "remove", original.path], cwd: repo)
+            try #require(removal.exitCode == 0)
+        }
+        let project = ProjectConfig(id: "p", name: "repo", path: repo.path, color: "#000000", addedAt: .now)
+        var recovered: [WorktreeTrashCleanupTicket] = []
+        WorktreeTrashCleaner.sweep(projects: [project], launcher: { recovered.append($0) })
+        #expect(recovered == (registrationRemoved ? [ticket] : []))
+        #expect(FileManager.default.fileExists(atPath: ticket.stagedPath.path))
+    }
+
     @Test func liveCleanerEventuallyDeletesTheTicketDirectory() async throws {
         let common = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-cleaner-\(UUID().uuidString)")

--- a/AlasTests/WorktreeTrashTests.swift
+++ b/AlasTests/WorktreeTrashTests.swift
@@ -102,6 +102,9 @@ struct WorktreeTrashTests {
         }
         try WorktreeTrash.markCommitted(oldCommitted, at: Date(timeIntervalSince1970: 100))
         try WorktreeTrash.markCommitted(newlyCommitted, at: Date(timeIntervalSince1970: 200))
+        try Data("100\n".utf8).write(
+            to: WorktreeTrash.committedMarkerURL(for: uncommitted)
+        )
 
         let tickets = WorktreeTrash.staleTickets(
             commonGitDirectories: [common],
@@ -133,7 +136,7 @@ struct WorktreeTrashTests {
         #expect(!capturedArguments[4].contains(ticket.stagedPath.path))
     }
 
-    @Test func cleanerShellLeavesReplacementInsertedAfterLaunchValidation() throws {
+    @Test func cleanerReplacementSurvivesAndNeverBecomesStaleCandidate() throws {
         let common = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-cleaner-swap-\(UUID().uuidString)")
         let original = common.appendingPathComponent("original")
@@ -149,7 +152,7 @@ struct WorktreeTrashTests {
             withIntermediateDirectories: true
         )
         try FileManager.default.moveItem(at: original, to: ticket.stagedPath)
-        try WorktreeTrash.markCommitted(ticket)
+        try WorktreeTrash.markCommitted(ticket, at: Date(timeIntervalSince1970: 100))
         let replacementMarker = ticket.stagedPath.appendingPathComponent("replacement.txt")
 
         try WorktreeTrashCleaner.launch(ticket, delaySeconds: 0) { executable, arguments in
@@ -170,6 +173,11 @@ struct WorktreeTrashTests {
         #expect(FileManager.default.fileExists(
             atPath: WorktreeTrash.committedMarkerURL(for: ticket).path
         ))
+        let staleTickets = WorktreeTrash.staleTickets(
+            commonGitDirectories: [common],
+            olderThan: Date(timeIntervalSince1970: 200)
+        )
+        #expect(staleTickets.isEmpty)
     }
 
     @Test func staleSweepDoesNotSpawnCleanerForReplacementDirectory() async throws {

--- a/AlasTests/WorktreeTrashTests.swift
+++ b/AlasTests/WorktreeTrashTests.swift
@@ -135,6 +135,10 @@ struct WorktreeTrashTests {
         #expect(capturedArguments[7] == ticket.stagedPath.path)
         #expect(capturedArguments[6] == WorktreeTrash.committedMarkerURL(for: ticket).path)
         #expect(!capturedArguments[4].contains(ticket.stagedPath.path))
+        #expect(capturedArguments[4].contains("except Exception:"))
+        #expect(capturedArguments[4].contains(
+            "os.rename(private_name, name, src_dir_fd=parentfd, dst_dir_fd=parentfd)"
+        ))
     }
 
     @Test func cleanerReplacementSurvivesWhenSwappedBeforeCleanerLaunch() throws {
@@ -213,7 +217,8 @@ struct WorktreeTrashTests {
         #expect(FileManager.default.fileExists(atPath: committedMarker.path))
     }
 
-    @Test func liveCleanerDeletesUnreadableDirectories() async throws {
+    @Test(arguments: [0o000, 0o500])
+    func liveCleanerDeletesDirectoriesWithoutOwnerWritePermission(permissions: Int) async throws {
         let common = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-cleaner-unreadable-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: common) }
@@ -229,7 +234,7 @@ struct WorktreeTrashTests {
             encoding: .utf8
         )
         try FileManager.default.setAttributes(
-            [.posixPermissions: 0o000],
+            [.posixPermissions: permissions],
             ofItemAtPath: unreadable.path
         )
         defer {

--- a/AlasTests/WorktreeTrashTests.swift
+++ b/AlasTests/WorktreeTrashTests.swift
@@ -48,6 +48,8 @@ struct WorktreeTrashTests {
         )
         try FileManager.default.createDirectory(at: old.stagedPath, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: young.stagedPath, withIntermediateDirectories: true)
+        try WorktreeTrash.markCommitted(old, at: Date(timeIntervalSince1970: 100))
+        try WorktreeTrash.markCommitted(young, at: Date(timeIntervalSince1970: 200))
         try FileManager.default.createDirectory(
             at: old.trashRoot.appendingPathComponent("unrecognized"),
             withIntermediateDirectories: true
@@ -69,6 +71,46 @@ struct WorktreeTrashTests {
         #expect(tickets == [old])
     }
 
+    @Test func staleTicketsUseCommitTimeAndIgnoreUncommittedDirectories() throws {
+        let common = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-trash-commit-test-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: common) }
+        let oldCommitted = WorktreeTrash.makeTicket(
+            commonGitDirectory: common,
+            originalPath: URL(fileURLWithPath: "/tmp/old-committed"),
+            now: Date(timeIntervalSince1970: 10),
+            id: UUID()
+        )
+        let newlyCommitted = WorktreeTrash.makeTicket(
+            commonGitDirectory: common,
+            originalPath: URL(fileURLWithPath: "/tmp/newly-committed"),
+            now: Date(timeIntervalSince1970: 20),
+            id: UUID()
+        )
+        let uncommitted = WorktreeTrash.makeTicket(
+            commonGitDirectory: common,
+            originalPath: URL(fileURLWithPath: "/tmp/uncommitted"),
+            now: Date(timeIntervalSince1970: 30),
+            id: UUID()
+        )
+        for ticket in [oldCommitted, newlyCommitted, uncommitted] {
+            try FileManager.default.createDirectory(at: ticket.stagedPath, withIntermediateDirectories: true)
+            try FileManager.default.setAttributes(
+                [.modificationDate: Date(timeIntervalSince1970: 1)],
+                ofItemAtPath: ticket.stagedPath.path
+            )
+        }
+        try WorktreeTrash.markCommitted(oldCommitted, at: Date(timeIntervalSince1970: 100))
+        try WorktreeTrash.markCommitted(newlyCommitted, at: Date(timeIntervalSince1970: 200))
+
+        let tickets = WorktreeTrash.staleTickets(
+            commonGitDirectories: [common],
+            olderThan: Date(timeIntervalSince1970: 150)
+        )
+
+        #expect(tickets == [oldCommitted])
+    }
+
     @Test func cleanerPassesTheValidatedPathAsAnArgument() throws {
         let ticket = WorktreeTrash.makeTicket(
             commonGitDirectory: URL(fileURLWithPath: "/tmp/repo/.git"),
@@ -84,6 +126,7 @@ struct WorktreeTrashTests {
 
         #expect(capturedExecutable?.path == "/usr/bin/nice")
         #expect(capturedArguments.last == ticket.stagedPath.path)
+        #expect(capturedArguments.dropLast().last == WorktreeTrash.committedMarkerURL(for: ticket).path)
         #expect(capturedArguments.dropLast().allSatisfy { !$0.contains(ticket.stagedPath.path) })
     }
 
@@ -116,6 +159,8 @@ struct WorktreeTrashTests {
         )
         try FileManager.default.createDirectory(at: old.stagedPath, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: young.stagedPath, withIntermediateDirectories: true)
+        try WorktreeTrash.markCommitted(old, at: Date(timeIntervalSince1970: 100))
+        try WorktreeTrash.markCommitted(young, at: Date(timeIntervalSince1970: 99_990))
         try FileManager.default.setAttributes(
             [.modificationDate: Date(timeIntervalSince1970: 100)],
             ofItemAtPath: old.stagedPath.path
@@ -157,6 +202,8 @@ struct WorktreeTrashTests {
             atomically: true,
             encoding: .utf8
         )
+        try WorktreeTrash.markCommitted(ticket)
+        let committedMarker = WorktreeTrash.committedMarkerURL(for: ticket)
 
         try WorktreeTrashCleaner.launch(ticket, delaySeconds: 0)
         let deadline = Date().addingTimeInterval(5)
@@ -165,5 +212,6 @@ struct WorktreeTrashTests {
         }
 
         #expect(!FileManager.default.fileExists(atPath: ticket.stagedPath.path))
+        #expect(!FileManager.default.fileExists(atPath: committedMarker.path))
     }
 }

--- a/AlasTests/WorktreeTrashTests.swift
+++ b/AlasTests/WorktreeTrashTests.swift
@@ -207,7 +207,10 @@ struct WorktreeTrashTests {
 
         try WorktreeTrashCleaner.launch(ticket, delaySeconds: 0)
         let deadline = Date().addingTimeInterval(5)
-        while FileManager.default.fileExists(atPath: ticket.stagedPath.path), Date() < deadline {
+        while Date() < deadline {
+            let stagedExists = FileManager.default.fileExists(atPath: ticket.stagedPath.path)
+            let markerExists = FileManager.default.fileExists(atPath: committedMarker.path)
+            if !stagedExists && !markerExists { break }
             try await Task.sleep(for: .milliseconds(20))
         }
 

--- a/docs/superpowers/plans/2026-09-10-fast-worktree-deletion.md
+++ b/docs/superpowers/plans/2026-09-10-fast-worktree-deletion.md
@@ -1,0 +1,1165 @@
+# Fast local worktree deletion implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make local worktree deletion return after a same-filesystem rename and Git registry update while a detached process removes the staged files.
+
+**Architecture:** AppState will call a new opt-in `WorktreeService.removeFastLocal` method for local worktrees. That method stages the directory under the repository's common Git directory and returns a validated cleanup ticket. AppState tears down its worktree-owned state, launches detached cleanup, and starts a best-effort stale-trash sweep. Existing `WorktreeService.remove` callers keep synchronous behavior.
+
+**Tech stack:** Swift 5.9, Foundation `Process` and `FileManager`, Swift Testing, Git worktree plumbing, macOS 15+
+
+**Spec:** `docs/superpowers/specs/2026-09-10-fast-worktree-deletion-design.md`
+
+## Global constraints
+
+- Keep code, comments, logs, and UI strings in English.
+- Use Swift Testing with `import Testing`, not XCTest.
+- Do not change the deletion preflight policy or confirmation copy.
+- Do not stage SSH deletions or Workspace Checkout removals.
+- Pass cleanup paths as process arguments. Never interpolate them into shell source.
+- Do not edit `project.yml`. Run `xcodegen` after creating Swift files so the generated Xcode project records them.
+- Do not add agent attribution to code, docs, or commits.
+- Run `xcodegen`, the macOS build, and the full test command before finishing.
+
+---
+
+### Task 1: Trash paths and cleanup tickets
+
+**Files:**
+
+- Create: `Alas/Sources/Git/WorktreeTrash.swift`
+- Create: `AlasTests/WorktreeTrashTests.swift`
+
+**Interfaces:**
+
+- Produces: `WorktreeTrashCleanupTicket`, an `Equatable` and `Sendable` value containing `trashRoot` and `stagedPath`.
+- Produces: `WorktreeRemovalOutcome` with `.synchronous` and `.staged(WorktreeTrashCleanupTicket)` cases.
+- Produces: `WorktreeTrash.root(commonGitDirectory:)`, `makeTicket(commonGitDirectory:originalPath:now:id:)`, `isValid(_:)`, and `staleTickets(commonGitDirectories:olderThan:)`.
+- Consumes: Foundation URL and file resource values only.
+
+- [ ] **Step 1: Write failing tests for naming, validation, and stale selection**
+
+Create a serialized Swift Testing suite. Use fixed dates and UUIDs so every assertion is deterministic:
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+struct WorktreeTrashTests {
+    @Test func ticketIsAnImmediateRecognizableChildOfTrashRoot() throws {
+        let common = URL(fileURLWithPath: "/tmp/repo/.git")
+        let original = URL(fileURLWithPath: "/tmp/feature/odd name")
+        let id = try #require(UUID(uuidString: "12345678-1234-1234-1234-123456789abc"))
+
+        let ticket = WorktreeTrash.makeTicket(
+            commonGitDirectory: common,
+            originalPath: original,
+            now: Date(timeIntervalSince1970: 1_789_041_600),
+            id: id
+        )
+
+        #expect(ticket.trashRoot == common.appendingPathComponent("alas/trash").standardizedFileURL)
+        #expect(ticket.stagedPath.deletingLastPathComponent() == ticket.trashRoot)
+        #expect(ticket.stagedPath.lastPathComponent.hasSuffix(".1789041600.12345678-1234-1234-1234-123456789abc"))
+        #expect(WorktreeTrash.isValid(ticket))
+        #expect(!WorktreeTrash.isValid(.init(
+            trashRoot: ticket.trashRoot,
+            stagedPath: ticket.trashRoot.appendingPathComponent("nested/entry")
+        )))
+        #expect(!WorktreeTrash.isValid(.init(
+            trashRoot: URL(fileURLWithPath: "/tmp"),
+            stagedPath: URL(fileURLWithPath: "/tmp/worktree.alas-worktree.1.12345678-1234-1234-1234-123456789abc")
+        )))
+    }
+
+    @Test func staleTicketsKeepOnlyOldValidDirectoriesAndDeduplicateRoots() throws {
+        let common = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-trash-test-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: common) }
+        let old = WorktreeTrash.makeTicket(
+            commonGitDirectory: common,
+            originalPath: URL(fileURLWithPath: "/tmp/old"),
+            now: Date(timeIntervalSince1970: 100),
+            id: UUID()
+        )
+        let young = WorktreeTrash.makeTicket(
+            commonGitDirectory: common,
+            originalPath: URL(fileURLWithPath: "/tmp/young"),
+            now: Date(timeIntervalSince1970: 200),
+            id: UUID()
+        )
+        try FileManager.default.createDirectory(at: old.stagedPath, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: young.stagedPath, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: old.trashRoot.appendingPathComponent("unrecognized"),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 100)],
+            ofItemAtPath: old.stagedPath.path
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 200)],
+            ofItemAtPath: young.stagedPath.path
+        )
+
+        let tickets = WorktreeTrash.staleTickets(
+            commonGitDirectories: [common, common],
+            olderThan: Date(timeIntervalSince1970: 150)
+        )
+
+        #expect(tickets == [old])
+    }
+}
+```
+
+- [ ] **Step 2: Run the new suite and verify it fails to compile**
+
+Run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/WorktreeTrashTests
+```
+
+Expected: compilation fails because `WorktreeTrash`, `WorktreeTrashCleanupTicket`, and `WorktreeRemovalOutcome` do not exist.
+
+- [ ] **Step 3: Implement the value types and path rules**
+
+Create `WorktreeTrash.swift` with these declarations and behavior:
+
+```swift
+import Foundation
+
+struct WorktreeTrashCleanupTicket: Equatable, Sendable {
+    let trashRoot: URL
+    let stagedPath: URL
+}
+
+enum WorktreeRemovalOutcome: Equatable, Sendable {
+    case synchronous
+    case staged(WorktreeTrashCleanupTicket)
+}
+
+enum WorktreeTrash {
+    static let relativeDirectory = "alas/trash"
+    private static let marker = "alas-worktree"
+
+    static func root(commonGitDirectory: URL) -> URL {
+        commonGitDirectory
+            .appendingPathComponent(relativeDirectory, isDirectory: true)
+            .standardizedFileURL
+    }
+
+    static func makeTicket(
+        commonGitDirectory: URL,
+        originalPath: URL,
+        now: Date = Date(),
+        id: UUID = UUID()
+    ) -> WorktreeTrashCleanupTicket {
+        let trashRoot = root(commonGitDirectory: commonGitDirectory)
+        let safeBase = sanitizedBaseName(originalPath.lastPathComponent)
+        let name = "\(safeBase).\(marker).\(Int(now.timeIntervalSince1970)).\(id.uuidString.lowercased())"
+        return WorktreeTrashCleanupTicket(
+            trashRoot: trashRoot,
+            stagedPath: trashRoot.appendingPathComponent(name, isDirectory: true)
+        )
+    }
+
+    static func isValid(_ ticket: WorktreeTrashCleanupTicket) -> Bool {
+        let root = ticket.trashRoot.standardizedFileURL
+        let target = ticket.stagedPath.standardizedFileURL
+        return root.lastPathComponent == "trash"
+            && root.deletingLastPathComponent().lastPathComponent == "alas"
+            && target.deletingLastPathComponent() == root
+            && isRecognizedEntryName(target.lastPathComponent)
+    }
+
+    static func staleTickets(
+        commonGitDirectories: [URL],
+        olderThan cutoff: Date,
+        fileManager: FileManager = .default
+    ) -> [WorktreeTrashCleanupTicket] {
+        let keys: Set<URLResourceKey> = [
+            .contentModificationDateKey,
+            .isDirectoryKey,
+            .isSymbolicLinkKey,
+        ]
+        let commonDirectories = Set(commonGitDirectories.map { $0.standardizedFileURL.path })
+        var tickets: [WorktreeTrashCleanupTicket] = []
+        for commonPath in commonDirectories.sorted() {
+            let trashRoot = root(commonGitDirectory: URL(fileURLWithPath: commonPath))
+            guard let entries = try? fileManager.contentsOfDirectory(
+                at: trashRoot,
+                includingPropertiesForKeys: Array(keys),
+                options: [.skipsHiddenFiles]
+            ) else { continue }
+            for entry in entries {
+                let ticket = WorktreeTrashCleanupTicket(
+                    trashRoot: trashRoot,
+                    stagedPath: entry.standardizedFileURL
+                )
+                guard isValid(ticket),
+                      let values = try? entry.resourceValues(forKeys: keys),
+                      values.isDirectory == true,
+                      values.isSymbolicLink != true,
+                      let modified = values.contentModificationDate,
+                      modified < cutoff
+                else { continue }
+                tickets.append(ticket)
+            }
+        }
+        return tickets.sorted { $0.stagedPath.path < $1.stagedPath.path }
+    }
+
+    private static func sanitizedBaseName(_ value: String) -> String {
+        var result = ""
+        var needsSeparator = false
+        for scalar in value.unicodeScalars {
+            let byte = scalar.value
+            let allowed = (48...57).contains(byte)
+                || (65...90).contains(byte)
+                || (97...122).contains(byte)
+                || byte == 45
+                || byte == 95
+            if allowed {
+                if needsSeparator, !result.isEmpty { result.append("-") }
+                result.unicodeScalars.append(scalar)
+                needsSeparator = false
+            } else {
+                needsSeparator = true
+            }
+        }
+        let trimmed = result.trimmingCharacters(in: CharacterSet(charactersIn: "-_"))
+        let limited = String(trimmed.prefix(48))
+        return limited.isEmpty ? "worktree" : limited
+    }
+
+    private static func isRecognizedEntryName(_ value: String) -> Bool {
+        let fields = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard fields.count == 4,
+              fields[1] == Substring(marker),
+              let epoch = Int(fields[2]),
+              epoch >= 0,
+              UUID(uuidString: String(fields[3])) != nil
+        else { return false }
+        return !fields[0].isEmpty
+    }
+}
+```
+
+The helper code keeps ASCII letters, digits, `_`, and `-`, replaces other runs with `-`, trims separators, limits the result to 48 characters, and falls back to `worktree`. The four dot-separated fields make stale-entry validation unambiguous.
+
+- [ ] **Step 4: Run the focused suite**
+
+Run `xcodegen`, then run the Task 1 test command again. Expected: both tests pass and the generated project contains the new source and test files.
+
+- [ ] **Step 5: Commit the path model**
+
+```bash
+git add Alas/Sources/Git/WorktreeTrash.swift AlasTests/WorktreeTrashTests.swift Alas.xcodeproj/project.pbxproj
+git commit -m "feat: define worktree trash paths"
+```
+
+---
+
+### Task 2: Staged local removal
+
+**Files:**
+
+- Modify: `Alas/Sources/Git/WorktreeService.swift:22-31,746-783,854-876,950-1085`
+- Modify: `AlasTests/WorktreeServiceTests.swift:242-278,603-642`
+
+**Interfaces:**
+
+- Consumes: `WorktreeTrash.makeTicket` and `WorktreeRemovalOutcome` from Task 1.
+- Produces: `WorktreeService.removeFastLocal(repoPath:worktree:deleteBranchIfMerged:force:usesRemoteHostRegistry:moveItem:) async throws -> WorktreeRemovalOutcome`.
+- Preserves: `WorktreeService.remove(...) async throws -> Void` without changing its behavior or callers.
+
+- [ ] **Step 1: Add failing integration tests for the commit boundary**
+
+Add tests beside the existing removal tests. Reuse the suite's `makeRepo()` helper:
+
+```swift
+private struct LinkedWorktreeFixture {
+    let repo: URL
+    let service: WorktreeService
+    let worktree: Worktree
+
+    func removeFiles() {
+        try? FileManager.default.removeItem(at: worktree.path)
+        try? FileManager.default.removeItem(at: repo)
+    }
+}
+
+private func makeLinkedWorktree(suffix: String) async throws -> LinkedWorktreeFixture {
+    let repo = try await makeRepo()
+    let destination = repo.deletingLastPathComponent()
+        .appendingPathComponent("\(repo.lastPathComponent)-\(suffix)")
+    let service = WorktreeService()
+    let worktree = try await service.add(
+        repoPath: repo,
+        base: "main",
+        branch: "feature/\(suffix)",
+        destination: destination,
+        projectId: "p"
+    )
+    return LinkedWorktreeFixture(repo: repo, service: service, worktree: worktree)
+}
+
+@Test func fastLocalRemoveReturnsStagedTicketBeforeFilesAreDeleted() async throws {
+    let repo = try await makeRepo()
+    let destination = repo.deletingLastPathComponent()
+        .appendingPathComponent("\(repo.lastPathComponent)-fast")
+    defer {
+        try? FileManager.default.removeItem(at: destination)
+        try? FileManager.default.removeItem(at: repo)
+    }
+    let service = WorktreeService()
+    let worktree = try await service.add(
+        repoPath: repo,
+        base: "main",
+        branch: "feature/fast",
+        destination: destination,
+        projectId: "p"
+    )
+    try "keep until cleaner".write(
+        to: destination.appendingPathComponent("marker.txt"),
+        atomically: true,
+        encoding: .utf8
+    )
+
+    let outcome = try await service.removeFastLocal(
+        repoPath: repo,
+        worktree: worktree,
+        deleteBranchIfMerged: false,
+        force: true
+    )
+    guard case .staged(let ticket) = outcome else {
+        Issue.record("Expected staged removal")
+        return
+    }
+    defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+
+    #expect(!FileManager.default.fileExists(atPath: destination.path))
+    #expect(FileManager.default.fileExists(
+        atPath: ticket.stagedPath.appendingPathComponent("marker.txt").path
+    ))
+    #expect(try await service.list(repoPath: repo, projectId: "p").count == 1)
+}
+
+@Test func fastLocalRemoveFailsClosedWhenWorktreeBecameDirty() async throws {
+    let fixture = try await makeLinkedWorktree(suffix: "became-dirty")
+    defer { fixture.removeFiles() }
+    try "dirty".write(
+        to: fixture.worktree.path.appendingPathComponent("new.txt"),
+        atomically: true,
+        encoding: .utf8
+    )
+
+    await #expect(throws: WorktreeService.WorktreeError.self) {
+        try await fixture.service.removeFastLocal(
+            repoPath: fixture.repo,
+            worktree: fixture.worktree,
+            deleteBranchIfMerged: false,
+            force: false
+        )
+    }
+    #expect(FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify the missing API failure**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/WorktreeServiceTests/fastLocalRemoveReturnsStagedTicketBeforeFilesAreDeleted \
+  -only-testing:AlasTests/WorktreeServiceTests/fastLocalRemoveFailsClosedWhenWorktreeBecameDirty
+```
+
+Expected: compilation fails because `removeFastLocal` does not exist.
+
+- [ ] **Step 3: Implement staging, registry removal, and rollback**
+
+Add the method next to `remove`. Keep all Git work under the caller's existing `ProjectMutationGate`:
+
+```swift
+func removeFastLocal(
+    repoPath: URL,
+    worktree: Worktree,
+    deleteBranchIfMerged: Bool,
+    force: Bool = false,
+    usesRemoteHostRegistry: Bool = true,
+    moveItem: @Sendable (URL, URL) throws -> Void = {
+        try WorktreeService.renameAtomically(from: $0, to: $1)
+    }
+) async throws -> WorktreeRemovalOutcome
+```
+
+Add `import Darwin` and this helper:
+
+```swift
+private static func renameAtomically(from source: URL, to destination: URL) throws {
+    let result: (status: Int32, error: Int32) = source.withUnsafeFileSystemRepresentation { sourcePath in
+        destination.withUnsafeFileSystemRepresentation { destinationPath in
+            guard let sourcePath, let destinationPath else { return (-1, EINVAL) }
+            let status = Darwin.rename(sourcePath, destinationPath)
+            return (status, status == 0 ? 0 : errno)
+        }
+    }
+    guard result.status == 0 else {
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(result.error))
+    }
+}
+```
+
+Do not use `FileManager.moveItem` in the live default because it may perform a
+cross-volume copy instead of failing immediately. Tests may inject
+`FileManager.moveItem` for controlled same-volume moves.
+
+The method must perform this exact sequence:
+
+1. Reject remote Alas paths by calling the existing synchronous `remove` with `usesRemoteHostRegistry` and returning `.synchronous`.
+2. Run `git worktree list --porcelain` with `usesRemoteHostRegistry: false`. Require one entry matching `worktree.path` after URL standardization. Record whether that entry is locked.
+3. Unless `force` is true, call `isWorktreeClean`. Throw `gitFailed("Worktree contains modified or untracked files.")` if it returns false. If it fails because Git LFS is missing, preserve the existing behavior by calling `canForceRemoveAfterMissingLFS`; proceed with one internal force only when that complete audit succeeds.
+4. Run `git fsmonitor--daemon stop` in the worktree with a two-second timeout and ignore its result.
+5. Resolve `git rev-parse --git-common-dir`. Resolve relative output against `repoPath`, standardize it, make a ticket, and create the trash root with intermediate directories.
+6. Call `moveItem(worktree.path, ticket.stagedPath)`. If common-dir resolution, trash creation, or this first move fails, call existing `remove` with the user's force value and return `.synchronous`.
+7. Call `git worktree remove` with the original path. Add one `--force` for an audited LFS-clean fallback or user force, and add two `--force` arguments when the registration was locked and the user approved force.
+8. If registry removal fails, call `moveItem(ticket.stagedPath, worktree.path)`. If rollback succeeds, throw `gitFailed` with Git's original stderr. If rollback fails, throw `gitFailed` with the original path, staged path, Git stderr, and rollback error. Do not invoke synchronous fallback after the first move succeeds.
+9. Preserve the existing best-effort `git branch -d` behavior, then return `.staged(ticket)`.
+
+Add a private porcelain parser that returns both registration presence and locked state for one standardized path. Do not infer the branch from the directory name.
+
+- [ ] **Step 4: Add failure-path and locked-worktree tests**
+
+Add these cases with real temporary repositories:
+
+```swift
+@Test func fastLocalRemoveFallsBackWhenRenameFails() async throws {
+    let fixture = try await makeLinkedWorktree(suffix: "rename-fallback")
+    defer { fixture.removeFiles() }
+
+    let outcome = try await fixture.service.removeFastLocal(
+        repoPath: fixture.repo,
+        worktree: fixture.worktree,
+        deleteBranchIfMerged: false,
+        force: false,
+        moveItem: { _, _ in throw CocoaError(.fileWriteNoPermission) }
+    )
+
+    #expect(outcome == .synchronous)
+    #expect(!FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+}
+
+@Test func fastLocalRemoveRestoresPathWhenRegistryRemovalFails() async throws {
+    let fixture = try await makeLinkedWorktree(suffix: "rollback")
+    defer { fixture.removeFiles() }
+    _ = try await Process.git(["worktree", "lock", fixture.worktree.path.path], cwd: fixture.repo)
+
+    await #expect(throws: WorktreeService.WorktreeError.self) {
+        try await fixture.service.removeFastLocal(
+            repoPath: fixture.repo,
+            worktree: fixture.worktree,
+            deleteBranchIfMerged: false,
+            force: false
+        )
+    }
+
+    #expect(FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+}
+
+@Test func fastLocalRemoveUsesDoubleForceForApprovedLockedWorktree() async throws {
+    let fixture = try await makeLinkedWorktree(suffix: "locked-fast")
+    defer { fixture.removeFiles() }
+    _ = try await Process.git(["worktree", "lock", fixture.worktree.path.path], cwd: fixture.repo)
+
+    let outcome = try await fixture.service.removeFastLocal(
+        repoPath: fixture.repo,
+        worktree: fixture.worktree,
+        deleteBranchIfMerged: false,
+        force: true
+    )
+    guard case .staged(let ticket) = outcome else {
+        Issue.record("Expected staged removal")
+        return
+    }
+    defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+    #expect(!FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+}
+
+@Test func fastLocalRemoveNeverStagesARegisteredRemotePath() async throws {
+    let fixture = try await makeLinkedWorktree(suffix: "remote-fallback")
+    defer { fixture.removeFiles() }
+    RemoteHostRegistry.shared.register(root: fixture.worktree.path.path, host: "test-host")
+    defer { RemoteHostRegistry.shared.unregister(root: fixture.worktree.path.path) }
+
+    let outcome = try await fixture.service.removeFastLocal(
+        repoPath: fixture.repo,
+        worktree: fixture.worktree,
+        deleteBranchIfMerged: false,
+        force: false,
+        usesRemoteHostRegistry: false
+    )
+
+    #expect(outcome == .synchronous)
+    #expect(!FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+}
+```
+
+Add a staged counterpart to `removeWithDeleteBranchUsesRealBranchName`. Pass
+the fixture's `repoPath` and `Worktree`, set `deleteBranchIfMerged: true`, and
+leave `force` false. Require a staged ticket, then assert
+`git branch --list feature/name` is empty. This protects the current
+branch-name behavior when a path template replaces `/` in directory names.
+
+Add the rollback-failure case with a direction-based injected move:
+
+```swift
+@Test func fastLocalRemoveReportsBothPathsWhenRollbackFails() async throws {
+    let fixture = try await makeLinkedWorktree(suffix: "rollback-fails")
+    defer { fixture.removeFiles() }
+    _ = try await Process.git(["worktree", "lock", fixture.worktree.path.path], cwd: fixture.repo)
+
+    do {
+        _ = try await fixture.service.removeFastLocal(
+            repoPath: fixture.repo,
+            worktree: fixture.worktree,
+            deleteBranchIfMerged: false,
+            force: false,
+            moveItem: { source, destination in
+                if source.standardizedFileURL == fixture.worktree.path.standardizedFileURL {
+                    try FileManager.default.moveItem(at: source, to: destination)
+                    try "collision".write(to: source, atomically: true, encoding: .utf8)
+                } else {
+                    throw CocoaError(.fileWriteFileExists)
+                }
+            }
+        )
+        Issue.record("Expected registry and rollback failure")
+    } catch {
+        let message = error.localizedDescription
+        #expect(message.contains(fixture.worktree.path.path))
+        let trash = WorktreeTrash.root(
+            commonGitDirectory: fixture.repo.appendingPathComponent(".git")
+        )
+        let staged = try #require(
+            FileManager.default.contentsOfDirectory(at: trash, includingPropertiesForKeys: nil).first
+        )
+        #expect(message.contains(staged.path))
+        #expect(FileManager.default.fileExists(atPath: staged.appendingPathComponent(".git").path))
+        try? FileManager.default.removeItem(at: trash)
+    }
+}
+```
+
+- [ ] **Step 5: Cover Git LFS and submodule compatibility**
+
+Extract the setup body in `removeRetriesWithoutLFSFiltersWhenGitStatusRequiresMissingLFS` into `makeMissingLFSFixture(suffix:)`. Return the repo, destination, `Worktree`, and marker URL. Keep the existing test by calling the helper and `remove`. Add these assertions for the staged variant:
+
+```swift
+@Test func fastLocalRemovePreservesMissingLFSCleanSemantics() async throws {
+    let fixture = try await makeMissingLFSFixture(suffix: "fast-missing-lfs")
+    defer { fixture.removeFiles() }
+
+    let outcome = try await WorktreeService().removeFastLocal(
+        repoPath: fixture.repo,
+        worktree: fixture.worktree,
+        deleteBranchIfMerged: false
+    )
+    guard case .staged(let ticket) = outcome else {
+        Issue.record("Expected staged removal")
+        return
+    }
+    defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+    #expect(!FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+    #expect(FileManager.default.fileExists(
+        atPath: ticket.stagedPath.appendingPathComponent(fixture.marker.lastPathComponent).path
+    ))
+}
+
+@Test func fastLocalRemoveSupportsInitializedSubmodulesAfterForceApproval() async throws {
+    let fixture = try await makeRepoWithInitializedSubmodule(suffix: "fast-submodule")
+    defer { fixture.removeFiles() }
+
+    let outcome = try await fixture.service.removeFastLocal(
+        repoPath: fixture.repo,
+        worktree: fixture.worktree,
+        deleteBranchIfMerged: false,
+        force: true
+    )
+    guard case .staged(let ticket) = outcome else {
+        Issue.record("Expected staged removal")
+        return
+    }
+    defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+    let listed = try await fixture.service.list(repoPath: fixture.repo, projectId: "p")
+    #expect(listed.count == 1)
+}
+```
+
+Add `removeFiles()` methods to both fixtures. Each method removes only its own temporary worktree, repository, and submodule source URLs.
+
+- [ ] **Step 6: Run all WorktreeService tests**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/WorktreeServiceTests
+```
+
+Expected: all tests pass, including existing synchronous removal, local-only submodule safety, and LFS cases.
+
+- [ ] **Step 7: Commit staged removal**
+
+```bash
+git add Alas/Sources/Git/WorktreeService.swift AlasTests/WorktreeServiceTests.swift
+git commit -m "feat: stage local worktrees before removal"
+```
+
+---
+
+### Task 3: Detached cleanup and stale recovery
+
+**Files:**
+
+- Create: `Alas/Sources/Git/WorktreeTrashCleaner.swift`
+- Modify: `Alas/Sources/Git/WorktreeService.swift:185-199`
+- Modify: `AlasTests/WorktreeTrashTests.swift`
+
+**Interfaces:**
+
+- Consumes: cleanup tickets and stale selection from Task 1.
+- Produces: `WorktreeTrashCleaner.launch(_:,delaySeconds:) throws` and `sweep(projects:now:launcher:)`.
+- Produces: `WorktreeService.localCommonGitDirectory(forWorktreeAt:) -> URL?` for local configured-project recovery.
+
+- [ ] **Step 1: Write failing tests for detached invocation and project-root recovery**
+
+Add tests that inject the process-spawn closure and sweep launcher:
+
+```swift
+@Test func cleanerPassesTheValidatedPathAsAnArgument() throws {
+    let ticket = WorktreeTrash.makeTicket(
+        commonGitDirectory: URL(fileURLWithPath: "/tmp/repo/.git"),
+        originalPath: URL(fileURLWithPath: "/tmp/a name; touch nope")
+    )
+    var capturedExecutable: URL?
+    var capturedArguments: [String] = []
+
+    try WorktreeTrashCleaner.launch(ticket, delaySeconds: 1) { executable, arguments in
+        capturedExecutable = executable
+        capturedArguments = arguments
+    }
+
+    #expect(capturedExecutable?.path == "/usr/bin/nice")
+    #expect(capturedArguments.last == ticket.stagedPath.path)
+    #expect(capturedArguments.dropLast().allSatisfy { !$0.contains(ticket.stagedPath.path) })
+}
+
+@Test func sweepLaunchesOnlyOldTicketsFromUniqueLocalProjects() async throws {
+    let repo = FileManager.default.temporaryDirectory
+        .appendingPathComponent("alas-sweep-\(UUID().uuidString)")
+    let linked = repo.deletingLastPathComponent()
+        .appendingPathComponent("\(repo.lastPathComponent)-linked")
+    defer {
+        try? FileManager.default.removeItem(at: linked)
+        try? FileManager.default.removeItem(at: repo)
+    }
+    try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+    _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+    _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: repo)
+    _ = try await Process.git(["worktree", "add", "-q", "-b", "linked", linked.path], cwd: repo)
+
+    let common = repo.appendingPathComponent(".git")
+    let old = WorktreeTrash.makeTicket(
+        commonGitDirectory: common,
+        originalPath: linked,
+        now: Date(timeIntervalSince1970: 100),
+        id: UUID()
+    )
+    let young = WorktreeTrash.makeTicket(
+        commonGitDirectory: common,
+        originalPath: linked,
+        now: Date(timeIntervalSince1970: 250),
+        id: UUID()
+    )
+    try FileManager.default.createDirectory(at: old.stagedPath, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: young.stagedPath, withIntermediateDirectories: true)
+    try FileManager.default.setAttributes(
+        [.modificationDate: Date(timeIntervalSince1970: 100)],
+        ofItemAtPath: old.stagedPath.path
+    )
+    try FileManager.default.setAttributes(
+        [.modificationDate: Date(timeIntervalSince1970: 99_990)],
+        ofItemAtPath: young.stagedPath.path
+    )
+
+    let addedAt = Date(timeIntervalSince1970: 1)
+    let projects = [
+        ProjectConfig(id: "main", name: "main", path: repo.path, color: "#000000", addedAt: addedAt),
+        ProjectConfig(id: "linked", name: "linked", path: linked.path, color: "#000000", addedAt: addedAt),
+        ProjectConfig(id: "remote", name: "remote", path: "/repo", color: "#000000", addedAt: addedAt, host: "host"),
+        ProjectConfig(id: "missing", name: "missing", path: "/missing", color: "#000000", addedAt: addedAt),
+    ]
+    var launched: [WorktreeTrashCleanupTicket] = []
+
+    WorktreeTrashCleaner.sweep(
+        projects: projects,
+        now: Date(timeIntervalSince1970: 100_000),
+        launcher: { launched.append($0) }
+    )
+
+    #expect(launched == [old])
+}
+```
+
+- [ ] **Step 2: Run the focused suite and verify the cleaner API is missing**
+
+Run the Task 1 focused suite command. Expected: compilation fails on `WorktreeTrashCleaner` and `localCommonGitDirectory`.
+
+- [ ] **Step 3: Expose local common-directory resolution**
+
+Change `localGitDirectory(forWorktreeAt:)` from `private` to internal and add:
+
+```swift
+static func localCommonGitDirectory(forWorktreeAt path: URL) -> URL? {
+    guard let gitDirectory = localGitDirectory(forWorktreeAt: path) else { return nil }
+    let marker = gitDirectory.appendingPathComponent("commondir")
+    guard let raw = try? String(contentsOf: marker, encoding: .utf8)
+        .trimmingCharacters(in: .whitespacesAndNewlines),
+          !raw.isEmpty
+    else { return gitDirectory.standardizedFileURL }
+    return (raw as NSString).isAbsolutePath
+        ? URL(fileURLWithPath: raw).standardizedFileURL
+        : gitDirectory.appendingPathComponent(raw).standardizedFileURL
+}
+```
+
+- [ ] **Step 4: Implement the detached launcher**
+
+Create `WorktreeTrashCleaner.swift` with the complete launcher and sweep structure below:
+
+```swift
+import Foundation
+import os
+
+enum WorktreeTrashCleaner {
+    typealias Launcher = (WorktreeTrashCleanupTicket) throws -> Void
+    typealias Spawn = (URL, [String]) throws -> Void
+
+    private static let logger = Logger(
+        subsystem: "io.nlopez.alas",
+        category: "worktree-trash"
+    )
+
+    enum CleanerError: LocalizedError {
+        case invalidTicket
+
+        var errorDescription: String? {
+            "Refusing to clean a path outside the Alas worktree trash directory."
+        }
+    }
+
+    static func launch(
+        _ ticket: WorktreeTrashCleanupTicket,
+        delaySeconds: Int = 1,
+        spawn: Spawn = spawnDetached
+    ) throws {
+        guard WorktreeTrash.isValid(ticket) else { throw CleanerError.invalidTicket }
+        try spawn(URL(fileURLWithPath: "/usr/bin/nice"), [
+            "-n", "10", "/bin/sh", "-c",
+            "/bin/sleep \"$1\"; exec /bin/rm -rf -- \"$2\"",
+            "alas-worktree-cleaner",
+            String(max(0, delaySeconds)),
+            ticket.stagedPath.path,
+        ])
+    }
+
+    static func sweep(
+        projects: [ProjectConfig],
+        now: Date = Date(),
+        launcher: Launcher = { try launch($0) }
+    ) {
+        let commonDirectories = projects.compactMap { project -> URL? in
+            guard project.host == nil else { return nil }
+            let path = URL(fileURLWithPath: project.path)
+            guard !path.isRemoteAlasPath else { return nil }
+            return WorktreeService.localCommonGitDirectory(forWorktreeAt: path)
+        }
+        let cutoff = now.addingTimeInterval(-24 * 60 * 60)
+        for ticket in WorktreeTrash.staleTickets(
+            commonGitDirectories: commonDirectories,
+            olderThan: cutoff
+        ) {
+            do {
+                try launcher(ticket)
+            } catch {
+                logger.error(
+                    "Could not launch stale worktree cleanup for \(ticket.stagedPath.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+    }
+
+    private static func spawnDetached(executable: URL, arguments: [String]) throws {
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = arguments
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        process.qualityOfService = .utility
+        try process.run()
+    }
+}
+```
+
+Call `WorktreeTrash.isValid` before spawning and throw a localized error for an invalid ticket. The static shell source is constant. The delay and path occupy `$1` and `$2`; neither value is interpolated into the script.
+
+`WorktreeTrash.staleTickets` deduplicates the common directories before scanning. `sweep` skips missing repositories because `localCommonGitDirectory` returns nil when `.git` cannot be resolved.
+
+- [ ] **Step 5: Add an eventual deletion test for the live launcher**
+
+Add this test. Its deadline prevents a broken cleaner from hanging the suite; it is not a performance threshold:
+
+```swift
+@Test func liveCleanerEventuallyDeletesTheTicketDirectory() async throws {
+    let common = FileManager.default.temporaryDirectory
+        .appendingPathComponent("alas-cleaner-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: common) }
+    let ticket = WorktreeTrash.makeTicket(
+        commonGitDirectory: common,
+        originalPath: URL(fileURLWithPath: "/tmp/clean-me")
+    )
+    try FileManager.default.createDirectory(at: ticket.stagedPath, withIntermediateDirectories: true)
+    try "marker".write(
+        to: ticket.stagedPath.appendingPathComponent("marker.txt"),
+        atomically: true,
+        encoding: .utf8
+    )
+
+    try WorktreeTrashCleaner.launch(ticket, delaySeconds: 0)
+    let deadline = Date().addingTimeInterval(5)
+    while FileManager.default.fileExists(atPath: ticket.stagedPath.path), Date() < deadline {
+        try await Task.sleep(for: .milliseconds(20))
+    }
+
+    #expect(!FileManager.default.fileExists(atPath: ticket.stagedPath.path))
+}
+```
+
+- [ ] **Step 6: Run the focused trash suite**
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/WorktreeTrashTests
+```
+
+Expected: all path, validation, spawn, live cleanup, deduplication, and cutoff tests pass.
+
+- [ ] **Step 7: Commit cleanup and recovery**
+
+```bash
+git add Alas/Sources/Git/WorktreeTrashCleaner.swift \
+  Alas/Sources/Git/WorktreeService.swift AlasTests/WorktreeTrashTests.swift \
+  Alas.xcodeproj/project.pbxproj
+git commit -m "feat: clean staged worktrees in background"
+```
+
+---
+
+### Task 4: AppState orchestration
+
+**Files:**
+
+- Modify: `Alas/Sources/App/AppState.swift:49-120,628-766,7338-7833`
+- Modify: `AlasTests/AppStateCleanupTests.swift:900-1085`
+
+**Interfaces:**
+
+- Consumes: `WorktreeService.removeFastLocal`, `WorktreeRemovalOutcome`, and `WorktreeTrashCleaner`.
+- Produces: AppState cleanup ordering and startup stale recovery.
+- Preserves: existing confirmation, pending-force, branch deletion, selection, and refresh behavior.
+
+- [ ] **Step 1: Write a failing AppState test for the cleanup boundary**
+
+Add a main-actor probe and test:
+
+```swift
+@MainActor
+private final class WorktreeCleanupProbe {
+    weak var state: AppState?
+    var worktreeID = ""
+    var launchedTickets: [WorktreeTrashCleanupTicket] = []
+    var tabsWereEmptyAtLaunch = false
+}
+
+@Test @MainActor
+func deleteWorktreeCleansAppStateBeforeLaunchingFileCleanup() async throws {
+    let repo = try await makeRepo(name: "delete-staged")
+    let linked = repo.deletingLastPathComponent().appendingPathComponent("delete-staged-linked")
+    defer {
+        try? FileManager.default.removeItem(at: linked)
+        try? FileManager.default.removeItem(at: repo)
+    }
+    let probe = WorktreeCleanupProbe()
+    let state = AppState(
+        worktreeCleanupLauncher: { ticket in
+            probe.launchedTickets.append(ticket)
+            probe.tabsWereEmptyAtLaunch = probe.state?.tabs.tabs(forWorktree: probe.worktreeID).isEmpty == true
+        }
+    )
+    probe.state = state
+    let project = try await state.projectsManager.addProject(
+        path: repo,
+        displayName: "delete-staged",
+        color: "#5fb7c4"
+    )
+    let worktree = try await WorktreeService().add(
+        repoPath: repo,
+        base: "main",
+        branch: "feature/staged",
+        destination: linked,
+        projectId: project.id
+    )
+    probe.worktreeID = worktree.id
+    try await state.projectsManager.refreshWorktrees(projectId: project.id)
+    state.tabs.appendTerminal(worktreeId: worktree.id, title: "term", sessionId: "session")
+
+    #expect(await state.cliDeleteWorktree(worktree, force: true, keepBranch: true) == .ok)
+    try await waitForOperationState(state.projectsManager, id: worktree.id, equals: nil)
+
+    let ticket = try #require(probe.launchedTickets.first)
+    defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+    #expect(probe.launchedTickets.count == 1)
+    #expect(probe.tabsWereEmptyAtLaunch)
+    #expect(FileManager.default.fileExists(atPath: ticket.stagedPath.path))
+    #expect(!state.projectsManager.worktrees(projectId: project.id).contains { $0.id == worktree.id })
+}
+```
+
+Add a second test whose injected `worktreeCleanupLauncher` throws `CocoaError(.fileWriteUnknown)`. Assert the operation state still clears, the removed worktree does not return, and the staged path remains for stale recovery.
+
+- [ ] **Step 2: Run the AppState tests and verify the initializer failure**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/AppStateCleanupTests/deleteWorktreeCleansAppStateBeforeLaunchingFileCleanup
+```
+
+Expected: compilation fails because AppState has no `worktreeCleanupLauncher` initializer parameter.
+
+- [ ] **Step 3: Add cleanup injection and startup recovery**
+
+Add:
+
+```swift
+typealias WorktreeCleanupLauncher = @MainActor (WorktreeTrashCleanupTicket) throws -> Void
+
+@ObservationIgnored
+private let worktreeCleanupLauncher: WorktreeCleanupLauncher
+```
+
+Extend `AppState.init` with this default:
+
+```swift
+worktreeCleanupLauncher: @escaping WorktreeCleanupLauncher = {
+    try WorktreeTrashCleaner.launch($0)
+}
+```
+
+After all stored properties are initialized, capture `projectsFile.projects` by value and start this utility task:
+
+```swift
+let cleanupProjects = projectsFile.projects
+Task.detached(priority: .utility) {
+    WorktreeTrashCleaner.sweep(projects: cleanupProjects)
+}
+```
+
+This is the application-startup recovery required by the spec. It must not await cleanup or block `AppState.init`.
+
+- [ ] **Step 4: Return removal outcomes through the mutation gate**
+
+Change `performRemoveWorktree` to return `WorktreeRemovalOutcome`. Inside its detached task, call existing `remove` and return `.synchronous` for remote worktrees. Call `removeFastLocal` for local worktrees. Keep the whole selection under `ProjectMutationGate.shared.withMutation(projectID:)`.
+
+```swift
+if worktree.path.isRemoteAlasPath {
+    try await WorktreeService().remove(
+        repoPath: repoPath,
+        worktree: worktree,
+        deleteBranchIfMerged: deleteBranchIfMerged,
+        force: force
+    )
+    return .synchronous
+}
+return try await WorktreeService().removeFastLocal(
+    repoPath: repoPath,
+    worktree: worktree,
+    deleteBranchIfMerged: deleteBranchIfMerged,
+    force: force
+)
+```
+
+- [ ] **Step 5: Launch cleanup after owned-state teardown**
+
+Store the successful outcome in `performDeleteWorktree`. Keep all current error handling. On success, use this order:
+
+1. Call `cleanupWorktreeState(worktreeId:)`.
+2. If the outcome is `.staged(ticket)`, call the injected launcher in `do/catch`. Log a launch failure without changing deletion state.
+3. Start a detached stale sweep using a snapshot of current projects.
+4. Clear operation state, remove persisted GG mode, refresh worktrees, and resolve selection through the existing code.
+
+The launcher call returns after process spawn. AppState must never await the cleaner process.
+
+The success section of `performDeleteWorktree` should have this shape:
+
+```swift
+let outcome: WorktreeRemovalOutcome
+do {
+    outcome = try await Self.performRemoveWorktree(
+        repoPath: repoPath,
+        worktree: worktree,
+        deleteBranchIfMerged: deleteBranchIfMerged,
+        force: force
+    )
+} catch let WorktreeService.WorktreeError.gitFailed(stderr) {
+    if !force,
+       let pending = Self.pendingForceDelete(
+           for: worktree,
+           repoPath: repoPath,
+           deleteBranchIfMerged: deleteBranchIfMerged,
+           removedIndex: removedIndex,
+           stderr: stderr
+       ) {
+        projectsManager.setOperationState(id: worktree.id, state: nil)
+        pendingForceDeleteWorktree = pending
+        return
+    }
+    projectsManager.setOperationState(
+        id: worktree.id,
+        state: .deleteFailed(message: stderr)
+    )
+    return
+} catch {
+    projectsManager.setOperationState(
+        id: worktree.id,
+        state: .deleteFailed(message: "\(error)")
+    )
+    return
+}
+
+cleanupWorktreeState(worktreeId: worktree.id)
+if case .staged(let ticket) = outcome {
+    do {
+        try worktreeCleanupLauncher(ticket)
+    } catch {
+        Self.logger.error(
+            "Could not launch worktree cleanup for \(ticket.stagedPath.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+        )
+    }
+    let cleanupProjects = projects
+    Task.detached(priority: .utility) {
+        WorktreeTrashCleaner.sweep(projects: cleanupProjects)
+    }
+}
+projectsManager.setOperationState(id: worktree.id, state: nil)
+removePersistedGGWorktreeMode(
+    projectId: worktree.projectId,
+    worktreeId: worktree.id
+)
+_ = try? await refreshProjectWorktrees(projectId: worktree.projectId)
+if selectedWorktreeId == worktree.id {
+    selectWorktree(id: selectionAfterRemoval(
+        removedFromProjectId: worktree.projectId,
+        removedAtIndex: removedIndex
+    ))
+}
+```
+
+- [ ] **Step 6: Run AppState cleanup and deletion policy tests**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/AppStateCleanupTests
+```
+
+Expected: all tests pass. Existing confirmation strings and pending-force behavior remain unchanged.
+
+- [ ] **Step 7: Commit AppState integration**
+
+```bash
+git add Alas/Sources/App/AppState.swift AlasTests/AppStateCleanupTests.swift
+git commit -m "feat: finish worktree deletion before file cleanup"
+```
+
+---
+
+### Task 5: Regression verification and behavioral benchmark
+
+**Files:**
+
+- Modify only if verification finds a defect in files already listed above.
+
+**Interfaces:**
+
+- Consumes: the completed staged deletion path.
+- Produces: evidence that code generation, build, focused tests, and the repository test suite behave as expected.
+
+- [ ] **Step 1: Regenerate the Xcode project and check for unintended changes**
+
+```bash
+xcodegen
+git status --short
+git diff --check
+```
+
+Expected: `xcodegen` succeeds. Earlier tasks already regenerated the project after adding files, so `Alas.xcodeproj` should not change now.
+
+- [ ] **Step 2: Run focused deletion suites**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test \
+  -only-testing:AlasTests/WorktreeTrashTests \
+  -only-testing:AlasTests/WorktreeServiceTests \
+  -only-testing:AlasTests/AppStateCleanupTests
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 3: Run the required build**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exit code 0. Existing Swift concurrency warnings may remain, but no new warnings should point at the changed files.
+
+- [ ] **Step 4: Run the required full test suite**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: exit code 0. The untouched baseline hung in `ACPTerminalTests.descendantCleanupRunsOffMainActor` while opening `ACPTerminal.swift`. If that exact hang repeats, capture a process sample and the xcresult path, stop the run, execute that test alone once, and report the baseline issue separately. Do not classify a new failure in changed code as baseline noise.
+
+- [ ] **Step 5: Exercise the file-count boundary without a timing assertion**
+
+Run the focused fast-removal integration test after increasing its temporary untracked marker set locally to at least 50,000 files without committing that test edit. Confirm the test returns a `.staged` ticket while the marker files still exist under `ticket.stagedPath`, then let the test cleanup remove them. The proof is the ordering boundary, not a duration threshold. Restore the temporary test edit with `apply_patch` before continuing.
+
+- [ ] **Step 6: Review the final diff**
+
+```bash
+git diff 4bee44f0..HEAD --stat
+git diff 4bee44f0..HEAD --check
+git status --short
+```
+
+Confirm the diff contains only the staged-removal implementation, focused tests, and the committed planning documents. Confirm `/Volumes/Ambrosio/repos/alas` remains clean on `main`.
+
+- [ ] **Step 7: Commit any verification fixes**
+
+If verification required code changes, stage only those files and commit them with a message describing the concrete fix. If no files changed, do not create an empty commit.

--- a/docs/superpowers/specs/2026-09-10-fast-worktree-deletion-design.md
+++ b/docs/superpowers/specs/2026-09-10-fast-worktree-deletion-design.md
@@ -1,0 +1,192 @@
+# Fast local worktree deletion
+
+## Problem
+
+Alas waits for `git worktree remove` to unlink every file before it treats a
+worktree as deleted. Large build directories make that delay proportional to
+the number of files. A local benchmark with an Alas checkout and 100,000
+untracked files spent 3.14 seconds in `git worktree remove --force`.
+
+Alas also performs a detailed preflight before confirmation. That work is
+intentional: initialized submodules may contain local-only commits, refs,
+reflogs, notes, stashes, or tags that Git's own worktree checks do not protect.
+This change must preserve that warning and confirmation behavior.
+
+Worktrunk makes removal feel immediate by moving a worktree into a trash
+directory with a same-filesystem rename, unregistering it from Git, and
+deleting its files in a detached process. In the same 100,000-file benchmark,
+`wt remove --force` returned with the original path gone in 0.14 seconds while
+file cleanup continued in the background.
+
+## Goals
+
+- Make successful local deletion independent of the worktree's file count on
+  the user-visible path.
+- Preserve the current dirty-file, lock, and local-only submodule checks.
+- Preserve branch deletion semantics and mutation serialization.
+- Let file cleanup survive normal Alas termination and recover from an
+  interrupted or failed cleanup.
+- Fall back to the current removal path whenever staging is unavailable.
+
+## Non-goals
+
+- Changing the preflight's safety policy or confirmation copy.
+- Speeding up SSH worktree deletion in this change.
+- Applying staged deletion to multi-repository Workspace Checkouts in this
+  change. Their coordinator has a separate removal and rollback protocol.
+- Finding or terminating arbitrary processes whose current directory is under
+  the worktree. Alas will stop only sessions and runners it owns.
+- Reporting background file cleanup as part of deletion progress. Once the
+  original path and Git registration are gone, deletion is complete from the
+  user's perspective.
+
+## Design
+
+### Staging location
+
+Resolve the repository's common Git directory with `git rev-parse
+--git-common-dir`, resolving a relative result against the command's working
+directory and standardizing the resulting URL. Create an Alas-owned trash
+directory at `<git-common-dir>/alas/trash/`. Each staged worktree uses a unique
+name made from the original directory name, a timestamp, and a random suffix.
+
+The service must validate that every cleanup target is an immediate child of
+this trash directory. Cleanup commands receive paths as arguments rather than
+interpolated shell text.
+
+### Removal flow
+
+The existing preflight and user confirmation remain unchanged. After
+confirmation, the operation continues under `ProjectMutationGate`:
+
+1. Verify that the target still represents the registered worktree selected
+   by the user. Recheck cleanliness unless the user confirmed force deletion.
+2. Stop Git's built-in fsmonitor daemon for the target on a best-effort basis.
+3. Rename the worktree directory into the repository's Alas trash directory.
+4. Remove the original, now-missing path from Git's worktree registry. Supply
+   the force level already approved by the user, including double force for a
+   locked worktree.
+5. Apply the current best-effort merged-branch deletion policy.
+
+If the rename fails because the worktree and common Git directory are on
+different volumes, because permissions deny it, or for any other filesystem
+reason, use the existing synchronous `git worktree remove` implementation.
+SSH worktrees always use that implementation.
+
+The staged path is an implementation detail. It must never appear as a live
+worktree in `ProjectsManager`, recent-worktree state, or selection state.
+
+Staging is exposed as a new, explicit local-removal operation rather than a
+behavior change to `WorktreeService.remove`. AppState opts into it and receives
+a cleanup ticket when staging succeeds. Existing direct callers, including the
+Workspace Checkout coordinator, retain synchronous `git worktree remove`
+behavior. A synchronous fallback returns no cleanup ticket.
+
+### Commit point and rollback
+
+The Git registry removal is the commit point. Before it succeeds, a failure
+must attempt to rename the staged directory back to its original path. If that
+rollback also fails, report both paths in the deletion error and leave the
+staged directory untouched for manual recovery.
+
+After the registry removal succeeds, failure to delete the optional branch
+does not restore the worktree. This matches the current best-effort branch
+deletion behavior.
+
+Failure to launch background cleanup also does not restore the worktree. The
+stale sweep owns recovery after the commit point.
+
+### Application cleanup
+
+Once staging, registry removal, and branch handling return successfully,
+`AppState` performs its existing `cleanupWorktreeState` work immediately. This
+detaches terminal surfaces, stops ACP runners, and requests shutdown of Alas's
+zmx sessions. If the removal returned a cleanup ticket, AppState then hands it
+to the detached cleanup launcher. This ordering prevents file deletion from
+racing application-owned session shutdown. A synchronous fallback returns no
+ticket and needs no further cleanup.
+
+The worktree row then disappears, selection moves to a surviving worktree,
+and project worktrees refresh through the existing path. No UI waits for file
+cleanup.
+
+External editors, watchers, and build processes are outside Alas's ownership.
+They may keep writing through an open directory descriptor after the rename.
+The cleanup process may therefore leave a non-empty trash entry. That is a
+recoverable cleanup failure, not a failed worktree deletion.
+
+### Detached cleanup and stale recovery
+
+Launch a low-priority detached process with standard input, output, and error
+disconnected from Alas. It recursively deletes the one validated staged path.
+The launcher must return after a successful spawn and must not await process
+termination.
+
+Before spawning the cleaner, request application-owned session shutdown. A
+short delay in the detached process gives those asynchronous zmx termination
+requests time to finish without delaying the UI.
+
+On application startup and after each successful staged deletion, resolve and
+deduplicate the common Git directories belonging to configured local projects,
+then scan their Alas trash directories. Entries older than 24 hours are cleanup
+candidates. Spawn one detached cleanup operation for those validated entries.
+Ignore younger entries because another Alas process may still be deleting them.
+Projects that are remote, missing, or no longer Git repositories are skipped.
+
+Malformed names and filesystem objects outside an Alas trash directory are
+never swept. Sweep failures are logged and retried on a later run.
+
+### Preflight performance
+
+Preflight optimization is a separate follow-up. The first implementation keeps
+its current sequence and remote submodule tag checks so the deletion safety
+policy does not change at the same time as the removal mechanism.
+
+## Alternatives considered
+
+### Hide the row while `git worktree remove` continues
+
+This would improve animation but leave the path and Git registration occupied.
+Creating the worktree again at the same path would still block, and late
+errors would require restoring optimistic state. It does not deliver the
+behavior that makes Worktrunk useful.
+
+### Invoke Worktrunk
+
+This would add a runtime dependency and inherit Worktrunk's configuration,
+hooks, branch integration rules, output parsing, and submodule safety policy.
+Those semantics do not match Alas closely enough for a core destructive
+operation.
+
+### Skip local-only submodule auditing
+
+This is faster before confirmation but can delete state that exists only in a
+submodule's per-worktree Git directory. The current protection is deliberate
+and covered by regression tests, so this design keeps it.
+
+## Testing
+
+Add focused Swift Testing coverage for:
+
+- Successful same-volume staging removes the original path and Git worktree
+  registration before a controllable cleanup process finishes.
+- Dirty worktrees still require explicit force and clean worktrees still fail
+  closed if they become dirty between preflight and staging.
+- Initialized submodules retain all existing local-only-state warnings.
+- Locked worktrees use the approved double-force registry removal.
+- A rename failure invokes the existing synchronous fallback.
+- A registry-removal failure restores the original path.
+- A failed rollback reports both the original and staged paths without
+  deleting the staged contents.
+- A cleanup-launch failure leaves a recoverable trash entry while deletion
+  remains successful.
+- The stale sweep selects only valid entries older than 24 hours.
+- SSH worktrees never enter the local staging path.
+- App state and selection finish before a suspended background cleanup is
+  released.
+
+Do not assert wall-clock thresholds in the test suite. The behavioral boundary
+is that removal completion does not wait for cleanup completion.
+
+Before finishing, run the repository's required `xcodegen`, macOS build, and
+test commands.


### PR DESCRIPTION
## Summary
- stage local worktrees into the repository trash with an atomic rename before Git registration cleanup
- detach low-priority file cleanup and recover only committed stale entries
- preserve synchronous removal for remote and rollback-sensitive checkout paths

## Verification
- `xcodegen`
- focused WorktreeTrash, WorktreeService, and AppState cleanup suites
- macOS build
- 50,000-file staged-ticket ordering check
- full suite reproduces the existing `ACPTerminalTests.descendantCleanupRunsOffMainActor` source-read hang; CI will provide an independent result