### PR TITLE
feat(remote): Improve remote changes list paths

### DIFF
--- a/Alas/Resources/RemoteWeb/app.js
+++ b/Alas/Resources/RemoteWeb/app.js
@@ -618,13 +618,17 @@ function renderChanges() {
 
   for (const section of sections) {
     list.append(el("h2", "changes-section-title", section.title));
-    for (const file of section.files || []) {
-      const parts = RemoteChangesView.splitPath(file.path);
+    for (const item of RemoteChangesView.fileRows(section.files)) {
+      if (item.type === "directory") {
+        list.append(el("div", "change-directory", item.dir));
+        continue;
+      }
+      const file = item.file;
       const row = document.createElement("button");
       row.type = "button";
-      row.className = "change-row";
+      row.className = "change-row" + (item.dir ? " change-row-nested" : "");
       row.onclick = () => openDiff(file.path, section.stage || null);
-      row.append(el("span", "change-dir", parts.dir), el("span", "change-name", parts.name));
+      row.append(el("span", "change-name", item.name));
       if (file.conflict) row.append(el("span", "change-conflict", "conflict"));
       row.append(el("span", "change-status", file.status));
       const counts = el("span", "change-counts");

--- a/Alas/Resources/RemoteWeb/changes-view.js
+++ b/Alas/Resources/RemoteWeb/changes-view.js
@@ -13,6 +13,27 @@ function splitPath(path) {
   return { dir: value.slice(0, index + 1), name: value.slice(index + 1) };
 }
 
+function fileRows(files) {
+  const rows = [];
+  let previousDirectory = null;
+  const sortedByDirectory = (files || []).slice().sort((a, b) => {
+    const aParts = splitPath(a.path);
+    const bParts = splitPath(b.path);
+    if (aParts.dir < bParts.dir) return -1;
+    if (aParts.dir > bParts.dir) return 1;
+    return aParts.name < bParts.name ? -1 : aParts.name > bParts.name ? 1 : 0;
+  });
+  for (const file of sortedByDirectory) {
+    const parts = splitPath(file.path);
+    if (parts.dir && parts.dir !== previousDirectory) {
+      rows.push({ type: "directory", dir: parts.dir.slice(0, -1) });
+    }
+    rows.push({ type: "file", file, path: file.path, dir: parts.dir, name: parts.name });
+    previousDirectory = parts.dir;
+  }
+  return rows;
+}
+
 function formatFileCounts(file) {
   const add = file && file.add ? file.add : 0;
   const del = file && file.del ? file.del : 0;
@@ -94,6 +115,7 @@ function metadataOnlyNotice(hunks, metadataNote) {
 globalThis.RemoteChangesView = {
   sortFiles,
   splitPath,
+  fileRows,
   changeSections,
   formatSummary,
   formatFileCounts,

--- a/Alas/Resources/RemoteWeb/index.html
+++ b/Alas/Resources/RemoteWeb/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="/icon.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/icon-180.png" />
   <title>Alas Remote</title>
-  <link rel="stylesheet" href="/style.css?v=44" />
+  <link rel="stylesheet" href="/style.css?v=45" />
 </head>
 <body>
   <header id="bar">
@@ -196,9 +196,9 @@
   <script src="/purify.min.js?v=28"></script>
   <script src="/session-ordering.js?v=1"></script>
   <script src="/worktree-creation.js?v=1"></script>
-  <script src="/changes-view.js?v=6"></script>
+  <script src="/changes-view.js?v=7"></script>
   <script src="/file-browser.js?v=3"></script>
-  <script src="/app.js?v=79"></script>
+  <script src="/app.js?v=80"></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {

--- a/Alas/Resources/RemoteWeb/style.css
+++ b/Alas/Resources/RemoteWeb/style.css
@@ -316,7 +316,8 @@ button.create-row.is-selected { border-color: var(--accent); background: color-m
 }
 .changes-section-title { margin: 14px 12px 4px; color: var(--fg-muted); font-size: 11px; font-weight: 700; letter-spacing: 0.45px; text-transform: uppercase; }
 .changes-section-title:first-child { margin-top: 4px; }
-.change-dir { color: var(--fg-faint); }
+.change-directory { padding: 8px 12px 4px; color: var(--fg-faint); font-size: 13px; }
+.change-row-nested { padding-left: 24px; }
 .change-name { font-weight: 600; }
 .change-counts { margin-left: auto; display: inline-flex; gap: 7px; font-variant-numeric: tabular-nums; }
 .count-add { color: var(--add); }

--- a/Alas/Resources/RemoteWeb/sw.js
+++ b/Alas/Resources/RemoteWeb/sw.js
@@ -1,13 +1,13 @@
-const CACHE_NAME = "alas-remote-shell-v59";
+const CACHE_NAME = "alas-remote-shell-v60";
 const SHELL_ASSETS = [
   "/",
   "/index.html",
-  "/style.css?v=44",
+  "/style.css?v=45",
   "/session-ordering.js?v=1",
   "/worktree-creation.js?v=1",
-  "/changes-view.js?v=6",
+  "/changes-view.js?v=7",
   "/file-browser.js?v=3",
-  "/app.js?v=79",
+  "/app.js?v=80",
   "/marked.min.js?v=28",
   "/purify.min.js?v=28",
   "/manifest.webmanifest",

--- a/scripts/tests/remote-web-changes/test-changes-view.js
+++ b/scripts/tests/remote-web-changes/test-changes-view.js
@@ -19,6 +19,42 @@ const view = globalThis.RemoteChangesView;
 }
 
 {
+  // Removing directory rows or leaving full paths on file rows would make
+  // filenames hard to find again on a narrow Changes tab.
+  const rows = view.fileRows([
+    { path: "README.md" },
+    { path: "Alas/Resources/RemoteWeb/app.js" },
+    { path: "Alas/Resources/RemoteWeb/index.html" },
+    { path: "Alas/Sources/ACP/Session/ACPSession.swift" }
+  ]);
+  assert.deepEqual(rows.map((row) => ({ type: row.type, path: row.path, dir: row.dir, name: row.name })), [
+    { type: "file", path: "README.md", dir: "", name: "README.md" },
+    { type: "directory", path: undefined, dir: "Alas/Resources/RemoteWeb", name: undefined },
+    { type: "file", path: "Alas/Resources/RemoteWeb/app.js", dir: "Alas/Resources/RemoteWeb/", name: "app.js" },
+    { type: "file", path: "Alas/Resources/RemoteWeb/index.html", dir: "Alas/Resources/RemoteWeb/", name: "index.html" },
+    { type: "directory", path: undefined, dir: "Alas/Sources/ACP/Session", name: undefined },
+    { type: "file", path: "Alas/Sources/ACP/Session/ACPSession.swift", dir: "Alas/Sources/ACP/Session/", name: "ACPSession.swift" }
+  ]);
+}
+
+{
+  // Sorting only by full path would split src's direct children around
+  // src/sub, emitting the src heading twice.
+  const rows = view.fileRows([
+    { path: "src/z.swift" },
+    { path: "src/sub/b.swift" },
+    { path: "src/a.swift" }
+  ]);
+  assert.deepEqual(rows.map((row) => row.type === "directory" ? row.dir : row.path), [
+    "src",
+    "src/a.swift",
+    "src/z.swift",
+    "src/sub",
+    "src/sub/b.swift"
+  ]);
+}
+
+{
   const summary = view.formatSummary({
     comparisonRef: "origin/main",
     files: [


### PR DESCRIPTION
## Summary
- group changed files under directory labels in Remote Web
- keep filenames, status, and line counts readable on narrow screens
- cover path grouping with the focused Remote Web Changes test

## Verification
- scripts/tests/remote-web-changes/run.sh
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-remote-web-changes-final-derived-data -quiet test