### PR TITLE
feat(acp): schedule ACP chat messages

### DIFF
--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -9,7 +9,7 @@ let messageNodes = new Map();                          // stableId → DOM node
 let transcriptMeta = null;   // {epoch, revision, firstIndex, totalCount} for the open session
 let olderFetchInFlight = false;
 let stopPending = false;
-let queueItems = [];             // [{id, text, imageCount, resourceCount, status, lastError}] from queueState
+let queueItems = [];             // [{id, text, imageCount, resourceCount, status, lastError, scheduledAt}] from queueState
 let steerUndoAvailable = false;
 let lastStreamingState = "idle"; // so composer state can be recomputed on text input
 let sessionTitles = new Map();
@@ -1416,7 +1416,7 @@ function queuedRow(item) {
 
   const stack = el("div", "queued-stack");
   const status = el("div", "queued-status");
-  status.appendChild(el("span", null, "Queued"));
+  status.appendChild(el("span", null, queuedStatus(item)));
   if (item.lastError) status.appendChild(el("span", "queued-error", " · " + item.lastError));
   stack.appendChild(status);
 
@@ -1433,6 +1433,10 @@ function queuedRow(item) {
 
   row.appendChild(stack);
   return row;
+}
+
+function queuedStatus(item) {
+  return item.scheduledAt ? "Scheduled for " + new Date(item.scheduledAt).toLocaleString() : "Queued";
 }
 
 function queuedActions(item) {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1563,7 +1563,14 @@ final class ACPSession: ObservableObject, Identifiable {
     /// item and the `.sending` head would stay stranded in the queue.
     func restorePendingSnapshot(_ snapshot: [QueuedPrompt]) {
         let insertAt = (queue.first?.status == .sending) ? 1 : 0
-        queue.insert(contentsOf: snapshot, at: insertAt)
+        queue.insert(contentsOf: snapshot.filter { $0.scheduledAt == nil }, at: insertAt)
+        for item in snapshot {
+            guard let scheduledAt = item.scheduledAt else { continue }
+            let index = queue.firstIndex {
+                $0.status == .pending && ($0.scheduledAt.map { $0 > scheduledAt } ?? false)
+            } ?? queue.endIndex
+            queue.insert(item, at: index)
+        }
     }
 
     /// Number of pending queue items. The transcript UI may render additional

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1444,16 +1444,18 @@ final class ACPSession: ObservableObject, Identifiable {
         queue.insert(item, at: insertAt)
     }
 
+    @discardableResult
     func enqueueScheduled(
         blocks: [ACPContentBlock],
         scheduledAt: Date,
         draft: ACPComposerDraft? = nil
-    ) {
+    ) -> UUID {
         let item = QueuedPrompt(blocks: blocks, scheduledAt: scheduledAt, draft: draft)
         let insertAt = queue.firstIndex {
             $0.status == .pending && ($0.scheduledAt.map { $0 > scheduledAt } ?? false)
         } ?? queue.endIndex
         queue.insert(item, at: insertAt)
+        return item.id
     }
 
     /// Remove a specific item by id. The drag-handle X on the bubble

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -237,6 +237,7 @@ final class ACPSession: ObservableObject, Identifiable {
     /// `session/new` or `session/load`.
     var remoteSessionId: String?
     @Published var queue: [QueuedPrompt] = []
+    var pendingQueuePersistenceCount = 0
     @Published var steerUndo: SteerUndoState?
     struct SteerUndoState: Equatable {
         /// Unique per-snapshot id used by SwiftUI for view diffing — letting

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1437,7 +1437,21 @@ final class ACPSession: ObservableObject, Identifiable {
         draft: ACPComposerDraft? = nil,
         delegatedSource: ACPDelegatedPromptSource? = nil
     ) {
-        queue.append(QueuedPrompt(blocks: blocks, draft: draft, delegatedSource: delegatedSource))
+        let item = QueuedPrompt(blocks: blocks, draft: draft, delegatedSource: delegatedSource)
+        let insertAt = queue.firstIndex { $0.status == .pending && $0.scheduledAt != nil } ?? queue.endIndex
+        queue.insert(item, at: insertAt)
+    }
+
+    func enqueueScheduled(
+        blocks: [ACPContentBlock],
+        scheduledAt: Date,
+        draft: ACPComposerDraft? = nil
+    ) {
+        let item = QueuedPrompt(blocks: blocks, scheduledAt: scheduledAt, draft: draft)
+        let insertAt = queue.firstIndex {
+            $0.status == .pending && ($0.scheduledAt.map { $0 > scheduledAt } ?? false)
+        } ?? queue.endIndex
+        queue.insert(item, at: insertAt)
     }
 
     /// Remove a specific item by id. The drag-handle X on the bubble
@@ -1501,6 +1515,7 @@ final class ACPSession: ObservableObject, Identifiable {
         var item = queue.remove(at: idx)
         item.status = .pending
         item.lastError = nil
+        item.scheduledAt = nil
 
         let insertAt = protectedPrefixCount
         queue.insert(item, at: min(insertAt, queue.count))

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1459,13 +1459,15 @@ final class ACPSession: ObservableObject, Identifiable {
     /// Remove a specific item by id. The drag-handle X on the bubble
     /// calls this. Safe on .sending items because the UI hides X then —
     /// but we double-guard here to avoid yanking an in-flight RPC.
-    func removeFromQueue(id: UUID) {
-        guard let idx = queue.firstIndex(where: { $0.id == id }) else { return }
-        if queue[idx].status == .sending { return }
+    @discardableResult
+    func removeFromQueue(id: UUID) -> Bool {
+        guard let idx = queue.firstIndex(where: { $0.id == id }) else { return false }
+        if queue[idx].status == .sending { return false }
         if forceSendAfterSendingHeadId == id {
             forceSendAfterSendingHeadId = nil
         }
         queue.remove(at: idx)
+        return true
     }
 
     /// Pull a queued item back into the composer for editing: remove it and

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1492,6 +1492,10 @@ final class ACPSession: ObservableObject, Identifiable {
         if queue.indices.contains(src), queue[src].status == .sending { return }
         // If moving across the .sending head (index 0 when sending), refuse.
         if !queue.isEmpty, queue[0].status == .sending, dst == 0 { return }
+        if let firstScheduled = queue.firstIndex(where: { $0.status == .pending && $0.scheduledAt != nil }),
+           (queue[src].scheduledAt != nil || dst >= firstScheduled) {
+            return
+        }
         let item = queue.remove(at: src)
         queue.insert(item, at: min(dst, queue.count))
     }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1433,11 +1433,12 @@ final class ACPSession: ObservableObject, Identifiable {
     /// runner when the user submits while the agent is busy (or while
     /// the queue is already non-empty — see ACPSubmitRoute).
     func enqueue(
+        id: UUID = UUID(),
         blocks: [ACPContentBlock],
         draft: ACPComposerDraft? = nil,
         delegatedSource: ACPDelegatedPromptSource? = nil
     ) {
-        let item = QueuedPrompt(blocks: blocks, draft: draft, delegatedSource: delegatedSource)
+        let item = QueuedPrompt(id: id, blocks: blocks, draft: draft, delegatedSource: delegatedSource)
         let insertAt = queue.firstIndex { $0.status == .pending && $0.scheduledAt != nil } ?? queue.endIndex
         queue.insert(item, at: insertAt)
     }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4442,6 +4442,7 @@ extension ACPSessionManager {
         await runner.flushPersistence()
         runners[sessionId] = nil
         elicitationCoordinators.removeValue(forKey: sessionId)?.stop()
+        onQueueChanged?(sessionId, false)
         await runner.connection.shutdown()
     }
 

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -294,8 +294,12 @@ final class ACPSessionManager: ObservableObject {
     /// Promote a queued item to the head (or steer to it when a turn is
     /// running) — the remote-web twin of the queued bubble's "send now".
     func queueForceSend(for id: ACPSession.ID, itemId: UUID) async {
-        guard await confirmedWriterLease(for: id) else { return }
-        runners[id]?.forceSendQueuedItem(id: itemId)
+        guard await confirmedWriterLease(for: id), let session = sessions[id] else { return }
+        if session.agentState != .ready {
+            await reattach(to: id)
+        }
+        guard let runner = runners[id] else { return }
+        runner.forceSendQueuedItem(id: itemId)
         onQueueChanged?(id, true)
     }
 

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -336,7 +336,7 @@ final class ACPSessionManager: ObservableObject {
         guard let draft = session.takeForEditing(id: itemId) else { return nil }
         persistQueue(for: session)
         runners[id]?.flushQueueIfIdle()
-        onQueueChanged?(id, false)
+        onQueueChanged?(id, retainedCleanupHasActivePromptWork(for: id))
         return RemoteQueueProjection.plainText(from: draft)
     }
 
@@ -345,7 +345,7 @@ final class ACPSessionManager: ObservableObject {
         session.clearPendingQueue()
         persistQueue(for: session)
         runners[id]?.flushQueueIfIdle()
-        onQueueChanged?(id, false)
+        onQueueChanged?(id, retainedCleanupHasActivePromptWork(for: id))
     }
 
     func queueSteerUndo(for id: ACPSession.ID) async {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4280,6 +4280,8 @@ extension ACPSessionManager {
     @discardableResult
     private func sendPendingQueueForceSend(sessionId: ACPSession.ID) -> Bool {
         guard let itemId = pendingQueueForceSends.removeValue(forKey: sessionId),
+              let session = sessions[sessionId],
+              session.queue.contains(where: { $0.id == itemId && $0.status == .pending }),
               let runner = runners[sessionId]
         else { return false }
         runner.forceSendQueuedItem(id: itemId)

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -319,6 +319,10 @@ final class ACPSessionManager: ObservableObject {
 
     private func deferQueueForceSend(session: ACPSession, itemId: UUID) {
         pendingQueueForceSends[session.id, default: []].append(itemId)
+        guard session.pendingQueuePersistenceCount == 0 else {
+            onQueueChanged?(session.id, true)
+            return
+        }
         var promoted = false
         for pendingId in pendingQueueForceSends[session.id, default: []].reversed() {
             promoted = session.forceQueueItem(id: pendingId) || promoted
@@ -4138,7 +4142,9 @@ extension ACPSessionManager {
                           $0.status == .pending && $0.lastError == nil && $0.scheduledAt != nil
                       })
                 else { return nil }
-                await reattach(to: id)
+                if hasDueReconnectSchedule(in: session) {
+                    await reattach(to: id)
+                }
                 scheduleScheduledQueueReconnect(sessionId: id)
                 onBootstrapped?(id)
                 return id

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4129,6 +4129,7 @@ extension ACPSessionManager {
     /// Remote SSH channel drops are commonly transient. Reuse the regular
     /// reattach path so restoration and queued-prompt handling stay identical.
     func scheduleAutoReconnect(sessionId: ACPSession.ID) {
+        scheduleScheduledQueueReconnect(sessionId: sessionId)
         guard sessions[sessionId] != nil,
               effectiveRemoteHost() != nil
         else { return }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4201,8 +4201,9 @@ extension ACPSessionManager {
             }
             try? await Task.sleep(for: .seconds(max(0, scheduledAt.timeIntervalSinceNow)))
             while !Task.isCancelled {
-                guard let self,
-                      let session = self.sessions[sessionId],
+                guard let self else { return }
+                await self.refreshScheduledReconnectQueue(sessionId: sessionId)
+                guard let session = self.sessions[sessionId],
                       self.hasDueReconnectSchedule(in: session)
                 else { return }
                 if case .needsAuth = session.setupState { return }
@@ -4215,6 +4216,15 @@ extension ACPSessionManager {
             }
         }
         scheduledReconnectTasks[sessionId] = (scheduledAt, task)
+    }
+
+    private func refreshScheduledReconnectQueue(sessionId: ACPSession.ID) async {
+        guard let session = sessions[sessionId] else { return }
+        do {
+            session.restoreQueue(try await persistence.loadQueue(sessionId: sessionId))
+        } catch {
+            persistenceError = error.localizedDescription
+        }
     }
 
     private func earliestReconnectSchedule(in session: ACPSession) -> Date? {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3438,6 +3438,7 @@ extension ACPSessionManager {
             runner.onUnexpectedDisconnect = { [weak self] in
                 Task { @MainActor in
                     self?.scheduleAutoReconnect(sessionId: sessionId)
+                    self?.onQueueChanged?(sessionId)
                 }
             }
             var runnerStarted = false

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4071,19 +4071,24 @@ extension ACPSessionManager {
             persistenceError = error.localizedDescription
             return []
         }
+        let tasks: [Task<ACPSession.ID?, Never>] = ids.map { id in
+            Task<ACPSession.ID?, Never> { @MainActor in
+                guard await persistedSessionRow(id: id) != nil,
+                      placeholderSession(id: id) != nil
+                else { return nil }
+                await hydrateIfNeeded(id: id)
+                guard let session = sessions[id],
+                      session.queue.contains(where: {
+                          $0.status == .pending && $0.lastError == nil && $0.scheduledAt != nil
+                      })
+                else { return nil }
+                await reattach(to: id)
+                return id
+            }
+        }
         var bootstrapped: [ACPSession.ID] = []
-        for id in ids {
-            guard await persistedSessionRow(id: id) != nil,
-                  placeholderSession(id: id) != nil
-            else { continue }
-            await hydrateIfNeeded(id: id)
-            guard let session = sessions[id],
-                  session.queue.contains(where: {
-                      $0.status == .pending && $0.lastError == nil && $0.scheduledAt != nil
-                  })
-            else { continue }
-            await reattach(to: id)
-            bootstrapped.append(id)
+        for task in tasks {
+            if let id = await task.value { bootstrapped.append(id) }
         }
         return bootstrapped
     }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -156,7 +156,7 @@ final class ACPSessionManager: ObservableObject {
     private var elicitationCoordinators: [ACPSession.ID: ACPElicitationCoordinator] = [:]
     private var autoReconnectTasks: [ACPSession.ID: Task<Void, Never>] = [:]
     private var scheduledReconnectTasks: [ACPSession.ID: (deadline: Date, task: Task<Void, Never>)] = [:]
-    private var managerQueuePersistenceSessionIds: Set<ACPSession.ID> = []
+    private var managerQueuePersistenceCounts: [ACPSession.ID: Int] = [:]
     private var disposalTasks: [ACPSession.ID: Task<Void, Error>] = [:]
     /// Per-session attach counter. The built-in MCP registration grace timer
     /// captures the epoch at attach and only writes the row if it still matches,
@@ -181,6 +181,23 @@ final class ACPSessionManager: ObservableObject {
 
     func retainedCleanupHasForkBarrierWork(for id: ACPSession.ID) -> Bool {
         runners[id]?.hasRetainedCleanupForkBarrierWork == true
+    }
+
+    private func beginManagerQueuePersistence(sessionId: ACPSession.ID) {
+        managerQueuePersistenceCounts[sessionId, default: 0] += 1
+    }
+
+    private func endManagerQueuePersistence(sessionId: ACPSession.ID) {
+        let remaining = (managerQueuePersistenceCounts[sessionId] ?? 1) - 1
+        if remaining > 0 {
+            managerQueuePersistenceCounts[sessionId] = remaining
+        } else {
+            managerQueuePersistenceCounts.removeValue(forKey: sessionId)
+        }
+    }
+
+    private func hasManagerQueuePersistence(sessionId: ACPSession.ID) -> Bool {
+        (managerQueuePersistenceCounts[sessionId] ?? 0) > 0
     }
 
     func retainedCleanupHasAutoReconnectWork(for id: ACPSession.ID) -> Bool {
@@ -301,7 +318,7 @@ final class ACPSessionManager: ObservableObject {
     /// running) — the remote-web twin of the queued bubble's "send now".
     func queueForceSend(for id: ACPSession.ID, itemId: UUID) async {
         guard let session = sessions[id] else { return }
-        guard !managerQueuePersistenceSessionIds.contains(id) else {
+        guard !hasManagerQueuePersistence(sessionId: id) else {
             deferQueueForceSend(session: session, itemId: itemId)
             return
         }
@@ -1704,7 +1721,7 @@ final class ACPSessionManager: ObservableObject {
         guard !isMirror(sessionId: session.id) else { return }
         let sessionId = session.id
         scheduleScheduledQueueReconnect(sessionId: sessionId)
-        if !managerQueuePersistenceSessionIds.contains(sessionId),
+        if !hasManagerQueuePersistence(sessionId: sessionId),
            let runner = runners[sessionId] {
             runner.persistQueue()
             return
@@ -4380,17 +4397,26 @@ extension ACPSessionManager {
         let task = enqueuePersistenceResult { persistence in
             try await persistence.upsertQueue(sessionId: sessionId, items: items, fence: fence)
         }
-        managerQueuePersistenceSessionIds.insert(sessionId)
+        beginManagerQueuePersistence(sessionId: sessionId)
         session.pendingQueuePersistenceCount += 1
         Task { @MainActor in
             let persisted = await task.value == true
             session.pendingQueuePersistenceCount -= 1
-            managerQueuePersistenceSessionIds.remove(sessionId)
             if !persisted, let scheduledId {
                 if session.removeFromQueue(id: scheduledId) {
-                    persistQueue(for: session)
+                    let items = session.queue
+                    let fence = leaseFence(sessionId: sessionId)
+                    let rollback = enqueuePersistence { persistence in
+                        _ = try await persistence.upsertQueue(
+                            sessionId: sessionId,
+                            items: items,
+                            fence: fence
+                        )
+                    }
+                    await rollback.value
                 }
             }
+            endManagerQueuePersistence(sessionId: sessionId)
             if persisted,
                !sendPendingQueueForceSend(sessionId: sessionId) {
                 if pendingQueueForceSends[sessionId]?.isEmpty == false {
@@ -4429,14 +4455,14 @@ extension ACPSessionManager {
         session.enqueue(blocks: blocks, delegatedSource: source)
         let fence = leaseFence(sessionId: sessionId)
         let items = session.queue
-        managerQueuePersistenceSessionIds.insert(sessionId)
+        beginManagerQueuePersistence(sessionId: sessionId)
         session.pendingQueuePersistenceCount += 1
         let task = enqueuePersistenceResult { persistence in
             try await persistence.upsertQueue(sessionId: sessionId, items: items, fence: fence)
         }
         let persisted = await task.value == true
         session.pendingQueuePersistenceCount -= 1
-        managerQueuePersistenceSessionIds.remove(sessionId)
+        endManagerQueuePersistence(sessionId: sessionId)
         guard persisted else {
             session.queue.removeAll { $0.delegatedSource == source }
             runners[sessionId]?.flushQueueIfIdle()
@@ -4478,14 +4504,14 @@ extension ACPSessionManager {
         )
         let fence = leaseFence(sessionId: sessionId)
         let items = session.queue
-        managerQueuePersistenceSessionIds.insert(sessionId)
+        beginManagerQueuePersistence(sessionId: sessionId)
         session.pendingQueuePersistenceCount += 1
         let task = enqueuePersistenceResult { persistence in
             try await persistence.upsertQueue(sessionId: sessionId, items: items, fence: fence)
         }
         let persisted = await task.value == true
         session.pendingQueuePersistenceCount -= 1
-        managerQueuePersistenceSessionIds.remove(sessionId)
+        endManagerQueuePersistence(sessionId: sessionId)
         guard persisted else {
             if let index = session.queue.firstIndex(where: { $0.id == id }) {
                 session.queue.remove(at: index)

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -173,6 +173,14 @@ final class ACPSessionManager: ObservableObject {
         runners[id]?.hasRetainedCleanupPromptWork == true
     }
 
+    func retainedCleanupHasForkBarrierWork(for id: ACPSession.ID) -> Bool {
+        runners[id]?.hasRetainedCleanupForkBarrierWork == true
+    }
+
+    func retainedCleanupHasAutoReconnectWork(for id: ACPSession.ID) -> Bool {
+        autoReconnectTasks[id] != nil
+    }
+
     /// Permission policy for a session that currently has an attached runner.
     /// Returns nil if no runner is attached (session not actively connected).
     func permissionPolicy(for id: ACPSession.ID) -> ACPPermissionPolicy? { runners[id]?.policy }
@@ -3444,7 +3452,7 @@ extension ACPSessionManager {
             runner.onUnexpectedDisconnect = { [weak self] in
                 Task { @MainActor in
                     self?.scheduleAutoReconnect(sessionId: sessionId)
-                    self?.onQueueChanged?(sessionId, false)
+                    self?.onQueueChanged?(sessionId, self?.retainedCleanupHasAutoReconnectWork(for: sessionId) == true)
                 }
             }
             var runnerStarted = false

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -301,22 +301,32 @@ final class ACPSessionManager: ObservableObject {
     func queueForceSend(for id: ACPSession.ID, itemId: UUID) async {
         guard let session = sessions[id] else { return }
         if case .spawning = session.agentState {
-            pendingQueueForceSends[id, default: []].append(itemId)
-            onQueueChanged?(id, true)
+            deferQueueForceSend(session: session, itemId: itemId)
             return
         }
         if session.agentState != .ready {
             await reattach(to: id)
         }
         if case .spawning = session.agentState {
-            pendingQueueForceSends[id, default: []].append(itemId)
-            onQueueChanged?(id, true)
+            deferQueueForceSend(session: session, itemId: itemId)
             return
         }
         guard await confirmedWriterLease(for: id) else { return }
         guard let runner = runners[id] else { return }
         runner.forceSendQueuedItem(id: itemId)
         onQueueChanged?(id, true)
+    }
+
+    private func deferQueueForceSend(session: ACPSession, itemId: UUID) {
+        pendingQueueForceSends[session.id, default: []].append(itemId)
+        var promoted = false
+        for pendingId in pendingQueueForceSends[session.id, default: []].reversed() {
+            promoted = session.forceQueueItem(id: pendingId) || promoted
+        }
+        if promoted {
+            persistQueue(for: session)
+        }
+        onQueueChanged?(session.id, true)
     }
 
     func queueRemove(for id: ACPSession.ID, itemId: UUID) async {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -155,7 +155,7 @@ final class ACPSessionManager: ObservableObject {
     private(set) var runners: [ACPSession.ID: ACPSessionRunner] = [:]
     private var elicitationCoordinators: [ACPSession.ID: ACPElicitationCoordinator] = [:]
     private var autoReconnectTasks: [ACPSession.ID: Task<Void, Never>] = [:]
-    private var scheduledReconnectTasks: [ACPSession.ID: Task<Void, Never>] = [:]
+    private var scheduledReconnectTasks: [ACPSession.ID: (deadline: Date, task: Task<Void, Never>)] = [:]
     private var disposalTasks: [ACPSession.ID: Task<Void, Error>] = [:]
     /// Per-session attach counter. The built-in MCP registration grace timer
     /// captures the epoch at attach and only writes the row if it still matches,
@@ -1126,7 +1126,7 @@ final class ACPSessionManager: ObservableObject {
 
     func closeSession(id: ACPSession.ID) {
         autoReconnectTasks.removeValue(forKey: id)?.cancel()
-        scheduledReconnectTasks.removeValue(forKey: id)?.cancel()
+        scheduledReconnectTasks.removeValue(forKey: id)?.task.cancel()
         // Flush any pending draft write before dropping the in-memory
         // session reference — otherwise a tab-switch-while-typing
         // window can lose the last ~300ms of input.
@@ -1187,7 +1187,7 @@ final class ACPSessionManager: ObservableObject {
         killRemoteHelperACPProcIfPossible(sessionId: id)
         onSessionEnded?(id)
         autoReconnectTasks.removeValue(forKey: id)?.cancel()
-        scheduledReconnectTasks.removeValue(forKey: id)?.cancel()
+        scheduledReconnectTasks.removeValue(forKey: id)?.task.cancel()
         cancelPendingDraftWrite(for: id)
         inFlightBackfills[id]?.cancel()
         inFlightBackfills[id] = nil
@@ -1669,6 +1669,7 @@ final class ACPSessionManager: ObservableObject {
         let sessionId = session.id
         let items = session.queue
         let fence = leaseFence(sessionId: sessionId)
+        scheduleScheduledQueueReconnect(sessionId: sessionId)
         enqueuePersistence { persistence in
             _ = try await persistence.upsertQueue(
                 sessionId: sessionId,
@@ -4000,7 +4001,7 @@ extension ACPSessionManager {
                 return
             }
             session.agentState = .ready
-            scheduledReconnectTasks.removeValue(forKey: sessionId)?.cancel()
+            scheduledReconnectTasks.removeValue(forKey: sessionId)?.task.cancel()
             if let remoteMCPNotice {
                 runner.appendAndPersistSystemNotice(remoteMCPNotice)
             }
@@ -4157,30 +4158,26 @@ extension ACPSessionManager {
     }
 
     private func scheduleScheduledQueueReconnect(sessionId: ACPSession.ID) {
-        guard scheduledReconnectTasks[sessionId] == nil else { return }
         guard let session = sessions[sessionId],
               session.agentState != .ready,
-              session.queue.contains(where: {
-                  $0.status == .pending && $0.lastError == nil && $0.scheduledAt != nil
-              })
+              let scheduledAt = earliestReconnectSchedule(in: session)
         else { return }
         if case .needsAuth = session.setupState { return }
-
-        let scheduledAt = session.queue.compactMap { item -> Date? in
-            guard item.status == .pending, item.lastError == nil else { return nil }
-            return item.scheduledAt
-        }.min()!
-        scheduledReconnectTasks[sessionId] = Task { @MainActor [weak self] in
-            defer { self?.scheduledReconnectTasks.removeValue(forKey: sessionId) }
+        if let existing = scheduledReconnectTasks[sessionId] {
+            guard existing.deadline != scheduledAt else { return }
+            existing.task.cancel()
+        }
+        let task = Task { @MainActor [weak self] in
+            defer {
+                if self?.scheduledReconnectTasks[sessionId]?.deadline == scheduledAt {
+                    self?.scheduledReconnectTasks.removeValue(forKey: sessionId)
+                }
+            }
             try? await Task.sleep(for: .seconds(max(0, scheduledAt.timeIntervalSinceNow)))
             while !Task.isCancelled {
                 guard let self,
                       let session = self.sessions[sessionId],
-                      session.queue.contains(where: {
-                          $0.status == .pending
-                              && $0.lastError == nil
-                              && ($0.scheduledAt?.timeIntervalSinceNow ?? .greatestFiniteMagnitude) <= 0
-                      })
+                      self.hasDueReconnectSchedule(in: session)
                 else { return }
                 if case .needsAuth = session.setupState { return }
                 await self.reattach(to: sessionId)
@@ -4190,6 +4187,24 @@ extension ACPSessionManager {
                 }
                 try? await Task.sleep(for: .seconds(30))
             }
+        }
+        scheduledReconnectTasks[sessionId] = (scheduledAt, task)
+    }
+
+    private func earliestReconnectSchedule(in session: ACPSession) -> Date? {
+        session.queue.compactMap { item -> Date? in
+            guard item.lastError == nil,
+                  item.status == .pending || item.status == .sending
+            else { return nil }
+            return item.scheduledAt
+        }.min()
+    }
+
+    private func hasDueReconnectSchedule(in session: ACPSession) -> Bool {
+        session.queue.contains { item in
+            item.lastError == nil
+                && (item.status == .pending || item.status == .sending)
+                && (item.scheduledAt?.timeIntervalSinceNow ?? .greatestFiniteMagnitude) <= 0
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -155,6 +155,7 @@ final class ACPSessionManager: ObservableObject {
     private(set) var runners: [ACPSession.ID: ACPSessionRunner] = [:]
     private var elicitationCoordinators: [ACPSession.ID: ACPElicitationCoordinator] = [:]
     private var autoReconnectTasks: [ACPSession.ID: Task<Void, Never>] = [:]
+    private var scheduledReconnectTasks: [ACPSession.ID: Task<Void, Never>] = [:]
     private var disposalTasks: [ACPSession.ID: Task<Void, Error>] = [:]
     /// Per-session attach counter. The built-in MCP registration grace timer
     /// captures the epoch at attach and only writes the row if it still matches,
@@ -1125,6 +1126,7 @@ final class ACPSessionManager: ObservableObject {
 
     func closeSession(id: ACPSession.ID) {
         autoReconnectTasks.removeValue(forKey: id)?.cancel()
+        scheduledReconnectTasks.removeValue(forKey: id)?.cancel()
         // Flush any pending draft write before dropping the in-memory
         // session reference — otherwise a tab-switch-while-typing
         // window can lose the last ~300ms of input.
@@ -1185,6 +1187,7 @@ final class ACPSessionManager: ObservableObject {
         killRemoteHelperACPProcIfPossible(sessionId: id)
         onSessionEnded?(id)
         autoReconnectTasks.removeValue(forKey: id)?.cancel()
+        scheduledReconnectTasks.removeValue(forKey: id)?.cancel()
         cancelPendingDraftWrite(for: id)
         inFlightBackfills[id]?.cancel()
         inFlightBackfills[id] = nil
@@ -3996,6 +3999,7 @@ extension ACPSessionManager {
                 return
             }
             session.agentState = .ready
+            scheduledReconnectTasks.removeValue(forKey: sessionId)?.cancel()
             if let remoteMCPNotice {
                 runner.appendAndPersistSystemNotice(remoteMCPNotice)
             }
@@ -4061,6 +4065,7 @@ extension ACPSessionManager {
                 await connection.shutdown()
             }
             await releaseWriterLease(sessionId: sessionId)
+            scheduleScheduledQueueReconnect(sessionId: sessionId)
         }
     }
 
@@ -4121,6 +4126,7 @@ extension ACPSessionManager {
             defer {
                 self?.autoReconnectTasks.removeValue(forKey: sessionId)
                 self?.sessions[sessionId]?.autoReconnecting = false
+                self?.scheduleScheduledQueueReconnect(sessionId: sessionId)
                 self?.onQueueChanged?(sessionId, false)
             }
             self?.sessions[sessionId]?.autoReconnecting = true
@@ -4145,6 +4151,43 @@ extension ACPSessionManager {
                 }
                 await self.reattach(to: sessionId)
                 if self.sessions[sessionId]?.agentState == .ready { return }
+            }
+        }
+    }
+
+    private func scheduleScheduledQueueReconnect(sessionId: ACPSession.ID) {
+        scheduledReconnectTasks.removeValue(forKey: sessionId)?.cancel()
+        guard let session = sessions[sessionId],
+              session.agentState != .ready,
+              session.queue.contains(where: {
+                  $0.status == .pending && $0.lastError == nil && $0.scheduledAt != nil
+              })
+        else { return }
+        if case .needsAuth = session.setupState { return }
+
+        let scheduledAt = session.queue.compactMap { item -> Date? in
+            guard item.status == .pending, item.lastError == nil else { return nil }
+            return item.scheduledAt
+        }.min()!
+        scheduledReconnectTasks[sessionId] = Task { @MainActor [weak self] in
+            defer { self?.scheduledReconnectTasks.removeValue(forKey: sessionId) }
+            try? await Task.sleep(for: .seconds(max(0, scheduledAt.timeIntervalSinceNow)))
+            while !Task.isCancelled {
+                guard let self,
+                      let session = self.sessions[sessionId],
+                      session.queue.contains(where: {
+                          $0.status == .pending
+                              && $0.lastError == nil
+                              && ($0.scheduledAt?.timeIntervalSinceNow ?? .greatestFiniteMagnitude) <= 0
+                      })
+                else { return }
+                if case .needsAuth = session.setupState { return }
+                await self.reattach(to: sessionId)
+                if self.sessions[sessionId]?.agentState == .ready {
+                    self.runners[sessionId]?.flushQueueIfIdle()
+                    return
+                }
+                try? await Task.sleep(for: .seconds(30))
             }
         }
     }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4307,23 +4307,42 @@ extension ACPSessionManager {
         attachments: [ACPMessage.Attachment],
         draft: ACPComposerDraft? = nil,
         scheduledAt: Date? = nil,
-        into sessionId: ACPSession.ID
+        into sessionId: ACPSession.ID,
+        onPersisted: (@MainActor (_ persisted: Bool) -> Void)? = nil
     ) {
-        guard let session = sessions[sessionId] else { return }
+        guard let session = sessions[sessionId] else {
+            Task { @MainActor in onPersisted?(false) }
+            return
+        }
         let blocks = ACPSessionRunner.blocks(text: text, attachments: attachments)
+        let scheduledId: UUID?
         if let scheduledAt {
-            session.enqueueScheduled(blocks: blocks, scheduledAt: scheduledAt, draft: draft)
+            scheduledId = session.enqueueScheduled(blocks: blocks, scheduledAt: scheduledAt, draft: draft)
         } else {
             session.enqueue(blocks: blocks, draft: draft)
+            scheduledId = nil
         }
         let items = session.queue
         let fence = leaseFence(sessionId: sessionId)
-        enqueuePersistence { persistence in
-            _ = try await persistence.upsertQueue(
-                sessionId: sessionId,
-                items: items,
-                fence: fence
-            )
+        guard onPersisted != nil else {
+            enqueuePersistence { persistence in
+                _ = try await persistence.upsertQueue(
+                    sessionId: sessionId,
+                    items: items,
+                    fence: fence
+                )
+            }
+            return
+        }
+        let task = enqueuePersistenceResult { persistence in
+            try await persistence.upsertQueue(sessionId: sessionId, items: items, fence: fence)
+        }
+        Task { @MainActor in
+            let persisted = await task.value == true
+            if !persisted, let scheduledId {
+                _ = session.removeFromQueue(id: scheduledId)
+            }
+            onPersisted?(persisted)
         }
     }
 
@@ -4448,6 +4467,12 @@ extension ACPSessionManager {
         } else {
             scheduledAt = nil
         }
+        let onScheduledPersisted: (@MainActor (Bool) -> Void)?
+        if scheduledAt == nil {
+            onScheduledPersisted = nil
+        } else {
+            onScheduledPersisted = { persisted in onCompleted(persisted) }
+        }
 
         switch session.agentState {
         case .ready:
@@ -4466,9 +4491,12 @@ extension ACPSessionManager {
                     attachments: attachments,
                     draft: draft,
                     scheduledAt: scheduledAt,
-                    into: sessionId
+                    into: sessionId,
+                    onPersisted: onScheduledPersisted
                 )
-                Task { @MainActor in onCompleted(true) }
+                if scheduledAt == nil {
+                    Task { @MainActor in onCompleted(true) }
+                }
                 Task { @MainActor in await reattach(to: sessionId) }
                 return true
             }
@@ -4485,9 +4513,12 @@ extension ACPSessionManager {
                 attachments: attachments,
                 draft: draft,
                 scheduledAt: scheduledAt,
-                into: sessionId
+                into: sessionId,
+                onPersisted: onScheduledPersisted
             )
-            Task { @MainActor in onCompleted(true) }
+            if scheduledAt == nil {
+                Task { @MainActor in onCompleted(true) }
+            }
             return true
 
         case .idle, .disconnected, .failed:
@@ -4501,9 +4532,12 @@ extension ACPSessionManager {
                 attachments: attachments,
                 draft: draft,
                 scheduledAt: scheduledAt,
-                into: sessionId
+                into: sessionId,
+                onPersisted: onScheduledPersisted
             )
-            Task { @MainActor in onCompleted(true) }
+            if scheduledAt == nil {
+                Task { @MainActor in onCompleted(true) }
+            }
             Task { @MainActor in await reattach(to: sessionId) }
             return true
         }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4561,7 +4561,12 @@ extension ACPSessionManager {
         if scheduledAt == nil {
             onScheduledPersisted = nil
         } else {
-            onScheduledPersisted = { persisted in onCompleted(persisted) }
+            onScheduledPersisted = { persisted in
+                onCompleted(persisted)
+                if persisted, let scheduledAt, scheduledAt > Date() {
+                    self.scheduleScheduledQueueReconnect(sessionId: sessionId)
+                }
+            }
         }
 
         switch session.agentState {
@@ -4587,7 +4592,9 @@ extension ACPSessionManager {
                 if scheduledAt == nil {
                     Task { @MainActor in onCompleted(true) }
                 }
-                Task { @MainActor in await reattach(to: sessionId) }
+                if scheduledAt.map({ $0 <= Date() }) ?? true {
+                    Task { @MainActor in await reattach(to: sessionId) }
+                }
                 return true
             }
             runner.send(text: text, attachments: attachments, intent: intent, draft: draft) { succeeded in
@@ -4630,8 +4637,6 @@ extension ACPSessionManager {
             }
             if scheduledAt.map({ $0 <= Date() }) ?? true {
                 Task { @MainActor in await reattach(to: sessionId) }
-            } else {
-                scheduleScheduledQueueReconnect(sessionId: sessionId)
             }
             return true
         }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4006,6 +4006,9 @@ extension ACPSessionManager {
             }
             session.agentState = .ready
             scheduledReconnectTasks.removeValue(forKey: sessionId)?.task.cancel()
+            if session.queue.contains(where: { $0.status == .sending }) {
+                session.restoreQueue(session.queue)
+            }
             if let remoteMCPNotice {
                 runner.appendAndPersistSystemNotice(remoteMCPNotice)
             }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3438,6 +3438,9 @@ extension ACPSessionManager {
                                               )
                                           },
                                           onPersist: { [weak self] in self?.changeNotifier.post() },
+                                          onPromptWorkChanged: { [weak self] in
+                                              self?.onQueueChanged?(sessionId, self?.retainedCleanupHasActivePromptWork(for: sessionId) == true)
+                                          },
                                           onSessionTitleUpdated: { [weak self] title in
                                               self?.refreshRecent()
                                               self?.onSessionTitleUpdated?(sessionId, title)

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4229,6 +4229,7 @@ extension ACPSessionManager {
         session.pendingQueuePersistenceCount -= 1
         guard persisted else {
             session.queue.removeAll { $0.delegatedSource == source }
+            runners[sessionId]?.flushQueueIfIdle()
             return false
         }
         runners[sessionId]?.flushQueueIfIdle()
@@ -4277,6 +4278,7 @@ extension ACPSessionManager {
             if let index = session.queue.firstIndex(where: { $0.id == id }) {
                 session.queue.remove(at: index)
             }
+            runners[sessionId]?.flushQueueIfIdle()
             return false
         }
         runners[sessionId]?.flushQueueIfIdle()

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4063,6 +4063,31 @@ extension ACPSessionManager {
         }
     }
 
+    func bootstrapScheduledQueueSessions() async -> [ACPSession.ID] {
+        let ids: [ACPSession.ID]
+        do {
+            ids = try await persistence.scheduledQueueSessionIds()
+        } catch {
+            persistenceError = error.localizedDescription
+            return []
+        }
+        var bootstrapped: [ACPSession.ID] = []
+        for id in ids {
+            guard await persistedSessionRow(id: id) != nil,
+                  placeholderSession(id: id) != nil
+            else { continue }
+            await hydrateIfNeeded(id: id)
+            guard let session = sessions[id],
+                  session.queue.contains(where: {
+                      $0.status == .pending && $0.lastError == nil && $0.scheduledAt != nil
+                  })
+            else { continue }
+            await reattach(to: id)
+            bootstrapped.append(id)
+        }
+        return bootstrapped
+    }
+
     /// Remote SSH channel drops are commonly transient. Reuse the regular
     /// reattach path so restoration and queued-prompt handling stay identical.
     func scheduleAutoReconnect(sessionId: ACPSession.ID) {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4217,19 +4217,18 @@ extension ACPSessionManager {
             return recordedSource == source
         }) else { return true }
 
-        let item = QueuedPrompt(
+        session.enqueue(
             id: id,
             blocks: ACPSessionRunner.blocks(text: text, attachments: []),
             delegatedSource: source
         )
-        session.queue.append(item)
         let fence = leaseFence(sessionId: sessionId)
         let items = session.queue
         let task = enqueuePersistenceResult { persistence in
             try await persistence.upsertQueue(sessionId: sessionId, items: items, fence: fence)
         }
         guard await task.value == true else {
-            if let index = session.queue.firstIndex(where: { $0.id == item.id }) {
+            if let index = session.queue.firstIndex(where: { $0.id == id }) {
                 session.queue.remove(at: index)
             }
             return false

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -351,7 +351,7 @@ final class ACPSessionManager: ObservableObject {
     func queueSteerUndo(for id: ACPSession.ID) async {
         guard await confirmedWriterLease(for: id) else { return }
         runners[id]?.steerUndo()
-        onQueueChanged?(id, false)
+        onQueueChanged?(id, retainedCleanupHasActivePromptWork(for: id))
     }
 
     /// Steer from the remote client: same route the composer's ⌥⏎ takes.

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -293,7 +293,7 @@ final class ACPSessionManager: ObservableObject {
 
     func queueRemove(for id: ACPSession.ID, itemId: UUID) async {
         guard await confirmedWriterLease(for: id), let session = sessions[id] else { return }
-        session.removeFromQueue(id: itemId)
+        guard session.removeFromQueue(id: itemId) else { return }
         persistQueue(for: session)
         runners[id]?.flushQueueIfIdle()
         onQueueChanged?(id, false)

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -3048,6 +3048,7 @@ extension ACPSessionManager {
                 // creation). Tear it down so it doesn't linger bound on
                 // localhost; a later reattach respawns it. No-op for stdio sessions.
                 onSessionEnded?(sessionId)
+                scheduleScheduledQueueReconnect(sessionId: sessionId)
             }
         }
         // The runner persists transcript mutations under `msg-<sid>-<index>`,
@@ -4156,7 +4157,7 @@ extension ACPSessionManager {
     }
 
     private func scheduleScheduledQueueReconnect(sessionId: ACPSession.ID) {
-        scheduledReconnectTasks.removeValue(forKey: sessionId)?.cancel()
+        guard scheduledReconnectTasks[sessionId] == nil else { return }
         guard let session = sessions[sessionId],
               session.agentState != .ready,
               session.queue.contains(where: {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -174,6 +174,10 @@ final class ACPSessionManager: ObservableObject {
         runners[id]?.hasRetainedCleanupPromptWork == true
     }
 
+    func retainedCleanupHasSteerWork(for id: ACPSession.ID) -> Bool {
+        runners[id]?.hasRetainedCleanupSteerWork == true
+    }
+
     func retainedCleanupHasForkBarrierWork(for id: ACPSession.ID) -> Bool {
         runners[id]?.hasRetainedCleanupForkBarrierWork == true
     }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -301,7 +301,6 @@ final class ACPSessionManager: ObservableObject {
     func queueForceSend(for id: ACPSession.ID, itemId: UUID) async {
         guard let session = sessions[id] else { return }
         if case .spawning = session.agentState {
-            guard await confirmedWriterLease(for: id) else { return }
             pendingQueueForceSends[id] = itemId
             onQueueChanged?(id, true)
             return
@@ -310,7 +309,6 @@ final class ACPSessionManager: ObservableObject {
             await reattach(to: id)
         }
         if case .spawning = session.agentState {
-            guard await confirmedWriterLease(for: id) else { return }
             pendingQueueForceSends[id] = itemId
             onQueueChanged?(id, true)
             return

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4203,7 +4203,10 @@ extension ACPSessionManager {
         guard let session = sessions[sessionId],
               session.agentState != .ready,
               let scheduledAt = earliestReconnectSchedule(in: session)
-        else { return }
+        else {
+            scheduledReconnectTasks.removeValue(forKey: sessionId)?.task.cancel()
+            return
+        }
         if case .needsAuth = session.setupState { return }
         if let existing = scheduledReconnectTasks[sessionId] {
             guard existing.deadline != scheduledAt else { return }
@@ -4292,11 +4295,11 @@ extension ACPSessionManager {
                 self.persistContextRecoveryPending(sessionId: sessionId, pending: false)
                 session.contextRestoreWarning = nil
                 session.markContextRecoveryRestored()
+                if !self.sendPendingQueueForceSend(sessionId: sessionId) {
+                    self.runners[sessionId]?.flushQueueIfIdle()
+                }
             } else {
                 session.contextRecoveryStatus = .failed("Transcript recovery failed.")
-            }
-            if !self.sendPendingQueueForceSend(sessionId: sessionId) {
-                self.runners[sessionId]?.flushQueueIfIdle()
             }
         }) else { return false }
         session.contextRecoveryStatus = .sendingTranscript
@@ -4372,8 +4375,10 @@ extension ACPSessionManager {
                     persistQueue(for: session)
                 }
             }
-            if persisted {
-                _ = sendPendingQueueForceSend(sessionId: sessionId)
+            if persisted,
+               !sendPendingQueueForceSend(sessionId: sessionId),
+               session.contextRecoveryStatus == nil {
+                runners[sessionId]?.flushQueueIfIdle()
             }
             onPersisted?(persisted)
         }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4027,16 +4027,13 @@ extension ACPSessionManager {
             if session.queue.contains(where: { $0.status == .sending }) {
                 session.restoreQueue(session.queue)
             }
-            if let itemId = pendingQueueForceSends.removeValue(forKey: sessionId) {
-                runner.forceSendQueuedItem(id: itemId)
-            }
             if let remoteMCPNotice {
                 runner.appendAndPersistSystemNotice(remoteMCPNotice)
             }
-            if shouldHoldQueueForRecovery {
-                sendTranscriptAsContext(sessionId: sessionId, agentName: nil)
-            } else {
-                runner.flushQueueIfIdle()
+            if !shouldHoldQueueForRecovery || !sendTranscriptAsContext(sessionId: sessionId, agentName: nil) {
+                if !sendPendingQueueForceSend(sessionId: sessionId) {
+                    runner.flushQueueIfIdle()
+                }
             }
             stderrTask.cancel()
         } catch {
@@ -4264,7 +4261,7 @@ extension ACPSessionManager {
               let prompt = transcriptContextPrompt(for: session, agentName: agentName)
         else { return false }
 
-        guard runner.sendRecoveryContext(prompt, onCompleted: { delivered in
+        guard runner.sendRecoveryContext(prompt, flushQueueOnCompletion: false, onCompleted: { delivered in
             if delivered {
                 self.persistContextRecoveryPending(sessionId: sessionId, pending: false)
                 session.contextRestoreWarning = nil
@@ -4272,8 +4269,21 @@ extension ACPSessionManager {
             } else {
                 session.contextRecoveryStatus = .failed("Transcript recovery failed.")
             }
+            if !self.sendPendingQueueForceSend(sessionId: sessionId) {
+                self.runners[sessionId]?.flushQueueIfIdle()
+            }
         }) else { return false }
         session.contextRecoveryStatus = .sendingTranscript
+        return true
+    }
+
+    @discardableResult
+    private func sendPendingQueueForceSend(sessionId: ACPSession.ID) -> Bool {
+        guard let itemId = pendingQueueForceSends.removeValue(forKey: sessionId),
+              let runner = runners[sessionId]
+        else { return false }
+        runner.forceSendQueuedItem(id: itemId)
+        onQueueChanged?(sessionId, true)
         return true
     }
 

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4363,12 +4363,17 @@ extension ACPSessionManager {
         let task = enqueuePersistenceResult { persistence in
             try await persistence.upsertQueue(sessionId: sessionId, items: items, fence: fence)
         }
+        session.pendingQueuePersistenceCount += 1
         Task { @MainActor in
             let persisted = await task.value == true
+            session.pendingQueuePersistenceCount -= 1
             if !persisted, let scheduledId {
                 if session.removeFromQueue(id: scheduledId) {
                     persistQueue(for: session)
                 }
+            }
+            if persisted {
+                _ = sendPendingQueueForceSend(sessionId: sessionId)
             }
             onPersisted?(persisted)
         }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -300,6 +300,10 @@ final class ACPSessionManager: ObservableObject {
     /// running) — the remote-web twin of the queued bubble's "send now".
     func queueForceSend(for id: ACPSession.ID, itemId: UUID) async {
         guard let session = sessions[id] else { return }
+        guard session.pendingQueuePersistenceCount == 0 else {
+            deferQueueForceSend(session: session, itemId: itemId)
+            return
+        }
         if case .spawning = session.agentState {
             deferQueueForceSend(session: session, itemId: itemId)
             return
@@ -1699,7 +1703,7 @@ final class ACPSessionManager: ObservableObject {
         guard !isMirror(sessionId: session.id) else { return }
         let sessionId = session.id
         scheduleScheduledQueueReconnect(sessionId: sessionId)
-        if let runner = runners[sessionId] {
+        if session.pendingQueuePersistenceCount == 0, let runner = runners[sessionId] {
             runner.persistQueue()
             return
         }
@@ -4313,10 +4317,10 @@ extension ACPSessionManager {
 
     @discardableResult
     private func sendPendingQueueForceSend(sessionId: ACPSession.ID) -> Bool {
-        guard let itemIds = pendingQueueForceSends.removeValue(forKey: sessionId),
-              let session = sessions[sessionId],
+        guard let session = sessions[sessionId],
               let runner = runners[sessionId]
         else { return false }
+        guard let itemIds = pendingQueueForceSends.removeValue(forKey: sessionId) else { return false }
         var sent = false
         for itemId in itemIds.reversed() where session.queue.contains(where: { $0.id == itemId && $0.status == .pending }) {
             sent = session.forceQueueItem(id: itemId) || sent
@@ -4381,9 +4385,12 @@ extension ACPSessionManager {
                 }
             }
             if persisted,
-               !sendPendingQueueForceSend(sessionId: sessionId),
-               session.contextRecoveryStatus == nil {
-                runners[sessionId]?.flushQueueIfIdle()
+               !sendPendingQueueForceSend(sessionId: sessionId) {
+                if pendingQueueForceSends[sessionId]?.isEmpty == false {
+                    Task { @MainActor in await reattach(to: sessionId) }
+                } else if session.contextRecoveryStatus == nil {
+                    runners[sessionId]?.flushQueueIfIdle()
+                }
             }
             onPersisted?(persisted)
         }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4217,7 +4217,10 @@ extension ACPSessionManager {
             scheduledReconnectTasks.removeValue(forKey: sessionId)?.task.cancel()
             return
         }
-        if case .needsAuth = session.setupState { return }
+        if case .needsAuth = session.setupState {
+            scheduledReconnectTasks.removeValue(forKey: sessionId)?.task.cancel()
+            return
+        }
         if let existing = scheduledReconnectTasks[sessionId] {
             guard existing.deadline != scheduledAt else { return }
             existing.task.cancel()
@@ -4426,12 +4429,14 @@ extension ACPSessionManager {
         session.enqueue(blocks: blocks, delegatedSource: source)
         let fence = leaseFence(sessionId: sessionId)
         let items = session.queue
+        managerQueuePersistenceSessionIds.insert(sessionId)
         session.pendingQueuePersistenceCount += 1
         let task = enqueuePersistenceResult { persistence in
             try await persistence.upsertQueue(sessionId: sessionId, items: items, fence: fence)
         }
         let persisted = await task.value == true
         session.pendingQueuePersistenceCount -= 1
+        managerQueuePersistenceSessionIds.remove(sessionId)
         guard persisted else {
             session.queue.removeAll { $0.delegatedSource == source }
             runners[sessionId]?.flushQueueIfIdle()
@@ -4473,12 +4478,14 @@ extension ACPSessionManager {
         )
         let fence = leaseFence(sessionId: sessionId)
         let items = session.queue
+        managerQueuePersistenceSessionIds.insert(sessionId)
         session.pendingQueuePersistenceCount += 1
         let task = enqueuePersistenceResult { persistence in
             try await persistence.upsertQueue(sessionId: sessionId, items: items, fence: fence)
         }
         let persisted = await task.value == true
         session.pendingQueuePersistenceCount -= 1
+        managerQueuePersistenceSessionIds.remove(sessionId)
         guard persisted else {
             if let index = session.queue.firstIndex(where: { $0.id == id }) {
                 session.queue.remove(at: index)

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -299,8 +299,9 @@ final class ACPSessionManager: ObservableObject {
     /// Promote a queued item to the head (or steer to it when a turn is
     /// running) — the remote-web twin of the queued bubble's "send now".
     func queueForceSend(for id: ACPSession.ID, itemId: UUID) async {
-        guard await confirmedWriterLease(for: id), let session = sessions[id] else { return }
+        guard let session = sessions[id] else { return }
         if case .spawning = session.agentState {
+            guard await confirmedWriterLease(for: id) else { return }
             pendingQueueForceSends[id] = itemId
             onQueueChanged?(id, true)
             return
@@ -309,10 +310,12 @@ final class ACPSessionManager: ObservableObject {
             await reattach(to: id)
         }
         if case .spawning = session.agentState {
+            guard await confirmedWriterLease(for: id) else { return }
             pendingQueueForceSends[id] = itemId
             onQueueChanged?(id, true)
             return
         }
+        guard await confirmedWriterLease(for: id) else { return }
         guard let runner = runners[id] else { return }
         runner.forceSendQueuedItem(id: itemId)
         onQueueChanged?(id, true)
@@ -4193,11 +4196,13 @@ extension ACPSessionManager {
             guard existing.deadline != scheduledAt else { return }
             existing.task.cancel()
         }
+        retainSession(id: sessionId)
         let task = Task { @MainActor [weak self] in
             defer {
                 if self?.scheduledReconnectTasks[sessionId]?.deadline == scheduledAt {
                     self?.scheduledReconnectTasks.removeValue(forKey: sessionId)
                 }
+                self?.releaseSession(id: sessionId)
             }
             try? await Task.sleep(for: .seconds(max(0, scheduledAt.timeIntervalSinceNow)))
             while !Task.isCancelled {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -103,6 +103,7 @@ final class ACPSessionManager: ObservableObject {
     private let onSessionTitleUpdated: ((ACPSession.ID, String) -> Void)?
     private let onInputAwaiting: ((ACPSession, ACPUserInputRequest) -> Void)?
     private let onDelegatedMessageAvailable: ((ACPSession.ID) -> Void)?
+    private let onQueueChanged: ((ACPSession.ID) -> Void)?
     private let mcpProjectContextProvider: MCPProjectContextProvider?
     private let frozenMCPAttachmentProvider: FrozenMCPAttachmentProvider?
     private let launchSpecTransformer: ACPLaunchSpecTransformer
@@ -283,6 +284,7 @@ final class ACPSessionManager: ObservableObject {
     func queueForceSend(for id: ACPSession.ID, itemId: UUID) async {
         guard await confirmedWriterLease(for: id) else { return }
         runners[id]?.forceSendQueuedItem(id: itemId)
+        onQueueChanged?(id)
     }
 
     func queueRemove(for id: ACPSession.ID, itemId: UUID) async {
@@ -290,6 +292,7 @@ final class ACPSessionManager: ObservableObject {
         session.removeFromQueue(id: itemId)
         persistQueue(for: session)
         runners[id]?.flushQueueIfIdle()
+        onQueueChanged?(id)
     }
 
     /// Clear a failed item's error so the flusher re-attempts it.
@@ -299,6 +302,7 @@ final class ACPSessionManager: ObservableObject {
         session.queue[idx].lastError = nil
         persistQueue(for: session)
         runners[id]?.flushQueueIfIdle()
+        onQueueChanged?(id)
     }
 
     /// Pull a queued item out for editing and hand its text back. `nil` when
@@ -328,6 +332,7 @@ final class ACPSessionManager: ObservableObject {
         guard let draft = session.takeForEditing(id: itemId) else { return nil }
         persistQueue(for: session)
         runners[id]?.flushQueueIfIdle()
+        onQueueChanged?(id)
         return RemoteQueueProjection.plainText(from: draft)
     }
 
@@ -336,6 +341,7 @@ final class ACPSessionManager: ObservableObject {
         session.clearPendingQueue()
         persistQueue(for: session)
         runners[id]?.flushQueueIfIdle()
+        onQueueChanged?(id)
     }
 
     func queueSteerUndo(for id: ACPSession.ID) async {
@@ -481,6 +487,7 @@ final class ACPSessionManager: ObservableObject {
          onSessionTitleUpdated: ((ACPSession.ID, String) -> Void)? = nil,
          onInputAwaiting: ((ACPSession, ACPUserInputRequest) -> Void)? = nil,
          onDelegatedMessageAvailable: ((ACPSession.ID) -> Void)? = nil,
+         onQueueChanged: ((ACPSession.ID) -> Void)? = nil,
          changeNotifier: ACPChangeNotifier? = nil,
          delegatedMessageNotifier: ACPChangeNotifier? = nil,
          setupEvaluator: ACPSetupEvaluator? = nil,
@@ -514,6 +521,7 @@ final class ACPSessionManager: ObservableObject {
         self.onSessionTitleUpdated = onSessionTitleUpdated
         self.onInputAwaiting = onInputAwaiting
         self.onDelegatedMessageAvailable = onDelegatedMessageAvailable
+        self.onQueueChanged = onQueueChanged
         self.mcpProjectContextProvider = mcpProjectContextProvider
         self.frozenMCPAttachmentProvider = frozenMCPAttachmentProvider
         self.launchSpecTransformer = launchSpecTransformer ?? { $0 }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4340,7 +4340,9 @@ extension ACPSessionManager {
         Task { @MainActor in
             let persisted = await task.value == true
             if !persisted, let scheduledId {
-                _ = session.removeFromQueue(id: scheduledId)
+                if session.removeFromQueue(id: scheduledId) {
+                    persistQueue(for: session)
+                }
             }
             onPersisted?(persisted)
         }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -103,7 +103,7 @@ final class ACPSessionManager: ObservableObject {
     private let onSessionTitleUpdated: ((ACPSession.ID, String) -> Void)?
     private let onInputAwaiting: ((ACPSession, ACPUserInputRequest) -> Void)?
     private let onDelegatedMessageAvailable: ((ACPSession.ID) -> Void)?
-    private let onQueueChanged: ((ACPSession.ID) -> Void)?
+    private let onQueueChanged: ((ACPSession.ID, Bool) -> Void)?
     private let mcpProjectContextProvider: MCPProjectContextProvider?
     private let frozenMCPAttachmentProvider: FrozenMCPAttachmentProvider?
     private let launchSpecTransformer: ACPLaunchSpecTransformer
@@ -168,6 +168,10 @@ final class ACPSessionManager: ObservableObject {
 
     /// Live session object if cached (does not trigger hydration).
     func liveSession(for id: ACPSession.ID) -> ACPSession? { sessions[id] }
+
+    func retainedCleanupHasActivePromptWork(for id: ACPSession.ID) -> Bool {
+        runners[id]?.hasRetainedCleanupPromptWork == true
+    }
 
     /// Permission policy for a session that currently has an attached runner.
     /// Returns nil if no runner is attached (session not actively connected).
@@ -284,7 +288,7 @@ final class ACPSessionManager: ObservableObject {
     func queueForceSend(for id: ACPSession.ID, itemId: UUID) async {
         guard await confirmedWriterLease(for: id) else { return }
         runners[id]?.forceSendQueuedItem(id: itemId)
-        onQueueChanged?(id)
+        onQueueChanged?(id, true)
     }
 
     func queueRemove(for id: ACPSession.ID, itemId: UUID) async {
@@ -292,7 +296,7 @@ final class ACPSessionManager: ObservableObject {
         session.removeFromQueue(id: itemId)
         persistQueue(for: session)
         runners[id]?.flushQueueIfIdle()
-        onQueueChanged?(id)
+        onQueueChanged?(id, false)
     }
 
     /// Clear a failed item's error so the flusher re-attempts it.
@@ -302,7 +306,7 @@ final class ACPSessionManager: ObservableObject {
         session.queue[idx].lastError = nil
         persistQueue(for: session)
         runners[id]?.flushQueueIfIdle()
-        onQueueChanged?(id)
+        onQueueChanged?(id, false)
     }
 
     /// Pull a queued item out for editing and hand its text back. `nil` when
@@ -332,7 +336,7 @@ final class ACPSessionManager: ObservableObject {
         guard let draft = session.takeForEditing(id: itemId) else { return nil }
         persistQueue(for: session)
         runners[id]?.flushQueueIfIdle()
-        onQueueChanged?(id)
+        onQueueChanged?(id, false)
         return RemoteQueueProjection.plainText(from: draft)
     }
 
@@ -341,12 +345,13 @@ final class ACPSessionManager: ObservableObject {
         session.clearPendingQueue()
         persistQueue(for: session)
         runners[id]?.flushQueueIfIdle()
-        onQueueChanged?(id)
+        onQueueChanged?(id, false)
     }
 
     func queueSteerUndo(for id: ACPSession.ID) async {
         guard await confirmedWriterLease(for: id) else { return }
         runners[id]?.steerUndo()
+        onQueueChanged?(id, false)
     }
 
     /// Steer from the remote client: same route the composer's ⌥⏎ takes.
@@ -359,6 +364,7 @@ final class ACPSessionManager: ObservableObject {
         }
         let accepted = submit(sessionId: id, text: text, attachments: attachments, intent: .steer,
                               onCompleted: { ok in onResult(ok) })
+        if accepted { onQueueChanged?(id, true) }
         if !accepted { onResult(false) }
     }
 
@@ -487,7 +493,7 @@ final class ACPSessionManager: ObservableObject {
          onSessionTitleUpdated: ((ACPSession.ID, String) -> Void)? = nil,
          onInputAwaiting: ((ACPSession, ACPUserInputRequest) -> Void)? = nil,
          onDelegatedMessageAvailable: ((ACPSession.ID) -> Void)? = nil,
-         onQueueChanged: ((ACPSession.ID) -> Void)? = nil,
+         onQueueChanged: ((ACPSession.ID, Bool) -> Void)? = nil,
          changeNotifier: ACPChangeNotifier? = nil,
          delegatedMessageNotifier: ACPChangeNotifier? = nil,
          setupEvaluator: ACPSetupEvaluator? = nil,
@@ -3438,7 +3444,7 @@ extension ACPSessionManager {
             runner.onUnexpectedDisconnect = { [weak self] in
                 Task { @MainActor in
                     self?.scheduleAutoReconnect(sessionId: sessionId)
-                    self?.onQueueChanged?(sessionId)
+                    self?.onQueueChanged?(sessionId, false)
                 }
             }
             var runnerStarted = false

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4228,6 +4228,7 @@ extension ACPSessionManager {
             while !Task.isCancelled {
                 guard let self else { return }
                 await self.refreshScheduledReconnectQueue(sessionId: sessionId)
+                guard !Task.isCancelled else { return }
                 guard let session = self.sessions[sessionId],
                       self.hasDueReconnectSchedule(in: session)
                 else { return }
@@ -4509,6 +4510,9 @@ extension ACPSessionManager {
         } else {
             scheduledAt = nil
         }
+        if scheduledAt != nil, session.pendingQueuePersistenceCount > 0 {
+            return false
+        }
         let onScheduledPersisted: (@MainActor (Bool) -> Void)?
         if scheduledAt == nil {
             onScheduledPersisted = nil
@@ -4580,7 +4584,11 @@ extension ACPSessionManager {
             if scheduledAt == nil {
                 Task { @MainActor in onCompleted(true) }
             }
-            Task { @MainActor in await reattach(to: sessionId) }
+            if scheduledAt.map({ $0 <= Date() }) ?? true {
+                Task { @MainActor in await reattach(to: sessionId) }
+            } else {
+                scheduleScheduledQueueReconnect(sessionId: sessionId)
+            }
             return true
         }
     }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -296,7 +296,7 @@ final class ACPSessionManager: ObservableObject {
         guard session.removeFromQueue(id: itemId) else { return }
         persistQueue(for: session)
         runners[id]?.flushQueueIfIdle()
-        onQueueChanged?(id, false)
+        onQueueChanged?(id, retainedCleanupHasActivePromptWork(for: id))
     }
 
     /// Clear a failed item's error so the flusher re-attempts it.

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -311,10 +311,11 @@ final class ACPSessionManager: ObservableObject {
     func queueRetry(for id: ACPSession.ID, itemId: UUID) async {
         guard await confirmedWriterLease(for: id), let session = sessions[id] else { return }
         guard let idx = session.queue.firstIndex(where: { $0.id == itemId }) else { return }
+        guard session.queue[idx].status == .pending, session.queue[idx].lastError != nil else { return }
         session.queue[idx].lastError = nil
         persistQueue(for: session)
         runners[id]?.flushQueueIfIdle()
-        onQueueChanged?(id, false)
+        onQueueChanged?(id, retainedCleanupHasActivePromptWork(for: id))
     }
 
     /// Pull a queued item out for editing and hand its text back. `nil` when
@@ -4113,6 +4114,7 @@ extension ACPSessionManager {
             defer {
                 self?.autoReconnectTasks.removeValue(forKey: sessionId)
                 self?.sessions[sessionId]?.autoReconnecting = false
+                self?.onQueueChanged?(sessionId, false)
             }
             self?.sessions[sessionId]?.autoReconnecting = true
             var attempt = 0

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4134,11 +4134,16 @@ extension ACPSessionManager {
         text: String,
         attachments: [ACPMessage.Attachment],
         draft: ACPComposerDraft? = nil,
+        scheduledAt: Date? = nil,
         into sessionId: ACPSession.ID
     ) {
         guard let session = sessions[sessionId] else { return }
         let blocks = ACPSessionRunner.blocks(text: text, attachments: attachments)
-        session.enqueue(blocks: blocks, draft: draft)
+        if let scheduledAt {
+            session.enqueueScheduled(blocks: blocks, scheduledAt: scheduledAt, draft: draft)
+        } else {
+            session.enqueue(blocks: blocks, draft: draft)
+        }
         let items = session.queue
         let fence = leaseFence(sessionId: sessionId)
         enqueuePersistence { persistence in
@@ -4258,6 +4263,12 @@ extension ACPSessionManager {
         if case .needsAuth = session.setupState {
             return false
         }
+        let scheduledAt: Date?
+        if case .schedule(let date) = intent {
+            scheduledAt = date
+        } else {
+            scheduledAt = nil
+        }
 
         switch session.agentState {
         case .ready:
@@ -4271,7 +4282,13 @@ extension ACPSessionManager {
                 // closure returns and registers its pending id (without the
                 // hop the completion fires too early and gets ignored).
                 session.agentState = .disconnected
-                enqueueWhileRecovering(text: text, attachments: attachments, draft: draft, into: sessionId)
+                enqueueWhileRecovering(
+                    text: text,
+                    attachments: attachments,
+                    draft: draft,
+                    scheduledAt: scheduledAt,
+                    into: sessionId
+                )
                 Task { @MainActor in onCompleted(true) }
                 Task { @MainActor in await reattach(to: sessionId) }
                 return true
@@ -4284,7 +4301,13 @@ extension ACPSessionManager {
         case .spawning:
             // An attach is in flight; the post-attach `flushQueueIfIdle()`
             // will pick up the freshly enqueued head.
-            enqueueWhileRecovering(text: text, attachments: attachments, draft: draft, into: sessionId)
+            enqueueWhileRecovering(
+                text: text,
+                attachments: attachments,
+                draft: draft,
+                scheduledAt: scheduledAt,
+                into: sessionId
+            )
             Task { @MainActor in onCompleted(true) }
             return true
 
@@ -4294,7 +4317,13 @@ extension ACPSessionManager {
             // submit closure returns and registers its pending id — firing
             // synchronously here would race the composer's bookkeeping and
             // get ignored, leaving the persisted draft uncleared.
-            enqueueWhileRecovering(text: text, attachments: attachments, draft: draft, into: sessionId)
+            enqueueWhileRecovering(
+                text: text,
+                attachments: attachments,
+                draft: draft,
+                scheduledAt: scheduledAt,
+                into: sessionId
+            )
             Task { @MainActor in onCompleted(true) }
             Task { @MainActor in await reattach(to: sessionId) }
             return true

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -301,7 +301,7 @@ final class ACPSessionManager: ObservableObject {
     func queueForceSend(for id: ACPSession.ID, itemId: UUID) async {
         guard let session = sessions[id] else { return }
         if case .spawning = session.agentState {
-            pendingQueueForceSends[id] = itemId
+            pendingQueueForceSends[id, default: []].append(itemId)
             onQueueChanged?(id, true)
             return
         }
@@ -309,7 +309,7 @@ final class ACPSessionManager: ObservableObject {
             await reattach(to: id)
         }
         if case .spawning = session.agentState {
-            pendingQueueForceSends[id] = itemId
+            pendingQueueForceSends[id, default: []].append(itemId)
             onQueueChanged?(id, true)
             return
         }
@@ -508,7 +508,7 @@ final class ACPSessionManager: ObservableObject {
         var sessionCapabilities: ACPInitializeResult.ACPAgentSessionCapabilities?
     }
     private var attachingConnections: [ACPSession.ID: AttachingConnection] = [:]
-    private var pendingQueueForceSends: [ACPSession.ID: UUID] = [:]
+    private var pendingQueueForceSends: [ACPSession.ID: [UUID]] = [:]
     private var delegatedMessageWatchTokens: [ACPSession.ID: Int32] = [:]
 
     init(worktreeId: String, worktreePath: String, owner: SessionOwnerID? = nil, store: ACPSessionStore? = nil,
@@ -2966,6 +2966,7 @@ extension ACPSessionManager {
         // Always sync the queue — it can change (drain/clear) with no new
         // transcript rows, so this must run before any early-return below.
         session.restoreQueue(result.queue)
+        scheduleScheduledQueueReconnect(sessionId: sessionId)
         guard !result.wireMessages.isEmpty else { return }
         let tailStart = replaceTranscriptWithTail(
             result.messages,
@@ -4128,6 +4129,7 @@ extension ACPSessionManager {
                       })
                 else { return nil }
                 await reattach(to: id)
+                scheduleScheduledQueueReconnect(sessionId: id)
                 onBootstrapped?(id)
                 return id
             }
@@ -4287,14 +4289,22 @@ extension ACPSessionManager {
 
     @discardableResult
     private func sendPendingQueueForceSend(sessionId: ACPSession.ID) -> Bool {
-        guard let itemId = pendingQueueForceSends.removeValue(forKey: sessionId),
+        guard let itemIds = pendingQueueForceSends.removeValue(forKey: sessionId),
               let session = sessions[sessionId],
-              session.queue.contains(where: { $0.id == itemId && $0.status == .pending }),
               let runner = runners[sessionId]
         else { return false }
-        runner.forceSendQueuedItem(id: itemId)
-        onQueueChanged?(sessionId, true)
-        return true
+        var sent = false
+        for itemId in itemIds.reversed() where session.queue.contains(where: { $0.id == itemId && $0.status == .pending }) {
+            sent = session.forceQueueItem(id: itemId) || sent
+        }
+        if sent {
+            runner.persistQueue()
+            runner.flushQueueIfIdle()
+        }
+        if sent {
+            onQueueChanged?(sessionId, true)
+        }
+        return sent
     }
 
     /// Enqueue a prompt into a session whose agent isn't `.ready` yet.

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4196,10 +4196,13 @@ extension ACPSessionManager {
         session.enqueue(blocks: blocks, delegatedSource: source)
         let fence = leaseFence(sessionId: sessionId)
         let items = session.queue
+        session.pendingQueuePersistenceCount += 1
         let task = enqueuePersistenceResult { persistence in
             try await persistence.upsertQueue(sessionId: sessionId, items: items, fence: fence)
         }
-        guard await task.value == true else {
+        let persisted = await task.value == true
+        session.pendingQueuePersistenceCount -= 1
+        guard persisted else {
             session.queue.removeAll { $0.delegatedSource == source }
             return false
         }
@@ -4239,10 +4242,13 @@ extension ACPSessionManager {
         )
         let fence = leaseFence(sessionId: sessionId)
         let items = session.queue
+        session.pendingQueuePersistenceCount += 1
         let task = enqueuePersistenceResult { persistence in
             try await persistence.upsertQueue(sessionId: sessionId, items: items, fence: fence)
         }
-        guard await task.value == true else {
+        let persisted = await task.value == true
+        session.pendingQueuePersistenceCount -= 1
+        guard persisted else {
             if let index = session.queue.firstIndex(where: { $0.id == id }) {
                 session.queue.remove(at: index)
             }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -300,8 +300,18 @@ final class ACPSessionManager: ObservableObject {
     /// running) — the remote-web twin of the queued bubble's "send now".
     func queueForceSend(for id: ACPSession.ID, itemId: UUID) async {
         guard await confirmedWriterLease(for: id), let session = sessions[id] else { return }
+        if case .spawning = session.agentState {
+            pendingQueueForceSends[id] = itemId
+            onQueueChanged?(id, true)
+            return
+        }
         if session.agentState != .ready {
             await reattach(to: id)
+        }
+        if case .spawning = session.agentState {
+            pendingQueueForceSends[id] = itemId
+            onQueueChanged?(id, true)
+            return
         }
         guard let runner = runners[id] else { return }
         runner.forceSendQueuedItem(id: itemId)
@@ -497,6 +507,7 @@ final class ACPSessionManager: ObservableObject {
         var sessionCapabilities: ACPInitializeResult.ACPAgentSessionCapabilities?
     }
     private var attachingConnections: [ACPSession.ID: AttachingConnection] = [:]
+    private var pendingQueueForceSends: [ACPSession.ID: UUID] = [:]
     private var delegatedMessageWatchTokens: [ACPSession.ID: Int32] = [:]
 
     init(worktreeId: String, worktreePath: String, owner: SessionOwnerID? = nil, store: ACPSessionStore? = nil,
@@ -1203,6 +1214,7 @@ final class ACPSessionManager: ObservableObject {
         transcriptScrollMemory.removeValue(forKey: id)
         pendingModel.removeValue(forKey: id)
         pendingMode.removeValue(forKey: id)
+        pendingQueueForceSends.removeValue(forKey: id)
         persistedRows.removeValue(forKey: id)
         recent.removeAll { $0.id == id }
     }
@@ -4011,6 +4023,9 @@ extension ACPSessionManager {
             scheduledReconnectTasks.removeValue(forKey: sessionId)?.task.cancel()
             if session.queue.contains(where: { $0.status == .sending }) {
                 session.restoreQueue(session.queue)
+            }
+            if let itemId = pendingQueueForceSends.removeValue(forKey: sessionId) {
+                runner.forceSendQueuedItem(id: itemId)
             }
             if let remoteMCPNotice {
                 runner.appendAndPersistSystemNotice(remoteMCPNotice)

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1698,9 +1698,13 @@ final class ACPSessionManager: ObservableObject {
     func persistQueue(for session: ACPSession) {
         guard !isMirror(sessionId: session.id) else { return }
         let sessionId = session.id
+        scheduleScheduledQueueReconnect(sessionId: sessionId)
+        if let runner = runners[sessionId] {
+            runner.persistQueue()
+            return
+        }
         let items = session.queue
         let fence = leaseFence(sessionId: sessionId)
-        scheduleScheduledQueueReconnect(sessionId: sessionId)
         enqueuePersistence { persistence in
             _ = try await persistence.upsertQueue(
                 sessionId: sessionId,

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -4076,7 +4076,9 @@ extension ACPSessionManager {
         }
     }
 
-    func bootstrapScheduledQueueSessions() async -> [ACPSession.ID] {
+    func bootstrapScheduledQueueSessions(
+        onBootstrapped: (@MainActor (ACPSession.ID) -> Void)? = nil
+    ) async -> [ACPSession.ID] {
         let ids: [ACPSession.ID]
         do {
             ids = try await persistence.scheduledQueueSessionIds()
@@ -4096,6 +4098,7 @@ extension ACPSessionManager {
                       })
                 else { return nil }
                 await reattach(to: id)
+                onBootstrapped?(id)
                 return id
             }
         }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -156,6 +156,7 @@ final class ACPSessionManager: ObservableObject {
     private var elicitationCoordinators: [ACPSession.ID: ACPElicitationCoordinator] = [:]
     private var autoReconnectTasks: [ACPSession.ID: Task<Void, Never>] = [:]
     private var scheduledReconnectTasks: [ACPSession.ID: (deadline: Date, task: Task<Void, Never>)] = [:]
+    private var managerQueuePersistenceSessionIds: Set<ACPSession.ID> = []
     private var disposalTasks: [ACPSession.ID: Task<Void, Error>] = [:]
     /// Per-session attach counter. The built-in MCP registration grace timer
     /// captures the epoch at attach and only writes the row if it still matches,
@@ -300,7 +301,7 @@ final class ACPSessionManager: ObservableObject {
     /// running) — the remote-web twin of the queued bubble's "send now".
     func queueForceSend(for id: ACPSession.ID, itemId: UUID) async {
         guard let session = sessions[id] else { return }
-        guard session.pendingQueuePersistenceCount == 0 else {
+        guard !managerQueuePersistenceSessionIds.contains(id) else {
             deferQueueForceSend(session: session, itemId: itemId)
             return
         }
@@ -1703,7 +1704,8 @@ final class ACPSessionManager: ObservableObject {
         guard !isMirror(sessionId: session.id) else { return }
         let sessionId = session.id
         scheduleScheduledQueueReconnect(sessionId: sessionId)
-        if session.pendingQueuePersistenceCount == 0, let runner = runners[sessionId] {
+        if !managerQueuePersistenceSessionIds.contains(sessionId),
+           let runner = runners[sessionId] {
             runner.persistQueue()
             return
         }
@@ -4375,10 +4377,12 @@ extension ACPSessionManager {
         let task = enqueuePersistenceResult { persistence in
             try await persistence.upsertQueue(sessionId: sessionId, items: items, fence: fence)
         }
+        managerQueuePersistenceSessionIds.insert(sessionId)
         session.pendingQueuePersistenceCount += 1
         Task { @MainActor in
             let persisted = await task.value == true
             session.pendingQueuePersistenceCount -= 1
+            managerQueuePersistenceSessionIds.remove(sessionId)
             if !persisted, let scheduledId {
                 if session.removeFromQueue(id: scheduledId) {
                     persistQueue(for: session)

--- a/Alas/Sources/ACP/Session/ACPSessionPersistence.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionPersistence.swift
@@ -580,6 +580,10 @@ actor ACPSessionPersistence {
         try openedStore().loadQueue(sessionId: sessionId)
     }
 
+    func scheduledQueueSessionIds() throws -> [String] {
+        try openedStore().scheduledQueueSessionIds()
+    }
+
     func loadLease(sessionId: String) throws -> ACPSessionLease? {
         try openedStore().loadLease(sessionId: sessionId)
     }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1722,6 +1722,10 @@ extension ACPSessionRunner {
         steerInProgress || activePromptID != nil || session.transcript.streamingState != .idle
     }
 
+    var hasRetainedCleanupForkBarrierWork: Bool {
+        nativeForkBarrierActive
+    }
+
     private func armSteerUndoExpiry() {
         steerUndoExpiryTask?.cancel()
         steerUndoExpiryTask = Task { [weak self] in

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1997,6 +1997,7 @@ extension ACPSessionRunner {
     @discardableResult
     func sendRecoveryContext(
         _ prompt: String,
+        flushQueueOnCompletion: Bool = true,
         onCompleted: (@MainActor (_ delivered: Bool) -> Void)? = nil
     ) -> Bool {
         guard !nativeForkBarrierActive else { return false }
@@ -2031,7 +2032,7 @@ extension ACPSessionRunner {
                     let isActivePrompt = self.activePromptID == promptID
                     if isActivePrompt {
                         self.activePromptID = nil
-                        if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {
+                        if flushQueueOnCompletion && self.deferCompletedOutputBoundaryUntilUpdatesDrain() {
                             self.flushQueueIfIdle()
                         }
                         self.onPromptWorkChanged?()

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -49,6 +49,7 @@ final class ACPSessionRunner {
     private let leaseFenceProvider: () -> ACPSessionLeaseFence?
     private let onAuthRequired: ((ACPSessionRunner, String) async -> Void)?
     private let onPersist: (() -> Void)?
+    private let onPromptWorkChanged: (() -> Void)?
     private let onSessionTitleUpdated: ((String) -> Void)?
     private var updatesTask: Task<Void, Never>?
     private var permissionsTask: Task<Void, Never>?
@@ -137,6 +138,7 @@ final class ACPSessionRunner {
          onUserCancel: (() -> Void)? = nil,
          onAuthRequired: ((ACPSessionRunner, String) async -> Void)? = nil,
          onPersist: (() -> Void)? = nil,
+         onPromptWorkChanged: (() -> Void)? = nil,
          onSessionTitleUpdated: ((String) -> Void)? = nil,
          onResumeTranscriptTail: (() -> Void)? = nil,
          streamingPersistDebounceNanos: UInt64 = 250_000_000,
@@ -161,6 +163,7 @@ final class ACPSessionRunner {
         self.ownerInstanceId = ownerInstanceId
         self.onAuthRequired = onAuthRequired
         self.onPersist = onPersist
+        self.onPromptWorkChanged = onPromptWorkChanged
         self.onSessionTitleUpdated = onSessionTitleUpdated
         self.streamingPersistDebounceNanos = streamingPersistDebounceNanos
         self.incomingUpdateCoalesceNanos = incomingUpdateCoalesceNanos
@@ -1927,6 +1930,7 @@ extension ACPSessionRunner {
                         if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {
                             self.flushQueueIfIdle()
                         }
+                        self.onPromptWorkChanged?()
                     }
                     self.cancelledPromptIDs.remove(promptID)
                     if !hasNewerActivePrompt {
@@ -1980,6 +1984,7 @@ extension ACPSessionRunner {
                         if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {
                             self.flushQueueIfIdle()
                         }
+                        self.onPromptWorkChanged?()
                     }
                     if !hasNewerActivePrompt {
                         onPromptFinished?(wasCancelled)
@@ -2029,6 +2034,7 @@ extension ACPSessionRunner {
                         if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {
                             self.flushQueueIfIdle()
                         }
+                        self.onPromptWorkChanged?()
                     }
                     // Always resolve the recovery status, even when a newer
                     // prompt (e.g. the user steered) has taken over the
@@ -2046,6 +2052,7 @@ extension ACPSessionRunner {
                         self.flushStreamingPersist()
                         self.activePromptID = nil
                         self.session.transcript.streamingState = .idle
+                        self.onPromptWorkChanged?()
                     }
                     // See the success path above: the recovery status must
                     // resolve regardless of supersession or the spinner strands.

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1726,6 +1726,10 @@ extension ACPSessionRunner {
             || (session.pendingQueuePersistenceCount > 0 && !session.queue.isEmpty)
     }
 
+    var hasRetainedCleanupSteerWork: Bool {
+        steerInProgress
+    }
+
     var hasRetainedCleanupForkBarrierWork: Bool {
         nativeForkBarrierActive
     }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -714,6 +714,8 @@ final class ACPSessionRunner {
         )
         session.clearRetryStatus()
         flushStreamingPersistOnStop()
+        scheduledQueueWakeTask?.cancel()
+        scheduledQueueWakeTask = nil
         incomingUpdateFlushTask?.cancel()
         incomingUpdateFlushTask = nil
         updatesTask?.cancel()

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -56,6 +56,7 @@ final class ACPSessionRunner {
     private var terminalsTask: Task<Void, Never>?
     private var seq: Int64 = 0
     private var steerUndoExpiryTask: Task<Void, Never>?
+    private var scheduledQueueWakeTask: Task<Void, Never>?
     /// Monotonic prompt counter + active/cancelled bookkeeping (inherited
     /// from main / PR #338). Reused by the queue's sendNow path:
     /// `activePromptID` identifies the task that currently owns
@@ -1354,6 +1355,17 @@ extension ACPSessionRunner {
         draft: ACPComposerDraft? = nil,
         onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
     ) {
+        if case .schedule(let date) = intent {
+            guard !blocks.isEmpty else {
+                Task { @MainActor in onPromptFinished?(false) }
+                return
+            }
+            session.enqueueScheduled(blocks: blocks, scheduledAt: date, draft: draft)
+            persistQueue()
+            flushQueueIfIdle()
+            Task { @MainActor in onPromptFinished?(true) }
+            return
+        }
         if nativeForkBarrierActive {
             guard !blocks.isEmpty else {
                 Task { @MainActor in onPromptFinished?(false) }
@@ -1380,8 +1392,10 @@ extension ACPSessionRunner {
         case .sendNow:
             sendNow(blocks: blocks, queuedItemId: nil, draft: draft, onPromptFinished: onPromptFinished)
         case .enqueue:
+            let scheduledWasHead = session.queue.first?.scheduledAt != nil
             session.enqueue(blocks: blocks, draft: draft)
             persistQueue()
+            if scheduledWasHead { flushQueueIfIdle() }
             // The user's prompt was accepted into the queue — from the
             // composer's perspective this is a successful submission so
             // the persisted draft can be cleared. The actual RPC fires
@@ -1517,6 +1531,12 @@ extension ACPSessionRunner {
               head.lastError == nil
         else { return }
         if case .needsAuth = session.setupState { return }
+        guard head.isReady() else {
+            scheduleQueueWake(at: head.scheduledAt!)
+            return
+        }
+        scheduledQueueWakeTask?.cancel()
+        scheduledQueueWakeTask = nil
         let brokerOperationKey = session.markQueueHeadSending()
         persistQueue()
         sendNow(
@@ -1525,6 +1545,17 @@ extension ACPSessionRunner {
             delegatedSource: head.delegatedSource,
             brokerOperationKey: brokerOperationKey
         )
+    }
+
+    private func scheduleQueueWake(at date: Date) {
+        scheduledQueueWakeTask?.cancel()
+        let delay = max(0, date.timeIntervalSinceNow)
+        scheduledQueueWakeTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard !Task.isCancelled else { return }
+            self?.scheduledQueueWakeTask = nil
+            self?.flushQueueIfIdle()
+        }
     }
 
     func beginNativeForkBarrier() async -> Bool {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1366,9 +1366,12 @@ extension ACPSessionRunner {
                 return
             }
             session.enqueueScheduled(blocks: blocks, scheduledAt: date, draft: draft)
-            persistQueue()
-            flushQueueIfIdle()
-            Task { @MainActor in onPromptFinished?(true) }
+            persistQueue(completion: { [weak self] persisted in
+                if persisted {
+                    self?.flushQueueIfIdle()
+                }
+                onPromptFinished?(persisted)
+            })
             return
         }
         if nativeForkBarrierActive {
@@ -1416,22 +1419,30 @@ extension ACPSessionRunner {
     /// swallowed — the same pattern as transcript persistence; surfacing
     /// would block the UI for a transient SQLite error and we'd rather
     /// lose a queue snapshot than the user's draft.
-    func persistQueue(acknowledging acknowledgement: ACPDurableConsumptionAcknowledgement? = nil) {
-        guard holdsLeaseForWrite() else { return }
+    func persistQueue(
+        acknowledging acknowledgement: ACPDurableConsumptionAcknowledgement? = nil,
+        completion: (@MainActor (_ persisted: Bool) -> Void)? = nil
+    ) {
+        guard holdsLeaseForWrite() else {
+            Task { @MainActor in completion?(false) }
+            return
+        }
         let items = session.queue
         let fence = leaseFenceProvider()
         let sessionId = sessionId
-        if let acknowledgement {
+        if acknowledgement != nil || completion != nil {
             enqueuePersistence({ persistence in
                 try await persistence.upsertQueue(
                     sessionId: sessionId,
                     items: items,
                     fence: fence
                 )
+                return true
             }, completion: { persisted in
                 if persisted == true {
-                    acknowledgement()
+                    acknowledgement?()
                 }
+                completion?(persisted == true)
             })
         } else {
             enqueuePersistence { persistence in

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1600,6 +1600,7 @@ extension ACPSessionRunner {
         guard let idx = session.queue.firstIndex(where: { $0.id == id }),
               session.queue[idx].status == .pending
         else { return }
+        guard session.agentState == .ready else { return }
 
         if nativeForkBarrierActive {
             guard session.forceQueueItem(id: id) else { return }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1365,10 +1365,12 @@ extension ACPSessionRunner {
                 Task { @MainActor in onPromptFinished?(false) }
                 return
             }
-            session.enqueueScheduled(blocks: blocks, scheduledAt: date, draft: draft)
+            let queuedId = session.enqueueScheduled(blocks: blocks, scheduledAt: date, draft: draft)
             persistQueue(completion: { [weak self] persisted in
                 if persisted {
                     self?.flushQueueIfIdle()
+                } else {
+                    _ = self?.session.removeFromQueue(id: queuedId)
                 }
                 onPromptFinished?(persisted)
             })

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1370,7 +1370,9 @@ extension ACPSessionRunner {
                 if persisted {
                     self?.flushQueueIfIdle()
                 } else {
-                    _ = self?.session.removeFromQueue(id: queuedId)
+                    if self?.session.removeFromQueue(id: queuedId) == true {
+                        self?.persistQueue()
+                    }
                 }
                 onPromptFinished?(persisted)
             })
@@ -1439,7 +1441,6 @@ extension ACPSessionRunner {
                     items: items,
                     fence: fence
                 )
-                return true
             }, completion: { persisted in
                 if persisted == true {
                     acknowledgement?()

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1448,7 +1448,9 @@ extension ACPSessionRunner {
                 self.session.pendingQueuePersistenceCount -= 1
                 if didPersist {
                     acknowledgement?()
-                    self.sendPendingQueueForceSendsAfterPersistence()
+                    if !self.sendPendingQueueForceSendsAfterPersistence(), acknowledgement != nil {
+                        self.flushQueueIfIdle()
+                    }
                 }
                 completion?(didPersist)
             })
@@ -1661,19 +1663,21 @@ extension ACPSessionRunner {
         )
     }
 
-    private func sendPendingQueueForceSendsAfterPersistence() {
+    @discardableResult
+    private func sendPendingQueueForceSendsAfterPersistence() -> Bool {
         guard session.pendingQueuePersistenceCount == 0,
               !pendingQueueForceSendsAfterPersistence.isEmpty
-        else { return }
+        else { return false }
         let itemIds = pendingQueueForceSendsAfterPersistence
         pendingQueueForceSendsAfterPersistence.removeAll()
         var forced = false
         for itemId in itemIds.reversed() {
             forced = session.forceQueueItem(id: itemId) || forced
         }
-        guard forced else { return }
+        guard forced else { return false }
         persistQueue()
         flushQueueIfIdle()
+        return true
     }
 
     /// Cancel the in-flight turn (if any), discard the ENTIRE queue

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -71,6 +71,7 @@ final class ACPSessionRunner {
     private var persistedMessageCount: Int
     private var persistenceTail: Task<Void, Never>?
     private var persistenceGeneration = 0
+    private var pendingQueueForceSendsAfterPersistence: [UUID] = []
     private var pendingCompletedOutputBoundaryUpdateCount: Int?
     private var pendingStreamingPersistIndices: Set<Int> = []
     /// Revisions distinguish a new streamed chunk from the payload currently
@@ -1435,6 +1436,7 @@ extension ACPSessionRunner {
         let fence = leaseFenceProvider()
         let sessionId = sessionId
         if acknowledgement != nil || completion != nil {
+            session.pendingQueuePersistenceCount += 1
             enqueuePersistence({ persistence in
                 try await persistence.upsertQueue(
                     sessionId: sessionId,
@@ -1442,10 +1444,13 @@ extension ACPSessionRunner {
                     fence: fence
                 )
             }, completion: { persisted in
-                if persisted == true {
+                let didPersist = persisted == true
+                self.session.pendingQueuePersistenceCount -= 1
+                if didPersist {
                     acknowledgement?()
+                    self.sendPendingQueueForceSendsAfterPersistence()
                 }
-                completion?(persisted == true)
+                completion?(didPersist)
             })
         } else {
             enqueuePersistence { persistence in
@@ -1618,6 +1623,12 @@ extension ACPSessionRunner {
               session.queue[idx].status == .pending
         else { return }
         guard session.agentState == .ready else { return }
+        guard session.pendingQueuePersistenceCount == 0 else {
+            if !pendingQueueForceSendsAfterPersistence.contains(id) {
+                pendingQueueForceSendsAfterPersistence.append(id)
+            }
+            return
+        }
 
         if nativeForkBarrierActive {
             guard session.forceQueueItem(id: id) else { return }
@@ -1648,6 +1659,21 @@ extension ACPSessionRunner {
             delegatedSource: item.delegatedSource,
             recordUserPrompt: !item.transcriptRecorded
         )
+    }
+
+    private func sendPendingQueueForceSendsAfterPersistence() {
+        guard session.pendingQueuePersistenceCount == 0,
+              !pendingQueueForceSendsAfterPersistence.isEmpty
+        else { return }
+        let itemIds = pendingQueueForceSendsAfterPersistence
+        pendingQueueForceSendsAfterPersistence.removeAll()
+        var forced = false
+        for itemId in itemIds.reversed() {
+            forced = session.forceQueueItem(id: itemId) || forced
+        }
+        guard forced else { return }
+        persistQueue()
+        flushQueueIfIdle()
     }
 
     /// Cancel the in-flight turn (if any), discard the ENTIRE queue

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1523,6 +1523,7 @@ extension ACPSessionRunner {
         guard !nativeForkBarrierActive,
               !steerInProgress,
               session.agentState == .ready,
+              session.pendingQueuePersistenceCount == 0,
               activePromptID == nil,
               session.transcript.streamingState == .idle,
               session.transcript.pendingUserInputs.isEmpty,

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1720,7 +1720,10 @@ extension ACPSessionRunner {
     func steerUndoSnapshot() -> [QueuedPrompt]? { session.steerUndo?.snapshot }
 
     var hasRetainedCleanupPromptWork: Bool {
-        steerInProgress || activePromptID != nil || session.transcript.streamingState != .idle
+        steerInProgress
+            || activePromptID != nil
+            || session.transcript.streamingState != .idle
+            || (session.pendingQueuePersistenceCount > 0 && !session.queue.isEmpty)
     }
 
     var hasRetainedCleanupForkBarrierWork: Bool {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1715,6 +1715,10 @@ extension ACPSessionRunner {
     /// Exposed for tests + the toast view so it can show / hide.
     func steerUndoSnapshot() -> [QueuedPrompt]? { session.steerUndo?.snapshot }
 
+    var hasRetainedCleanupPromptWork: Bool {
+        steerInProgress || activePromptID != nil || session.transcript.streamingState != .idle
+    }
+
     private func armSteerUndoExpiry() {
         steerUndoExpiryTask?.cancel()
         steerUndoExpiryTask = Task { [weak self] in

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -948,7 +948,9 @@ extension ACPSessionStore {
                   let payload = row["payload"] as? Data,
                   let items = try? JSONDecoder().decode([QueuedPrompt].self, from: payload),
                   items.contains(where: {
-                      $0.status == .pending && $0.lastError == nil && $0.scheduledAt != nil
+                      ($0.status == .pending || $0.status == .sending)
+                          && $0.lastError == nil
+                          && $0.scheduledAt != nil
                   })
             else { return nil }
             return sessionId

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -935,6 +935,25 @@ extension ACPSessionStore {
         guard let payload = rows.first?["payload"] as? Data else { return [] }
         return (try? JSONDecoder().decode([QueuedPrompt].self, from: payload)) ?? []
     }
+
+    func scheduledQueueSessionIds() throws -> [String] {
+        let rows = try db.query("""
+        SELECT q.session_id, q.payload
+        FROM session_queue q
+        JOIN sessions s ON s.id = q.session_id
+        WHERE s.archived = 0
+        """)
+        return rows.compactMap { row in
+            guard let sessionId = row["session_id"] as? String,
+                  let payload = row["payload"] as? Data,
+                  let items = try? JSONDecoder().decode([QueuedPrompt].self, from: payload),
+                  items.contains(where: {
+                      $0.status == .pending && $0.lastError == nil && $0.scheduledAt != nil
+                  })
+            else { return nil }
+            return sessionId
+        }
+    }
 }
 
 extension ACPSessionStore {

--- a/Alas/Sources/ACP/Session/ACPSubmitIntent.swift
+++ b/Alas/Sources/ACP/Session/ACPSubmitIntent.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum ACPSubmitIntent: Equatable { case auto, steer }
+enum ACPSubmitIntent: Equatable { case auto, steer, schedule(Date) }
 
 enum ACPSubmitRoute: Equatable {
     /// State is idle AND queue is empty — send the prompt directly.
@@ -39,6 +39,8 @@ enum ACPSubmitRoute: Equatable {
             return canSendNow ? .sendNow : .enqueue
         case .steer:
             return canSendNow ? .sendNow : .steer
+        case .schedule:
+            return .enqueue
         }
     }
 }

--- a/Alas/Sources/ACP/Session/QueuedPrompt.swift
+++ b/Alas/Sources/ACP/Session/QueuedPrompt.swift
@@ -6,6 +6,7 @@ struct QueuedPrompt: Identifiable, Equatable, Codable, Sendable {
     let id: UUID
     var blocks: [ACPContentBlock]
     let enqueuedAt: Date
+    var scheduledAt: Date?
     var status: Status
     var lastError: String?
     /// Set the first time `sendNow` dispatches this item: the user prompt
@@ -29,6 +30,7 @@ struct QueuedPrompt: Identifiable, Equatable, Codable, Sendable {
     init(id: UUID = UUID(),
          blocks: [ACPContentBlock],
          enqueuedAt: Date = Date(),
+         scheduledAt: Date? = nil,
          status: Status = .pending,
          lastError: String? = nil,
          draft: ACPComposerDraft? = nil,
@@ -39,6 +41,7 @@ struct QueuedPrompt: Identifiable, Equatable, Codable, Sendable {
         self.id = id
         self.blocks = blocks
         self.enqueuedAt = enqueuedAt
+        self.scheduledAt = scheduledAt
         self.status = status
         self.lastError = lastError
         self.draft = draft
@@ -48,7 +51,7 @@ struct QueuedPrompt: Identifiable, Equatable, Codable, Sendable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, blocks, enqueuedAt, status, lastError, draft, delegatedSource, transcriptRecorded, brokerOperationAttempt
+        case id, blocks, enqueuedAt, scheduledAt, status, lastError, draft, delegatedSource, transcriptRecorded, brokerOperationAttempt
     }
 
     init(from decoder: Decoder) throws {
@@ -56,6 +59,7 @@ struct QueuedPrompt: Identifiable, Equatable, Codable, Sendable {
         id = try c.decode(UUID.self, forKey: .id)
         blocks = try c.decode([ACPContentBlock].self, forKey: .blocks)
         enqueuedAt = try c.decode(Date.self, forKey: .enqueuedAt)
+        scheduledAt = try? c.decode(Date.self, forKey: .scheduledAt)
         status = try c.decode(Status.self, forKey: .status)
         lastError = try? c.decode(String.self, forKey: .lastError)
         draft = try? c.decode(ACPComposerDraft.self, forKey: .draft)
@@ -73,6 +77,10 @@ struct QueuedPrompt: Identifiable, Equatable, Codable, Sendable {
         var copy = self
         copy.status = .pending
         return copy
+    }
+
+    func isReady(at date: Date = Date()) -> Bool {
+        scheduledAt.map { $0 <= date } ?? true
     }
 
     /// The draft to load back into the composer when this item is edited:

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -234,6 +234,7 @@ struct ACPInputField: NSViewRepresentable {
         func undoManager(for view: NSTextView) -> UndoManager? { editorUndoManager }
         private var nextSubmitID = 0
         private var pendingSubmitID: Int?
+        private var pendingScheduledSubmitIDs: Set<Int> = []
         private var pendingImageFileInsertions = 0
         private var imageFileInsertionGeneration = 0
         private var pendingRestyleWork: DispatchWorkItem?
@@ -417,6 +418,7 @@ struct ACPInputField: NSViewRepresentable {
 
         func submit(_ textView: NSTextView, intent: ACPSubmitIntent = .auto) {
             guard pendingImageFileInsertions == 0 else { return }
+            guard pendingScheduledSubmitIDs.isEmpty else { return }
             flushPendingRestyleNow()
             if let tv = textView as? ACPNSTextView {
                 tv.dismissSlashPanel()
@@ -440,6 +442,9 @@ struct ACPInputField: NSViewRepresentable {
                 // Durable draft finalization lives with the submit owner, so
                 // tab switches can outlive this coordinator.
             }) {
+                if case .schedule = intent {
+                    pendingScheduledSubmitIDs.insert(submitID)
+                }
                 pendingSubmitID = submitID
                 clearVisibleDraft(in: textView)
             }
@@ -555,14 +560,28 @@ struct ACPInputField: NSViewRepresentable {
             succeeded: Bool,
             textView: NSTextView?
         ) {
-            guard pendingSubmitID == id else { return }
-            pendingSubmitID = nil
+            let isCurrentSubmit = pendingSubmitID == id
+            let isPendingSchedule = pendingScheduledSubmitIDs.remove(id) != nil
+            guard isCurrentSubmit || isPendingSchedule else { return }
+            if isCurrentSubmit {
+                pendingSubmitID = nil
+            }
             if succeeded {
-                onDraftClear()
+                if isCurrentSubmit {
+                    onDraftClear()
+                }
             } else {
-                onDraftChange(draft)
+                let restoredDraft: ACPComposerDraft
+                if isCurrentSubmit {
+                    restoredDraft = draft
+                } else if let textView {
+                    restoredDraft = Self.draft(from: textView.attributedString()).appending(draft)
+                } else {
+                    restoredDraft = lastSyncedDraft.appending(draft)
+                }
+                onDraftChange(restoredDraft)
                 if let textView {
-                    restore(draft, into: textView)
+                    restore(restoredDraft, into: textView)
                 }
             }
         }

--- a/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
@@ -108,8 +108,10 @@ struct ACPComposerActionButton: View {
                     Spacer()
                     Button("Cancel") { showsCustomSchedule = false }
                     Button("Schedule") {
-                        onSchedule(customScheduleDate)
-                        showsCustomSchedule = false
+                        if customScheduleDate > Date() {
+                            onSchedule(customScheduleDate)
+                            showsCustomSchedule = false
+                        }
                     }
                     .buttonStyle(.borderedProminent)
                     .disabled(customScheduleDate <= Date())

--- a/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
@@ -60,12 +60,15 @@ struct ACPComposerActionButton: View {
             Menu {
                 let now = Date()
                 ForEach(ACPSchedulePreset.allCases) { preset in
-                    if let date = preset.date(after: now) {
-                        Button(preset.title) { onSchedule(date) }
+                    if preset.date(after: now) != nil {
+                        Button(preset.title) {
+                            if let date = preset.date(after: Date()) { onSchedule(date) }
+                        }
                     }
                 }
                 Divider()
                 Button("Custom date and time…") {
+                    let now = Date()
                     customScheduleDate = ACPSchedulePreset.laterToday.date(after: now)
                         ?? ACPSchedulePreset.tomorrowMorning.date(after: now)!
                     showsCustomSchedule = true

--- a/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftUI
 
 /// Single state-driven button that replaces the composer's separate Send
@@ -8,9 +9,12 @@ struct ACPComposerActionButton: View {
     let action: ComposerAction
     let onPrimary: () -> Void
     let onMenu: (ComposerMenuItem) -> Void
+    let onSchedule: (Date) -> Void
     let queueBadgeCount: Int
 
     @Environment(\.theme) private var theme
+    @State private var customScheduleDate = Date()
+    @State private var showsCustomSchedule = false
 
     var body: some View {
         switch action {
@@ -25,26 +29,92 @@ struct ACPComposerActionButton: View {
         }
     }
 
-    // MARK: - Send (single capsule, accent-colored)
+    // MARK: - Send (split capsule, accent-colored)
 
     private var sendCapsule: some View {
-        Button(action: onPrimary) {
-            HStack(spacing: 5) {
-                Image(systemName: "arrow.up")
-                    .font(.system(size: 12, weight: .bold))
-                Text("Send")
-                    .font(.system(size: 11.5, weight: .semibold))
+        HStack(spacing: 1) {
+            Button(action: onPrimary) {
+                HStack(spacing: 5) {
+                    Image(systemName: "arrow.up")
+                        .font(.system(size: 12, weight: .bold))
+                    Text("Send")
+                        .font(.system(size: 11.5, weight: .semibold))
+                }
+                .foregroundStyle(theme.color("bg-0"))
+                .padding(.horizontal, 11)
+                .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
+                .background(
+                    UnevenRoundedRectangle(
+                        cornerRadii: .init(
+                            topLeading: ACPComposerActionButtonMetrics.cornerRadius,
+                            bottomLeading: ACPComposerActionButtonMetrics.cornerRadius
+                        )
+                    )
+                    .fill(theme.color("accent"))
+                )
+                .overlay(alignment: .topTrailing) { badgeOverlay }
             }
-            .foregroundStyle(theme.color("bg-0"))
-            .padding(.horizontal, 11)
-            .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
-            .background(
-                RoundedRectangle(cornerRadius: ACPComposerActionButtonMetrics.cornerRadius).fill(theme.color("accent"))
-            )
-            .overlay(alignment: .topTrailing) { badgeOverlay }
+            .buttonStyle(.plain)
+            .help("Send (⏎)")
+
+            Menu {
+                let now = Date()
+                ForEach(ACPSchedulePreset.allCases) { preset in
+                    if let date = preset.date(after: now) {
+                        Button(preset.title) { onSchedule(date) }
+                    }
+                }
+                Divider()
+                Button("Custom date and time…") {
+                    customScheduleDate = ACPSchedulePreset.laterToday.date(after: now)
+                        ?? ACPSchedulePreset.tomorrowMorning.date(after: now)!
+                    showsCustomSchedule = true
+                }
+            } label: {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(theme.color("bg-0"))
+                    .padding(.horizontal, 7)
+                    .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
+                    .background(
+                        UnevenRoundedRectangle(
+                            cornerRadii: .init(
+                                bottomTrailing: ACPComposerActionButtonMetrics.cornerRadius,
+                                topTrailing: ACPComposerActionButtonMetrics.cornerRadius
+                            )
+                        )
+                        .fill(theme.color("accent"))
+                    )
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .help("Schedule send")
         }
-        .buttonStyle(.plain)
-        .help("Send (⏎)")
+        .popover(isPresented: $showsCustomSchedule) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Schedule message")
+                    .font(.headline)
+                DatePicker(
+                    "Send at",
+                    selection: $customScheduleDate,
+                    in: Date()...,
+                    displayedComponents: [.date, .hourAndMinute]
+                )
+                HStack {
+                    Spacer()
+                    Button("Cancel") { showsCustomSchedule = false }
+                    Button("Schedule") {
+                        onSchedule(customScheduleDate)
+                        showsCustomSchedule = false
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(customScheduleDate <= Date())
+                }
+            }
+            .padding(16)
+            .frame(width: 320)
+        }
     }
 
     // MARK: - Stop (single capsule, destructive treatment)

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -369,6 +369,7 @@ struct ACPComposer: View {
                     action: currentAction,
                     onPrimary: handlePrimary,
                     onMenu: handleMenu,
+                    onSchedule: { actions.submitWithIntent?(.schedule($0)) },
                     queueBadgeCount: session.visibleQueueCount
                 )
             }

--- a/Alas/Sources/ACP/UI/ACPQueuedBubble.swift
+++ b/Alas/Sources/ACP/UI/ACPQueuedBubble.swift
@@ -37,7 +37,10 @@ struct ACPQueuedBubble: View {
         .onHover { inside in
             if inside { hover.enter() } else { hover.leave() }
         }
-        .modifier(PendingDraggableModifier(enabled: item.status == .pending, payload: item.id.uuidString))
+        .modifier(PendingDraggableModifier(
+            enabled: item.status == .pending && item.scheduledAt == nil,
+            payload: item.id.uuidString
+        ))
     }
 
     private var statusRow: some View {
@@ -45,7 +48,7 @@ struct ACPQueuedBubble: View {
             if item.status == .sending {
                 ProgressView().scaleEffect(0.45).frame(width: 12, height: 12)
             }
-            Text(item.status == .sending ? "Sending" : "Queued")
+            statusText
                 .font(.system(size: 9, weight: .semibold))
                 .tracking(0.4)
                 .textCase(.uppercase)
@@ -58,6 +61,17 @@ struct ACPQueuedBubble: View {
             }
         }
         .lineLimit(1)
+    }
+
+    @ViewBuilder
+    private var statusText: some View {
+        if item.status == .sending {
+            Text("Sending")
+        } else if let scheduledAt = item.scheduledAt {
+            Text("Scheduled for \(scheduledAt, format: .dateTime.weekday(.abbreviated).month(.abbreviated).day().hour().minute())")
+        } else {
+            Text("Queued")
+        }
     }
 
     private var imageRow: some View {

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -415,7 +415,7 @@ private struct ACPSessionView: View {
             },
             onQueueForceSend: { id in
                 guard ACPTranscriptQueuePolicy.allowsQueueMutation(isMirror: isMirror) else { return }
-                manager.runners[sessionId]?.forceSendQueuedItem(id: id)
+                Task { await manager.queueForceSend(for: sessionId, itemId: id) }
             },
             onQueueRemove: { id in
                 guard ACPTranscriptQueuePolicy.allowsQueueMutation(isMirror: isMirror) else { return }

--- a/Alas/Sources/ACP/UI/ComposerAction.swift
+++ b/Alas/Sources/ACP/UI/ComposerAction.swift
@@ -9,7 +9,8 @@ enum ComposerAction: Equatable {
     /// Idle agent + non-empty composer. Tapping submits the prompt.
     case send
     /// Busy agent + non-empty composer. Primary action enqueues the prompt;
-    /// the menu exposes steer and stop.
+    /// the menu exposes steer and stop. Scheduling stays on the idle Send
+    /// affordance so the busy Queue button keeps its existing shape.
     case queue(menu: [ComposerMenuItem])
     /// Busy agent + empty composer. Tapping cancels the in-flight turn.
     case stop

--- a/Alas/Sources/ACP/UI/ComposerAction.swift
+++ b/Alas/Sources/ACP/UI/ComposerAction.swift
@@ -40,22 +40,21 @@ enum ACPSchedulePreset: CaseIterable, Identifiable {
     func date(after now: Date, calendar: Calendar = .current) -> Date? {
         switch self {
         case .laterToday:
-            guard let twoHoursLater = calendar.date(byAdding: .hour, value: 2, to: now) else { return nil }
-            let start = calendar.startOfDay(for: twoHoursLater)
-            let components = calendar.dateComponents([.hour, .minute], from: twoHoursLater)
-            let minutes = (components.hour ?? 0) * 60 + (components.minute ?? 0)
-            guard let rounded = calendar.date(byAdding: .minute, value: ((minutes + 29) / 30) * 30, to: start),
-                  calendar.isDate(rounded, inSameDayAs: now)
+            let components = calendar.dateComponents([.hour, .minute], from: now)
+            let minutes = (components.hour ?? 0) * 60 + (components.minute ?? 0) + 120
+            let rounded = ((minutes + 29) / 30) * 30
+            guard rounded < 24 * 60,
+                  let date = calendar.date(bySettingHour: rounded / 60, minute: rounded % 60, second: 0, of: now)
             else { return nil }
-            return rounded
+            return date
         case .tomorrowMorning:
             guard let tomorrow = calendar.date(byAdding: .day, value: 1, to: now) else { return nil }
-            return calendar.date(byAdding: .hour, value: 9, to: calendar.startOfDay(for: tomorrow))
+            return calendar.date(bySettingHour: 9, minute: 0, second: 0, of: tomorrow)
         case .nextMondayMorning:
             let weekday = calendar.component(.weekday, from: now)
             let days = (9 - weekday) % 7
             guard let monday = calendar.date(byAdding: .day, value: days == 0 ? 7 : days, to: now) else { return nil }
-            return calendar.date(byAdding: .hour, value: 9, to: calendar.startOfDay(for: monday))
+            return calendar.date(bySettingHour: 9, minute: 0, second: 0, of: monday)
         }
     }
 }

--- a/Alas/Sources/ACP/UI/ComposerAction.swift
+++ b/Alas/Sources/ACP/UI/ComposerAction.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Mutually-exclusive states the composer's single action button can be in.
 /// Derived from `(streamingState, hasText, agentState)` via
 /// `composerAction(...)`. The view layer renders one capsule per case.
@@ -18,6 +20,44 @@ enum ComposerAction: Equatable {
 enum ComposerMenuItem: Hashable {
     case steer
     case stop
+}
+
+enum ACPSchedulePreset: CaseIterable, Identifiable {
+    case laterToday
+    case tomorrowMorning
+    case nextMondayMorning
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .laterToday: "Later today"
+        case .tomorrowMorning: "Tomorrow at 9:00 AM"
+        case .nextMondayMorning: "Next Monday at 9:00 AM"
+        }
+    }
+
+    func date(after now: Date, calendar: Calendar = .current) -> Date? {
+        switch self {
+        case .laterToday:
+            guard let twoHoursLater = calendar.date(byAdding: .hour, value: 2, to: now) else { return nil }
+            let start = calendar.startOfDay(for: twoHoursLater)
+            let components = calendar.dateComponents([.hour, .minute], from: twoHoursLater)
+            let minutes = (components.hour ?? 0) * 60 + (components.minute ?? 0)
+            guard let rounded = calendar.date(byAdding: .minute, value: ((minutes + 29) / 30) * 30, to: start),
+                  calendar.isDate(rounded, inSameDayAs: now)
+            else { return nil }
+            return rounded
+        case .tomorrowMorning:
+            guard let tomorrow = calendar.date(byAdding: .day, value: 1, to: now) else { return nil }
+            return calendar.date(byAdding: .hour, value: 9, to: calendar.startOfDay(for: tomorrow))
+        case .nextMondayMorning:
+            let weekday = calendar.component(.weekday, from: now)
+            let days = (9 - weekday) % 7
+            guard let monday = calendar.date(byAdding: .day, value: days == 0 ? 7 : days, to: now) else { return nil }
+            return calendar.date(byAdding: .hour, value: 9, to: calendar.startOfDay(for: monday))
+        }
+    }
 }
 
 /// Pure derive — no SwiftUI imports, no session/runner references.

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6590,15 +6590,19 @@ final class AppState {
             guard item.status == .pending, item.lastError == nil else { return nil }
             return item.scheduledAt
         }.min()
+        if case .needsAuth = session.setupState { return nil }
+        let hasScheduledQueueWork = nextScheduledAt != nil || session.queue.contains {
+            $0.status == .sending && $0.scheduledAt != nil
+        }
         switch session.agentState {
         case .ready, .spawning:
             break
         case .disconnected:
-            guard nextScheduledAt != nil else { return nil }
+            guard hasScheduledQueueWork else { return nil }
         case .idle:
             return nil
         case .failed:
-            guard nextScheduledAt != nil else { return nil }
+            guard hasScheduledQueueWork else { return nil }
         }
         if session.queue.first?.lastError != nil { return nil }
         let activePromptCleanupDelay: Duration = switch session.transcript.streamingState {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6617,6 +6617,14 @@ final class AppState {
         }) {
             return activePromptCleanupDelay
         }
+        let hasForcedQueueWork = session.queue.contains {
+            $0.scheduledAt == nil && (
+                $0.status == .sending || ($0.status == .pending && session.pendingQueuePersistenceCount > 0)
+            )
+        }
+        if hasForcedQueueWork, manager.retainedCleanupHasActivePromptWork(for: sessionId) {
+            return activePromptCleanupDelay
+        }
         if manager.retainedCleanupHasForkBarrierWork(for: sessionId) {
             return .seconds(30)
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6531,10 +6531,20 @@ final class AppState {
     }
 
     private func retainedScheduledSessionStillNeedsRunner(manager: ACPSessionManager, sessionId: ACPSession.ID) -> Bool {
-        guard let session = manager.liveSession(for: sessionId) else { return false }
-        return session.queue.contains { item in
-            item.status == .sending || (item.status == .pending && item.scheduledAt != nil && item.lastError == nil)
+        retainedScheduledSessionCleanupDelay(manager: manager, sessionId: sessionId) != nil
+    }
+
+    private func retainedScheduledSessionCleanupDelay(manager: ACPSessionManager, sessionId: ACPSession.ID) -> Duration? {
+        guard let session = manager.liveSession(for: sessionId) else { return nil }
+        if session.queue.contains(where: { $0.status == .sending && $0.scheduledAt != nil }) {
+            return .milliseconds(250)
         }
+        let nextScheduledAt = session.queue.compactMap { item -> Date? in
+            guard item.status == .pending, item.lastError == nil else { return nil }
+            return item.scheduledAt
+        }.min()
+        guard let nextScheduledAt else { return nil }
+        return .seconds(max(0, nextScheduledAt.timeIntervalSinceNow))
     }
 
     private func scheduleRetainedACPSessionCleanup(owner: SessionOwnerID, sessionId: ACPSession.ID) {
@@ -6548,13 +6558,13 @@ final class AppState {
                     self.clearRetainedACPSessionCleanup(worktreeId: key, sessionId: sessionId, id: id)
                     return
                 }
-                if !self.retainedScheduledSessionStillNeedsRunner(manager: manager, sessionId: sessionId) {
+                guard let delay = self.retainedScheduledSessionCleanupDelay(manager: manager, sessionId: sessionId) else {
                     self.clearRetainedACPSessionCleanup(worktreeId: key, sessionId: sessionId, id: id)
                     self.cleanupACPSession(owner: owner, sessionId: sessionId)
                     return
                 }
                 do {
-                    try await Task.sleep(for: .milliseconds(250))
+                    try await Task.sleep(for: delay)
                 } catch {
                     return
                 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6614,6 +6614,9 @@ final class AppState {
         }
         guard let nextScheduledAt else { return nil }
         let secondsUntilScheduledSend = nextScheduledAt.timeIntervalSinceNow
+        if case .spawning = session.agentState, secondsUntilScheduledSend <= 0 {
+            return .seconds(30)
+        }
         guard secondsUntilScheduledSend > 0 else { return activePromptCleanupDelay }
         return .seconds(secondsUntilScheduledSend)
     }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1090,14 +1090,11 @@ final class AppState {
     }
 
     private func bootstrapScheduledACPSessions(owner: SessionOwnerID, manager: ACPSessionManager) async {
-        let sessionIds = await manager.bootstrapScheduledQueueSessions()
-        let tasks = sessionIds.compactMap { sessionId -> Task<Void, Never>? in
-            guard !hasACPSessionTab(owner: owner, sessionId: sessionId) else { return nil }
-            return Task { @MainActor in
-                cleanupACPSession(owner: owner, sessionId: sessionId)
-            }
+        _ = await manager.bootstrapScheduledQueueSessions { [weak self] sessionId in
+            guard let self else { return }
+            guard !hasACPSessionTab(owner: owner, sessionId: sessionId) else { return }
+            cleanupACPSession(owner: owner, sessionId: sessionId)
         }
-        for task in tasks { await task.value }
     }
 
     private func hasACPSessionTab(owner: SessionOwnerID, sessionId: ACPSession.ID) -> Bool {
@@ -6598,8 +6595,10 @@ final class AppState {
             break
         case .disconnected:
             guard nextScheduledAt != nil else { return nil }
-        case .idle, .failed:
+        case .idle:
             return nil
+        case .failed:
+            guard nextScheduledAt != nil else { return nil }
         }
         if session.queue.first?.lastError != nil { return nil }
         let activePromptCleanupDelay: Duration = switch session.transcript.streamingState {
@@ -6665,14 +6664,18 @@ final class AppState {
     }
 
     private func reattachRetainedScheduledSessionIfDue(manager: ACPSessionManager, sessionId: ACPSession.ID) {
-        guard let session = manager.liveSession(for: sessionId),
-              case .disconnected = session.agentState,
-              session.queue.contains(where: { item in
-                  item.status == .pending
-                      && item.lastError == nil
-                      && (item.scheduledAt?.timeIntervalSinceNow ?? .greatestFiniteMagnitude) <= 0
-              })
-        else { return }
+        guard let session = manager.liveSession(for: sessionId) else { return }
+        switch session.agentState {
+        case .disconnected, .failed:
+            break
+        case .idle, .ready, .spawning:
+            return
+        }
+        guard session.queue.contains(where: { item in
+            item.status == .pending
+                && item.lastError == nil
+                && (item.scheduledAt?.timeIntervalSinceNow ?? .greatestFiniteMagnitude) <= 0
+        }) else { return }
         Task { @MainActor in await manager.reattach(to: sessionId) }
     }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1068,9 +1068,13 @@ final class AppState {
 
     private func restoreLoadedWorkspaceCheckoutACPSessions() async {
         guard config.workspacesEnabled, workspacesManager.canMutate else { return }
-        for checkout in workspacesManager.checkouts where checkout.archivedAt == nil {
-            _ = await restoreWorkspaceCheckoutACPSessions(checkout)
+        let tasks = workspacesManager.checkouts.compactMap { checkout -> Task<Void, Never>? in
+            guard checkout.archivedAt == nil else { return nil }
+            return Task { @MainActor in
+                _ = await restoreWorkspaceCheckoutACPSessions(checkout)
+            }
         }
+        for task in tasks { await task.value }
     }
 
     private func bootstrapScheduledACPSessions(worktreeIds: [String]) async {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1061,12 +1061,38 @@ final class AppState {
         Task { [weak self] in
             await self?.reconcileInterruptedDelegations()
         }
+        Task { @MainActor [weak self] in
+            await self?.bootstrapScheduledACPSessions(worktreeIds: allWorktreeIds)
+        }
     }
 
     private func restoreLoadedWorkspaceCheckoutACPSessions() async {
         guard config.workspacesEnabled, workspacesManager.canMutate else { return }
         for checkout in workspacesManager.checkouts where checkout.archivedAt == nil {
             _ = await restoreWorkspaceCheckoutACPSessions(checkout)
+        }
+    }
+
+    private func bootstrapScheduledACPSessions(worktreeIds: [String]) async {
+        for worktreeId in worktreeIds {
+            guard let worktree = worktree(withId: worktreeId),
+                  let manager = acpManager(for: worktree)
+            else { continue }
+            await bootstrapScheduledACPSessions(owner: .worktree(worktreeId), manager: manager)
+        }
+    }
+
+    private func bootstrapScheduledACPSessions(owner: SessionOwnerID, manager: ACPSessionManager) async {
+        let sessionIds = await manager.bootstrapScheduledQueueSessions()
+        for sessionId in sessionIds where !hasACPSessionTab(owner: owner, sessionId: sessionId) {
+            cleanupACPSession(owner: owner, sessionId: sessionId)
+        }
+    }
+
+    private func hasACPSessionTab(owner: SessionOwnerID, sessionId: ACPSession.ID) -> Bool {
+        tabs.tabs(for: owner).contains {
+            guard case .acpSession(let state) = $0 else { return false }
+            return state.sessionId == sessionId
         }
     }
 
@@ -8949,6 +8975,7 @@ final class AppState {
             guard manager.placeholderSession(id: state.sessionId) != nil else { continue }
             await manager.hydrateIfNeeded(id: state.sessionId)
         }
+        await bootstrapScheduledACPSessions(owner: owner, manager: manager)
         return true
     }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6676,7 +6676,7 @@ final class AppState {
             return
         }
         guard session.queue.contains(where: { item in
-            item.status == .pending
+            (item.status == .pending || item.status == .sending)
                 && item.lastError == nil
                 && (item.scheduledAt?.timeIntervalSinceNow ?? .greatestFiniteMagnitude) <= 0
         }) else { return }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6594,15 +6594,20 @@ final class AppState {
         let hasScheduledQueueWork = nextScheduledAt != nil || session.queue.contains {
             $0.status == .sending && $0.scheduledAt != nil
         }
+        let hasForcedQueueWork = session.queue.contains {
+            $0.scheduledAt == nil && (
+                $0.status == .sending || ($0.status == .pending && session.pendingQueuePersistenceCount > 0)
+            )
+        }
         switch session.agentState {
         case .ready, .spawning:
             break
         case .disconnected:
-            guard hasScheduledQueueWork else { return nil }
+            guard hasScheduledQueueWork || hasForcedQueueWork else { return nil }
         case .idle:
             return nil
         case .failed:
-            guard hasScheduledQueueWork else { return nil }
+            guard hasScheduledQueueWork || hasForcedQueueWork else { return nil }
         }
         if session.queue.first?.lastError != nil { return nil }
         let activePromptCleanupDelay: Duration = switch session.transcript.streamingState {
@@ -6616,11 +6621,6 @@ final class AppState {
             $0.status == .sending && ($0.scheduledAt != nil || nextScheduledAt != nil)
         }) {
             return activePromptCleanupDelay
-        }
-        let hasForcedQueueWork = session.queue.contains {
-            $0.scheduledAt == nil && (
-                $0.status == .sending || ($0.status == .pending && session.pendingQueuePersistenceCount > 0)
-            )
         }
         if hasForcedQueueWork, manager.retainedCleanupHasActivePromptWork(for: sessionId) {
             return activePromptCleanupDelay

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6534,23 +6534,33 @@ final class AppState {
         retainedScheduledSessionCleanupDelay(manager: manager, sessionId: sessionId) != nil
     }
 
-    private func retainedScheduledSessionCleanupDelay(manager: ACPSessionManager, sessionId: ACPSession.ID) -> Duration? {
+    private func retainedScheduledSessionCleanupDelay(
+        manager: ACPSessionManager,
+        sessionId: ACPSession.ID,
+        retainSendingPrompt: Bool = false
+    ) -> Duration? {
         guard let session = manager.liveSession(for: sessionId) else { return nil }
         if session.queue.first?.lastError != nil { return nil }
-        if session.queue.contains(where: { $0.status == .sending && $0.scheduledAt != nil }) {
-            return .milliseconds(250)
-        }
         let nextScheduledAt = session.queue.compactMap { item -> Date? in
             guard item.status == .pending, item.lastError == nil else { return nil }
             return item.scheduledAt
         }.min()
+        if session.queue.contains(where: {
+            $0.status == .sending && ($0.scheduledAt != nil || retainSendingPrompt || nextScheduledAt != nil)
+        }) {
+            return .milliseconds(250)
+        }
         guard let nextScheduledAt else { return nil }
         let secondsUntilScheduledSend = nextScheduledAt.timeIntervalSinceNow
         guard secondsUntilScheduledSend > 0 else { return .milliseconds(250) }
         return .seconds(secondsUntilScheduledSend)
     }
 
-    private func scheduleRetainedACPSessionCleanup(owner: SessionOwnerID, sessionId: ACPSession.ID) {
+    private func scheduleRetainedACPSessionCleanup(
+        owner: SessionOwnerID,
+        sessionId: ACPSession.ID,
+        retainSendingPrompt: Bool = false
+    ) {
         let key = owner.storageKey
         guard retainedACPSessionCleanupTasks[key]?[sessionId] == nil else { return }
         let id = UUID()
@@ -6561,7 +6571,11 @@ final class AppState {
                     self.clearRetainedACPSessionCleanup(worktreeId: key, sessionId: sessionId, id: id)
                     return
                 }
-                guard let delay = self.retainedScheduledSessionCleanupDelay(manager: manager, sessionId: sessionId) else {
+                guard let delay = self.retainedScheduledSessionCleanupDelay(
+                    manager: manager,
+                    sessionId: sessionId,
+                    retainSendingPrompt: retainSendingPrompt
+                ) else {
                     self.clearRetainedACPSessionCleanup(worktreeId: key, sessionId: sessionId, id: id)
                     self.cleanupACPSession(owner: owner, sessionId: sessionId)
                     return
@@ -6579,7 +6593,11 @@ final class AppState {
     private func restartRetainedACPSessionCleanupIfNeeded(owner: SessionOwnerID, sessionId: ACPSession.ID) {
         guard retainedACPSessionCleanupTasks[owner.storageKey]?[sessionId] != nil else { return }
         cancelRetainedACPSessionCleanup(owner: owner, sessionId: sessionId)
-        cleanupACPSession(owner: owner, sessionId: sessionId)
+        guard acpManagers[owner]?.liveSession(for: sessionId)?.queue.contains(where: { $0.status == .sending }) == true else {
+            cleanupACPSession(owner: owner, sessionId: sessionId)
+            return
+        }
+        scheduleRetainedACPSessionCleanup(owner: owner, sessionId: sessionId, retainSendingPrompt: true)
     }
 
     private func cancelRetainedACPSessionCleanup(owner: SessionOwnerID, sessionId: ACPSession.ID) {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6597,9 +6597,7 @@ final class AppState {
         case .ready, .spawning:
             break
         case .disconnected:
-            guard nextScheduledAt != nil,
-                  manager.retainedCleanupHasAutoReconnectWork(for: sessionId)
-            else { return nil }
+            guard nextScheduledAt != nil else { return nil }
         case .idle, .failed:
             return nil
         }
@@ -6655,6 +6653,7 @@ final class AppState {
                     self.cleanupACPSession(owner: owner, sessionId: sessionId)
                     return
                 }
+                self.reattachRetainedScheduledSessionIfDue(manager: manager, sessionId: sessionId)
                 do {
                     try await Task.sleep(for: delay)
                 } catch {
@@ -6663,6 +6662,18 @@ final class AppState {
             }
         }
         retainedACPSessionCleanupTasks[key, default: [:]][sessionId] = PendingACPDetach(id: id, task: task)
+    }
+
+    private func reattachRetainedScheduledSessionIfDue(manager: ACPSessionManager, sessionId: ACPSession.ID) {
+        guard let session = manager.liveSession(for: sessionId),
+              case .disconnected = session.agentState,
+              session.queue.contains(where: { item in
+                  item.status == .pending
+                      && item.lastError == nil
+                      && (item.scheduledAt?.timeIntervalSinceNow ?? .greatestFiniteMagnitude) <= 0
+              })
+        else { return }
+        Task { @MainActor in await manager.reattach(to: sessionId) }
     }
 
     private func restartRetainedACPSessionCleanupIfNeeded(

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6480,6 +6480,9 @@ final class AppState {
 
     private func cleanupACPSession(owner: SessionOwnerID, sessionId: String) {
         guard let manager = acpManagers[owner] else { return }
+        if manager.liveSession(for: sessionId)?.queue.contains(where: { $0.status == .pending && $0.scheduledAt != nil }) == true {
+            return
+        }
         // Flush any in-flight debounced draft write for this session
         // before the tab goes away. The manager itself stays alive
         // (other tabs may share it), so the global flush from

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6617,15 +6617,15 @@ final class AppState {
         }) {
             return activePromptCleanupDelay
         }
+        if manager.retainedCleanupHasForkBarrierWork(for: sessionId) {
+            return .seconds(30)
+        }
         guard let nextScheduledAt else { return nil }
         let secondsUntilScheduledSend = nextScheduledAt.timeIntervalSinceNow
         if case .disconnected = session.agentState, secondsUntilScheduledSend <= 0 {
             return .seconds(30)
         }
         if case .spawning = session.agentState, secondsUntilScheduledSend <= 0 {
-            return .seconds(30)
-        }
-        if manager.retainedCleanupHasForkBarrierWork(for: sessionId), secondsUntilScheduledSend <= 0 {
             return .seconds(30)
         }
         guard secondsUntilScheduledSend > 0 else { return activePromptCleanupDelay }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6625,6 +6625,9 @@ final class AppState {
         if hasForcedQueueWork, manager.retainedCleanupHasActivePromptWork(for: sessionId) {
             return activePromptCleanupDelay
         }
+        if manager.retainedCleanupHasSteerWork(for: sessionId) {
+            return activePromptCleanupDelay
+        }
         if manager.retainedCleanupHasForkBarrierWork(for: sessionId) {
             return .seconds(30)
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6544,7 +6544,9 @@ final class AppState {
             return item.scheduledAt
         }.min()
         guard let nextScheduledAt else { return nil }
-        return .seconds(max(0, nextScheduledAt.timeIntervalSinceNow))
+        let secondsUntilScheduledSend = nextScheduledAt.timeIntervalSinceNow
+        guard secondsUntilScheduledSend > 0 else { return .milliseconds(250) }
+        return .seconds(secondsUntilScheduledSend)
     }
 
     private func scheduleRetainedACPSessionCleanup(owner: SessionOwnerID, sessionId: ACPSession.ID) {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -9189,6 +9189,7 @@ final class AppState {
         guard let worktreeId = selectedWorktreeId,
               let worktree = worktree(withId: worktreeId) else { return }
         guard let mgr = acpManager(for: worktree) else { return }
+        cancelRetainedACPSessionCleanup(owner: .worktree(worktree.id), sessionId: sessionId)
 
         // Focus the tab if it's already there.
         let tabIdToFocus: TabID? = tabs.tabs(forWorktree: worktree.id).compactMap { tab -> TabID? in
@@ -9222,6 +9223,7 @@ final class AppState {
     /// their database, tabs, and lifecycle are tied to the checkout owner.
     func openExistingACPSession(sessionId: ACPSession.ID, owner: SessionOwnerID) async {
         guard let mgr = acpManager(for: owner) else { return }
+        cancelRetainedACPSessionCleanup(owner: owner, sessionId: sessionId)
 
         let tabIdToFocus: TabID? = tabs.tabs(for: owner).compactMap { tab -> TabID? in
             if case .acpSession(let state) = tab, state.sessionId == sessionId { return tab.id }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6540,6 +6540,7 @@ final class AppState {
         retainSendingPrompt: Bool = false
     ) -> Duration? {
         guard let session = manager.liveSession(for: sessionId) else { return nil }
+        guard session.agentState == .ready else { return nil }
         if session.queue.first?.lastError != nil { return nil }
         let nextScheduledAt = session.queue.compactMap { item -> Date? in
             guard item.status == .pending, item.lastError == nil else { return nil }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6537,17 +6537,25 @@ final class AppState {
     private func retainedScheduledSessionCleanupDelay(
         manager: ACPSessionManager,
         sessionId: ACPSession.ID,
-        retainSendingPrompt: Bool = false
+        retainActivePrompt: Bool = false
     ) -> Duration? {
         guard let session = manager.liveSession(for: sessionId) else { return nil }
-        guard session.agentState == .ready else { return nil }
+        switch session.agentState {
+        case .ready, .spawning:
+            break
+        case .idle, .disconnected, .failed:
+            return nil
+        }
         if session.queue.first?.lastError != nil { return nil }
         let nextScheduledAt = session.queue.compactMap { item -> Date? in
             guard item.status == .pending, item.lastError == nil else { return nil }
             return item.scheduledAt
         }.min()
+        if retainActivePrompt && manager.retainedCleanupHasActivePromptWork(for: sessionId) {
+            return .milliseconds(250)
+        }
         if session.queue.contains(where: {
-            $0.status == .sending && ($0.scheduledAt != nil || retainSendingPrompt || nextScheduledAt != nil)
+            $0.status == .sending && ($0.scheduledAt != nil || nextScheduledAt != nil)
         }) {
             return .milliseconds(250)
         }
@@ -6560,7 +6568,7 @@ final class AppState {
     private func scheduleRetainedACPSessionCleanup(
         owner: SessionOwnerID,
         sessionId: ACPSession.ID,
-        retainSendingPrompt: Bool = false
+        retainActivePrompt: Bool = false
     ) {
         let key = owner.storageKey
         guard retainedACPSessionCleanupTasks[key]?[sessionId] == nil else { return }
@@ -6575,7 +6583,7 @@ final class AppState {
                 guard let delay = self.retainedScheduledSessionCleanupDelay(
                     manager: manager,
                     sessionId: sessionId,
-                    retainSendingPrompt: retainSendingPrompt
+                    retainActivePrompt: retainActivePrompt
                 ) else {
                     self.clearRetainedACPSessionCleanup(worktreeId: key, sessionId: sessionId, id: id)
                     self.cleanupACPSession(owner: owner, sessionId: sessionId)
@@ -6591,14 +6599,18 @@ final class AppState {
         retainedACPSessionCleanupTasks[key, default: [:]][sessionId] = PendingACPDetach(id: id, task: task)
     }
 
-    private func restartRetainedACPSessionCleanupIfNeeded(owner: SessionOwnerID, sessionId: ACPSession.ID) {
+    private func restartRetainedACPSessionCleanupIfNeeded(
+        owner: SessionOwnerID,
+        sessionId: ACPSession.ID,
+        retainActivePrompt: Bool = false
+    ) {
         guard retainedACPSessionCleanupTasks[owner.storageKey]?[sessionId] != nil else { return }
         cancelRetainedACPSessionCleanup(owner: owner, sessionId: sessionId)
-        guard acpManagers[owner]?.liveSession(for: sessionId)?.queue.contains(where: { $0.status == .sending }) == true else {
+        guard retainActivePrompt else {
             cleanupACPSession(owner: owner, sessionId: sessionId)
             return
         }
-        scheduleRetainedACPSessionCleanup(owner: owner, sessionId: sessionId, retainSendingPrompt: true)
+        scheduleRetainedACPSessionCleanup(owner: owner, sessionId: sessionId, retainActivePrompt: true)
     }
 
     private func cancelRetainedACPSessionCleanup(owner: SessionOwnerID, sessionId: ACPSession.ID) {
@@ -8284,8 +8296,12 @@ final class AppState {
                     await self.deliverPendingDelegatedMessages(to: sessionId, manager: manager)
                 }
             },
-            onQueueChanged: { [weak self] sessionId in
-                self?.restartRetainedACPSessionCleanupIfNeeded(owner: owner, sessionId: sessionId)
+            onQueueChanged: { [weak self] sessionId, retainActivePrompt in
+                self?.restartRetainedACPSessionCleanupIfNeeded(
+                    owner: owner,
+                    sessionId: sessionId,
+                    retainActivePrompt: retainActivePrompt
+                )
             },
             brokerServiceFactory: {
                 let resourceURL = Bundle.main.resourceURL ?? Bundle.main.bundleURL
@@ -8576,8 +8592,12 @@ final class AppState {
                     owner: owner
                 )
             },
-            onQueueChanged: { [weak self] sessionId in
-                self?.restartRetainedACPSessionCleanupIfNeeded(owner: owner, sessionId: sessionId)
+            onQueueChanged: { [weak self] sessionId, retainActivePrompt in
+                self?.restartRetainedACPSessionCleanupIfNeeded(
+                    owner: owner,
+                    sessionId: sessionId,
+                    retainActivePrompt: retainActivePrompt
+                )
             },
             launchSpecTransformer: { [weak self] spec in
                 guard let self,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6657,9 +6657,14 @@ final class AppState {
     }
 
     private func awaitPendingACPDetach(worktreeId: String, sessionId: ACPSession.ID) async {
-        guard let pending = pendingACPDetachTasks[worktreeId]?[sessionId] else { return }
+        await awaitPendingACPDetach(owner: .worktree(worktreeId), sessionId: sessionId)
+    }
+
+    private func awaitPendingACPDetach(owner: SessionOwnerID, sessionId: ACPSession.ID) async {
+        let key = owner.storageKey
+        guard let pending = pendingACPDetachTasks[key]?[sessionId] else { return }
         await pending.task.value
-        clearPendingACPDetach(worktreeId: worktreeId, sessionId: sessionId, id: pending.id)
+        clearPendingACPDetach(worktreeId: key, sessionId: sessionId, id: pending.id)
     }
 
     private func clearPendingACPDetach(worktreeId: String, sessionId: ACPSession.ID, id: UUID) {
@@ -9188,6 +9193,7 @@ final class AppState {
     func openExistingACPSession(sessionId: ACPSession.ID) async {
         guard let worktreeId = selectedWorktreeId,
               let worktree = worktree(withId: worktreeId) else { return }
+        await awaitPendingACPDetach(owner: .worktree(worktree.id), sessionId: sessionId)
         guard let mgr = acpManager(for: worktree) else { return }
         cancelRetainedACPSessionCleanup(owner: .worktree(worktree.id), sessionId: sessionId)
 
@@ -9222,6 +9228,7 @@ final class AppState {
     /// Checkout-owned sessions must not fall back to Repository Focus because
     /// their database, tabs, and lifecycle are tied to the checkout owner.
     func openExistingACPSession(sessionId: ACPSession.ID, owner: SessionOwnerID) async {
+        await awaitPendingACPDetach(owner: owner, sessionId: sessionId)
         guard let mgr = acpManager(for: owner) else { return }
         cancelRetainedACPSessionCleanup(owner: owner, sessionId: sessionId)
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -151,6 +151,18 @@ final class AppState {
     var retainedACPSessionCleanupCountForTesting: Int {
         retainedACPSessionCleanupTasks.values.reduce(0) { $0 + $1.count }
     }
+
+    func retainedACPSessionCleanupDelayForTesting(
+        manager: ACPSessionManager,
+        sessionId: ACPSession.ID,
+        retainActivePrompt: Bool = false
+    ) -> Duration? {
+        retainedScheduledSessionCleanupDelay(
+            manager: manager,
+            sessionId: sessionId,
+            retainActivePrompt: retainActivePrompt
+        )
+    }
 #endif
     @ObservationIgnored
     private var acpAuthTerminalExitHandlers: [String: () -> Void] = [:]
@@ -6551,13 +6563,17 @@ final class AppState {
             guard item.status == .pending, item.lastError == nil else { return nil }
             return item.scheduledAt
         }.min()
+        let activePromptCleanupDelay: Duration = switch session.transcript.streamingState {
+        case .awaitingInput, .awaitingPermission: .seconds(3600)
+        case .idle, .sending, .streaming: .milliseconds(250)
+        }
         if retainActivePrompt && manager.retainedCleanupHasActivePromptWork(for: sessionId) {
-            return .milliseconds(250)
+            return activePromptCleanupDelay
         }
         if session.queue.contains(where: {
             $0.status == .sending && ($0.scheduledAt != nil || nextScheduledAt != nil)
         }) {
-            return .milliseconds(250)
+            return activePromptCleanupDelay
         }
         guard let nextScheduledAt else { return nil }
         let secondsUntilScheduledSend = nextScheduledAt.timeIntervalSinceNow

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6605,7 +6605,7 @@ final class AppState {
         case .disconnected:
             guard hasScheduledQueueWork || hasForcedQueueWork else { return nil }
         case .idle:
-            return nil
+            guard hasScheduledQueueWork || hasForcedQueueWork else { return nil }
         case .failed:
             guard hasScheduledQueueWork || hasForcedQueueWork else { return nil }
         }
@@ -6634,6 +6634,9 @@ final class AppState {
         guard let nextScheduledAt else { return nil }
         let secondsUntilScheduledSend = nextScheduledAt.timeIntervalSinceNow
         if case .disconnected = session.agentState, secondsUntilScheduledSend <= 0 {
+            return .seconds(30)
+        }
+        if case .idle = session.agentState, secondsUntilScheduledSend <= 0 {
             return .seconds(30)
         }
         if case .spawning = session.agentState, secondsUntilScheduledSend <= 0 {
@@ -6684,7 +6687,9 @@ final class AppState {
         switch session.agentState {
         case .disconnected, .failed:
             break
-        case .idle, .ready, .spawning:
+        case .idle:
+            break
+        case .ready, .spawning:
             return
         }
         guard session.queue.contains(where: { item in

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6536,6 +6536,7 @@ final class AppState {
 
     private func retainedScheduledSessionCleanupDelay(manager: ACPSessionManager, sessionId: ACPSession.ID) -> Duration? {
         guard let session = manager.liveSession(for: sessionId) else { return nil }
+        if session.queue.first?.lastError != nil { return nil }
         if session.queue.contains(where: { $0.status == .sending && $0.scheduledAt != nil }) {
             return .milliseconds(250)
         }
@@ -6573,6 +6574,12 @@ final class AppState {
             }
         }
         retainedACPSessionCleanupTasks[key, default: [:]][sessionId] = PendingACPDetach(id: id, task: task)
+    }
+
+    private func restartRetainedACPSessionCleanupIfNeeded(owner: SessionOwnerID, sessionId: ACPSession.ID) {
+        guard retainedACPSessionCleanupTasks[owner.storageKey]?[sessionId] != nil else { return }
+        cancelRetainedACPSessionCleanup(owner: owner, sessionId: sessionId)
+        cleanupACPSession(owner: owner, sessionId: sessionId)
     }
 
     private func cancelRetainedACPSessionCleanup(owner: SessionOwnerID, sessionId: ACPSession.ID) {
@@ -8258,6 +8265,9 @@ final class AppState {
                     await self.deliverPendingDelegatedMessages(to: sessionId, manager: manager)
                 }
             },
+            onQueueChanged: { [weak self] sessionId in
+                self?.restartRetainedACPSessionCleanupIfNeeded(owner: owner, sessionId: sessionId)
+            },
             brokerServiceFactory: {
                 let resourceURL = Bundle.main.resourceURL ?? Bundle.main.bundleURL
                 return try await LocalACPBrokerServicePool.shared.service(resourceURL: resourceURL)
@@ -8546,6 +8556,9 @@ final class AppState {
                     requestId: self.notificationRequestId(for: request),
                     owner: owner
                 )
+            },
+            onQueueChanged: { [weak self] sessionId in
+                self?.restartRetainedACPSessionCleanupIfNeeded(owner: owner, sessionId: sessionId)
             },
             launchSpecTransformer: { [weak self] spec in
                 guard let self,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6650,12 +6650,13 @@ final class AppState {
     ) {
         let key = owner.storageKey
         guard retainedACPSessionCleanupTasks[key]?[sessionId] == nil else { return }
+        acpManagers[owner]?.retainSession(id: sessionId)
         let id = UUID()
         let task = Task { @MainActor [weak self] in
             while !Task.isCancelled {
                 guard let self else { return }
                 guard let manager = self.acpManagers[owner] else {
-                    self.clearRetainedACPSessionCleanup(worktreeId: key, sessionId: sessionId, id: id)
+                    self.clearRetainedACPSessionCleanup(owner: owner, sessionId: sessionId, id: id)
                     return
                 }
                 guard let delay = self.retainedScheduledSessionCleanupDelay(
@@ -6663,7 +6664,7 @@ final class AppState {
                     sessionId: sessionId,
                     retainActivePrompt: retainActivePrompt
                 ) else {
-                    self.clearRetainedACPSessionCleanup(worktreeId: key, sessionId: sessionId, id: id)
+                    self.clearRetainedACPSessionCleanup(owner: owner, sessionId: sessionId, id: id)
                     self.cleanupACPSession(owner: owner, sessionId: sessionId)
                     return
                 }
@@ -6710,29 +6711,34 @@ final class AppState {
 
     private func cancelRetainedACPSessionCleanup(owner: SessionOwnerID, sessionId: ACPSession.ID) {
         let key = owner.storageKey
-        retainedACPSessionCleanupTasks[key]?[sessionId]?.task.cancel()
+        guard let pending = retainedACPSessionCleanupTasks[key]?[sessionId] else { return }
+        pending.task.cancel()
         retainedACPSessionCleanupTasks[key]?.removeValue(forKey: sessionId)
         if retainedACPSessionCleanupTasks[key]?.isEmpty == true {
             retainedACPSessionCleanupTasks.removeValue(forKey: key)
         }
+        acpManagers[owner]?.releaseSession(id: sessionId)
     }
 
     private func cancelRetainedACPSessionCleanups(owner: SessionOwnerID) {
         let key = owner.storageKey
         if let pendingBySession = retainedACPSessionCleanupTasks[key] {
-            for pending in pendingBySession.values {
+            for (sessionId, pending) in pendingBySession {
                 pending.task.cancel()
+                acpManagers[owner]?.releaseSession(id: sessionId)
             }
         }
         retainedACPSessionCleanupTasks.removeValue(forKey: key)
     }
 
-    private func clearRetainedACPSessionCleanup(worktreeId: String, sessionId: ACPSession.ID, id: UUID) {
-        guard retainedACPSessionCleanupTasks[worktreeId]?[sessionId]?.id == id else { return }
-        retainedACPSessionCleanupTasks[worktreeId]?.removeValue(forKey: sessionId)
-        if retainedACPSessionCleanupTasks[worktreeId]?.isEmpty == true {
-            retainedACPSessionCleanupTasks.removeValue(forKey: worktreeId)
+    private func clearRetainedACPSessionCleanup(owner: SessionOwnerID, sessionId: ACPSession.ID, id: UUID) {
+        let key = owner.storageKey
+        guard retainedACPSessionCleanupTasks[key]?[sessionId]?.id == id else { return }
+        retainedACPSessionCleanupTasks[key]?.removeValue(forKey: sessionId)
+        if retainedACPSessionCleanupTasks[key]?.isEmpty == true {
+            retainedACPSessionCleanupTasks.removeValue(forKey: key)
         }
+        acpManagers[owner]?.releaseSession(id: sessionId)
     }
 
     private func awaitPendingACPDetach(worktreeId: String, sessionId: ACPSession.ID) async {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6701,6 +6701,8 @@ final class AppState {
         retainActivePrompt: Bool = false
     ) {
         guard retainedACPSessionCleanupTasks[owner.storageKey]?[sessionId] != nil else { return }
+        acpManagers[owner]?.retainSession(id: sessionId)
+        defer { acpManagers[owner]?.releaseSession(id: sessionId) }
         cancelRetainedACPSessionCleanup(owner: owner, sessionId: sessionId)
         guard retainActivePrompt else {
             cleanupACPSession(owner: owner, sessionId: sessionId)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6589,17 +6589,21 @@ final class AppState {
         retainActivePrompt: Bool = false
     ) -> Duration? {
         guard let session = manager.liveSession(for: sessionId) else { return nil }
-        switch session.agentState {
-        case .ready, .spawning:
-            break
-        case .idle, .disconnected, .failed:
-            return nil
-        }
-        if session.queue.first?.lastError != nil { return nil }
         let nextScheduledAt = session.queue.compactMap { item -> Date? in
             guard item.status == .pending, item.lastError == nil else { return nil }
             return item.scheduledAt
         }.min()
+        switch session.agentState {
+        case .ready, .spawning:
+            break
+        case .disconnected:
+            guard nextScheduledAt != nil,
+                  manager.retainedCleanupHasAutoReconnectWork(for: sessionId)
+            else { return nil }
+        case .idle, .failed:
+            return nil
+        }
+        if session.queue.first?.lastError != nil { return nil }
         let activePromptCleanupDelay: Duration = switch session.transcript.streamingState {
         case .awaitingInput, .awaitingPermission: .seconds(3600)
         case .idle, .sending, .streaming: .milliseconds(250)
@@ -6614,7 +6618,13 @@ final class AppState {
         }
         guard let nextScheduledAt else { return nil }
         let secondsUntilScheduledSend = nextScheduledAt.timeIntervalSinceNow
+        if case .disconnected = session.agentState, secondsUntilScheduledSend <= 0 {
+            return .seconds(30)
+        }
         if case .spawning = session.agentState, secondsUntilScheduledSend <= 0 {
+            return .seconds(30)
+        }
+        if manager.retainedCleanupHasForkBarrierWork(for: sessionId), secondsUntilScheduledSend <= 0 {
             return .seconds(30)
         }
         guard secondsUntilScheduledSend > 0 else { return activePromptCleanupDelay }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -140,10 +140,16 @@ final class AppState {
     @ObservationIgnored
     private var pendingACPDetachTasks: [String: [ACPSession.ID: PendingACPDetach]] = [:]
     @ObservationIgnored
+    private var retainedACPSessionCleanupTasks: [String: [ACPSession.ID: PendingACPDetach]] = [:]
+    @ObservationIgnored
     private var reconciledCreateFailureCompletionClaims: Set<String> = []
 #if DEBUG
     var pendingACPDetachCountForTesting: Int {
         pendingACPDetachTasks.values.reduce(0) { $0 + $1.count }
+    }
+
+    var retainedACPSessionCleanupCountForTesting: Int {
+        retainedACPSessionCleanupTasks.values.reduce(0) { $0 + $1.count }
     }
 #endif
     @ObservationIgnored
@@ -6480,9 +6486,11 @@ final class AppState {
 
     private func cleanupACPSession(owner: SessionOwnerID, sessionId: String) {
         guard let manager = acpManagers[owner] else { return }
-        if manager.liveSession(for: sessionId)?.queue.contains(where: { $0.status == .pending && $0.scheduledAt != nil }) == true {
+        if retainedScheduledSessionStillNeedsRunner(manager: manager, sessionId: sessionId) {
+            scheduleRetainedACPSessionCleanup(owner: owner, sessionId: sessionId)
             return
         }
+        cancelRetainedACPSessionCleanup(owner: owner, sessionId: sessionId)
         // Flush any in-flight debounced draft write for this session
         // before the tab goes away. The manager itself stays alive
         // (other tabs may share it), so the global flush from
@@ -6519,6 +6527,66 @@ final class AppState {
         Task { @MainActor [weak self] in
             await task.value
             self?.clearPendingACPDetach(worktreeId: pendingKey, sessionId: sessionId, id: pendingID)
+        }
+    }
+
+    private func retainedScheduledSessionStillNeedsRunner(manager: ACPSessionManager, sessionId: ACPSession.ID) -> Bool {
+        guard let session = manager.liveSession(for: sessionId) else { return false }
+        return session.queue.contains { item in
+            item.status == .sending || (item.status == .pending && item.scheduledAt != nil && item.lastError == nil)
+        }
+    }
+
+    private func scheduleRetainedACPSessionCleanup(owner: SessionOwnerID, sessionId: ACPSession.ID) {
+        let key = owner.storageKey
+        guard retainedACPSessionCleanupTasks[key]?[sessionId] == nil else { return }
+        let id = UUID()
+        let task = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                guard let manager = self.acpManagers[owner] else {
+                    self.clearRetainedACPSessionCleanup(worktreeId: key, sessionId: sessionId, id: id)
+                    return
+                }
+                if !self.retainedScheduledSessionStillNeedsRunner(manager: manager, sessionId: sessionId) {
+                    self.clearRetainedACPSessionCleanup(worktreeId: key, sessionId: sessionId, id: id)
+                    self.cleanupACPSession(owner: owner, sessionId: sessionId)
+                    return
+                }
+                do {
+                    try await Task.sleep(for: .milliseconds(250))
+                } catch {
+                    return
+                }
+            }
+        }
+        retainedACPSessionCleanupTasks[key, default: [:]][sessionId] = PendingACPDetach(id: id, task: task)
+    }
+
+    private func cancelRetainedACPSessionCleanup(owner: SessionOwnerID, sessionId: ACPSession.ID) {
+        let key = owner.storageKey
+        retainedACPSessionCleanupTasks[key]?[sessionId]?.task.cancel()
+        retainedACPSessionCleanupTasks[key]?.removeValue(forKey: sessionId)
+        if retainedACPSessionCleanupTasks[key]?.isEmpty == true {
+            retainedACPSessionCleanupTasks.removeValue(forKey: key)
+        }
+    }
+
+    private func cancelRetainedACPSessionCleanups(owner: SessionOwnerID) {
+        let key = owner.storageKey
+        if let pendingBySession = retainedACPSessionCleanupTasks[key] {
+            for pending in pendingBySession.values {
+                pending.task.cancel()
+            }
+        }
+        retainedACPSessionCleanupTasks.removeValue(forKey: key)
+    }
+
+    private func clearRetainedACPSessionCleanup(worktreeId: String, sessionId: ACPSession.ID, id: UUID) {
+        guard retainedACPSessionCleanupTasks[worktreeId]?[sessionId]?.id == id else { return }
+        retainedACPSessionCleanupTasks[worktreeId]?.removeValue(forKey: sessionId)
+        if retainedACPSessionCleanupTasks[worktreeId]?.isEmpty == true {
+            retainedACPSessionCleanupTasks.removeValue(forKey: worktreeId)
         }
     }
 
@@ -6586,6 +6654,7 @@ final class AppState {
                 }
                 if case .acpSession(let state) = tab {
                     await awaitPendingACPDetach(worktreeId: worktreeID, sessionId: state.sessionId)
+                    cancelRetainedACPSessionCleanup(owner: .worktree(worktreeID), sessionId: state.sessionId)
                     guard closedTabHistory.last?.id == entry.id else { continue }
                     guard worktree(withId: worktreeID) != nil else {
                         closedTabHistory.remove(id: entry.id)
@@ -8684,6 +8753,7 @@ final class AppState {
     }
 
     private func prepareACPManagerForDisposal(_ manager: ACPSessionManager, owner: SessionOwnerID) {
+        cancelRetainedACPSessionCleanups(owner: owner)
         // Flush any pending debounced draft writes before tearing the
         // manager down — otherwise the last ~300ms of typing in any
         // composer for this worktree never reaches SQLite.

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1074,19 +1074,26 @@ final class AppState {
     }
 
     private func bootstrapScheduledACPSessions(worktreeIds: [String]) async {
-        for worktreeId in worktreeIds {
+        let tasks = worktreeIds.compactMap { worktreeId -> Task<Void, Never>? in
             guard let worktree = worktree(withId: worktreeId),
                   let manager = acpManager(for: worktree)
-            else { continue }
-            await bootstrapScheduledACPSessions(owner: .worktree(worktreeId), manager: manager)
+            else { return nil }
+            return Task { @MainActor in
+                await bootstrapScheduledACPSessions(owner: .worktree(worktreeId), manager: manager)
+            }
         }
+        for task in tasks { await task.value }
     }
 
     private func bootstrapScheduledACPSessions(owner: SessionOwnerID, manager: ACPSessionManager) async {
         let sessionIds = await manager.bootstrapScheduledQueueSessions()
-        for sessionId in sessionIds where !hasACPSessionTab(owner: owner, sessionId: sessionId) {
-            cleanupACPSession(owner: owner, sessionId: sessionId)
+        let tasks = sessionIds.compactMap { sessionId -> Task<Void, Never>? in
+            guard !hasACPSessionTab(owner: owner, sessionId: sessionId) else { return nil }
+            return Task { @MainActor in
+                cleanupACPSession(owner: owner, sessionId: sessionId)
+            }
         }
+        for task in tasks { await task.value }
     }
 
     private func hasACPSessionTab(owner: SessionOwnerID, sessionId: ACPSession.ID) -> Bool {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -6577,7 +6577,7 @@ final class AppState {
         }
         guard let nextScheduledAt else { return nil }
         let secondsUntilScheduledSend = nextScheduledAt.timeIntervalSinceNow
-        guard secondsUntilScheduledSend > 0 else { return .milliseconds(250) }
+        guard secondsUntilScheduledSend > 0 else { return activePromptCleanupDelay }
         return .seconds(secondsUntilScheduledSend)
     }
 

--- a/Alas/Sources/Remote/Gateway/RemoteQueueProjection.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteQueueProjection.swift
@@ -26,7 +26,8 @@ enum RemoteQueueProjection {
                 imageCount: imageCount,
                 resourceCount: resourceCount,
                 status: item.status.rawValue,
-                lastError: item.lastError)
+                lastError: item.lastError,
+                scheduledAt: item.scheduledAt)
         }
     }
 

--- a/Alas/Sources/Remote/Gateway/RemoteQueueProjection.swift
+++ b/Alas/Sources/Remote/Gateway/RemoteQueueProjection.swift
@@ -27,7 +27,7 @@ enum RemoteQueueProjection {
                 resourceCount: resourceCount,
                 status: item.status.rawValue,
                 lastError: item.lastError,
-                scheduledAt: item.scheduledAt)
+                scheduledAt: item.scheduledAt.map { $0.timeIntervalSince1970 * 1_000 })
         }
     }
 

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -24,6 +24,7 @@ struct RemoteQueuedPrompt: Codable, Equatable, Sendable {
     let resourceCount: Int
     let status: String      // "pending" | "sending"
     let lastError: String?
+    let scheduledAt: Date?
 }
 
 struct RemoteWorktreeSummary: Codable, Equatable, Sendable {

--- a/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
+++ b/Alas/Sources/Remote/Protocol/RemoteMessageWireJSON.swift
@@ -24,7 +24,7 @@ struct RemoteQueuedPrompt: Codable, Equatable, Sendable {
     let resourceCount: Int
     let status: String      // "pending" | "sending"
     let lastError: String?
-    let scheduledAt: Date?
+    let scheduledAt: Double? // Unix milliseconds for JavaScript Date
 }
 
 struct RemoteWorktreeSummary: Codable, Equatable, Sendable {

--- a/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
@@ -281,4 +281,20 @@ struct ACPSessionManagerReattachTests {
 
         #expect(session.agentState != .disconnected)
     }
+
+    @Test("scheduled reconnect retains disconnected session")
+    func scheduledReconnectRetainsDisconnectedSession() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-scheduled-retain-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "no-such-agent-\(UUID().uuidString)")
+        session.agentState = .disconnected
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(60))
+
+        mgr.retainSession(id: session.id)
+        mgr.scheduleAutoReconnect(sessionId: session.id)
+        mgr.releaseSession(id: session.id)
+
+        #expect(mgr.liveSession(for: session.id) != nil)
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
@@ -297,4 +297,22 @@ struct ACPSessionManagerReattachTests {
 
         #expect(mgr.liveSession(for: session.id) != nil)
     }
+
+    @Test("scheduled reconnect refreshes stale mirror queue")
+    func scheduledReconnectRefreshesStaleMirrorQueue() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-scheduled-refresh-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "no-such-agent-\(UUID().uuidString)")
+        session.agentState = .disconnected
+        session.enqueueScheduled(blocks: [.text("removed elsewhere")], scheduledAt: Date().addingTimeInterval(-1))
+
+        mgr.scheduleAutoReconnect(sessionId: session.id)
+        for _ in 0 ..< 50 where !session.queue.isEmpty {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(session.queue.isEmpty)
+        #expect(session.agentState == .disconnected)
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
@@ -264,4 +264,21 @@ struct ACPSessionManagerReattachTests {
 
         #expect(session.agentState != .disconnected)
     }
+
+    @Test("local disconnect schedules due queue reattach")
+    func localDisconnectSchedulesDueQueueReattach() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-local-scheduled-reattach-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "no-such-agent-\(UUID().uuidString)")
+        session.agentState = .disconnected
+        session.enqueueScheduled(blocks: [.text("due")], scheduledAt: Date().addingTimeInterval(-1))
+
+        mgr.scheduleAutoReconnect(sessionId: session.id)
+        for _ in 0 ..< 50 where session.agentState == .disconnected {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(session.agentState != .disconnected)
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
@@ -298,6 +298,29 @@ struct ACPSessionManagerReattachTests {
         #expect(mgr.liveSession(for: session.id) != nil)
     }
 
+    @Test("removing last scheduled item cancels reconnect retention")
+    func removingLastScheduledItemCancelsReconnectRetention() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-scheduled-cancel-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "no-such-agent-\(UUID().uuidString)")
+        session.agentState = .disconnected
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(60))
+
+        mgr.retainSession(id: session.id)
+        mgr.scheduleAutoReconnect(sessionId: session.id)
+        mgr.releaseSession(id: session.id)
+        #expect(mgr.liveSession(for: session.id) != nil)
+
+        session.clearPendingQueue()
+        mgr.persistQueue(for: session)
+        for _ in 0 ..< 50 where mgr.liveSession(for: session.id) != nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(mgr.liveSession(for: session.id) == nil)
+    }
+
     @Test("scheduled reconnect refreshes stale mirror queue")
     func scheduledReconnectRefreshesStaleMirrorQueue() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-scheduled-refresh-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionForkAttachTests.swift
@@ -5,6 +5,11 @@ import Testing
 @MainActor
 @Suite("ACPSessionManager fork attach")
 struct ACPSessionForkAttachTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    }
+
     @Test("negotiating fork uses native ACP and persists the returned remote session")
     func negotiatingForkUsesNativeACP() async throws {
         let store = try seededForkStore()
@@ -174,6 +179,12 @@ struct ACPSessionForkAttachTests {
         #expect(sourceClient.sent.contains { $0.method == "session/prompt" } == false)
         #expect(source.queue.count == 1)
         #expect(submitCompleted == true)
+        #expect(
+            AppState(store: MemoryStore()).retainedACPSessionCleanupDelayForTesting(
+                manager: manager,
+                sessionId: source.id
+            ) == .seconds(30)
+        )
 
         await forkGate.release()
         await attachTask.value

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -89,6 +89,34 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(queueChanges.contains { $0.0 == session.id && $0.1 == false })
     }
 
+    @Test("bootstrap attaches overdue persisted scheduled queues")
+    func bootstrapAttachesOverduePersistedScheduledQueues() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let seeded = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let seededSession = seeded.createSession(id: "scheduled-session", agentId: "claude")
+        seeded.enqueueWhileRecovering(
+            text: "overdue",
+            attachments: [],
+            scheduledAt: Date().addingTimeInterval(-1),
+            into: seededSession.id
+        )
+        await seeded.flushPersistence()
+
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-scheduled")
+        client.script(method: "session/prompt") { _ in Data("null".utf8) }
+        let manager = manager(store: store, client: client)
+
+        let bootstrapped = await manager.bootstrapScheduledQueueSessions()
+        try await waitUntilAsync {
+            await client.sent.contains { $0.method == "session/prompt" }
+        }
+
+        #expect(bootstrapped == [seededSession.id])
+        #expect(try store.loadQueue(sessionId: seededSession.id).isEmpty)
+    }
+
     @Test("reopened local broker session attaches from persisted cursor")
     func reopenedLocalBrokerSessionAttachesFromPersistedCursor() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -1575,6 +1575,65 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(!row.contextRecoveryPending)
     }
 
+    @Test("pending force send waits for transcript recovery")
+    func pendingForceSendWaitsForTranscriptRecovery() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-old"))
+        let priorPrompt: ACPMessage = .user(id: UUID(), text: "prior prompt", attachments: [])
+        try appendMessage(priorPrompt, to: store, seq: 0)
+        let forced = QueuedPrompt(blocks: [.text("forced prompt")])
+        try store.upsertQueue(sessionId: "local", items: [forced])
+        let newSessionGate = AttachPhaseGate()
+        let recoveryGate = PromptGate()
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            throw JSONRPCError(code: -32601, message: "Method not found", data: nil)
+        }
+        client.scriptAsync(method: "session/new") { _ in
+            await newSessionGate.enterAndWait()
+            return try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-new",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+        client.scriptAsync(method: "session/prompt") { request in
+            let params = try #require(request.params as? ACPSessionPromptParams)
+            if params.prompt.contains(where: { block in
+                guard case .text(let text) = block else { return false }
+                return text.contains("prior prompt")
+            }) {
+                await recoveryGate.waitInPrompt()
+            }
+            return Data("null".utf8)
+        }
+        let manager = manager(store: store, client: client)
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+
+        let attachTask = Task { @MainActor in
+            await manager.attach(to: session.id, freshlyCreated: false)
+        }
+        for _ in 0 ..< 50 where !(await newSessionGate.hasEntered) {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(await newSessionGate.hasEntered)
+        await manager.queueForceSend(for: session.id, itemId: forced.id)
+        await newSessionGate.release()
+        try await waitUntil { client.sent.filter { $0.method == "session/prompt" }.count == 1 }
+        await recoveryGate.release()
+        await attachTask.value
+
+        try await waitUntil {
+            let prompts = client.sent.compactMap { $0.params as? ACPSessionPromptParams }
+            return prompts.count == 2 && prompts[1].prompt == [.text("forced prompt")]
+        }
+    }
+
     @Test("new auth failure enters needsAuth with initialized auth method")
     func newAuthFailureEntersNeedsAuthWithInitializedAuthMethod() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -117,6 +117,24 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(try store.loadQueue(sessionId: seededSession.id).isEmpty)
     }
 
+    @Test("bootstrap defers future scheduled queues until deadline")
+    func bootstrapDefersFutureScheduledQueuesUntilDeadline() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: nil))
+        try store.upsertQueue(sessionId: "local", items: [
+            QueuedPrompt(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(60))
+        ])
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        let manager = manager(store: store, client: client)
+
+        let bootstrapped = await manager.bootstrapScheduledQueueSessions()
+
+        #expect(bootstrapped == ["local"])
+        #expect(client.sent.isEmpty)
+    }
+
     @Test("bootstrapped scheduled mirror claims released lease at deadline")
     func bootstrappedScheduledMirrorClaimsReleasedLeaseAtDeadline() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -117,6 +117,36 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(try store.loadQueue(sessionId: seededSession.id).isEmpty)
     }
 
+    @Test("bootstrapped scheduled mirror claims released lease at deadline")
+    func bootstrappedScheduledMirrorClaimsReleasedLeaseAtDeadline() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-existing"))
+        try store.upsertQueue(sessionId: "local", items: [
+            QueuedPrompt(blocks: [.text("due soon")], scheduledAt: Date().addingTimeInterval(0.3))
+        ])
+        try store.seizeLease(
+            sessionId: "local",
+            instanceId: "OTHER",
+            pid: Int64(getpid()),
+            now: Int64(Date().timeIntervalSince1970)
+        )
+        let lease = try #require(try store.loadLease(sessionId: "local"))
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/load", sessionId: "remote-existing")
+        client.script(method: "session/prompt") { _ in Data("null".utf8) }
+        let manager = manager(store: store, client: client)
+
+        let bootstrapped = await manager.bootstrapScheduledQueueSessions()
+        try store.releaseLease(sessionId: "local", instanceId: "OTHER", leaseToken: lease.token)
+        try await waitUntil(timeoutNanos: 2_000_000_000) {
+            client.sent.contains { $0.method == "session/prompt" }
+        }
+
+        #expect(bootstrapped == ["local"])
+        #expect(try store.loadQueue(sessionId: "local").isEmpty)
+    }
+
     @Test("reopened local broker session attaches from persisted cursor")
     func reopenedLocalBrokerSessionAttachesFromPersistedCursor() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -59,6 +59,36 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(row.acpBrokerAcknowledgedCursor == 0)
     }
 
+    @Test("auth-required runner teardown notifies queue cleanup")
+    func authRequiredRunnerTeardownNotifiesQueueCleanup() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        let method = terminalAuthMethod()
+        scriptInitialize(client, authMethods: [method])
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-auth")
+        client.script(method: "session/prompt") { _ in
+            throw JSONRPCError(
+                code: -32000,
+                message: "Internal error: authentication required",
+                data: nil
+            )
+        }
+        var queueChanges: [(ACPSession.ID, Bool)] = []
+        let manager = manager(store: store, client: client, onQueueChanged: { sessionId, retainActivePrompt in
+            queueChanges.append((sessionId, retainActivePrompt))
+        })
+        let session = manager.createSession(id: "auth-session", agentId: "claude")
+        await manager.attach(to: session.id, freshlyCreated: true)
+
+        await manager.sendPrompt(for: session.id, text: "hello", attachments: []) { _ in }
+        try await waitUntil {
+            queueChanges.contains { $0.0 == session.id && $0.1 == false }
+        }
+
+        #expect(session.agentState == .failed("authentication required"))
+        #expect(queueChanges.contains { $0.0 == session.id && $0.1 == false })
+    }
+
     @Test("reopened local broker session attaches from persisted cursor")
     func reopenedLocalBrokerSessionAttachesFromPersistedCursor() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())
@@ -2532,12 +2562,14 @@ struct ACPSessionManagerAttachRestoreTests {
     private func manager(
         store: ACPSessionStore,
         client: ACPMockClient,
-        mcpProjectContextProvider: ACPSessionManager.MCPProjectContextProvider? = nil
+        mcpProjectContextProvider: ACPSessionManager.MCPProjectContextProvider? = nil,
+        onQueueChanged: ((ACPSession.ID, Bool) -> Void)? = nil
     ) -> ACPSessionManager {
         ACPSessionManager(
             worktreeId: "wt",
             worktreePath: "/tmp/wt",
             store: store,
+            onQueueChanged: onQueueChanged,
             setupEvaluator: { _ in .ready },
             connectionFactory: { _, _, _ in ACPConnection(client: client) },
             mcpProjectContextProvider: mcpProjectContextProvider

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -35,6 +35,21 @@ struct ACPSessionManagerTests {
         #expect(try store.loadQueue(sessionId: "session").map(\.id) == [promptID])
     }
 
+    @Test("mission prompts stay ahead of scheduled prompts")
+    func missionPromptStaysAheadOfScheduledPrompt() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-mission-schedule-order-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let manager = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = manager.createSession(id: "session", agentId: "codex", autoRunDefault: false)
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: .distantFuture)
+        let promptID = UUID()
+
+        #expect(await manager.enqueuePrompt(id: promptID, text: "now", into: session.id))
+        #expect(session.queue.map(\.blocks) == [[.text("now")], [.text("later")]])
+        #expect(session.queue.map(\.scheduledAt) == [nil, .distantFuture])
+    }
+
     @Test("delegated prompt already recorded in the transcript is not requeued")
     func delegatedPromptRecordedInTranscriptIsNotRequeued() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-delegated-dedupe-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -10,6 +10,36 @@ struct ACPSessionManagerTests {
         func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
     }
 
+    private actor AsyncGate {
+        private var entered = false
+        private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+        private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+        func enterAndWait() async {
+            entered = true
+            let waiters = entryWaiters
+            entryWaiters.removeAll()
+            for waiter in waiters {
+                waiter.resume()
+            }
+            await withCheckedContinuation { continuation in
+                releaseContinuation = continuation
+            }
+        }
+
+        func waitUntilEntered() async {
+            if entered { return }
+            await withCheckedContinuation { continuation in
+                entryWaiters.append(continuation)
+            }
+        }
+
+        func release() {
+            releaseContinuation?.resume()
+            releaseContinuation = nil
+        }
+    }
+
     private func scriptInitialize(_ client: ACPMockClient) {
         client.script(method: "initialize") { _ in
             try JSONEncoder().encode(ACPInitializeResult(
@@ -539,6 +569,49 @@ struct ACPSessionManagerTests {
         await mgr.queueForceSend(for: session.id, itemId: itemId)
 
         #expect(session.agentState != .disconnected)
+    }
+
+    @Test("queue force send during attach sends after ready")
+    func queueForceSendDuringAttachSendsAfterReady() async throws {
+        let gate = AsyncGate()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-force-send-spawning-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let client = ACPMockClient()
+        client.scriptAsync(method: "initialize") { _ in
+            await gate.enterAndWait()
+            return try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: nil,
+                authMethods: []
+            ))
+        }
+        scriptSessionResult(client, method: "session/new", sessionId: "remote")
+        client.script(method: "session/prompt") { _ in Data("null".utf8) }
+        let mgr = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in ACPConnection(client: client) }
+        )
+        let session = mgr.createSession(id: "session", agentId: "claude")
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: .distantFuture)
+        let itemId = try #require(session.queue.first?.id)
+        let attachTask = Task { @MainActor in
+            await mgr.attach(to: session.id, freshlyCreated: true)
+        }
+        await gate.waitUntilEntered()
+
+        await mgr.queueForceSend(for: session.id, itemId: itemId)
+        #expect(client.sent.contains(where: { $0.method == "session/prompt" }) == false)
+        await gate.release()
+        await attachTask.value
+        for _ in 0 ..< 50 where !client.sent.contains(where: { $0.method == "session/prompt" }) {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(client.sent.contains(where: { $0.method == "session/prompt" }))
     }
 
     @Test("persistQueue writes to SQLite without requiring a runner")

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -679,8 +679,11 @@ struct ACPSessionManagerTests {
         let itemId = try #require(session.queue.first?.id)
 
         await mgr.queueForceSend(for: session.id, itemId: itemId)
+        await mgr.flushPersistence()
 
         #expect(queueChanged)
+        #expect(session.queue.first?.scheduledAt == nil)
+        #expect(try store.loadQueue(sessionId: session.id).first?.scheduledAt == nil)
     }
 
     @Test("stale force send during attach falls back to queue flush")

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -50,6 +50,28 @@ struct ACPSessionManagerTests {
         #expect(session.queue.map(\.scheduledAt) == [nil, .distantFuture])
     }
 
+    @Test("remote queue clear notifies queue change")
+    func remoteQueueClearNotifiesQueueChange() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-remote-queue-change-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        var changedSessions: [ACPSession.ID] = []
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            onQueueChanged: { changedSessions.append($0) }
+        )
+        let session = manager.createSession(id: "session", agentId: "codex", autoRunDefault: false)
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: .distantFuture)
+
+        #expect(await manager.acquireWriterLease(sessionId: session.id))
+        await manager.queueClear(for: session.id)
+
+        #expect(changedSessions == [session.id])
+        #expect(session.queue.isEmpty)
+    }
+
     @Test("delegated prompt already recorded in the transcript is not requeued")
     func delegatedPromptRecordedInTranscriptIsNotRequeued() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-delegated-dedupe-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -524,6 +524,23 @@ struct ACPSessionManagerTests {
         )
     }
 
+    @Test("queue force send reattaches disconnected sessions first")
+    func queueForceSendReattachesDisconnectedSession() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-force-send-reattach-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(id: "session", agentId: "no-such-agent-\(UUID().uuidString)")
+        session.agentState = .disconnected
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: .distantFuture)
+        let itemId = try #require(session.queue.first?.id)
+
+        #expect(await mgr.acquireWriterLease(sessionId: session.id))
+        await mgr.queueForceSend(for: session.id, itemId: itemId)
+
+        #expect(session.agentState != .disconnected)
+    }
+
     @Test("persistQueue writes to SQLite without requiring a runner")
     func persistQueueWithoutRunner() async throws {
         // Regression: ACPTabView's queue actions used to call

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -613,6 +613,54 @@ struct ACPSessionManagerTests {
         #expect(client.sent.contains(where: { $0.method == "session/prompt" }))
     }
 
+    @Test("stale force send during attach falls back to queue flush")
+    func staleForceSendDuringAttachFallsBackToQueueFlush() async throws {
+        let gate = AsyncGate()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-stale-force-send-spawning-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let client = ACPMockClient()
+        client.scriptAsync(method: "initialize") { _ in
+            await gate.enterAndWait()
+            return try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: nil,
+                authMethods: []
+            ))
+        }
+        scriptSessionResult(client, method: "session/new", sessionId: "remote")
+        client.script(method: "session/prompt") { request in
+            let params = try #require(request.params as? ACPSessionPromptParams)
+            #expect(params.prompt == [.text("fallback")])
+            return Data("null".utf8)
+        }
+        let mgr = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in ACPConnection(client: client) }
+        )
+        let session = mgr.createSession(id: "session", agentId: "claude")
+        session.enqueue(blocks: [.text("removed")])
+        session.enqueue(blocks: [.text("fallback")])
+        let removedId = try #require(session.queue.first?.id)
+        let attachTask = Task { @MainActor in
+            await mgr.attach(to: session.id, freshlyCreated: true)
+        }
+        await gate.waitUntilEntered()
+
+        await mgr.queueForceSend(for: session.id, itemId: removedId)
+        await mgr.queueRemove(for: session.id, itemId: removedId)
+        await gate.release()
+        await attachTask.value
+        for _ in 0 ..< 50 where !client.sent.contains(where: { $0.method == "session/prompt" }) {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(client.sent.contains(where: { $0.method == "session/prompt" }))
+    }
+
     @Test("persistQueue writes to SQLite without requiring a runner")
     func persistQueueWithoutRunner() async throws {
         // Regression: ACPTabView's queue actions used to call

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -5,6 +5,11 @@ import Testing
 @MainActor
 @Suite("ACPSessionManager")
 struct ACPSessionManagerTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    }
+
     private func scriptInitialize(_ client: ACPMockClient) {
         client.script(method: "initialize") { _ in
             try JSONEncoder().encode(ACPInitializeResult(
@@ -488,6 +493,35 @@ struct ACPSessionManagerTests {
         }
 
         #expect(client.sent.contains { $0.method == "session/prompt" })
+    }
+
+    @Test("disconnected forced sending row stays retained")
+    func disconnectedForcedSendingRowStaysRetained() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-disconnected-force-send-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/new", sessionId: "remote")
+        let mgr = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in ACPConnection(client: client) }
+        )
+        let session = mgr.createSession(id: "session", agentId: "claude")
+        await mgr.attach(to: session.id, freshlyCreated: true)
+        session.queue.append(QueuedPrompt(blocks: [.text("forced")], status: .sending))
+        session.transcript.streamingState = .sending
+        session.agentState = .disconnected
+
+        #expect(
+            AppState(store: MemoryStore()).retainedACPSessionCleanupDelayForTesting(
+                manager: mgr,
+                sessionId: session.id
+            ) == .milliseconds(250)
+        )
     }
 
     @Test("persistQueue writes to SQLite without requiring a runner")

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -60,7 +60,7 @@ struct ACPSessionManagerTests {
             worktreeId: "wt",
             worktreePath: "/tmp/wt",
             store: store,
-            onQueueChanged: { changedSessions.append($0) }
+            onQueueChanged: { sessionId, _ in changedSessions.append(sessionId) }
         )
         let session = manager.createSession(id: "session", agentId: "codex", autoRunDefault: false)
         session.enqueueScheduled(blocks: [.text("later")], scheduledAt: .distantFuture)

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -95,6 +95,32 @@ struct ACPSessionManagerTests {
         #expect(session.queue.map(\.id) == [itemId])
     }
 
+    @Test("remote queue retry ignores stale retry requests")
+    func remoteQueueRetryIgnoresStaleRequests() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-remote-queue-retry-stale-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        var changedSessions: [ACPSession.ID] = []
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            onQueueChanged: { sessionId, _ in changedSessions.append(sessionId) }
+        )
+        let session = manager.createSession(id: "session", agentId: "codex", autoRunDefault: false)
+        let sendingId = UUID()
+        let pendingId = UUID()
+        session.queue.append(QueuedPrompt(id: sendingId, blocks: [.text("sending")], status: .sending))
+        session.queue.append(QueuedPrompt(id: pendingId, blocks: [.text("pending")], status: .pending))
+
+        #expect(await manager.acquireWriterLease(sessionId: session.id))
+        await manager.queueRetry(for: session.id, itemId: sendingId)
+        await manager.queueRetry(for: session.id, itemId: pendingId)
+
+        #expect(changedSessions.isEmpty)
+        #expect(session.queue.map(\.id) == [sendingId, pendingId])
+    }
+
     @Test("delegated prompt already recorded in the transcript is not requeued")
     func delegatedPromptRecordedInTranscriptIsNotRequeued() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-delegated-dedupe-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -5,6 +5,29 @@ import Testing
 @MainActor
 @Suite("ACPSessionManager")
 struct ACPSessionManagerTests {
+    private func scriptInitialize(_ client: ACPMockClient) {
+        client.script(method: "initialize") { _ in
+            try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: nil,
+                authMethods: []
+            ))
+        }
+    }
+
+    private func scriptSessionResult(_ client: ACPMockClient, method: String, sessionId: String) {
+        client.script(method: method) { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: sessionId,
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+    }
+
     @Test("ordinary stable prompt is persisted only once")
     func ordinaryStablePromptIsPersistedOnlyOnce() async throws {
         let url = FileManager.default.temporaryDirectory
@@ -437,6 +460,34 @@ struct ACPSessionManagerTests {
 
         await mgr.detach(sessionId: session.id)
         #expect(session.queue[0].status == .pending)
+    }
+
+    @Test("attach normalizes an in-flight scheduled row before flushing")
+    func attachNormalizesSendingScheduleBeforeFlush() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-attach-sending-schedule-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/new", sessionId: "remote")
+        client.script(method: "session/prompt") { _ in Data("null".utf8) }
+        let mgr = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in ACPConnection(client: client) }
+        )
+        let session = mgr.createSession(id: "session", agentId: "claude")
+        session.enqueueScheduled(blocks: [.text("queued")], scheduledAt: Date().addingTimeInterval(-1))
+        session.markQueueHeadSending()
+
+        await mgr.attach(to: session.id, freshlyCreated: true)
+        for _ in 0 ..< 20 where !session.queue.isEmpty {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        #expect(client.sent.contains { $0.method == "session/prompt" })
     }
 
     @Test("persistQueue writes to SQLite without requiring a runner")

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -613,6 +613,28 @@ struct ACPSessionManagerTests {
         #expect(client.sent.contains(where: { $0.method == "session/prompt" }))
     }
 
+    @Test("queue force send during pre-lease spawn is retained")
+    func queueForceSendDuringPreLeaseSpawnIsRetained() async throws {
+        var queueChanged = false
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-force-send-prelease-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            onQueueChanged: { _, _ in queueChanged = true }
+        )
+        let session = mgr.createSession(id: "session", agentId: "claude")
+        session.agentState = .spawning
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: .distantFuture)
+        let itemId = try #require(session.queue.first?.id)
+
+        await mgr.queueForceSend(for: session.id, itemId: itemId)
+
+        #expect(queueChanged)
+    }
+
     @Test("stale force send during attach falls back to queue flush")
     func staleForceSendDuringAttachFallsBackToQueueFlush() async throws {
         let gate = AsyncGate()

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -72,6 +72,29 @@ struct ACPSessionManagerTests {
         #expect(session.queue.isEmpty)
     }
 
+    @Test("remote queue remove ignores sending items without notifying")
+    func remoteQueueRemoveSendingItemDoesNotNotify() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-remote-queue-remove-sending-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        var changedSessions: [ACPSession.ID] = []
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            onQueueChanged: { sessionId, _ in changedSessions.append(sessionId) }
+        )
+        let session = manager.createSession(id: "session", agentId: "codex", autoRunDefault: false)
+        let itemId = UUID()
+        session.queue.append(QueuedPrompt(id: itemId, blocks: [.text("sending")], status: .sending))
+
+        #expect(await manager.acquireWriterLease(sessionId: session.id))
+        await manager.queueRemove(for: session.id, itemId: itemId)
+
+        #expect(changedSessions.isEmpty)
+        #expect(session.queue.map(\.id) == [itemId])
+    }
+
     @Test("delegated prompt already recorded in the transcript is not requeued")
     func delegatedPromptRecordedInTranscriptIsNotRequeued() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-delegated-dedupe-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -565,7 +565,6 @@ struct ACPSessionManagerTests {
         session.enqueueScheduled(blocks: [.text("later")], scheduledAt: .distantFuture)
         let itemId = try #require(session.queue.first?.id)
 
-        #expect(await mgr.acquireWriterLease(sessionId: session.id))
         await mgr.queueForceSend(for: session.id, itemId: itemId)
 
         #expect(session.agentState != .disconnected)

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -686,6 +686,30 @@ struct ACPSessionManagerTests {
         #expect(try store.loadQueue(sessionId: session.id).first?.scheduledAt == nil)
     }
 
+    @Test("queue force send during recovering persistence keeps schedule parked")
+    func queueForceSendDuringRecoveringPersistenceKeepsScheduleParked() async throws {
+        var queueChanged = false
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-force-send-recovering-persistence-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            onQueueChanged: { _, _ in queueChanged = true }
+        )
+        let session = mgr.createSession(id: "session", agentId: "claude")
+        session.agentState = .spawning
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: .distantFuture)
+        let itemId = try #require(session.queue.first?.id)
+        session.pendingQueuePersistenceCount = 1
+
+        await mgr.queueForceSend(for: session.id, itemId: itemId)
+
+        #expect(queueChanged)
+        #expect(session.queue.first?.scheduledAt != nil)
+    }
+
     @Test("stale force send during attach falls back to queue flush")
     func staleForceSendDuringAttachFallsBackToQueueFlush() async throws {
         let gate = AsyncGate()

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -613,6 +613,54 @@ struct ACPSessionManagerTests {
         #expect(client.sent.contains(where: { $0.method == "session/prompt" }))
     }
 
+    @Test("queue force send during attach preserves every requested item")
+    func queueForceSendDuringAttachPreservesEveryRequestedItem() async throws {
+        let gate = AsyncGate()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-force-send-spawning-many-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let client = ACPMockClient()
+        client.scriptAsync(method: "initialize") { _ in
+            await gate.enterAndWait()
+            return try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: nil,
+                authMethods: []
+            ))
+        }
+        scriptSessionResult(client, method: "session/new", sessionId: "remote")
+        client.script(method: "session/prompt") { _ in Data("null".utf8) }
+        let mgr = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _, _, _ in ACPConnection(client: client) }
+        )
+        let session = mgr.createSession(id: "session", agentId: "claude")
+        session.enqueueScheduled(blocks: [.text("first")], scheduledAt: .distantFuture)
+        session.enqueueScheduled(blocks: [.text("second")], scheduledAt: .distantFuture)
+        let firstId = try #require(session.queue.first?.id)
+        let secondId = try #require(session.queue.dropFirst().first?.id)
+        let attachTask = Task { @MainActor in
+            await mgr.attach(to: session.id, freshlyCreated: true)
+        }
+        await gate.waitUntilEntered()
+
+        await mgr.queueForceSend(for: session.id, itemId: firstId)
+        await mgr.queueForceSend(for: session.id, itemId: secondId)
+        await gate.release()
+        await attachTask.value
+        for _ in 0 ..< 100 where client.sent.filter({ $0.method == "session/prompt" }).count < 2 {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        let prompts = try client.sent
+            .filter { $0.method == "session/prompt" }
+            .map { try #require($0.params as? ACPSessionPromptParams).prompt }
+        #expect(prompts == [[.text("first")], [.text("second")]])
+    }
+
     @Test("queue force send during pre-lease spawn is retained")
     func queueForceSendDuringPreLeaseSpawnIsRetained() async throws {
         var queueChanged = false

--- a/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
+++ b/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
@@ -64,6 +64,16 @@ struct ACPSessionQueueAPITests {
         #expect(s.queue.map { $0.blocks } == [[.text("b")], [.text("c")], [.text("a")]])
     }
 
+    @Test("moving a normal prompt cannot put it behind a scheduled prompt")
+    func moveKeepsNormalPromptsAheadOfScheduledPrompts() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("now")])
+        s.enqueueScheduled(blocks: [.text("later")], scheduledAt: .distantFuture)
+
+        s.moveInQueue(from: 0, to: 1)
+        #expect(s.queue.map(\.blocks) == [[.text("now")], [.text("later")]])
+    }
+
     @Test("move(from:to:) refuses to move a .sending head")
     func moveSendingNoop() {
         let s = mkSession()

--- a/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
+++ b/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
@@ -352,6 +352,21 @@ struct ACPSessionQueueAPITests {
         #expect(s.queue[1].blocks == [.text("existing-pending")])
     }
 
+    @Test("restorePendingSnapshot keeps restored schedules behind normal prompts")
+    func restoreSnapshotKeepsSchedulesBehindNormalPrompts() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("queued while undo was available")])
+
+        s.restorePendingSnapshot([
+            QueuedPrompt(blocks: [.text("restored schedule")], scheduledAt: .distantFuture),
+        ])
+
+        #expect(s.queue.map(\.blocks) == [
+            [.text("queued while undo was available")],
+            [.text("restored schedule")],
+        ])
+    }
+
     @Test("enqueue(blocks:draft:) stores the structured draft on the item")
     func enqueueWithDraft() {
         let s = mkSession()

--- a/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
+++ b/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
@@ -23,6 +23,26 @@ struct ACPSessionQueueAPITests {
         #expect(s.queue[0].blocks == [.text("hello")])
     }
 
+    @Test("normal prompts stay ahead of scheduled prompts")
+    func normalPromptsStayAheadOfScheduledPrompts() {
+        let s = mkSession()
+        s.enqueueScheduled(
+            blocks: [.text("tomorrow")],
+            scheduledAt: Date(timeIntervalSince1970: 200)
+        )
+        s.enqueueScheduled(
+            blocks: [.text("later today")],
+            scheduledAt: Date(timeIntervalSince1970: 100)
+        )
+        s.enqueue(blocks: [.text("now")])
+
+        #expect(s.queue.map(\.blocks) == [
+            [.text("now")],
+            [.text("later today")],
+            [.text("tomorrow")],
+        ])
+    }
+
     @Test("remove(id:) drops matching item, leaves others")
     func remove() {
         let s = mkSession()
@@ -65,6 +85,18 @@ struct ACPSessionQueueAPITests {
         #expect(s.forceQueueItem(id: id))
         #expect(s.queue.map { $0.blocks } == [[.text("b")], [.text("a")]])
         #expect(s.queue[0].status == .pending)
+    }
+
+    @Test("forcing a scheduled prompt sends it now")
+    func forceScheduledPromptClearsDeadline() {
+        let s = mkSession()
+        s.enqueueScheduled(
+            blocks: [.text("later")],
+            scheduledAt: Date(timeIntervalSince1970: 200)
+        )
+
+        #expect(s.forceQueueItem(id: s.queue[0].id))
+        #expect(s.queue[0].scheduledAt == nil)
     }
 
     @Test("forceQueueItem clears a previous queue error")

--- a/AlasTests/ACP/Session/ACPSessionRecoveryTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRecoveryTests.swift
@@ -260,4 +260,47 @@ struct ACPSessionManagerSubmitTests {
             Issue.record("reattach from desync did not invoke attach(): setupState=\(session.setupState), agentState=\(session.agentState)")
         }
     }
+
+    @Test("future scheduled submit while disconnected does not attach immediately")
+    func futureScheduledSubmitWhileDisconnectedDoesNotAttachImmediately() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-submit-future-schedule-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(
+            worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "no-such-agent-\(UUID().uuidString)")
+        session.agentState = .disconnected
+
+        let accepted = mgr.submit(
+            sessionId: session.id,
+            text: "later",
+            attachments: [],
+            intent: .schedule(Date().addingTimeInterval(60))
+        ) { _ in }
+
+        #expect(accepted)
+        #expect(session.queue.count == 1)
+        #expect(session.agentState == .disconnected)
+    }
+
+    @Test("scheduled submit is rejected while queue persistence is pending")
+    func scheduledSubmitRejectedWhileQueuePersistencePending() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-submit-pending-schedule-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(
+            worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        session.pendingQueuePersistenceCount = 1
+
+        let accepted = mgr.submit(
+            sessionId: session.id,
+            text: "second schedule",
+            attachments: [],
+            intent: .schedule(Date().addingTimeInterval(60))
+        ) { _ in }
+
+        #expect(!accepted)
+        #expect(session.queue.isEmpty)
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -528,6 +528,7 @@ struct ACPSessionRunnerQueueTests {
         runner.persistQueue()
 
         runner.forceSendQueuedItem(id: selectedId)
+        #expect(runner.hasRetainedCleanupSteerWork)
         try await Task.sleep(nanoseconds: 250_000_000)
 
         #expect(mock.sent.contains { $0.method == "session/cancel" })

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -79,6 +79,22 @@ struct ACPSessionRunnerQueueTests {
         #expect(mock.sent.contains { $0.method == "session/prompt" })
     }
 
+    @Test("stop cancels a scheduled queue wake")
+    func stopCancelsScheduledQueueWake() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        runner.send(
+            blocks: [.text("soon")],
+            intent: .schedule(Date().addingTimeInterval(0.05))
+        )
+
+        runner.stop()
+        try await Task.sleep(nanoseconds: 150_000_000)
+
+        #expect(session.queue.first?.status == .pending)
+        #expect(!mock.sent.contains { $0.method == "session/prompt" })
+    }
+
     @Test("an immediate prompt does not wait behind a scheduled prompt")
     func immediatePromptBypassesScheduledPrompt() async throws {
         let (runner, mock, session, _) = try mkRunner()

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -65,6 +65,42 @@ struct ACPSessionRunnerQueueTests {
         #expect(try store.loadQueue(sessionId: "s") == session.queue)
     }
 
+    @Test("failed scheduled persist rollback wins over later snapshots")
+    func failedScheduledPersistRollbackWinsOverLaterSnapshots() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rn-scheduled-rollback-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let mock = ACPMockClient()
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+        session.agentState = .ready
+        var fenceCalls = 0
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            ownerInstanceId: "ME",
+            canWrite: { true },
+            leaseFenceProvider: {
+                fenceCalls += 1
+                return fenceCalls == 1
+                    ? ACPSessionLeaseFence(sessionId: "s", ownerInstance: "ME", token: "stale")
+                    : nil
+            })
+
+        runner.send(blocks: [.text("failed")], intent: .schedule(Date().addingTimeInterval(60)))
+        runner.send(blocks: [.text("kept")], intent: .schedule(Date().addingTimeInterval(120)))
+        await runner.flushPersistence()
+
+        #expect(session.queue.map(\.blocks) == [[.text("kept")]])
+        #expect(try store.loadQueue(sessionId: "s").map(\.blocks) == [[.text("kept")]])
+    }
+
     @Test("force send preserves schedules while disconnected")
     func forceSendPreservesScheduleWhileDisconnected() async throws {
         let (runner, mock, session, _) = try mkRunner()

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -5,7 +5,9 @@ import Testing
 @MainActor
 @Suite("ACPSessionRunner queue routing")
 struct ACPSessionRunnerQueueTests {
-    private func mkRunner() throws -> (ACPSessionRunner, ACPMockClient, ACPSession, ACPSessionStore) {
+    private func mkRunner(
+        onPromptWorkChanged: (() -> Void)? = nil
+    ) throws -> (ACPSessionRunner, ACPMockClient, ACPSession, ACPSessionStore) {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-q-\(UUID()).sqlite")
         let store = try ACPSessionStore(path: url.path)
         try store.upsertSession(.init(
@@ -20,7 +22,8 @@ struct ACPSessionRunnerQueueTests {
             connection: ACPConnection(client: mock),
             store: store,
             sessionId: "s",
-            worktreePath: FileManager.default.temporaryDirectory.path)
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            onPromptWorkChanged: onPromptWorkChanged)
         return (runner, mock, session, store)
     }
 
@@ -223,6 +226,24 @@ struct ACPSessionRunnerQueueTests {
         #expect(session.queue.first?.status == .pending)
         #expect(!mock.sent.contains { $0.method == "session/prompt" })
         #expect(runner.hasRetainedCleanupPromptWork)
+    }
+
+    @Test("queued prompt completion notifies prompt work changed")
+    func queuedPromptCompletionNotifiesPromptWorkChanged() async throws {
+        var changeCount = 0
+        let (runner, mock, session, _) = try mkRunner {
+            changeCount += 1
+        }
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        session.enqueue(blocks: [.text("queued")])
+
+        runner.flushQueueIfIdle()
+        for _ in 0 ..< 20 where changeCount == 0 {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        #expect(changeCount > 0)
+        #expect(session.queue.isEmpty)
     }
 
     @Test("flushQueueIfIdle is a no-op while state is .streaming")

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -47,6 +47,54 @@ struct ACPSessionRunnerQueueTests {
         #expect(session.queue.isEmpty)
     }
 
+    @Test("scheduled intent persists without sending before its deadline")
+    func scheduledIntentWaits() async throws {
+        let (runner, mock, session, store) = try mkRunner()
+        runner.send(
+            blocks: [.text("later")],
+            intent: .schedule(Date().addingTimeInterval(60))
+        )
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(session.queue.count == 1)
+        #expect(session.queue[0].scheduledAt != nil)
+        #expect(!mock.sent.contains { $0.method == "session/prompt" })
+        #expect(try store.loadQueue(sessionId: "s") == session.queue)
+    }
+
+    @Test("scheduled prompt flushes once its deadline arrives")
+    func scheduledPromptFlushesAtDeadline() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        runner.send(
+            blocks: [.text("soon")],
+            intent: .schedule(Date().addingTimeInterval(0.1))
+        )
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(!mock.sent.contains { $0.method == "session/prompt" })
+
+        try await Task.sleep(nanoseconds: 250_000_000)
+        #expect(session.queue.isEmpty)
+        #expect(mock.sent.contains { $0.method == "session/prompt" })
+    }
+
+    @Test("an immediate prompt does not wait behind a scheduled prompt")
+    func immediatePromptBypassesScheduledPrompt() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        runner.send(
+            blocks: [.text("later")],
+            intent: .schedule(Date().addingTimeInterval(60))
+        )
+        runner.send(blocks: [.text("now")], intent: .auto)
+
+        try await Task.sleep(nanoseconds: 150_000_000)
+        #expect(mock.sent.contains { $0.method == "session/prompt" })
+        #expect(session.queue.count == 1)
+        #expect(session.queue[0].blocks == [.text("later")])
+    }
+
     @Test(".auto while .idle with non-empty queue → enqueues (queue is authoritative)")
     func enqueuesWhenIdleAndQueueNonEmpty() async throws {
         let (runner, mock, session, _) = try mkRunner()

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -381,8 +381,8 @@ struct ACPSessionRunnerQueueTests {
         #expect(session.queue[0].brokerOperationKey != operationKey)
     }
 
-    @Test("queued prompt response ack waits for durable queue pop")
-    func queuedPromptResponseAckWaitsForDurableQueuePop() async throws {
+    @Test("queued prompt response ack waits for durable queue pop and resumes draining")
+    func queuedPromptResponseAckWaitsForDurableQueuePopAndResumesDraining() async throws {
         let (runner, mock, session, store) = try mkRunner()
         let acknowledgement = DurableAcknowledgementRecorder()
         mock.scriptResponse(method: "session/prompt") { _ in
@@ -392,16 +392,19 @@ struct ACPSessionRunnerQueueTests {
             )
         }
         session.enqueue(blocks: [.text("ack-after-pop")])
+        session.enqueue(blocks: [.text("next")])
         runner.persistQueue()
         await runner.flushPersistence()
 
         runner.flushQueueIfIdle()
-        try await Task.sleep(nanoseconds: 200_000_000)
+        try await Task.sleep(nanoseconds: 300_000_000)
         await runner.flushPersistence()
 
+        let prompts = mock.sent.filter { $0.method == "session/prompt" }
+        #expect(prompts.count == 2)
         #expect(session.queue.isEmpty)
         #expect(try store.loadQueue(sessionId: "s").isEmpty)
-        #expect(acknowledgement.recordedCount == 1)
+        #expect(acknowledgement.recordedCount == 2)
     }
 
     @Test(".steer while streaming with queue → cancel sent, queue cleared, new prompt sent, snapshot captured")

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -158,6 +158,27 @@ struct ACPSessionRunnerQueueTests {
         #expect(try store.loadQueue(sessionId: "s").isEmpty)
     }
 
+    @Test("flushQueueIfIdle waits for pending queue persistence")
+    func waitsForPendingQueuePersistence() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        session.enqueue(blocks: [.text("pending durable enqueue")])
+        session.pendingQueuePersistenceCount = 1
+
+        runner.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(session.queue.first?.status == .pending)
+        #expect(!mock.sent.contains { $0.method == "session/prompt" })
+
+        session.pendingQueuePersistenceCount = 0
+        runner.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(session.queue.isEmpty)
+        #expect(mock.sent.contains { $0.method == "session/prompt" })
+    }
+
     @Test("flushQueueIfIdle is a no-op while state is .streaming")
     func noopWhileStreaming() async throws {
         let (runner, mock, session, _) = try mkRunner()

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -62,6 +62,19 @@ struct ACPSessionRunnerQueueTests {
         #expect(try store.loadQueue(sessionId: "s") == session.queue)
     }
 
+    @Test("force send preserves schedules while disconnected")
+    func forceSendPreservesScheduleWhileDisconnected() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(60))
+        let itemId = try #require(session.queue.first?.id)
+        session.agentState = .disconnected
+
+        runner.forceSendQueuedItem(id: itemId)
+
+        #expect(session.queue.first?.scheduledAt != nil)
+        #expect(!mock.sent.contains { $0.method == "session/prompt" })
+    }
+
     @Test("scheduled prompt flushes once its deadline arrives")
     func scheduledPromptFlushesAtDeadline() async throws {
         let (runner, mock, session, _) = try mkRunner()

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -208,6 +208,23 @@ struct ACPSessionRunnerQueueTests {
         #expect(mock.sent.contains { $0.method == "session/prompt" })
     }
 
+    @Test("force send parked by queue persistence is retained")
+    func forceSendBlockedByQueuePersistenceIsRetained() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(60))
+        let itemId = try #require(session.queue.first?.id)
+        session.pendingQueuePersistenceCount = 1
+
+        runner.forceSendQueuedItem(id: itemId)
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(session.queue.first?.scheduledAt == nil)
+        #expect(session.queue.first?.status == .pending)
+        #expect(!mock.sent.contains { $0.method == "session/prompt" })
+        #expect(runner.hasRetainedCleanupPromptWork)
+    }
+
     @Test("flushQueueIfIdle is a no-op while state is .streaming")
     func noopWhileStreaming() async throws {
         let (runner, mock, session, _) = try mkRunner()

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -65,6 +65,20 @@ struct ACPSessionRunnerQueueTests {
         #expect(try store.loadQueue(sessionId: "s") == session.queue)
     }
 
+    @Test("force send waits for initial scheduled persistence")
+    func forceSendWaitsForInitialScheduledPersistence() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        runner.send(blocks: [.text("later")], intent: .schedule(Date().addingTimeInterval(60)))
+        let itemId = try #require(session.queue.first?.id)
+
+        runner.forceSendQueuedItem(id: itemId)
+        try await Task.sleep(nanoseconds: 150_000_000)
+
+        #expect(session.queue.isEmpty)
+        #expect(mock.sent.contains { $0.method == "session/prompt" })
+    }
+
     @Test("failed scheduled persist rollback wins over later snapshots")
     func failedScheduledPersistRollbackWinsOverLaterSnapshots() async throws {
         let url = FileManager.default.temporaryDirectory
@@ -258,7 +272,7 @@ struct ACPSessionRunnerQueueTests {
         runner.forceSendQueuedItem(id: itemId)
         try await Task.sleep(nanoseconds: 50_000_000)
 
-        #expect(session.queue.first?.scheduledAt == nil)
+        #expect(session.queue.first?.scheduledAt != nil)
         #expect(session.queue.first?.status == .pending)
         #expect(!mock.sent.contains { $0.method == "session/prompt" })
         #expect(runner.hasRetainedCleanupPromptWork)

--- a/AlasTests/ACP/Session/ACPSessionStoreQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreQueueTests.swift
@@ -52,6 +52,20 @@ struct ACPSessionStoreQueueTests {
         #expect(loaded.isEmpty)
     }
 
+    @Test("scheduledQueueSessionIds includes scheduled sending items")
+    func scheduledQueueSessionIdsIncludesSending() throws {
+        let (store, sid) = try mkStore()
+        try store.upsertQueue(sessionId: sid, items: [
+            QueuedPrompt(
+                blocks: [.text("half sent")],
+                scheduledAt: Date().addingTimeInterval(-1),
+                status: .sending
+            ),
+        ])
+
+        #expect(try store.scheduledQueueSessionIds() == [sid])
+    }
+
     @Test("schema target version includes session_queue (v3+)")
     func schemaIncludesQueue() throws {
         let (store, _) = try mkStore()

--- a/AlasTests/ACP/Session/QueuedPromptTests.swift
+++ b/AlasTests/ACP/Session/QueuedPromptTests.swift
@@ -20,6 +20,38 @@ struct QueuedPromptTests {
         #expect(decoded == original)
     }
 
+    @Test("scheduled date round-trips while legacy queue JSON decodes without one")
+    func scheduledDateCompatibility() throws {
+        let scheduledAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let prompt = QueuedPrompt(
+            blocks: [.text("later")],
+            enqueuedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            scheduledAt: scheduledAt
+        )
+
+        let decoded = try JSONDecoder().decode(
+            QueuedPrompt.self,
+            from: JSONEncoder().encode(prompt)
+        )
+        #expect(decoded.scheduledAt == scheduledAt)
+
+        let legacy = #"{"id":"00000000-0000-0000-0000-000000000001","blocks":[{"type":"text","text":"legacy"}],"enqueuedAt":0,"status":"pending"}"#
+        #expect(try JSONDecoder().decode(
+            QueuedPrompt.self,
+            from: Data(legacy.utf8)
+        ).scheduledAt == nil)
+    }
+
+    @Test("a scheduled prompt becomes ready at its deadline")
+    func scheduledPromptReadiness() {
+        let deadline = Date(timeIntervalSince1970: 100)
+        let prompt = QueuedPrompt(blocks: [.text("later")], scheduledAt: deadline)
+
+        #expect(!prompt.isReady(at: Date(timeIntervalSince1970: 99)))
+        #expect(prompt.isReady(at: deadline))
+        #expect(prompt.isReady(at: Date(timeIntervalSince1970: 101)))
+    }
+
     @Test("normalizeAfterRestore flips .sending to .pending and clears lastError untouched")
     func normalize() {
         let q = QueuedPrompt(id: UUID(), blocks: [.text("x")],

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -367,6 +367,47 @@ struct ACPComposerDraftBridgeTests {
         #expect(ACPInputField.Coordinator.draft(from: textView.attributedString()) == newerDraft)
     }
 
+    @Test("failed scheduled completion restores submitted draft after intervening edit")
+    func failedScheduledCompletionRestoresSubmittedDraftAfterInterveningEdit() {
+        let submittedDraft = ACPComposerDraft(segments: [.text("hello")])
+        let newerDraft = ACPComposerDraft(segments: [.text("new")])
+        let restoredDraft = ACPComposerDraft(segments: [.text("new\nhello")])
+        let textView = NSTextView()
+        textView.textStorage?.setAttributedString(ACPInputField.Coordinator.attributedString(from: submittedDraft))
+        var changedDrafts: [ACPComposerDraft] = []
+        var clearCount = 0
+        var submitCount = 0
+        var completion: (@MainActor (Bool) -> Void)?
+
+        let coordinator = ACPInputField.Coordinator(
+            worktreeRoot: URL(fileURLWithPath: "/tmp"),
+            initialDraft: .empty,
+            focusRequest: 0,
+            sendOnEnter: true,
+            onDraftChange: { changedDrafts.append($0) },
+            onDraftClear: { clearCount += 1 },
+            onSubmit: { _, _, intent, draft, onFinished in
+                #expect(intent == .schedule(.distantFuture))
+                #expect(draft == submittedDraft)
+                submitCount += 1
+                completion = onFinished
+                return true
+            }
+        )
+        coordinator.textView = textView
+
+        coordinator.submit(textView, intent: .schedule(.distantFuture))
+        textView.textStorage?.setAttributedString(ACPInputField.Coordinator.attributedString(from: newerDraft))
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+        coordinator.submit(textView, intent: .schedule(.distantFuture))
+        completion?(false)
+
+        #expect(submitCount == 1)
+        #expect(changedDrafts == [newerDraft, newerDraft.appending(submittedDraft)])
+        #expect(clearCount == 0)
+        #expect(ACPInputField.Coordinator.draft(from: textView.attributedString()) == restoredDraft)
+    }
+
     @Test("persisted draft sync clears a remounted submitted draft")
     func persistedDraftSyncClearsRemountedSubmittedDraft() {
         let submittedDraft = ACPComposerDraft(segments: [.text("already sent")])

--- a/AlasTests/ACP/UI/ComposerActionTests.swift
+++ b/AlasTests/ACP/UI/ComposerActionTests.swift
@@ -1,8 +1,36 @@
+import Foundation
 import Testing
 @testable import Alas
 
 @Suite("ComposerAction derive function")
 struct ComposerActionTests {
+    @Test("schedule presets use the local calendar and round later today up to 30 minutes")
+    func schedulePresets() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let now = calendar.date(from: DateComponents(
+            year: 2026, month: 9, day: 10, hour: 14, minute: 10
+        ))!
+
+        #expect(ACPSchedulePreset.laterToday.date(after: now, calendar: calendar)
+            == calendar.date(from: DateComponents(year: 2026, month: 9, day: 10, hour: 16, minute: 30)))
+        #expect(ACPSchedulePreset.tomorrowMorning.date(after: now, calendar: calendar)
+            == calendar.date(from: DateComponents(year: 2026, month: 9, day: 11, hour: 9)))
+        #expect(ACPSchedulePreset.nextMondayMorning.date(after: now, calendar: calendar)
+            == calendar.date(from: DateComponents(year: 2026, month: 9, day: 14, hour: 9)))
+    }
+
+    @Test("later today is unavailable when two rounded hours cross midnight")
+    func laterTodayDoesNotCrossMidnight() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let now = calendar.date(from: DateComponents(
+            year: 2026, month: 9, day: 10, hour: 22, minute: 15
+        ))!
+
+        #expect(ACPSchedulePreset.laterToday.date(after: now, calendar: calendar) == nil)
+    }
+
     // MARK: - Agent lifecycle
 
     @Test("idle streaming + text shows Send for every agent lifecycle state")

--- a/AlasTests/ACP/UI/ComposerActionTests.swift
+++ b/AlasTests/ACP/UI/ComposerActionTests.swift
@@ -31,6 +31,18 @@ struct ComposerActionTests {
         #expect(ACPSchedulePreset.laterToday.date(after: now, calendar: calendar) == nil)
     }
 
+    @Test("morning presets retain their wall-clock time across daylight saving changes")
+    func morningPresetsAreDSTSafe() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/New_York")!
+        let now = calendar.date(from: DateComponents(
+            year: 2026, month: 3, day: 7, hour: 12
+        ))!
+
+        #expect(ACPSchedulePreset.tomorrowMorning.date(after: now, calendar: calendar)
+            == calendar.date(from: DateComponents(year: 2026, month: 3, day: 8, hour: 9)))
+    }
+
     // MARK: - Agent lifecycle
 
     @Test("idle streaming + text shows Send for every agent lifecycle state")

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -498,16 +498,8 @@ struct ClosedTabAppStateTests {
         #expect(fixture.state.pendingACPDetachCountForTesting == 0)
     }
 
-    @Test func closedACPSessionWithDisconnectedScheduledPromptDetachesImmediately() async throws {
-        let gate = AsyncGate()
-        let state = AppState(
-            store: MemoryStore(),
-            acpDetachRunner: { _, sessionId in
-                #expect(sessionId == "disconnected-scheduled-close")
-                await gate.enterAndWait()
-            }
-        )
-        let fixture = makeFixture(state: state)
+    @Test func closedACPSessionWithDisconnectedScheduledPromptStaysRetained() async throws {
+        let fixture = makeFixture()
         let manager = try #require(fixture.state.acpManager(for: fixture.first))
         let session = manager.createSession(id: "disconnected-scheduled-close", agentId: "claude")
         session.agentState = .disconnected
@@ -518,16 +510,8 @@ struct ClosedTabAppStateTests {
         )
 
         fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
-        await gate.waitUntilEntered()
 
-        #expect(fixture.state.retainedACPSessionCleanupCountForTesting == 0)
-        #expect(fixture.state.pendingACPDetachCountForTesting == 1)
-
-        await gate.release()
-        for _ in 0 ..< 20 where fixture.state.pendingACPDetachCountForTesting != 0 {
-            await Task.yield()
-        }
-
+        #expect(fixture.state.retainedACPSessionCleanupCountForTesting == 1)
         #expect(fixture.state.pendingACPDetachCountForTesting == 0)
     }
 

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -536,15 +536,18 @@ struct ClosedTabAppStateTests {
         let session = manager.createSession(id: "disconnected-scheduled-close", agentId: "claude")
         session.agentState = .disconnected
         session.enqueueScheduled(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(60))
+        manager.retainSession(id: session.id)
         let tab = fixture.state.tabs.append(
             acpSession: ACPSessionTabState(sessionId: session.id, title: "Closed chat"),
             to: fixture.first.id
         )
 
         fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
+        manager.releaseSession(id: session.id)
 
         #expect(fixture.state.retainedACPSessionCleanupCountForTesting == 1)
         #expect(fixture.state.pendingACPDetachCountForTesting == 0)
+        #expect(manager.liveSession(for: session.id) != nil)
     }
 
     @Test func reopeningACPSessionDoesNotRestoreAfterWorktreeCleanupDuringDetach() async {

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -267,7 +267,7 @@ struct ClosedTabAppStateTests {
         let fixture = makeFixture(state: state)
         let manager = try #require(fixture.state.acpManager(for: fixture.first))
         let session = manager.createSession(id: "scheduled-close", agentId: "claude")
-        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: .distantFuture)
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(0.05))
         let tab = fixture.state.tabs.append(
             acpSession: ACPSessionTabState(sessionId: session.id, title: "Closed chat"),
             to: fixture.first.id
@@ -280,6 +280,39 @@ struct ClosedTabAppStateTests {
         #expect(manager.liveSession(for: session.id) != nil)
 
         session.queue.removeAll()
+        await gate.waitUntilEntered()
+
+        #expect(fixture.state.retainedACPSessionCleanupCountForTesting == 0)
+        #expect(fixture.state.pendingACPDetachCountForTesting == 1)
+
+        await gate.release()
+        for _ in 0 ..< 20 where fixture.state.pendingACPDetachCountForTesting != 0 {
+            await Task.yield()
+        }
+
+        #expect(fixture.state.pendingACPDetachCountForTesting == 0)
+    }
+
+    @Test func closedACPSessionWithOrdinarySendingPromptDetachesImmediately() async throws {
+        let gate = AsyncGate()
+        let state = AppState(
+            store: MemoryStore(),
+            acpDetachRunner: { _, sessionId in
+                #expect(sessionId == "ordinary-sending-close")
+                await gate.enterAndWait()
+            }
+        )
+        let fixture = makeFixture(state: state)
+        let manager = try #require(fixture.state.acpManager(for: fixture.first))
+        let session = manager.createSession(id: "ordinary-sending-close", agentId: "claude")
+        session.enqueue(blocks: [.text("now")])
+        _ = session.markQueueHeadSending()
+        let tab = fixture.state.tabs.append(
+            acpSession: ACPSessionTabState(sessionId: session.id, title: "Closed chat"),
+            to: fixture.first.id
+        )
+
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
         await gate.waitUntilEntered()
 
         #expect(fixture.state.retainedACPSessionCleanupCountForTesting == 0)

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -550,6 +550,26 @@ struct ClosedTabAppStateTests {
         #expect(manager.liveSession(for: session.id) != nil)
     }
 
+    @Test func closedACPSessionWithIdleScheduledPromptStaysRetained() async throws {
+        let fixture = makeFixture()
+        let manager = try #require(fixture.state.acpManager(for: fixture.first))
+        let session = manager.createSession(id: "idle-scheduled-close", agentId: "claude")
+        session.agentState = .idle
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(60))
+        manager.retainSession(id: session.id)
+        let tab = fixture.state.tabs.append(
+            acpSession: ACPSessionTabState(sessionId: session.id, title: "Closed chat"),
+            to: fixture.first.id
+        )
+
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
+        manager.releaseSession(id: session.id)
+
+        #expect(fixture.state.retainedACPSessionCleanupCountForTesting == 1)
+        #expect(fixture.state.pendingACPDetachCountForTesting == 0)
+        #expect(manager.liveSession(for: session.id) != nil)
+    }
+
     @Test func retainedDisconnectedScheduleSurvivesQueueRestart() async throws {
         let fixture = makeFixture()
         let manager = try #require(fixture.state.acpManager(for: fixture.first))

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -327,6 +327,25 @@ struct ClosedTabAppStateTests {
         #expect(fixture.state.pendingACPDetachCountForTesting == 0)
     }
 
+    @Test func closedACPSessionAwaitingInputUsesParkedRetainedCleanupDelay() async throws {
+        let fixture = makeFixture()
+        let manager = try #require(fixture.state.acpManager(for: fixture.first))
+        let session = manager.createSession(id: "awaiting-input-close", agentId: "claude")
+        session.agentState = .ready
+        session.transcript.streamingState = .awaitingInput
+        session.enqueue(blocks: [.text("now")])
+        _ = session.markQueueHeadSending()
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(60))
+
+        #expect(
+            fixture.state.retainedACPSessionCleanupDelayForTesting(
+                manager: manager,
+                sessionId: session.id,
+                retainActivePrompt: true
+            ) == .seconds(3600)
+        )
+    }
+
     @Test func closedACPSessionWithFailedQueueHeadDetachesImmediately() async throws {
         let gate = AsyncGate()
         let state = AppState(

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -346,6 +346,22 @@ struct ClosedTabAppStateTests {
         )
     }
 
+    @Test func closedACPSessionDirectAwaitingInputUsesParkedDelayForOverdueSchedule() async throws {
+        let fixture = makeFixture()
+        let manager = try #require(fixture.state.acpManager(for: fixture.first))
+        let session = manager.createSession(id: "direct-awaiting-input-close", agentId: "claude")
+        session.agentState = .ready
+        session.transcript.streamingState = .awaitingInput
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(-1))
+
+        #expect(
+            fixture.state.retainedACPSessionCleanupDelayForTesting(
+                manager: manager,
+                sessionId: session.id
+            ) == .seconds(3600)
+        )
+    }
+
     @Test func closedACPSessionWithFailedQueueHeadDetachesImmediately() async throws {
         let gate = AsyncGate()
         let state = AppState(

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -550,6 +550,30 @@ struct ClosedTabAppStateTests {
         #expect(manager.liveSession(for: session.id) != nil)
     }
 
+    @Test func retainedDisconnectedScheduleSurvivesQueueRestart() async throws {
+        let fixture = makeFixture()
+        let manager = try #require(fixture.state.acpManager(for: fixture.first))
+        let session = manager.createSession(id: "disconnected-scheduled-restart", agentId: "claude")
+        session.agentState = .disconnected
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(60))
+        session.enqueueScheduled(blocks: [.text("later again")], scheduledAt: Date().addingTimeInterval(120))
+        let removedId = try #require(session.queue.first?.id)
+        manager.retainSession(id: session.id)
+        let tab = fixture.state.tabs.append(
+            acpSession: ACPSessionTabState(sessionId: session.id, title: "Closed chat"),
+            to: fixture.first.id
+        )
+
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
+        manager.releaseSession(id: session.id)
+        #expect(await manager.acquireWriterLease(sessionId: session.id))
+        await manager.queueRemove(for: session.id, itemId: removedId)
+
+        #expect(fixture.state.retainedACPSessionCleanupCountForTesting == 1)
+        #expect(manager.liveSession(for: session.id) != nil)
+        #expect(session.queue.count == 1)
+    }
+
     @Test func reopeningACPSessionDoesNotRestoreAfterWorktreeCleanupDuringDetach() async {
         let gate = AsyncGate()
         let state = AppState(

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -401,6 +401,67 @@ struct ClosedTabAppStateTests {
         #expect(fixture.state.retainedACPSessionCleanupCountForTesting == 0)
     }
 
+    @Test func openExistingACPSessionWaitsForPendingDetach() async throws {
+        let gate = AsyncGate()
+        let state = AppState(
+            store: MemoryStore(),
+            acpDetachRunner: { _, _ in await gate.enterAndWait() }
+        )
+        let fixture = makeFixture(state: state)
+        fixture.state.selectWorktree(id: fixture.first.id)
+        let manager = try #require(fixture.state.acpManager(for: fixture.first))
+        let session = manager.createSession(id: "reopen-pending-detach", agentId: "claude")
+        let tab = fixture.state.tabs.append(
+            acpSession: ACPSessionTabState(sessionId: session.id, title: "Closed chat"),
+            to: fixture.first.id
+        )
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
+        await gate.waitUntilEntered()
+
+        let reopen = Task { @MainActor in
+            await fixture.state.openExistingACPSession(sessionId: session.id)
+        }
+        await Task.yield()
+        #expect(fixture.state.tabs.tabs(forWorktree: fixture.first.id).isEmpty)
+
+        await gate.release()
+        await reopen.value
+
+        #expect(fixture.state.pendingACPDetachCountForTesting == 0)
+        #expect(fixture.state.tabs.tabs(forWorktree: fixture.first.id).count == 1)
+    }
+
+    @Test func openExistingOwnedACPSessionWaitsForPendingDetach() async throws {
+        let gate = AsyncGate()
+        let state = AppState(
+            store: MemoryStore(),
+            acpDetachRunner: { _, _ in await gate.enterAndWait() }
+        )
+        let fixture = makeFixture(state: state)
+        let owner = SessionOwnerID.worktree(fixture.first.id)
+        _ = fixture.state.acpManager(for: fixture.first)
+        let manager = try #require(fixture.state.acpManager(for: owner))
+        let session = manager.createSession(id: "reopen-owned-pending-detach", agentId: "claude")
+        let tab = fixture.state.tabs.append(
+            acpSession: ACPSessionTabState(sessionId: session.id, title: "Closed chat"),
+            to: owner
+        )
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
+        await gate.waitUntilEntered()
+
+        let reopen = Task { @MainActor in
+            await fixture.state.openExistingACPSession(sessionId: session.id, owner: owner)
+        }
+        await Task.yield()
+        #expect(fixture.state.tabs.tabs(for: owner).isEmpty)
+
+        await gate.release()
+        await reopen.value
+
+        #expect(fixture.state.pendingACPDetachCountForTesting == 0)
+        #expect(fixture.state.tabs.tabs(for: owner).count == 1)
+    }
+
     @Test func closedACPSessionWithFailedQueueHeadDetachesImmediately() async throws {
         let gate = AsyncGate()
         let state = AppState(

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -326,6 +326,41 @@ struct ClosedTabAppStateTests {
         #expect(fixture.state.pendingACPDetachCountForTesting == 0)
     }
 
+    @Test func closedACPSessionWithFailedQueueHeadDetachesImmediately() async throws {
+        let gate = AsyncGate()
+        let state = AppState(
+            store: MemoryStore(),
+            acpDetachRunner: { _, sessionId in
+                #expect(sessionId == "failed-head-close")
+                await gate.enterAndWait()
+            }
+        )
+        let fixture = makeFixture(state: state)
+        let manager = try #require(fixture.state.acpManager(for: fixture.first))
+        let session = manager.createSession(id: "failed-head-close", agentId: "claude")
+        session.enqueueScheduled(blocks: [.text("failed")], scheduledAt: Date().addingTimeInterval(-1))
+        _ = session.markQueueHeadSending()
+        session.setQueueHeadError("failed")
+        session.enqueueScheduled(blocks: [.text("blocked later")], scheduledAt: Date().addingTimeInterval(60))
+        let tab = fixture.state.tabs.append(
+            acpSession: ACPSessionTabState(sessionId: session.id, title: "Closed chat"),
+            to: fixture.first.id
+        )
+
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
+        await gate.waitUntilEntered()
+
+        #expect(fixture.state.retainedACPSessionCleanupCountForTesting == 0)
+        #expect(fixture.state.pendingACPDetachCountForTesting == 1)
+
+        await gate.release()
+        for _ in 0 ..< 20 where fixture.state.pendingACPDetachCountForTesting != 0 {
+            await Task.yield()
+        }
+
+        #expect(fixture.state.pendingACPDetachCountForTesting == 0)
+    }
+
     @Test func reopeningACPSessionDoesNotRestoreAfterWorktreeCleanupDuringDetach() async {
         let gate = AsyncGate()
         let state = AppState(

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -267,6 +267,7 @@ struct ClosedTabAppStateTests {
         let fixture = makeFixture(state: state)
         let manager = try #require(fixture.state.acpManager(for: fixture.first))
         let session = manager.createSession(id: "scheduled-close", agentId: "claude")
+        session.agentState = .ready
         session.enqueueScheduled(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(0.05))
         let tab = fixture.state.tabs.append(
             acpSession: ACPSessionTabState(sessionId: session.id, title: "Closed chat"),
@@ -338,10 +339,44 @@ struct ClosedTabAppStateTests {
         let fixture = makeFixture(state: state)
         let manager = try #require(fixture.state.acpManager(for: fixture.first))
         let session = manager.createSession(id: "failed-head-close", agentId: "claude")
+        session.agentState = .ready
         session.enqueueScheduled(blocks: [.text("failed")], scheduledAt: Date().addingTimeInterval(-1))
         _ = session.markQueueHeadSending()
         session.setQueueHeadError("failed")
         session.enqueueScheduled(blocks: [.text("blocked later")], scheduledAt: Date().addingTimeInterval(60))
+        let tab = fixture.state.tabs.append(
+            acpSession: ACPSessionTabState(sessionId: session.id, title: "Closed chat"),
+            to: fixture.first.id
+        )
+
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
+        await gate.waitUntilEntered()
+
+        #expect(fixture.state.retainedACPSessionCleanupCountForTesting == 0)
+        #expect(fixture.state.pendingACPDetachCountForTesting == 1)
+
+        await gate.release()
+        for _ in 0 ..< 20 where fixture.state.pendingACPDetachCountForTesting != 0 {
+            await Task.yield()
+        }
+
+        #expect(fixture.state.pendingACPDetachCountForTesting == 0)
+    }
+
+    @Test func closedACPSessionWithDisconnectedScheduledPromptDetachesImmediately() async throws {
+        let gate = AsyncGate()
+        let state = AppState(
+            store: MemoryStore(),
+            acpDetachRunner: { _, sessionId in
+                #expect(sessionId == "disconnected-scheduled-close")
+                await gate.enterAndWait()
+            }
+        )
+        let fixture = makeFixture(state: state)
+        let manager = try #require(fixture.state.acpManager(for: fixture.first))
+        let session = manager.createSession(id: "disconnected-scheduled-close", agentId: "claude")
+        session.agentState = .disconnected
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(60))
         let tab = fixture.state.tabs.append(
             acpSession: ACPSessionTabState(sessionId: session.id, title: "Closed chat"),
             to: fixture.first.id

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -362,6 +362,45 @@ struct ClosedTabAppStateTests {
         )
     }
 
+    @Test func openExistingACPSessionCancelsRetainedCleanup() async throws {
+        let fixture = makeFixture()
+        fixture.state.selectWorktree(id: fixture.first.id)
+        let manager = try #require(fixture.state.acpManager(for: fixture.first))
+        let session = manager.createSession(id: "reopen-scheduled-close", agentId: "claude")
+        session.agentState = .ready
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(60))
+        let tab = fixture.state.tabs.append(
+            acpSession: ACPSessionTabState(sessionId: session.id, title: "Closed chat"),
+            to: fixture.first.id
+        )
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
+        #expect(fixture.state.retainedACPSessionCleanupCountForTesting == 1)
+
+        await fixture.state.openExistingACPSession(sessionId: session.id)
+
+        #expect(fixture.state.retainedACPSessionCleanupCountForTesting == 0)
+    }
+
+    @Test func openExistingOwnedACPSessionCancelsRetainedCleanup() async throws {
+        let fixture = makeFixture()
+        let owner = SessionOwnerID.worktree(fixture.first.id)
+        _ = fixture.state.acpManager(for: fixture.first)
+        let manager = try #require(fixture.state.acpManager(for: owner))
+        let session = manager.createSession(id: "reopen-owned-scheduled-close", agentId: "claude")
+        session.agentState = .ready
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(60))
+        let tab = fixture.state.tabs.append(
+            acpSession: ACPSessionTabState(sessionId: session.id, title: "Closed chat"),
+            to: owner
+        )
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
+        #expect(fixture.state.retainedACPSessionCleanupCountForTesting == 1)
+
+        await fixture.state.openExistingACPSession(sessionId: session.id, owner: owner)
+
+        #expect(fixture.state.retainedACPSessionCleanupCountForTesting == 0)
+    }
+
     @Test func closedACPSessionWithFailedQueueHeadDetachesImmediately() async throws {
         let gate = AsyncGate()
         let state = AppState(

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -362,6 +362,38 @@ struct ClosedTabAppStateTests {
         )
     }
 
+    @Test func closedACPSessionDisconnectedSendingScheduleStaysRetained() async throws {
+        let fixture = makeFixture()
+        let manager = try #require(fixture.state.acpManager(for: fixture.first))
+        let session = manager.createSession(id: "disconnected-sending-schedule", agentId: "claude")
+        session.agentState = .disconnected
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(60))
+        _ = session.markQueueHeadSending()
+
+        #expect(
+            fixture.state.retainedACPSessionCleanupDelayForTesting(
+                manager: manager,
+                sessionId: session.id
+            ) == .milliseconds(250)
+        )
+    }
+
+    @Test func closedACPSessionAuthBlockedScheduleDoesNotStayRetained() async throws {
+        let fixture = makeFixture()
+        let manager = try #require(fixture.state.acpManager(for: fixture.first))
+        let session = manager.createSession(id: "auth-blocked-schedule", agentId: "claude")
+        session.agentState = .failed("authentication required")
+        session.setupState = .needsAuth(methods: [], reason: "Sign in")
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: Date().addingTimeInterval(60))
+
+        #expect(
+            fixture.state.retainedACPSessionCleanupDelayForTesting(
+                manager: manager,
+                sessionId: session.id
+            ) == nil
+        )
+    }
+
     @Test func openExistingACPSessionCancelsRetainedCleanup() async throws {
         let fixture = makeFixture()
         fixture.state.selectWorktree(id: fixture.first.id)

--- a/AlasTests/ClosedTabAppStateTests.swift
+++ b/AlasTests/ClosedTabAppStateTests.swift
@@ -255,6 +255,44 @@ struct ClosedTabAppStateTests {
         #expect(fixture.state.canReopenClosedTab)
     }
 
+    @Test func closedACPSessionWithScheduledPromptDetachesAfterQueueDrains() async throws {
+        let gate = AsyncGate()
+        let state = AppState(
+            store: MemoryStore(),
+            acpDetachRunner: { _, sessionId in
+                #expect(sessionId == "scheduled-close")
+                await gate.enterAndWait()
+            }
+        )
+        let fixture = makeFixture(state: state)
+        let manager = try #require(fixture.state.acpManager(for: fixture.first))
+        let session = manager.createSession(id: "scheduled-close", agentId: "claude")
+        session.enqueueScheduled(blocks: [.text("later")], scheduledAt: .distantFuture)
+        let tab = fixture.state.tabs.append(
+            acpSession: ACPSessionTabState(sessionId: session.id, title: "Closed chat"),
+            to: fixture.first.id
+        )
+
+        fixture.state.requestCloseTab(worktreeId: fixture.first.id, tabId: tab.id)
+
+        #expect(fixture.state.retainedACPSessionCleanupCountForTesting == 1)
+        #expect(fixture.state.pendingACPDetachCountForTesting == 0)
+        #expect(manager.liveSession(for: session.id) != nil)
+
+        session.queue.removeAll()
+        await gate.waitUntilEntered()
+
+        #expect(fixture.state.retainedACPSessionCleanupCountForTesting == 0)
+        #expect(fixture.state.pendingACPDetachCountForTesting == 1)
+
+        await gate.release()
+        for _ in 0 ..< 20 where fixture.state.pendingACPDetachCountForTesting != 0 {
+            await Task.yield()
+        }
+
+        #expect(fixture.state.pendingACPDetachCountForTesting == 0)
+    }
+
     @Test func reopeningACPSessionDoesNotRestoreAfterWorktreeCleanupDuringDetach() async {
         let gate = AsyncGate()
         let state = AppState(

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -626,7 +626,7 @@ struct RemoteProtocolTests {
             sessionId: "s1",
             items: [
                 RemoteQueuedPrompt(id: "i1", text: "first", imageCount: 0, resourceCount: 0, status: "sending", lastError: nil, scheduledAt: nil),
-                RemoteQueuedPrompt(id: "i2", text: "second", imageCount: 2, resourceCount: 1, status: "pending", lastError: "boom", scheduledAt: Date(timeIntervalSince1970: 1_800_000_000)),
+                RemoteQueuedPrompt(id: "i2", text: "second", imageCount: 2, resourceCount: 1, status: "pending", lastError: "boom", scheduledAt: 1_800_000_000_000),
             ],
             steerUndoAvailable: true)
         #expect(try roundTrip(state) == state)

--- a/AlasTests/Remote/RemoteProtocolTests.swift
+++ b/AlasTests/Remote/RemoteProtocolTests.swift
@@ -625,8 +625,8 @@ struct RemoteProtocolTests {
         let state = RemoteServerMessage.queueState(
             sessionId: "s1",
             items: [
-                RemoteQueuedPrompt(id: "i1", text: "first", imageCount: 0, resourceCount: 0, status: "sending", lastError: nil),
-                RemoteQueuedPrompt(id: "i2", text: "second", imageCount: 2, resourceCount: 1, status: "pending", lastError: "boom"),
+                RemoteQueuedPrompt(id: "i1", text: "first", imageCount: 0, resourceCount: 0, status: "sending", lastError: nil, scheduledAt: nil),
+                RemoteQueuedPrompt(id: "i2", text: "second", imageCount: 2, resourceCount: 1, status: "pending", lastError: "boom", scheduledAt: Date(timeIntervalSince1970: 1_800_000_000)),
             ],
             steerUndoAvailable: true)
         #expect(try roundTrip(state) == state)

--- a/AlasTests/Remote/RemoteQueueProjectionTests.swift
+++ b/AlasTests/Remote/RemoteQueueProjectionTests.swift
@@ -44,7 +44,7 @@ struct RemoteQueueProjectionTests {
         let deadline = Date(timeIntervalSince1970: 1_800_000_000)
         let projected = RemoteQueueProjection.project([item(text: "later", scheduledAt: deadline)])
 
-        #expect(projected[0].scheduledAt == deadline)
+        #expect(projected[0].scheduledAt == 1_800_000_000_000)
     }
 
     @Test func joinsMultipleTextBlocksAndCountsImages() {

--- a/AlasTests/Remote/RemoteQueueProjectionTests.swift
+++ b/AlasTests/Remote/RemoteQueueProjectionTests.swift
@@ -7,14 +7,15 @@ struct RemoteQueueProjectionTests {
         text: String? = nil,
         imageURIs: [String] = [],
         status: QueuedPrompt.Status = .pending,
-        lastError: String? = nil
+        lastError: String? = nil,
+        scheduledAt: Date? = nil
     ) -> QueuedPrompt {
         var blocks: [ACPContentBlock] = []
         if let text { blocks.append(.text(text)) }
         for uri in imageURIs {
             blocks.append(.image(data: "AAAA", uri: uri, mimeType: "image/png"))
         }
-        return QueuedPrompt(blocks: blocks, status: status, lastError: lastError)
+        return QueuedPrompt(blocks: blocks, scheduledAt: scheduledAt, status: status, lastError: lastError)
     }
 
     @Test func projectsPendingTextItem() {
@@ -37,6 +38,13 @@ struct RemoteQueueProjectionTests {
         let errored = RemoteQueueProjection.project([item(text: "b", lastError: "boom")])
         #expect(errored[0].status == "pending")
         #expect(errored[0].lastError == "boom")
+    }
+
+    @Test func projectsScheduledDeadline() {
+        let deadline = Date(timeIntervalSince1970: 1_800_000_000)
+        let projected = RemoteQueueProjection.project([item(text: "later", scheduledAt: deadline)])
+
+        #expect(projected[0].scheduledAt == deadline)
     }
 
     @Test func joinsMultipleTextBlocksAndCountsImages() {

--- a/AlasTests/Remote/RemoteWebAssetTests.swift
+++ b/AlasTests/Remote/RemoteWebAssetTests.swift
@@ -405,6 +405,13 @@ struct RemoteWebAssetTests {
         #expect(js.contains("let steerUndoAvailable = false;"))
     }
 
+    @Test func remoteWebDisplaysScheduledQueueDeadlines() throws {
+        let js = try asset("app.js")
+
+        #expect(js.contains("function queuedStatus(item)"))
+        #expect(js.contains("Scheduled for"))
+    }
+
     // Regression (review, task 6): pendingAttachments feeds hasText in
     // composerAction, but the mutation sites (attach picker, chip removal,
     // restoreRejectedPrompt) only ever called renderChips(), never


### PR DESCRIPTION
## Summary

Adds Slack-style scheduled sending to the ACP chat composer. Future prompts remain local to the app, persist with the existing queue, and are delivered when the app is open; overdue prompts deliver on the next open.

## Changes

- Add an accent split Send button with Later today, Tomorrow 9 AM, Next Monday 9 AM, and a custom date/time picker.
- Persist schedule deadlines on queued prompts, keep normal prompts ahead of scheduled ones, and show scheduled timing in the queue bubble.
- Wake the session queue at the deadline; Send now clears the deadline and delivers immediately.
- Add coverage for presets, persistence compatibility, queue ordering, deadline delivery, and normal-message priority.

## Verification

- Focused scheduling tests pass.
- Full macOS build passes.
- Full test suite completed with 26 existing unrelated failures in terminal, Git, UI, and workspace suites.