### PR TITLE
feat(worktree): Add merged-worktree detection with bulk cleanup and archive

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1077,6 +1077,7 @@
 		A4AB930CA0EEA2CEF0302646 /* ImageCheckerboardBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206F1DBCB1C34D71BEBB7DE4 /* ImageCheckerboardBackground.swift */; };
 		A5742BE7348C02324B8119D0 /* BaseBranchSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */; };
 		A58568C1EFF4A274FBDC83A4 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CA3930F30444A51FB2393D /* Theme.swift */; };
+		A5ED5D357F25C442E3B9F37F /* AppStateWorktreeArchiveBatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BDFFDEF35A4EE346186298 /* AppStateWorktreeArchiveBatchTests.swift */; };
 		A5F5FBA73F2E50F7FC86E960 /* CommitPrimaryAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45413FEBB779051893272FC7 /* CommitPrimaryAction.swift */; };
 		A630ABCDF04C36956349606C /* DiffDisplayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8CB5B1DA091EE7D5DA0436 /* DiffDisplayModel.swift */; };
 		A65ED0AF2D8880576486505C /* DiffReviewRenderContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B7B8B82A8D4F5B1F1DF1731 /* DiffReviewRenderContext.swift */; };
@@ -2920,6 +2921,7 @@
 		C47AF847BD698EAB373D128B /* ZmxClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxClient.swift; sourceTree = "<group>"; };
 		C48DB0098D71F26ABF594615 /* permission-request.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "permission-request.json"; sourceTree = "<group>"; };
 		C496549308D5C3DD20E988AD /* ACPComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposer.swift; sourceTree = "<group>"; };
+		C4BDFFDEF35A4EE346186298 /* AppStateWorktreeArchiveBatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateWorktreeArchiveBatchTests.swift; sourceTree = "<group>"; };
 		C4E0BB32D1A3B26473464A0F /* ZmxEnv.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxEnv.swift; sourceTree = "<group>"; };
 		C506EF972D34E2F937D4FEEC /* InstallerHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallerHost.swift; sourceTree = "<group>"; };
 		C50700F7960B44D0116F09C8 /* DiffCodeText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffCodeText.swift; sourceTree = "<group>"; };
@@ -3632,6 +3634,7 @@
 				23190FA641E518CAFA0A8177 /* AppStateRunScriptCreationTests.swift */,
 				EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */,
 				279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */,
+				C4BDFFDEF35A4EE346186298 /* AppStateWorktreeArchiveBatchTests.swift */,
 				4A0A451D5E0D66CB2F4121AD /* AppStateWorktreeCleanupBatchTests.swift */,
 				6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */,
 				652C404D30685CB2FE79BD81 /* BaseResolutionMappingTests.swift */,
@@ -7488,6 +7491,7 @@
 				F8C643420F6CF51D3B74164D /* AppStateRunScriptCreationTests.swift in Sources */,
 				07385C7266A0694AB7F4E872 /* AppStateSpacesTests.swift in Sources */,
 				956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */,
+				A5ED5D357F25C442E3B9F37F /* AppStateWorktreeArchiveBatchTests.swift in Sources */,
 				322ACA90D1ED6EDEA8B40D1D /* AppStateWorktreeCleanupBatchTests.swift in Sources */,
 				536F79023AAEDB205061DAA0 /* AttachIssueDialogModelTests.swift in Sources */,
 				A5742BE7348C02324B8119D0 /* BaseBranchSelectorTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1266,6 +1266,7 @@
 		C3840EDD0105467D0678B69C /* AppConfigSidebarChromeOverridesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */; };
 		C38EA8BB207FB273032CE292 /* ACPBrokerProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928B582B3F81A605236CBBED /* ACPBrokerProtocolTests.swift */; };
 		C3B1121E68B4F36F1540C2E1 /* CommitReviewLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A5CD97B6A04929595B0A9D /* CommitReviewLoaderTests.swift */; };
+		C3D10C1D8A34F95910C588E1 /* WorktreeCleanupScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6FBF16129E6C161D72B5D6 /* WorktreeCleanupScannerTests.swift */; };
 		C3E59948BD9108C1BD3243AD /* RemoteServerPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9126D442E8CDB093FA36BA5 /* RemoteServerPane.swift */; };
 		C4466064F783E6667C5FD25D /* UpdateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2763F93ADFDCDF6B31D16475 /* UpdateController.swift */; };
 		C457E9DF053B34D6D0097D28 /* WorkspaceCheckoutDetailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91823F1B360DE788FE34896 /* WorkspaceCheckoutDetailModel.swift */; };
@@ -1527,6 +1528,7 @@
 		E7C047F37A5C7100149FED4A /* ImageDiffPairResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76942B028C3CBAED16BC4CC1 /* ImageDiffPairResolverTests.swift */; };
 		E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A9977C979705A40595FD5E /* TabsManagerTests.swift */; };
 		E83BA776F26C011D034CAE18 /* HoverHighlightFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019A03B92542169A6595D432 /* HoverHighlightFeature.swift */; };
+		E83E41675C0AB59BB72DC989 /* WorktreeCleanupScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9027D09C88B49FAA47D27FC2 /* WorktreeCleanupScanner.swift */; };
 		E867128A3FF1EFD04C2D65E4 /* session-new-request.json in Resources */ = {isa = PBXBuildFile; fileRef = 22677ECD3E098EBE6389D776 /* session-new-request.json */; };
 		E89040915D30C5E67C67B4C8 /* RevisionFollowControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C05EF64FD7701A941C81837 /* RevisionFollowControl.swift */; };
 		E8932BD40AA76C26A52D9BAC /* MergeResultPaneRenderPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE47FEB79311AC99E61C3AF6 /* MergeResultPaneRenderPlanTests.swift */; };
@@ -1863,6 +1865,7 @@
 		1CEAAB5A1851AAC887017ACB /* ACPContextCompactionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContextCompactionView.swift; sourceTree = "<group>"; };
 		1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateSyncStatusTests.swift; sourceTree = "<group>"; };
 		1D4A5200C6EBB6434DD6B8BD /* ShortcutReservationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservationsTests.swift; sourceTree = "<group>"; };
+		1D6FBF16129E6C161D72B5D6 /* WorktreeCleanupScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCleanupScannerTests.swift; sourceTree = "<group>"; };
 		1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionHydrationStateTests.swift; sourceTree = "<group>"; };
 		1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptStatusTests.swift; sourceTree = "<group>"; };
 		1E410585102A601ACED1E8B5 /* AppKitDiffScrollerStressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffScrollerStressTests.swift; sourceTree = "<group>"; };
@@ -2594,6 +2597,7 @@
 		8FABF9037326B7EE23FCC040 /* FileSearchRanker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchRanker.swift; sourceTree = "<group>"; };
 		8FC31E49E6E453B417479C95 /* WorkspaceWorkItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceWorkItemTests.swift; sourceTree = "<group>"; };
 		8FD014AF7EB850F639BE7FC4 /* ACPOrchestrationPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPOrchestrationPersistence.swift; sourceTree = "<group>"; };
+		9027D09C88B49FAA47D27FC2 /* WorktreeCleanupScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCleanupScanner.swift; sourceTree = "<group>"; };
 		906D92F7AD84F313508D9CFD /* ACPComposerShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerShell.swift; sourceTree = "<group>"; };
 		90762AFB51B237B783D4190C /* ACPChatLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatLayoutTests.swift; sourceTree = "<group>"; };
 		90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Discard.swift"; sourceTree = "<group>"; };
@@ -5335,6 +5339,7 @@
 			isa = PBXGroup;
 			children = (
 				16E7DEF50A57E025C6676757 /* WorktreeCleanupClassifierTests.swift */,
+				1D6FBF16129E6C161D72B5D6 /* WorktreeCleanupScannerTests.swift */,
 			);
 			path = Git;
 			sourceTree = "<group>";
@@ -5536,6 +5541,7 @@
 			isa = PBXGroup;
 			children = (
 				70FAF16F7CB886AABE85EB55 /* WorktreeCleanupClassifier.swift */,
+				9027D09C88B49FAA47D27FC2 /* WorktreeCleanupScanner.swift */,
 				436254D89E46DCB53E278D8C /* WorktreeCleanupTypes.swift */,
 			);
 			path = WorktreeCleanup;
@@ -7221,6 +7227,7 @@
 				419ECA1CDD6FA2EC685A74E3 /* WorkspaceWorkItems.swift in Sources */,
 				28D41D400C04EF69F8A31A26 /* WorkspacesManager.swift in Sources */,
 				069D7DFAE10DD2D73FA51FAC /* WorktreeCleanupClassifier.swift in Sources */,
+				E83E41675C0AB59BB72DC989 /* WorktreeCleanupScanner.swift in Sources */,
 				40530C892BEFDCDB0831C22F /* WorktreeCleanupTypes.swift in Sources */,
 				2D63742A552F72DC6BEBF7DC /* WorktreeCreationCompletion.swift in Sources */,
 				9D2E53FB0A57BC38C146EA5E /* WorktreeLaunchSurface.swift in Sources */,
@@ -7983,6 +7990,7 @@
 				806C55C225BA072937201651 /* WorkspaceWorkItemTests.swift in Sources */,
 				9B783C828AE04E6F346E1B2C /* WorktreeCleanupClassifierTests.swift in Sources */,
 				502424D2A1042DF67A4332EE /* WorktreeCleanupConfigTests.swift in Sources */,
+				C3D10C1D8A34F95910C588E1 /* WorktreeCleanupScannerTests.swift in Sources */,
 				B34227BF866AFDACB3194333 /* WorktreeCodableTests.swift in Sources */,
 				8B0593FC9BC9E683E0685DD0 /* WorktreeCreateFetchTests.swift in Sources */,
 				A127B7AA4E95BEF74927FBDE /* WorktreePathTemplateRendererTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -891,6 +891,7 @@
 		8876AC7DC1852F059506AF41 /* WorkspaceNavigationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF872EEC1CAD3B6B84D92F3 /* WorkspaceNavigationStateTests.swift */; };
 		8878193CEBDB48D61823D7FE /* MemberReviewRollupBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278E898CD3B7402DD67E8787 /* MemberReviewRollupBuilder.swift */; };
 		887B90FE9E87033A31567CC0 /* WorktreeSortMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3F4EE1590F6355AF2AD9DA /* WorktreeSortMenuTests.swift */; };
+		88A13347D0CB153554F00B24 /* WorktreeCleanupSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5B56D03C0EDB3BA50D6E13 /* WorktreeCleanupSheet.swift */; };
 		88A139C7B3C3C9F20EF5945A /* ACPChangeNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419EF533C4D29448483045DA /* ACPChangeNotifier.swift */; };
 		88C1A4EBC12F7F7BA7FE9B06 /* ACPMarkdownInlineTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A01D6512394EF1C41782AD /* ACPMarkdownInlineTextView.swift */; };
 		8915EF49F1031BD55C419625 /* GeminiInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */; };
@@ -2191,6 +2192,7 @@
 		4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParserTests.swift; sourceTree = "<group>"; };
 		4D5734FB0E75909C5E9DBD7D /* AppState+ReviewPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+ReviewPalette.swift"; sourceTree = "<group>"; };
 		4D59124348BCE765816A0C6C /* GGStackReadinessModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackReadinessModel.swift; sourceTree = "<group>"; };
+		4D5B56D03C0EDB3BA50D6E13 /* WorktreeCleanupSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCleanupSheet.swift; sourceTree = "<group>"; };
 		4D63B166AF2C533BE6E59365 /* session-update-agent-chunk.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-agent-chunk.json"; sourceTree = "<group>"; };
 		4D974BDA7FAE214495278557 /* ACPUserInputPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPUserInputPrompt.swift; sourceTree = "<group>"; };
 		4DA695BB3D2901435BFF6C0E /* ACPProcessLiveness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPProcessLiveness.swift; sourceTree = "<group>"; };
@@ -4010,6 +4012,7 @@
 				0FA3C5D49DC1B6AB83479412 /* SSHHostPicker.swift */,
 				3790CACE965BC5005DA5A51B /* SSHHostSuggestions.swift */,
 				C5C3DA2CD5F77528816E599E /* WorktreeCleanupModel.swift */,
+				4D5B56D03C0EDB3BA50D6E13 /* WorktreeCleanupSheet.swift */,
 				C2E05FF3EC7EAB497BA0FFE0 /* RepoSelector */,
 				0FBA7369556FEE7D57C06F44 /* ReviewTarget */,
 				32D9058F5A271C892A5B2515 /* Workspace */,
@@ -7252,6 +7255,7 @@
 				069D7DFAE10DD2D73FA51FAC /* WorktreeCleanupClassifier.swift in Sources */,
 				2046F27F05CD33F89D4C250B /* WorktreeCleanupModel.swift in Sources */,
 				E83E41675C0AB59BB72DC989 /* WorktreeCleanupScanner.swift in Sources */,
+				88A13347D0CB153554F00B24 /* WorktreeCleanupSheet.swift in Sources */,
 				40530C892BEFDCDB0831C22F /* WorktreeCleanupTypes.swift in Sources */,
 				2D63742A552F72DC6BEBF7DC /* WorktreeCreationCompletion.swift in Sources */,
 				9D2E53FB0A57BC38C146EA5E /* WorktreeLaunchSurface.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1279,6 +1279,7 @@
 		C54DD220F01DC5BB858BB407 /* AgentInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B597B64DC2E72758FBE2A /* AgentInstaller.swift */; };
 		C55B79DC0AAE96CFA14BE76F /* CommitFilesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E7E4823B42BBA6EA7610DB /* CommitFilesListView.swift */; };
 		C5644E1144140B99E8676064 /* ACPSlashPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C3F02ECEA5D545FA268DB8 /* ACPSlashPicker.swift */; };
+		C57BECCAC94025DB94D752B8 /* MergedReviewRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1002ED416A96D64EC80B7AF /* MergedReviewRequestTests.swift */; };
 		C5FB3A21BB1DF1BDCF813375 /* ACPTranscriptQueuePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE44D56C6CCA9782CE56331 /* ACPTranscriptQueuePolicy.swift */; };
 		C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDEA496740F5B0B5EE808B /* Process+Git.swift */; };
 		C653712419D5B5A78AA53E84 /* AgentsPaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5E3661944CDA65ABCCB826 /* AgentsPaneTests.swift */; };
@@ -3230,6 +3231,7 @@
 		F0A443685B2A3322208D51AE /* ACPSessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreTests.swift; sourceTree = "<group>"; };
 		F0D567F7F894902AD192D220 /* mason-lsps.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "mason-lsps.json"; sourceTree = "<group>"; };
 		F0DCBE3FBD88DC56C81B8FDB /* GGStackReadinessModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackReadinessModelTests.swift; sourceTree = "<group>"; };
+		F1002ED416A96D64EC80B7AF /* MergedReviewRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergedReviewRequestTests.swift; sourceTree = "<group>"; };
 		F12340A649892955245BECB7 /* DefinitionFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionFeature.swift; sourceTree = "<group>"; };
 		F125642F0AD2F6755B5E067B /* ACPDelegatedPromptSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDelegatedPromptSource.swift; sourceTree = "<group>"; };
 		F15CFDEF63A656129A3EFEEB /* RunScriptStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptStoreTests.swift; sourceTree = "<group>"; };
@@ -5683,6 +5685,7 @@
 				48594A1746139E9C11B175FF /* GitHubCLIProviderVerdictTests.swift */,
 				C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */,
 				6D95FBEE2C9BF1AD1A602C28 /* GitLabCLIProviderVerdictTests.swift */,
+				F1002ED416A96D64EC80B7AF /* MergedReviewRequestTests.swift */,
 				327D6F0E386398E6A512ADDF /* ProviderReviewActionsTests.swift */,
 				4B05E0E44B026AE7E8EA3101 /* ReviewEvidenceTests.swift */,
 				B0F47561DB37D2ED72B6BE25 /* ReviewLoopDrawerTests.swift */,
@@ -7732,6 +7735,7 @@
 				7CA34C93E31EA98047AF6D81 /* MergeScrollCoordinatorTests.swift in Sources */,
 				72CF403FFD14D75FC0DD15E3 /* MergeView3WayLayoutTests.swift in Sources */,
 				9ED684E261871342BA6DFAC9 /* MergeWordDiffTests.swift in Sources */,
+				C57BECCAC94025DB94D752B8 /* MergedReviewRequestTests.swift in Sources */,
 				B966D129022E68797918D90F /* MermaidAttachmentCoordinatorTests.swift in Sources */,
 				E099FB5101ED328389233B35 /* MermaidDiagramLayoutTests.swift in Sources */,
 				63B3A5BB582C8C7ACE51E9E5 /* MermaidDiagramThemeTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -550,6 +550,7 @@
 		4FD9E5FFB4C75850CF7B2FE7 /* StagedDiffLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CD99C81057F377C5E249B7 /* StagedDiffLoaderTests.swift */; };
 		4FE322C88A2B06C317DDA9B5 /* ReviewSessionTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C593F9F14DD962C9822C64 /* ReviewSessionTabView.swift */; };
 		5015F89D084573BFC8A9E2C3 /* AttachedIssueDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7A1961A7FEA8DC28BD6C87A /* AttachedIssueDraft.swift */; };
+		502424D2A1042DF67A4332EE /* WorktreeCleanupConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB33BFC223CB0A5C6CBC4AF /* WorktreeCleanupConfigTests.swift */; };
 		5026424BC4EA8196D12E6F46 /* BuildIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EE31A4EB90FFE45DC46420 /* BuildIdentityTests.swift */; };
 		502B274A6E7E801B76B8564A /* ACPScrollDirectionClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DE5F609BDA1D7CE2DF4A491 /* ACPScrollDirectionClassifier.swift */; };
 		5031D53ED872A86B7C253696 /* MergeConflictToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */; };
@@ -3214,6 +3215,7 @@
 		EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRow.swift; sourceTree = "<group>"; };
 		EE6F36C31DB1C13D86416B4B /* PiACPInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiACPInstaller.swift; sourceTree = "<group>"; };
 		EE91017BB71AB08265C7B56E /* ACPComposerControlPresentationDictationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerControlPresentationDictationTests.swift; sourceTree = "<group>"; };
+		EEB33BFC223CB0A5C6CBC4AF /* WorktreeCleanupConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCleanupConfigTests.swift; sourceTree = "<group>"; };
 		EECB91379591DA21D216A894 /* RelativeTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelativeTime.swift; sourceTree = "<group>"; };
 		EECD5B53A23694EF60F63041 /* MergeConflictAgentProposalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictAgentProposalView.swift; sourceTree = "<group>"; };
 		EF16ADC997E65FD6AEE5562A /* DiffReviewComments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewComments.swift; sourceTree = "<group>"; };
@@ -5740,6 +5742,7 @@
 				5B9261D66BAD364C3EEAB4DA /* AppConfigHarnessMCPTests.swift */,
 				4D4F87B7B6F4A6E6ED882F1F /* HarnessConfigAutoRunTests.swift */,
 				792BD8DAE4AAED201252C9E2 /* ProjectMCPServerTests.swift */,
+				EEB33BFC223CB0A5C6CBC4AF /* WorktreeCleanupConfigTests.swift */,
 			);
 			path = Persistence;
 			sourceTree = "<group>";
@@ -7975,6 +7978,7 @@
 				E0AB8DE437378E43F55AAFDD /* WorkspaceTerminalSessionTests.swift in Sources */,
 				806C55C225BA072937201651 /* WorkspaceWorkItemTests.swift in Sources */,
 				9B783C828AE04E6F346E1B2C /* WorktreeCleanupClassifierTests.swift in Sources */,
+				502424D2A1042DF67A4332EE /* WorktreeCleanupConfigTests.swift in Sources */,
 				B34227BF866AFDACB3194333 /* WorktreeCodableTests.swift in Sources */,
 				8B0593FC9BC9E683E0685DD0 /* WorktreeCreateFetchTests.swift in Sources */,
 				A127B7AA4E95BEF74927FBDE /* WorktreePathTemplateRendererTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		0657FD1930271CA4C1F698DD /* RangeReviewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43B2247BD2DC3FE9E1EA2CC /* RangeReviewLoader.swift */; };
 		065F01BB553C415040414D37 /* ImageDiffSwipeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802EF6C18E2E27F68F6B770E /* ImageDiffSwipeView.swift */; };
 		065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */; };
+		069D7DFAE10DD2D73FA51FAC /* WorktreeCleanupClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70FAF16F7CB886AABE85EB55 /* WorktreeCleanupClassifier.swift */; };
 		06AD46194E45984A1297D928 /* CommitHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */; };
 		0722316C2ADB93575221246D /* ACPBareURLLinkifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F3473392B284B69E6621DB /* ACPBareURLLinkifier.swift */; };
 		07385C7266A0694AB7F4E872 /* AppStateSpacesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */; };
@@ -438,6 +439,7 @@
 		3FD4E84E222D586F7C6D3946 /* TabsManagerReviewSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9D3F3FFE39D7E29827D83D /* TabsManagerReviewSessionTests.swift */; };
 		3FE3D85D5E833DE3A91FD444 /* CopilotInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64C0B7363363C77718B446C /* CopilotInstaller.swift */; };
 		40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */; };
+		40530C892BEFDCDB0831C22F /* WorktreeCleanupTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436254D89E46DCB53E278D8C /* WorktreeCleanupTypes.swift */; };
 		4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */; };
 		407C480A97251F3D342D84F7 /* PairedDelimiterDeadKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D9C87FA802239BCCC9F4F4 /* PairedDelimiterDeadKeyTests.swift */; };
 		40A21E55EB86B5F3D42AEFF2 /* InlineDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */; };
@@ -1005,6 +1007,7 @@
 		9AC7E08307DA010181E2DE58 /* ACPFirstRunConnectingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4BB6C10F3718F7D0A50BAE /* ACPFirstRunConnectingPolicy.swift */; };
 		9B00878F781FADB428684B2D /* DiffDisplaySignatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 283613E170E25F69521F64ED /* DiffDisplaySignatureTests.swift */; };
 		9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */; };
+		9B783C828AE04E6F346E1B2C /* WorktreeCleanupClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E7DEF50A57E025C6676757 /* WorktreeCleanupClassifierTests.swift */; };
 		9BA16B0D5FC26501D54B5192 /* WorkingTreeStageAllActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F931B1EEA7F04855BAE5A43 /* WorkingTreeStageAllActionTests.swift */; };
 		9BAF14A88AEB1F888D7541DC /* MarkdownCodeBoxSurfaceOptInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED105A2C41B953A4DC9B8F6 /* MarkdownCodeBoxSurfaceOptInTests.swift */; };
 		9C03E77926427C9236E2922C /* ReviewCommentWireDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D7BE909731E9D15A032A6E0 /* ReviewCommentWireDTO.swift */; };
@@ -1821,6 +1824,7 @@
 		16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTreeTests.swift; sourceTree = "<group>"; };
 		16CA8FEE64D73BDEBAF74878 /* Kbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kbd.swift; sourceTree = "<group>"; };
 		16D35671971686B20DEA33CB /* TrackedRevision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackedRevision.swift; sourceTree = "<group>"; };
+		16E7DEF50A57E025C6676757 /* WorktreeCleanupClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCleanupClassifierTests.swift; sourceTree = "<group>"; };
 		178EAF6036A9BEAEA2C55082 /* ProjectMCPServerEditorPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectMCPServerEditorPolicyTests.swift; sourceTree = "<group>"; };
 		179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimerTests.swift; sourceTree = "<group>"; };
 		17C2AC0F8B3A1B75239995AC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -2107,6 +2111,7 @@
 		431BECA1461B76DF86BBFBDF /* FileTreeRowIndentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeRowIndentationTests.swift; sourceTree = "<group>"; };
 		434F3B598AEDAE75EFD64E98 /* ACPTranscriptRowHostingViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptRowHostingViewTests.swift; sourceTree = "<group>"; };
 		435D9E527A76820947F426A8 /* ACPFilesystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFilesystem.swift; sourceTree = "<group>"; };
+		436254D89E46DCB53E278D8C /* WorktreeCleanupTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCleanupTypes.swift; sourceTree = "<group>"; };
 		436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewCompletionTests.swift; sourceTree = "<group>"; };
 		43C24D126BC74FF514F19E5D /* RemoteContentSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteContentSearch.swift; sourceTree = "<group>"; };
 		43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstallerTests.swift; sourceTree = "<group>"; };
@@ -2398,6 +2403,7 @@
 		7095EA2868EF619BA4202BDF /* MergeScrollCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeScrollCoordinator.swift; sourceTree = "<group>"; };
 		7097AF3FAAB8D3FB80151A8B /* RunScriptLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptLaunchTests.swift; sourceTree = "<group>"; };
 		70BDCB22C2FDC36F6022ADB3 /* GGStackCreateModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGStackCreateModeTests.swift; sourceTree = "<group>"; };
+		70FAF16F7CB886AABE85EB55 /* WorktreeCleanupClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCleanupClassifier.swift; sourceTree = "<group>"; };
 		711089871B07DDA4E1744ED1 /* WorkspaceSpaceMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSpaceMigration.swift; sourceTree = "<group>"; };
 		71196F28AFF66FFA70E008D6 /* WorktreePathTemplateRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreePathTemplateRendererTests.swift; sourceTree = "<group>"; };
 		711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorktreeDialog.swift; sourceTree = "<group>"; };
@@ -3940,6 +3946,7 @@
 				E53B7655C8A8FB0CEC069C7B /* Center */,
 				2ED9D6E2F4F80DC4EC282918 /* Code */,
 				EAD92DAB367A7F31FF1223D1 /* Diagnostics */,
+				ACAED31EB4CD74307DDFA0DD /* Git */,
 				C71D037587A1C3F230C2D36F /* Harness */,
 				CD11051897966EA15D00BC48 /* Integrations */,
 				A1FB93E408DF8DB661167BB6 /* Issues */,
@@ -4108,6 +4115,7 @@
 				91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */,
 				6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */,
 				FCE6979EDAEAE45BC2A49A20 /* CommitAI */,
+				BF976DF4DEAC003F7EAC8AE9 /* WorktreeCleanup */,
 			);
 			path = Git;
 			sourceTree = "<group>";
@@ -5319,6 +5327,14 @@
 			path = Ghostty;
 			sourceTree = "<group>";
 		};
+		ACAED31EB4CD74307DDFA0DD /* Git */ = {
+			isa = PBXGroup;
+			children = (
+				16E7DEF50A57E025C6676757 /* WorktreeCleanupClassifierTests.swift */,
+			);
+			path = Git;
+			sourceTree = "<group>";
+		};
 		ACC0836A63CA705CA3A6CFB5 /* Server */ = {
 			isa = PBXGroup;
 			children = (
@@ -5510,6 +5526,15 @@
 				0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */,
 			);
 			path = Features;
+			sourceTree = "<group>";
+		};
+		BF976DF4DEAC003F7EAC8AE9 /* WorktreeCleanup */ = {
+			isa = PBXGroup;
+			children = (
+				70FAF16F7CB886AABE85EB55 /* WorktreeCleanupClassifier.swift */,
+				436254D89E46DCB53E278D8C /* WorktreeCleanupTypes.swift */,
+			);
+			path = WorktreeCleanup;
 			sourceTree = "<group>";
 		};
 		C1CE17139DAF0E60FE9D92C2 /* Adapter */ = {
@@ -7189,6 +7214,8 @@
 				C25405D2F1A57B8BC0E5D3EC /* WorkspaceStore.swift in Sources */,
 				419ECA1CDD6FA2EC685A74E3 /* WorkspaceWorkItems.swift in Sources */,
 				28D41D400C04EF69F8A31A26 /* WorkspacesManager.swift in Sources */,
+				069D7DFAE10DD2D73FA51FAC /* WorktreeCleanupClassifier.swift in Sources */,
+				40530C892BEFDCDB0831C22F /* WorktreeCleanupTypes.swift in Sources */,
 				2D63742A552F72DC6BEBF7DC /* WorktreeCreationCompletion.swift in Sources */,
 				9D2E53FB0A57BC38C146EA5E /* WorktreeLaunchSurface.swift in Sources */,
 				F098EBE9088B2EE1DAAF1BFD /* WorktreePathTemplateRenderer.swift in Sources */,
@@ -7947,6 +7974,7 @@
 				8FEA3E8F98A94470463409D3 /* WorkspaceStoreTests.swift in Sources */,
 				E0AB8DE437378E43F55AAFDD /* WorkspaceTerminalSessionTests.swift in Sources */,
 				806C55C225BA072937201651 /* WorkspaceWorkItemTests.swift in Sources */,
+				9B783C828AE04E6F346E1B2C /* WorktreeCleanupClassifierTests.swift in Sources */,
 				B34227BF866AFDACB3194333 /* WorktreeCodableTests.swift in Sources */,
 				8B0593FC9BC9E683E0685DD0 /* WorktreeCreateFetchTests.swift in Sources */,
 				A127B7AA4E95BEF74927FBDE /* WorktreePathTemplateRendererTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -337,6 +337,7 @@
 		318F74C3CB02BFF1D06DF7DA /* GGUndoMarkerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724A473AB9439DAA535B33F8 /* GGUndoMarkerStore.swift */; };
 		31A3E28F0B49F85D2F58AF8E /* GGConfigReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A2D492EE89A160CD404985 /* GGConfigReader.swift */; };
 		31CB9FBE16CECDE2C6D94EC6 /* RemoteStatusFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191BAF20EAD2D227D9E7B418 /* RemoteStatusFingerprint.swift */; };
+		322ACA90D1ED6EDEA8B40D1D /* AppStateWorktreeCleanupBatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0A451D5E0D66CB2F4121AD /* AppStateWorktreeCleanupBatchTests.swift */; };
 		32324CCE247B8B4784674453 /* RemoteContentSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8249F7BF5F86B0AFD5CAB8 /* RemoteContentSearchTests.swift */; };
 		32660CEE9955165AE3CCDFBE /* InstallerHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364507D55CD5D73CD44819E7 /* InstallerHostTests.swift */; };
 		32674DB95F2B62C00FC0AAA2 /* RemoteProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A54DD8080E3395C8E7049E /* RemoteProtocol.swift */; };
@@ -809,6 +810,7 @@
 		7D1B0EE0FC9379F72C82AE6C /* DragOutPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38228AE1419253ADBC80E226 /* DragOutPayload.swift */; };
 		7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4575017544CD7603B3AB9069 /* GitEventFilter.swift */; };
 		7DAAFE51C9C35BADB78B4A30 /* SSHIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C63CBD839A151565AE577AE /* SSHIntegrationTests.swift */; };
+		7DCDDC33E40307B36D741C74 /* WorktreeCleanupFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = F496C1472B52D466B3086184 /* WorktreeCleanupFixtures.swift */; };
 		7DEFB0A61614D65F509A11AE /* ImageDiffDifferenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4246F7A17DCEC4D2A669BC43 /* ImageDiffDifferenceView.swift */; };
 		7DFE8DCEA8A4BABF51F54215 /* GitTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A92711BC1D9A78D8A80561 /* GitTypes.swift */; };
 		7E2E0B87C53DBAAE4AEF81E9 /* GGStackModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A948C5D9B5EB13DBAC21E538 /* GGStackModelsTests.swift */; };
@@ -2156,6 +2158,7 @@
 		490AFAD12616D61858A19A31 /* ACPSetupCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSetupCheckerTests.swift; sourceTree = "<group>"; };
 		4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationCard.swift; sourceTree = "<group>"; };
 		4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateDiscardPathsTests.swift; sourceTree = "<group>"; };
+		4A0A451D5E0D66CB2F4121AD /* AppStateWorktreeCleanupBatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateWorktreeCleanupBatchTests.swift; sourceTree = "<group>"; };
 		4A27D815CB567E3FEF2D3E6B /* InstallSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallSourceTests.swift; sourceTree = "<group>"; };
 		4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCLIInjectionTests.swift; sourceTree = "<group>"; };
 		4AC5721A309B06845548B46B /* WorkspaceSpacePersistenceBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSpacePersistenceBridge.swift; sourceTree = "<group>"; };
@@ -3260,6 +3263,7 @@
 		F40A1779F98074142F57210B /* PiMCPAdapterInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiMCPAdapterInspectorTests.swift; sourceTree = "<group>"; };
 		F4120556B9870D6246D0F30A /* ReviewSessionTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionTabViewTests.swift; sourceTree = "<group>"; };
 		F4526714086C04ED5B472C90 /* DiffInlineCommentCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineCommentCard.swift; sourceTree = "<group>"; };
+		F496C1472B52D466B3086184 /* WorktreeCleanupFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCleanupFixtures.swift; sourceTree = "<group>"; };
 		F4A5662DEEA883E342579177 /* RemoteWorktreeFileAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWorktreeFileAccess.swift; sourceTree = "<group>"; };
 		F55C4A7D3820C97CB1CD980D /* IssueResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueResolver.swift; sourceTree = "<group>"; };
 		F56A35888F0783BA6F296CED /* MermaidDiagramViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidDiagramViewer.swift; sourceTree = "<group>"; };
@@ -3628,6 +3632,7 @@
 				23190FA641E518CAFA0A8177 /* AppStateRunScriptCreationTests.swift */,
 				EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */,
 				279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */,
+				4A0A451D5E0D66CB2F4121AD /* AppStateWorktreeCleanupBatchTests.swift */,
 				6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */,
 				652C404D30685CB2FE79BD81 /* BaseResolutionMappingTests.swift */,
 				308A1ADAE5DCA81A50FFDF82 /* BinaryFileTypeTests.swift */,
@@ -3936,6 +3941,7 @@
 				318E4E3130F42671D888DC5C /* WorkingTreeFlatRowTests.swift */,
 				5F931B1EEA7F04855BAE5A43 /* WorkingTreeStageAllActionTests.swift */,
 				AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */,
+				F496C1472B52D466B3086184 /* WorktreeCleanupFixtures.swift */,
 				8B94010802299E6AC5597E85 /* WorktreeCodableTests.swift */,
 				3B7BE659F7E386D15047C374 /* WorktreeCreateFetchTests.swift */,
 				71196F28AFF66FFA70E008D6 /* WorktreePathTemplateRendererTests.swift */,
@@ -7482,6 +7488,7 @@
 				F8C643420F6CF51D3B74164D /* AppStateRunScriptCreationTests.swift in Sources */,
 				07385C7266A0694AB7F4E872 /* AppStateSpacesTests.swift in Sources */,
 				956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */,
+				322ACA90D1ED6EDEA8B40D1D /* AppStateWorktreeCleanupBatchTests.swift in Sources */,
 				536F79023AAEDB205061DAA0 /* AttachIssueDialogModelTests.swift in Sources */,
 				A5742BE7348C02324B8119D0 /* BaseBranchSelectorTests.swift in Sources */,
 				B3240B739972444A6CB14F7C /* BaseResolutionMappingTests.swift in Sources */,
@@ -7990,6 +7997,7 @@
 				806C55C225BA072937201651 /* WorkspaceWorkItemTests.swift in Sources */,
 				9B783C828AE04E6F346E1B2C /* WorktreeCleanupClassifierTests.swift in Sources */,
 				502424D2A1042DF67A4332EE /* WorktreeCleanupConfigTests.swift in Sources */,
+				7DCDDC33E40307B36D741C74 /* WorktreeCleanupFixtures.swift in Sources */,
 				C3D10C1D8A34F95910C588E1 /* WorktreeCleanupScannerTests.swift in Sources */,
 				B34227BF866AFDACB3194333 /* WorktreeCodableTests.swift in Sources */,
 				8B0593FC9BC9E683E0685DD0 /* WorktreeCreateFetchTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		1F867279ADAB2BAC843D3676 /* ACPRemoteAdapterManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD81CB1D751F983C64191FF /* ACPRemoteAdapterManagementTests.swift */; };
 		1F89B774F2DC7DD818AD4E5B /* ACPSessionRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F332906E17C5865856DBB90B /* ACPSessionRunner.swift */; };
 		20096441D4850614A3CB8187 /* ACPSessionStoreCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D7C5464CA7B663A9A7BBFF /* ACPSessionStoreCRUDTests.swift */; };
+		2046F27F05CD33F89D4C250B /* WorktreeCleanupModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C3DA2CD5F77528816E599E /* WorktreeCleanupModel.swift */; };
 		208E237B41BA6F234151683D /* HTTPRequestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA7CD14A8FA2D335A59B062 /* HTTPRequestParser.swift */; };
 		209FB0AAF20BDE5850A139F4 /* ACPSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7615FEA1F225EBDE52CF5E14 /* ACPSessionManager.swift */; };
 		20A737A3B3A70564B9A9FDE3 /* WorkspaceCheckoutBoundaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2FE4EE19E484F6CF12C3DE /* WorkspaceCheckoutBoundaryTests.swift */; };
@@ -1623,6 +1624,7 @@
 		F916235528BF9A5E4773804E /* AppKitDiffReviewFlingPerfTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71DEA04B12C341C540CCD54A /* AppKitDiffReviewFlingPerfTests.swift */; };
 		F92535799AE74C9BF1DC3D88 /* EditorLSPStatusOverridePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B17505E5DB94014B6FCB18 /* EditorLSPStatusOverridePicker.swift */; };
 		F927B660B51081F2FACA5070 /* FileSystemOpenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596BB6B295D768E2C0D3BC85 /* FileSystemOpenTests.swift */; };
+		F9AE54377BCC8E36A218EAB8 /* WorktreeCleanupModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA42E56D99B4B54E23DFAB5 /* WorktreeCleanupModelTests.swift */; };
 		F9BE25DD2C3A008328978575 /* AgentAutoLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */; };
 		F9C3EA369FF29AC5D7BCA3C6 /* AgentHookSocketServerCLITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */; };
 		F9FED997CCAD027FBBE36C1D /* PendingReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5679CA959D40E1682A91F31 /* PendingReview.swift */; };
@@ -2931,6 +2933,7 @@
 		C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstaller.swift; sourceTree = "<group>"; };
 		C57B57158094E321BD68D224 /* AttachIssueDialogModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachIssueDialogModel.swift; sourceTree = "<group>"; };
 		C5ADF2AC196D39DF59097D4A /* CopyFeedbackStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyFeedbackStateTests.swift; sourceTree = "<group>"; };
+		C5C3DA2CD5F77528816E599E /* WorktreeCleanupModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCleanupModel.swift; sourceTree = "<group>"; };
 		C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcherTests.swift; sourceTree = "<group>"; };
 		C60A6B7CB83D842FEE2D801C /* ThreePaneSizingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneSizingTests.swift; sourceTree = "<group>"; };
 		C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTabView.swift; sourceTree = "<group>"; };
@@ -3233,6 +3236,7 @@
 		EF5F310D158323C328E56929 /* ACPDictationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDictationServiceTests.swift; sourceTree = "<group>"; };
 		EF69D638124D1B4D1C04BD31 /* ProviderReviewPublishConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewPublishConfirmationView.swift; sourceTree = "<group>"; };
 		EF9480C66C4CDDB090A5F4FB /* GGAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGAvailabilityTests.swift; sourceTree = "<group>"; };
+		EFA42E56D99B4B54E23DFAB5 /* WorktreeCleanupModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCleanupModelTests.swift; sourceTree = "<group>"; };
 		EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateSpacesTests.swift; sourceTree = "<group>"; };
 		F03C1E46A0853704E9B4449A /* JSONRPCFramerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCFramerTests.swift; sourceTree = "<group>"; };
 		F0641A41FC56C8F251D0C2BC /* tool-call-content-blocks.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tool-call-content-blocks.json"; sourceTree = "<group>"; };
@@ -3963,6 +3967,7 @@
 				E53B7655C8A8FB0CEC069C7B /* Center */,
 				2ED9D6E2F4F80DC4EC282918 /* Code */,
 				EAD92DAB367A7F31FF1223D1 /* Diagnostics */,
+				8CA464DE1DF338568BD53EFD /* Dialogs */,
 				ACAED31EB4CD74307DDFA0DD /* Git */,
 				C71D037587A1C3F230C2D36F /* Harness */,
 				CD11051897966EA15D00BC48 /* Integrations */,
@@ -4004,6 +4009,7 @@
 				B22A7BCA8F63051E6D842055 /* RepositoryImportService.swift */,
 				0FA3C5D49DC1B6AB83479412 /* SSHHostPicker.swift */,
 				3790CACE965BC5005DA5A51B /* SSHHostSuggestions.swift */,
+				C5C3DA2CD5F77528816E599E /* WorktreeCleanupModel.swift */,
 				C2E05FF3EC7EAB497BA0FFE0 /* RepoSelector */,
 				0FBA7369556FEE7D57C06F44 /* ReviewTarget */,
 				32D9058F5A271C892A5B2515 /* Workspace */,
@@ -5099,6 +5105,14 @@
 				F2C55C7FEAEBBB60A829C248 /* PairedTextEditorMarkdownStylingTests.swift */,
 			);
 			path = UI;
+			sourceTree = "<group>";
+		};
+		8CA464DE1DF338568BD53EFD /* Dialogs */ = {
+			isa = PBXGroup;
+			children = (
+				EFA42E56D99B4B54E23DFAB5 /* WorktreeCleanupModelTests.swift */,
+			);
+			path = Dialogs;
 			sourceTree = "<group>";
 		};
 		8E450763881EC336B91FA7E8 /* Integrations */ = {
@@ -7236,6 +7250,7 @@
 				419ECA1CDD6FA2EC685A74E3 /* WorkspaceWorkItems.swift in Sources */,
 				28D41D400C04EF69F8A31A26 /* WorkspacesManager.swift in Sources */,
 				069D7DFAE10DD2D73FA51FAC /* WorktreeCleanupClassifier.swift in Sources */,
+				2046F27F05CD33F89D4C250B /* WorktreeCleanupModel.swift in Sources */,
 				E83E41675C0AB59BB72DC989 /* WorktreeCleanupScanner.swift in Sources */,
 				40530C892BEFDCDB0831C22F /* WorktreeCleanupTypes.swift in Sources */,
 				2D63742A552F72DC6BEBF7DC /* WorktreeCreationCompletion.swift in Sources */,
@@ -8002,6 +8017,7 @@
 				9B783C828AE04E6F346E1B2C /* WorktreeCleanupClassifierTests.swift in Sources */,
 				502424D2A1042DF67A4332EE /* WorktreeCleanupConfigTests.swift in Sources */,
 				7DCDDC33E40307B36D741C74 /* WorktreeCleanupFixtures.swift in Sources */,
+				F9AE54377BCC8E36A218EAB8 /* WorktreeCleanupModelTests.swift in Sources */,
 				C3D10C1D8A34F95910C588E1 /* WorktreeCleanupScannerTests.swift in Sources */,
 				B34227BF866AFDACB3194333 /* WorktreeCodableTests.swift in Sources */,
 				8B0593FC9BC9E683E0685DD0 /* WorktreeCreateFetchTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7561,14 +7561,14 @@ final class AppState {
             archiveBatch: { [weak self] worktrees in
                 self?.batchArchiveWorktrees(worktrees) ?? []
             },
-            confirm: { title, message in
+            confirm: { title, message, confirmButtonTitle in
                 let alert = NSAlert()
                 alert.messageText = title
                 alert.informativeText = message
                 alert.alertStyle = .warning
-                let deleteButton = alert.addButton(withTitle: "Delete")
+                let confirmButton = alert.addButton(withTitle: confirmButtonTitle)
                 alert.addButton(withTitle: "Cancel")
-                deleteButton.hasDestructiveAction = true
+                confirmButton.hasDestructiveAction = true
                 return alert.runModal() == .alertFirstButtonReturn
             }
         )

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4361,6 +4361,23 @@ final class AppState {
         saveProjects()
     }
 
+    /// Live sessions attached to a worktree's open terminal/ACP tabs, counted
+    /// directly rather than through harness activity state (busy/awaiting) —
+    /// mirrors the cleanup sheet's own `activeSessionCount` probe. Used to
+    /// re-check a worktree immediately before a batch action touches it: the
+    /// scan that produced the candidate list can be stale by the time the
+    /// user confirms, and a session opened in that window (from another
+    /// window, say) must not be torn down by `cleanupWorktreeState`.
+    private func hasLiveSessions(worktreeId: String) -> Bool {
+        tabs.tabs(forWorktree: worktreeId).contains { tab in
+            switch tab {
+            case .terminal(let s):   return !s.root.leaves().isEmpty
+            case .acpSession:        return true
+            default:                 return false
+            }
+        }
+    }
+
     /// Archive several worktrees at once. Nothing on disk is touched — this
     /// only marks each path hidden in `ProjectConfig`, which is what persists
     /// across relaunch.
@@ -4401,6 +4418,19 @@ final class AppState {
                     worktreeId: worktree.id,
                     branch: worktree.branch,
                     outcome: .skipped(reason: "Main worktree")
+                ))
+                continue
+            }
+            // Re-check right before archiving: the scan that selected this
+            // worktree can be stale by the time the user confirms, and a
+            // session opened since then must not be torn down.
+            guard !hasLiveSessions(worktreeId: worktree.id),
+                  projectsManager.operationState(for: worktree.id) == nil
+            else {
+                results.append(WorktreeBatchResult(
+                    worktreeId: worktree.id,
+                    branch: worktree.branch,
+                    outcome: .skipped(reason: "Became busy since this list was scanned")
                 ))
                 continue
             }
@@ -7499,6 +7529,19 @@ final class AppState {
                     worktreeId: worktree.id,
                     branch: worktree.branch,
                     outcome: .skipped(reason: "Main worktree")
+                ))
+                continue
+            }
+            // Re-check right before deleting: the scan that selected this
+            // worktree can be stale by the time the user confirms, and a
+            // session opened since then must not be torn down.
+            guard !hasLiveSessions(worktreeId: worktree.id),
+                  projectsManager.operationState(for: worktree.id) == nil
+            else {
+                results.append(WorktreeBatchResult(
+                    worktreeId: worktree.id,
+                    branch: worktree.branch,
+                    outcome: .skipped(reason: "Became busy since this list was scanned")
                 ))
                 continue
             }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4376,26 +4376,12 @@ final class AppState {
             total + dirtyEditorTabIds(worktreeId: worktree.id).count
         }
         if dirtyCount > 0 {
-            switch promptForDirtyBuffers(
+            guard promptForDirtyBuffersInBatch(
                 action: "Archive",
-                branch: "\(worktrees.count) worktrees",
+                worktreeCount: worktrees.count,
                 dirtyCount: dirtyCount,
                 onDiskDestructive: false
-            ) {
-            case .save:
-                // Saving is per-worktree and asynchronous; the sheet's flow is
-                // synchronous, so ask the user to save and retry rather than
-                // half-archiving. Report it as a skip, not a failure.
-                return worktrees.map {
-                    WorktreeBatchResult(
-                        worktreeId: $0.id,
-                        branch: $0.branch,
-                        outcome: .skipped(reason: "Save the open editors first")
-                    )
-                }
-            case .discard:
-                break
-            case .cancel:
+            ) == .discard else {
                 return []
             }
         }
@@ -7486,28 +7472,12 @@ final class AppState {
             total + dirtyEditorTabIds(worktreeId: worktree.id).count
         }
         if dirtyCount > 0 {
-            switch promptForDirtyBuffers(
+            guard promptForDirtyBuffersInBatch(
                 action: "Delete",
-                branch: "\(worktrees.count) worktrees",
+                worktreeCount: worktrees.count,
                 dirtyCount: dirtyCount,
-                onDiskDestructive: true,
-                keepBranch: keepBranch
-            ) {
-            case .save:
-                // Saving is per-worktree and asynchronous; the batch's flow is
-                // synchronous from here, so ask the user to save and retry
-                // rather than half-deleting. Report it as a skip, not a
-                // failure — mirrors `batchArchiveWorktrees`'s handling.
-                return worktrees.map {
-                    WorktreeBatchResult(
-                        worktreeId: $0.id,
-                        branch: $0.branch,
-                        outcome: .skipped(reason: "Save the open editors first")
-                    )
-                }
-            case .discard:
-                break
-            case .cancel:
+                onDiskDestructive: true
+            ) == .discard else {
                 return []
             }
         }
@@ -7618,15 +7588,23 @@ final class AppState {
                         activeSessionCount: { [weak self] worktreeId in
                             await MainActor.run {
                                 guard let self else { return 0 }
-                                let ids = self.tabs.tabs(forWorktree: worktreeId).flatMap { tab -> [String] in
+                                // Count every open terminal/ACP session tab, not just
+                                // ones the harness currently reports as busy or
+                                // awaiting input. `HarnessService.summary` filters
+                                // out idle activity — including a session with no
+                                // activity record at all — so a plain shell or an
+                                // idle agent session would read as zero live
+                                // sessions even though `cleanupWorktreeState` closes
+                                // it (and can kill its process) on delete/archive.
+                                // The acceptance criterion is "no active agent OR
+                                // terminal sessions", not "no busy agent sessions".
+                                return self.tabs.tabs(forWorktree: worktreeId).reduce(0) { count, tab in
                                     switch tab {
-                                    case .terminal(let s):   return s.root.leaves().map(\.sessionId)
-                                    case .acpSession(let s): return [s.sessionId]
-                                    default:                 return []
+                                    case .terminal(let s):   return count + s.root.leaves().count
+                                    case .acpSession:        return count + 1
+                                    default:                 return count
                                     }
                                 }
-                                guard let summary = self.harness.summary(forSessionIds: ids) else { return 0 }
-                                return summary.sessions.count
                             }
                         },
                         operationInFlight: { [weak self] worktreeId in
@@ -8373,6 +8351,39 @@ final class AppState {
         case save
         case discard
         case cancel
+    }
+
+    private enum DirtyBufferBatchChoice {
+        case discard
+        case cancel
+    }
+
+    /// Two-choice variant of `promptForDirtyBuffers` for batch actions. The
+    /// single-item flow can offer a truthful "Save & <action>" button because
+    /// it saves that one worktree before proceeding; a batch has no such step
+    /// wired in, so offering the same button and then neither saving nor
+    /// acting on it would make the button lie about what it does. This asks
+    /// the user to save manually and retry instead.
+    private func promptForDirtyBuffersInBatch(
+        action: String,
+        worktreeCount: Int,
+        dirtyCount: Int,
+        onDiskDestructive: Bool
+    ) -> DirtyBufferBatchChoice {
+        let alert = NSAlert()
+        alert.messageText = "\(action) \(worktreeCount) \(worktreeCount == 1 ? "worktree" : "worktrees")?"
+        let countSentence = dirtyCount == 1
+            ? "1 file has unsaved changes."
+            : "\(dirtyCount) files have unsaved changes."
+        let actionSentence = onDiskDestructive
+            ? "Save it first, then retry — \(action.lowercased())ing will discard it along with the worktree's files."
+            : "Save it first, then retry — the worktree stays on disk, but its open tabs will close."
+        alert.informativeText = "\(countSentence) \(actionSentence)"
+        alert.alertStyle = .warning
+        let discardButton = alert.addButton(withTitle: "Discard & \(action)")
+        alert.addButton(withTitle: "Cancel")
+        discardButton.hasDestructiveAction = true
+        return alert.runModal() == .alertFirstButtonReturn ? .discard : .cancel
     }
 
     /// Returns the editor tabs in this worktree whose buffers have unsaved

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7488,43 +7488,13 @@ final class AppState {
     func makeWorktreeCleanupModel(projectId: String) -> WorktreeCleanupModel? {
         guard let project = projects.first(where: { $0.id == projectId }) else { return nil }
         let idleThresholdDays = config.worktrees.cleanupIdleDays
-        let baseBranch = config.worktrees.baseBranch
-
-        let scanner = WorktreeCleanupScanner(
-            dependencies: WorktreeCleanupScanner.Dependencies(
-                gitFacts: { worktree in
-                    await WorktreeCleanupScanner.gitFacts(
-                        worktreePath: worktree.path,
-                        branch: worktree.branch,
-                        baseBranch: baseBranch
-                    )
-                },
-                mergeIndex: { project in
-                    await Self.forgeMergeIndex(project: project, baseBranch: baseBranch)
-                },
-                // Both hop to the main actor: session and operation state are
-                // main-actor isolated, the scanner is not.
-                activeSessionCount: { [weak self] worktreeId in
-                    await MainActor.run {
-                        guard let self else { return 0 }
-                        let ids = self.tabs.tabs(forWorktree: worktreeId).flatMap { tab -> [String] in
-                            switch tab {
-                            case .terminal(let s):   return s.root.leaves().map(\.sessionId)
-                            case .acpSession(let s): return [s.sessionId]
-                            default:                 return []
-                            }
-                        }
-                        guard let summary = self.harness.summary(forSessionIds: ids) else { return 0 }
-                        return summary.sessions.count
-                    }
-                },
-                operationInFlight: { [weak self] worktreeId in
-                    await MainActor.run {
-                        self?.projectsManager.operationState(for: worktreeId) != nil
-                    }
-                }
-            )
-        )
+        let repoPath = URL(fileURLWithPath: project.path)
+        // `config.worktrees.baseBranch` is a global default across every
+        // project and may not exist in this repository. Resolve it against the
+        // repo's real branches the way every other base-branch consumer does,
+        // and do it per scan rather than once here: branches can change while
+        // the sheet is open.
+        let configuredDefault = config.worktrees.baseBranch
 
         return WorktreeCleanupModel(
             projectId: projectId,
@@ -7534,6 +7504,48 @@ final class AppState {
                 let worktrees = await MainActor.run {
                     self.projectsManager.visibleWorktrees(projectId: projectId)
                 }
+                let availableBranches = (try? await GitService().branches(at: repoPath)) ?? []
+                let baseBranch = NewWorktreeDialog.preferredBaseBranch(
+                    availableBranches: availableBranches,
+                    configuredDefault: configuredDefault
+                )
+                // Built here, not once per model, so all three dependencies
+                // close over the base branch resolved for *this* scan.
+                let scanner = WorktreeCleanupScanner(
+                    dependencies: WorktreeCleanupScanner.Dependencies(
+                        gitFacts: { worktree in
+                            await WorktreeCleanupScanner.gitFacts(
+                                worktreePath: worktree.path,
+                                branch: worktree.branch,
+                                baseBranch: baseBranch
+                            )
+                        },
+                        mergeIndex: { project in
+                            await Self.forgeMergeIndex(project: project, baseBranch: baseBranch)
+                        },
+                        // Both hop to the main actor: session and operation
+                        // state are main-actor isolated, the scanner is not.
+                        activeSessionCount: { [weak self] worktreeId in
+                            await MainActor.run {
+                                guard let self else { return 0 }
+                                let ids = self.tabs.tabs(forWorktree: worktreeId).flatMap { tab -> [String] in
+                                    switch tab {
+                                    case .terminal(let s):   return s.root.leaves().map(\.sessionId)
+                                    case .acpSession(let s): return [s.sessionId]
+                                    default:                 return []
+                                    }
+                                }
+                                guard let summary = self.harness.summary(forSessionIds: ids) else { return 0 }
+                                return summary.sessions.count
+                            }
+                        },
+                        operationInFlight: { [weak self] worktreeId in
+                            await MainActor.run {
+                                self?.projectsManager.operationState(for: worktreeId) != nil
+                            }
+                        }
+                    )
+                )
                 return .success(await scanner.scan(
                     project: project,
                     worktrees: worktrees,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4422,8 +4422,18 @@ final class AppState {
                 continue
             }
             // Re-check right before archiving: the scan that selected this
-            // worktree can be stale by the time the user confirms, and a
-            // session opened since then must not be torn down.
+            // worktree — and even the whole-batch dirty-buffer prompt above —
+            // can be stale by the time this specific item is reached. A
+            // buffer edited, or a session opened, in that gap must not be
+            // torn down.
+            guard dirtyEditorTabIds(worktreeId: worktree.id).isEmpty else {
+                results.append(WorktreeBatchResult(
+                    worktreeId: worktree.id,
+                    branch: worktree.branch,
+                    outcome: .skipped(reason: "Has unsaved changes since this list was scanned")
+                ))
+                continue
+            }
             guard !hasLiveSessions(worktreeId: worktree.id),
                   projectsManager.operationState(for: worktree.id) == nil
             else {
@@ -7532,9 +7542,21 @@ final class AppState {
                 ))
                 continue
             }
-            // Re-check right before deleting: the scan that selected this
-            // worktree can be stale by the time the user confirms, and a
-            // session opened since then must not be torn down.
+            // Re-check right before deleting. This closes two gaps at once:
+            // the scan that selected this worktree (or even the whole-batch
+            // dirty-buffer prompt above) can be stale by the time the user
+            // confirms, and — because each `await performDeleteWorktree`
+            // below suspends and yields the main actor — a *later* item in
+            // this very loop can pick up a buffer edited or a session opened
+            // while an *earlier* item was still being removed.
+            guard dirtyEditorTabIds(worktreeId: worktree.id).isEmpty else {
+                results.append(WorktreeBatchResult(
+                    worktreeId: worktree.id,
+                    branch: worktree.branch,
+                    outcome: .skipped(reason: "Has unsaved changes since this list was scanned")
+                ))
+                continue
+            }
             guard !hasLiveSessions(worktreeId: worktree.id),
                   projectsManager.operationState(for: worktree.id) == nil
             else {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4389,9 +4389,17 @@ final class AppState {
     func batchArchiveWorktrees(_ worktrees: [Worktree]) -> [WorktreeBatchResult] {
         guard !worktrees.isEmpty else { return [] }
 
-        let dirtyCount = worktrees.reduce(0) { total, worktree in
-            total + dirtyEditorTabIds(worktreeId: worktree.id).count
-        }
+        // Snapshot which tabs are dirty right now, before the prompt. If the
+        // user confirms "Discard & Archive", those specific buffers stay
+        // marked dirty in the tab model until cleanup actually closes them —
+        // discarding doesn't retroactively un-dirty anything — so the
+        // per-item re-check below must compare against this snapshot rather
+        // than against "is anything dirty right now", or the confirmed
+        // discard would skip every worktree it was meant to cover.
+        let dirtyTabsAtConfirmation = Dictionary(
+            uniqueKeysWithValues: worktrees.map { ($0.id, Set(dirtyEditorTabIds(worktreeId: $0.id))) }
+        )
+        let dirtyCount = dirtyTabsAtConfirmation.values.reduce(0) { $0 + $1.count }
         if dirtyCount > 0 {
             guard promptForDirtyBuffersInBatch(
                 action: "Archive",
@@ -4423,10 +4431,13 @@ final class AppState {
             }
             // Re-check right before archiving: the scan that selected this
             // worktree — and even the whole-batch dirty-buffer prompt above —
-            // can be stale by the time this specific item is reached. A
-            // buffer edited, or a session opened, in that gap must not be
-            // torn down.
-            guard dirtyEditorTabIds(worktreeId: worktree.id).isEmpty else {
+            // can be stale by the time this specific item is reached. Only
+            // dirtiness the confirmation didn't already cover counts: a tab
+            // dirty at confirmation time and discarded is expected here, but
+            // a tab that turned dirty (or newly opened dirty) since then must
+            // not be torn down.
+            let currentDirtyTabs = Set(dirtyEditorTabIds(worktreeId: worktree.id))
+            guard currentDirtyTabs.isSubset(of: dirtyTabsAtConfirmation[worktree.id] ?? []) else {
                 results.append(WorktreeBatchResult(
                     worktreeId: worktree.id,
                     branch: worktree.branch,
@@ -7508,9 +7519,17 @@ final class AppState {
     ) async -> [WorktreeBatchResult] {
         guard !worktrees.isEmpty else { return [] }
 
-        let dirtyCount = worktrees.reduce(0) { total, worktree in
-            total + dirtyEditorTabIds(worktreeId: worktree.id).count
-        }
+        // Snapshot which tabs are dirty right now, before the prompt. If the
+        // user confirms "Discard & Delete", those specific buffers stay
+        // marked dirty in the tab model until cleanup actually closes them —
+        // discarding doesn't retroactively un-dirty anything — so the
+        // per-item re-check below must compare against this snapshot rather
+        // than against "is anything dirty right now", or the confirmed
+        // discard would skip every worktree it was meant to cover.
+        let dirtyTabsAtConfirmation = Dictionary(
+            uniqueKeysWithValues: worktrees.map { ($0.id, Set(dirtyEditorTabIds(worktreeId: $0.id))) }
+        )
+        let dirtyCount = dirtyTabsAtConfirmation.values.reduce(0) { $0 + $1.count }
         if dirtyCount > 0 {
             guard promptForDirtyBuffersInBatch(
                 action: "Delete",
@@ -7548,8 +7567,12 @@ final class AppState {
             // confirms, and — because each `await performDeleteWorktree`
             // below suspends and yields the main actor — a *later* item in
             // this very loop can pick up a buffer edited or a session opened
-            // while an *earlier* item was still being removed.
-            guard dirtyEditorTabIds(worktreeId: worktree.id).isEmpty else {
+            // while an *earlier* item was still being removed. Only
+            // dirtiness the confirmation didn't already cover counts: a tab
+            // dirty at confirmation time and discarded is expected here, but
+            // a tab that turned dirty since then must not be torn down.
+            let currentDirtyTabs = Set(dirtyEditorTabIds(worktreeId: worktree.id))
+            guard currentDirtyTabs.isSubset(of: dirtyTabsAtConfirmation[worktree.id] ?? []) else {
                 results.append(WorktreeBatchResult(
                     worktreeId: worktree.id,
                     branch: worktree.branch,
@@ -7564,6 +7587,21 @@ final class AppState {
                     worktreeId: worktree.id,
                     branch: worktree.branch,
                     outcome: .skipped(reason: "Became busy since this list was scanned")
+                ))
+                continue
+            }
+            // Re-read the worktree's actual current branch immediately before
+            // removal — the cached `Worktree.branch` from the scan could be
+            // stale if something switched this checkout to a detached HEAD
+            // (or a different branch entirely) in the meantime. A detached
+            // worktree's commits are reachable only via its own HEAD, so
+            // removing one on stale information risks orphaning commits that
+            // did not exist, or were not detached, at scan time.
+            guard WorktreeService.localBranchName(forWorktreeAt: worktree.path) == worktree.branch else {
+                results.append(WorktreeBatchResult(
+                    worktreeId: worktree.id,
+                    branch: worktree.branch,
+                    outcome: .skipped(reason: "Branch changed since this list was scanned")
                 ))
                 continue
             }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7340,6 +7340,75 @@ final class AppState {
         beginDeleteWorktree(worktree, keepBranch: keepBranch)
     }
 
+    /// Delete several worktrees in one pass, reusing the single-item deletion
+    /// path so every existing protection applies. Runs sequentially: git
+    /// worktree mutations on one repository serialize anyway, and sequential
+    /// execution keeps per-item results in a predictable order. A failure is
+    /// recorded and the batch continues.
+    ///
+    /// Callers are responsible for confirming with the user first — this method
+    /// deletes without prompting.
+    func batchDeleteWorktrees(
+        _ worktrees: [Worktree],
+        keepBranch: Bool
+    ) async -> [WorktreeBatchResult] {
+        guard !worktrees.isEmpty else { return [] }
+
+        var results: [WorktreeBatchResult] = []
+        var touchedProjectIds: Set<String> = []
+
+        for worktree in worktrees {
+            guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
+                results.append(WorktreeBatchResult(
+                    worktreeId: worktree.id,
+                    branch: worktree.branch,
+                    outcome: .failed(message: "Could not find the project for this worktree.")
+                ))
+                continue
+            }
+            guard !projectsManager.isMain(worktree, in: project) else {
+                results.append(WorktreeBatchResult(
+                    worktreeId: worktree.id,
+                    branch: worktree.branch,
+                    outcome: .skipped(reason: "Main worktree")
+                ))
+                continue
+            }
+
+            let siblingsBefore = projectsManager.visibleWorktrees(projectId: worktree.projectId)
+            let removedIndex = siblingsBefore.firstIndex(where: { $0.id == worktree.id }) ?? 0
+            projectsManager.setOperationState(id: worktree.id, state: .deleting)
+
+            let outcome = await performDeleteWorktree(
+                worktree: worktree,
+                repoPath: URL(fileURLWithPath: project.path),
+                deleteBranchIfMerged: Self.resolveDeleteBranchIfMerged(
+                    globalDeleteOnRemove: config.worktrees.deleteBranchOnRemove,
+                    keepBranch: keepBranch
+                ),
+                force: false,
+                removedIndex: removedIndex,
+                // One refresh at the end, not one per item.
+                refreshAfter: false,
+                // No modal mid-batch: a worktree needing force is reported and
+                // left for the user to handle through the single-item flow.
+                promptsForForce: false
+            )
+
+            results.append(WorktreeBatchResult(
+                worktreeId: worktree.id,
+                branch: worktree.branch,
+                outcome: outcome
+            ))
+            touchedProjectIds.insert(worktree.projectId)
+        }
+
+        for projectId in touchedProjectIds {
+            _ = try? await refreshProjectWorktrees(projectId: projectId)
+        }
+        return results
+    }
+
     private func beginDeleteWorktree(_ worktree: Worktree, keepBranch: Bool) {
         guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
             showFileActionError(title: "Delete Failed", message: "Could not find the project for this worktree.")
@@ -7717,14 +7786,20 @@ final class AppState {
 
     /// Runs the git removal off the main actor, then resumes on MainActor
     /// for state cleanup. On dirty-worktree failure publishes
-    /// `pendingForceDeleteWorktree` instead of showing a blocking modal.
+    /// `pendingForceDeleteWorktree` instead of showing a blocking modal —
+    /// unless `promptsForForce` is false, in which case that modal is
+    /// suppressed and the outcome is reported back instead (see
+    /// `batchDeleteWorktrees`, which must never pop a modal mid-run).
+    @discardableResult
     private func performDeleteWorktree(
         worktree: Worktree,
         repoPath: URL,
         deleteBranchIfMerged: Bool,
         force: Bool,
-        removedIndex: Int
-    ) async {
+        removedIndex: Int,
+        refreshAfter: Bool = true,
+        promptsForForce: Bool = true
+    ) async -> WorktreeBatchOutcome {
         do {
             try await Self.performRemoveWorktree(
                 repoPath: repoPath,
@@ -7734,6 +7809,7 @@ final class AppState {
             )
         } catch let WorktreeService.WorktreeError.gitFailed(stderr) {
             if !force,
+               promptsForForce,
                let pending = Self.pendingForceDelete(
                     for: worktree,
                     repoPath: repoPath,
@@ -7744,20 +7820,31 @@ final class AppState {
                 // Clear deleting so the user can see the row again while deciding.
                 projectsManager.setOperationState(id: worktree.id, state: nil)
                 pendingForceDeleteWorktree = pending
-                return
+                return .needsForce
+            } else if !force,
+                      !promptsForForce,
+                      Self.forceDeleteReason(for: stderr) != nil {
+                // Batches never force implicitly and must not hijack the app
+                // with a modal mid-run: record the state and report it back so
+                // the sheet can tell the user to handle this one individually.
+                projectsManager.setOperationState(
+                    id: worktree.id,
+                    state: .deleteFailed(message: stderr)
+                )
+                return .needsForce
             } else {
                 projectsManager.setOperationState(
                     id: worktree.id,
                     state: .deleteFailed(message: stderr)
                 )
-                return
+                return .failed(message: stderr)
             }
         } catch {
             projectsManager.setOperationState(
                 id: worktree.id,
                 state: .deleteFailed(message: "\(error)")
             )
-            return
+            return .failed(message: "\(error)")
         }
 
         cleanupWorktreeState(worktreeId: worktree.id)
@@ -7768,13 +7855,16 @@ final class AppState {
             projectId: worktree.projectId,
             worktreeId: worktree.id
         )
-        _ = try? await refreshProjectWorktrees(projectId: worktree.projectId)
+        if refreshAfter {
+            _ = try? await refreshProjectWorktrees(projectId: worktree.projectId)
+        }
         if selectedWorktreeId == worktree.id {
             selectWorktree(id: selectionAfterRemoval(
                 removedFromProjectId: worktree.projectId,
                 removedAtIndex: removedIndex
             ))
         }
+        return .deleted
     }
 
     /// Called from the SwiftUI alert when the user confirms force delete.
@@ -9626,6 +9716,26 @@ final class AppState {
         else { return }
         state.restartGGLand(target: session.target)
     }
+}
+
+/// Per-item outcome of a bulk worktree operation. The batch never aborts, so
+/// each selected worktree always produces exactly one of these.
+enum WorktreeBatchOutcome: Equatable, Sendable {
+    case deleted
+    case archived
+    case failed(message: String)
+    /// Git refused without `--force`. Batches never force implicitly; the user
+    /// handles these individually through the existing single-item flow.
+    case needsForce
+    case skipped(reason: String)
+}
+
+struct WorktreeBatchResult: Identifiable, Equatable, Sendable {
+    let worktreeId: String
+    let branch: String
+    let outcome: WorktreeBatchOutcome
+
+    var id: String { worktreeId }
 }
 
 private extension WorkspaceCheckoutMember {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4330,6 +4330,74 @@ final class AppState {
         saveProjects()
     }
 
+    /// Archive several worktrees at once. Nothing on disk is touched — this
+    /// only marks each path hidden in `ProjectConfig`, which is what persists
+    /// across relaunch.
+    ///
+    /// Unsaved editor buffers are checked across the whole selection before any
+    /// archiving happens, so the user answers one prompt rather than one per
+    /// worktree. Cancelling that prompt cancels the whole batch.
+    @discardableResult
+    func batchArchiveWorktrees(_ worktrees: [Worktree]) -> [WorktreeBatchResult] {
+        guard !worktrees.isEmpty else { return [] }
+
+        let dirtyCount = worktrees.reduce(0) { total, worktree in
+            total + dirtyEditorTabIds(worktreeId: worktree.id).count
+        }
+        if dirtyCount > 0 {
+            switch promptForDirtyBuffers(
+                action: "Archive",
+                branch: "\(worktrees.count) worktrees",
+                dirtyCount: dirtyCount,
+                onDiskDestructive: false
+            ) {
+            case .save:
+                // Saving is per-worktree and asynchronous; the sheet's flow is
+                // synchronous, so ask the user to save and retry rather than
+                // half-archiving. Report it as a skip, not a failure.
+                return worktrees.map {
+                    WorktreeBatchResult(
+                        worktreeId: $0.id,
+                        branch: $0.branch,
+                        outcome: .skipped(reason: "Save the open editors first")
+                    )
+                }
+            case .discard:
+                break
+            case .cancel:
+                return []
+            }
+        }
+
+        var results: [WorktreeBatchResult] = []
+        for worktree in worktrees {
+            guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
+                results.append(WorktreeBatchResult(
+                    worktreeId: worktree.id,
+                    branch: worktree.branch,
+                    outcome: .failed(message: "Could not find the project for this worktree.")
+                ))
+                continue
+            }
+            guard !projectsManager.isMain(worktree, in: project) else {
+                results.append(WorktreeBatchResult(
+                    worktreeId: worktree.id,
+                    branch: worktree.branch,
+                    outcome: .skipped(reason: "Main worktree")
+                ))
+                continue
+            }
+
+            archiveWorktreeAfterSaving(worktree)
+            results.append(WorktreeBatchResult(
+                worktreeId: worktree.id,
+                branch: worktree.branch,
+                outcome: .archived
+            ))
+        }
+        return results
+    }
+
     func startHarness() {
         LegacyHookSweep.sweepAll()
         harness.notifications.setEnabled(config.harness.notifyOnFinish)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7474,6 +7474,12 @@ final class AppState {
         for projectId in touchedProjectIds {
             _ = try? await refreshProjectWorktrees(projectId: projectId)
         }
+        // Per-item deletion skipped selection reconciliation because the list
+        // was still stale at that point. Now that every touched project has
+        // been refreshed, drop a selection that points at a deleted worktree.
+        if let current = selectedWorktreeId, !allWorktreeIds().contains(current) {
+            selectWorktree(id: resolvedSelectionForActiveSpace())
+        }
         return results
     }
 
@@ -8040,14 +8046,18 @@ final class AppState {
             projectId: worktree.projectId,
             worktreeId: worktree.id
         )
+        // Selection reconciliation only makes sense once the project list no
+        // longer contains the deleted worktree. Callers that skip the refresh
+        // (batches, which refresh once at the end) reconcile the selection
+        // themselves afterwards.
         if refreshAfter {
             _ = try? await refreshProjectWorktrees(projectId: worktree.projectId)
-        }
-        if selectedWorktreeId == worktree.id {
-            selectWorktree(id: selectionAfterRemoval(
-                removedFromProjectId: worktree.projectId,
-                removedAtIndex: removedIndex
-            ))
+            if selectedWorktreeId == worktree.id {
+                selectWorktree(id: selectionAfterRemoval(
+                    removedFromProjectId: worktree.projectId,
+                    removedAtIndex: removedIndex
+                ))
+            }
         }
         return .deleted
     }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7477,6 +7477,123 @@ final class AppState {
         return results
     }
 
+    /// Builds a cleanup model wired to live git, code-host, and session state.
+    /// Returns nil when the project no longer exists.
+    func makeWorktreeCleanupModel(projectId: String) -> WorktreeCleanupModel? {
+        guard let project = projects.first(where: { $0.id == projectId }) else { return nil }
+        let idleThresholdDays = config.worktrees.cleanupIdleDays
+        let baseBranch = config.worktrees.baseBranch
+
+        let scanner = WorktreeCleanupScanner(
+            dependencies: WorktreeCleanupScanner.Dependencies(
+                gitFacts: { worktree in
+                    await WorktreeCleanupScanner.gitFacts(
+                        worktreePath: worktree.path,
+                        branch: worktree.branch,
+                        baseBranch: baseBranch
+                    )
+                },
+                mergeIndex: { project in
+                    await Self.forgeMergeIndex(project: project, baseBranch: baseBranch)
+                },
+                // Both hop to the main actor: session and operation state are
+                // main-actor isolated, the scanner is not.
+                activeSessionCount: { [weak self] worktreeId in
+                    await MainActor.run {
+                        guard let self else { return 0 }
+                        let ids = self.tabs.tabs(forWorktree: worktreeId).flatMap { tab -> [String] in
+                            switch tab {
+                            case .terminal(let s):   return s.root.leaves().map(\.sessionId)
+                            case .acpSession(let s): return [s.sessionId]
+                            default:                 return []
+                            }
+                        }
+                        guard let summary = self.harness.summary(forSessionIds: ids) else { return 0 }
+                        return summary.sessions.count
+                    }
+                },
+                operationInFlight: { [weak self] worktreeId in
+                    await MainActor.run {
+                        self?.projectsManager.operationState(for: worktreeId) != nil
+                    }
+                }
+            )
+        )
+
+        return WorktreeCleanupModel(
+            projectId: projectId,
+            keepBranches: !config.worktrees.deleteBranchOnRemove,
+            scan: { [weak self] in
+                guard let self else { return .success([]) }
+                let worktrees = await MainActor.run {
+                    self.projectsManager.visibleWorktrees(projectId: projectId)
+                }
+                return .success(await scanner.scan(
+                    project: project,
+                    worktrees: worktrees,
+                    baseBranch: baseBranch,
+                    now: Date(),
+                    idleThresholdDays: idleThresholdDays
+                ))
+            },
+            deleteBatch: { [weak self] worktrees, keepBranch in
+                guard let self else { return [] }
+                return await self.batchDeleteWorktrees(worktrees, keepBranch: keepBranch)
+            },
+            archiveBatch: { [weak self] worktrees in
+                self?.batchArchiveWorktrees(worktrees) ?? []
+            },
+            confirm: { title, message in
+                let alert = NSAlert()
+                alert.messageText = title
+                alert.informativeText = message
+                alert.alertStyle = .warning
+                let deleteButton = alert.addButton(withTitle: "Delete")
+                alert.addButton(withTitle: "Cancel")
+                deleteButton.hasDestructiveAction = true
+                return alert.runModal() == .alertFirstButtonReturn
+            }
+        )
+    }
+
+    /// One batched merged-review-request query per repository. Any failure —
+    /// no remote, no provider, CLI missing, auth expired — surfaces as a
+    /// `.failure` so the scanner can report `unknown` rather than inventing a
+    /// "not merged" answer.
+    nonisolated private static func forgeMergeIndex(
+        project: ProjectConfig,
+        baseBranch: String
+    ) async -> Result<WorktreeForgeMergeIndex, Error> {
+        let repoPath = URL(fileURLWithPath: project.path)
+        let registry = CodeHostProviderRegistry.live()
+        do {
+            let remotes = try await GitService().remotes(worktreePath: repoPath)
+            guard let remote = CodeHostRemoteDetector.detect(
+                from: remotes,
+                supportedKinds: registry.supportedKinds,
+                preferredRemoteName: CodeHostRemoteDetector.preferredRemoteName(
+                    forBaseBranch: baseBranch,
+                    remotes: remotes
+                )
+            ) else {
+                return .failure(CodeHostProviderError.malformedOutput(
+                    "no supported code host remote"
+                ))
+            }
+            guard let provider = registry.provider(for: remote.kind) else {
+                return .failure(CodeHostProviderError.unsupportedProvider(remote.kind))
+            }
+            let refs = try await provider.mergedReviewRequests(
+                remote: remote,
+                limit: 200,
+                cwd: repoPath
+            )
+            return .success(WorktreeForgeMergeIndex(refs: refs))
+        } catch {
+            return .failure(error)
+        }
+    }
+
     private func beginDeleteWorktree(_ worktree: Worktree, keepBranch: Bool) {
         guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
             showFileActionError(title: "Delete Failed", message: "Could not find the project for this worktree.")

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7470,12 +7470,47 @@ final class AppState {
     /// recorded and the batch continues.
     ///
     /// Callers are responsible for confirming with the user first — this method
-    /// deletes without prompting.
+    /// deletes without prompting. Unsaved editor buffers are checked across the
+    /// whole selection before any deletion happens: `performDeleteWorktree`
+    /// alone does not check them (that gate lives in the single-item
+    /// `deleteWorktree`, above `beginDeleteWorktree`), so without this check a
+    /// worktree that is clean on disk but has an unsaved buffer would be
+    /// deleted and its buffer silently discarded by `cleanupWorktreeState`.
     func batchDeleteWorktrees(
         _ worktrees: [Worktree],
         keepBranch: Bool
     ) async -> [WorktreeBatchResult] {
         guard !worktrees.isEmpty else { return [] }
+
+        let dirtyCount = worktrees.reduce(0) { total, worktree in
+            total + dirtyEditorTabIds(worktreeId: worktree.id).count
+        }
+        if dirtyCount > 0 {
+            switch promptForDirtyBuffers(
+                action: "Delete",
+                branch: "\(worktrees.count) worktrees",
+                dirtyCount: dirtyCount,
+                onDiskDestructive: true,
+                keepBranch: keepBranch
+            ) {
+            case .save:
+                // Saving is per-worktree and asynchronous; the batch's flow is
+                // synchronous from here, so ask the user to save and retry
+                // rather than half-deleting. Report it as a skip, not a
+                // failure — mirrors `batchArchiveWorktrees`'s handling.
+                return worktrees.map {
+                    WorktreeBatchResult(
+                        worktreeId: $0.id,
+                        branch: $0.branch,
+                        outcome: .skipped(reason: "Save the open editors first")
+                    )
+                }
+            case .discard:
+                break
+            case .cancel:
+                return []
+            }
+        }
 
         var results: [WorktreeBatchResult] = []
         var touchedProjectIds: Set<String> = []

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -6,6 +6,11 @@ struct NewWorktreePresentation: Identifiable, Equatable {
     let projectId: String?
 }
 
+struct WorktreeCleanupPresentation: Identifiable, Equatable {
+    let id = UUID()
+    let projectId: String
+}
+
 private struct CommitReviewSessionLaunchError: Identifiable, Equatable {
     let id = UUID()
     let message: String
@@ -27,6 +32,7 @@ struct RootView: View {
     @State private var editingProject: ProjectConfig?
     @State private var removingProject: ProjectConfig?
     @State private var newWorktreePresentation: NewWorktreePresentation?
+    @State private var worktreeCleanupPresentation: WorktreeCleanupPresentation?
     @State private var creatingWorkspaceCheckout: Workspace?
     @State private var editingWorkspace: Workspace?
     @State private var commitReviewSessionLaunchError: CommitReviewSessionLaunchError?
@@ -61,7 +67,8 @@ struct RootView: View {
                 showNewProject: $showNewProject,
                 editingProject: $editingProject,
                 removingProject: $removingProject,
-                newWorktreePresentation: $newWorktreePresentation
+                newWorktreePresentation: $newWorktreePresentation,
+                worktreeCleanupPresentation: $worktreeCleanupPresentation
             ))
             .sheet(item: $creatingWorkspaceCheckout) { workspace in
                 CreateWorkspaceCheckoutDialog(
@@ -201,6 +208,9 @@ struct RootView: View {
             },
             onNewWorktree: { projectId in
                 newWorktreePresentation = NewWorktreePresentation(projectId: projectId)
+            },
+            onCleanupWorktrees: { projectId in
+                worktreeCleanupPresentation = WorktreeCleanupPresentation(projectId: projectId)
             },
             onHideSidebar: {
                 state.config.sidebarVisible = false
@@ -485,6 +495,7 @@ private struct RootPresentationHandlers: ViewModifier {
     @Binding var editingProject: ProjectConfig?
     @Binding var removingProject: ProjectConfig?
     @Binding var newWorktreePresentation: NewWorktreePresentation?
+    @Binding var worktreeCleanupPresentation: WorktreeCleanupPresentation?
 
     func body(content: Content) -> some View {
         content
@@ -496,7 +507,8 @@ private struct RootPresentationHandlers: ViewModifier {
             ))
             .modifier(RootWorktreePresentationHandlers(
                 state: state,
-                newWorktreePresentation: $newWorktreePresentation
+                newWorktreePresentation: $newWorktreePresentation,
+                worktreeCleanupPresentation: $worktreeCleanupPresentation
             ))
             .modifier(RootRunScriptPresentationHandlers(state: state))
             .modifier(RootReviewMergePresentationHandlers(state: state))
@@ -552,6 +564,7 @@ private struct RootProjectPresentationHandlers: ViewModifier {
 private struct RootWorktreePresentationHandlers: ViewModifier {
     @Bindable var state: AppState
     @Binding var newWorktreePresentation: NewWorktreePresentation?
+    @Binding var worktreeCleanupPresentation: WorktreeCleanupPresentation?
 
     func body(content: Content) -> some View {
         content
@@ -563,6 +576,13 @@ private struct RootWorktreePresentationHandlers: ViewModifier {
                         set: { if !$0 { newWorktreePresentation = nil } }
                     ),
                     presetProjectId: presentation.projectId
+                )
+            }
+            .sheet(item: $worktreeCleanupPresentation) { presentation in
+                WorktreeCleanupSheetHost(
+                    state: state,
+                    projectId: presentation.projectId,
+                    onClose: { worktreeCleanupPresentation = nil }
                 )
             }
     }

--- a/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
+++ b/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+enum WorktreeCleanupScanState: Equatable {
+    case idle
+    case scanning
+    case loaded([WorktreeCleanupCandidate])
+    case failed(message: String)
+
+    var candidates: [WorktreeCleanupCandidate] {
+        if case .loaded(let candidates) = self { return candidates }
+        return []
+    }
+}
+
+/// Drives the cleanup sheet: runs scans, tracks selection and per-item results.
+/// Everything here is deliberately view-free so the selection and confirmation
+/// rules can be tested without rendering.
+@MainActor
+@Observable
+final class WorktreeCleanupModel {
+    let projectId: String
+    private(set) var scanState: WorktreeCleanupScanState = .idle
+    private(set) var selectedIds: Set<String> = []
+    private(set) var results: [WorktreeBatchResult] = []
+    private(set) var isRunning = false
+    var keepBranches: Bool
+
+    private let scan: @Sendable () async -> Result<[WorktreeCleanupCandidate], Error>
+    private let deleteBatch: ([Worktree], Bool) async -> [WorktreeBatchResult]
+    private let archiveBatch: ([Worktree]) -> [WorktreeBatchResult]
+    private let confirm: (String, String) -> Bool
+
+    init(
+        projectId: String,
+        keepBranches: Bool,
+        scan: @escaping @Sendable () async -> Result<[WorktreeCleanupCandidate], Error>,
+        deleteBatch: @escaping ([Worktree], Bool) async -> [WorktreeBatchResult],
+        archiveBatch: @escaping ([Worktree]) -> [WorktreeBatchResult],
+        confirm: @escaping (String, String) -> Bool
+    ) {
+        self.projectId = projectId
+        self.keepBranches = keepBranches
+        self.scan = scan
+        self.deleteBatch = deleteBatch
+        self.archiveBatch = archiveBatch
+        self.confirm = confirm
+    }
+
+    var candidates: [WorktreeCleanupCandidate] { scanState.candidates }
+
+    func runScan() async {
+        scanState = .scanning
+        results = []
+        switch await scan() {
+        case .success(let candidates):
+            applyScanResult(candidates)
+        case .failure(let error):
+            scanState = .failed(
+                message: (error as? LocalizedError)?.errorDescription ?? "\(error)"
+            )
+        }
+    }
+
+    /// Applies a fresh scan, keeping any manual selection that still refers to
+    /// a row present in the new result, and adding newly-qualifying candidates.
+    func applyScanResult(_ candidates: [WorktreeCleanupCandidate]) {
+        let previousSelection = selectedIds
+        let hadResults = !scanState.candidates.isEmpty
+        scanState = .loaded(candidates)
+        if hadResults {
+            let selectable = Set(candidates.filter(\.isSelectable).map(\.id))
+            selectedIds = previousSelection.intersection(selectable)
+        } else {
+            selectedIds = Self.defaultSelection(from: candidates)
+        }
+    }
+
+    static func defaultSelection(
+        from candidates: [WorktreeCleanupCandidate]
+    ) -> Set<String> {
+        Set(candidates.filter(\.isSelectedByDefault).map(\.id))
+    }
+
+    /// Per-item override. Excluded rows never become selectable, which is what
+    /// keeps a main or remote worktree out of any batch.
+    func toggle(_ id: String) {
+        guard let candidate = candidates.first(where: { $0.id == id }),
+              candidate.isSelectable
+        else { return }
+        if selectedIds.contains(id) {
+            selectedIds.remove(id)
+        } else {
+            selectedIds.insert(id)
+        }
+    }
+
+    /// Selected worktrees in display order, so results read in the same order
+    /// as the list the user was looking at.
+    func selectedWorktrees() -> [Worktree] {
+        candidates
+            .filter { selectedIds.contains($0.id) }
+            .map(\.worktree)
+    }
+
+    func confirmationMessage() -> String {
+        let branches = selectedWorktrees().map(\.branch)
+        let list = branches.map { "• \($0)" }.joined(separator: "\n")
+        let branchPolicy = keepBranches
+            ? "Local branches will be kept."
+            : "Local branches will be deleted if merged."
+        return """
+        These worktrees will be removed from disk:
+
+        \(list)
+
+        \(branchPolicy)
+        """
+    }
+
+    func deleteSelected() async {
+        let targets = selectedWorktrees()
+        guard !targets.isEmpty, !isRunning else { return }
+        guard confirm(
+            "Delete \(targets.count) \(targets.count == 1 ? "worktree" : "worktrees")?",
+            confirmationMessage()
+        ) else { return }
+
+        isRunning = true
+        results = await deleteBatch(targets, keepBranches)
+        isRunning = false
+        await runScan()
+    }
+
+    func archiveSelected() async {
+        let targets = selectedWorktrees()
+        guard !targets.isEmpty, !isRunning else { return }
+        isRunning = true
+        results = archiveBatch(targets)
+        isRunning = false
+        await runScan()
+    }
+
+    static func summary(for results: [WorktreeBatchResult]) -> String {
+        var deleted = 0, archived = 0, failed = 0, needsForce = 0, skipped = 0
+        for result in results {
+            switch result.outcome {
+            case .deleted:    deleted += 1
+            case .archived:   archived += 1
+            case .failed:     failed += 1
+            case .needsForce: needsForce += 1
+            case .skipped:    skipped += 1
+            }
+        }
+        var parts: [String] = []
+        if deleted > 0 { parts.append("\(deleted) deleted") }
+        if archived > 0 { parts.append("\(archived) archived") }
+        if failed > 0 { parts.append("\(failed) failed") }
+        if needsForce > 0 { parts.append("\(needsForce) need force delete") }
+        if skipped > 0 { parts.append("\(skipped) skipped") }
+        return parts.isEmpty ? "Nothing to do" : parts.joined(separator: ", ")
+    }
+}
+
+#if DEBUG
+extension WorktreeCleanupModel {
+    /// Seeds a model with fixed candidates, bypassing scanning.
+    static func forTesting(
+        candidates: [WorktreeCleanupCandidate]
+    ) -> WorktreeCleanupModel {
+        let model = WorktreeCleanupModel(
+            projectId: "p",
+            keepBranches: false,
+            scan: { .success(candidates) },
+            deleteBatch: { _, _ in [] },
+            archiveBatch: { _ in [] },
+            confirm: { _, _ in true }
+        )
+        model.applyScanResult(candidates)
+        return model
+    }
+}
+#endif

--- a/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
+++ b/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
@@ -28,7 +28,10 @@ final class WorktreeCleanupModel {
     private let scan: @Sendable () async -> Result<[WorktreeCleanupCandidate], Error>
     private let deleteBatch: ([Worktree], Bool) async -> [WorktreeBatchResult]
     private let archiveBatch: ([Worktree]) -> [WorktreeBatchResult]
-    private let confirm: (String, String) -> Bool
+    /// `(title, message, confirmButtonTitle) -> confirmed`. The button title is
+    /// passed in because both destructive batch actions route through the same
+    /// prompt, and an archive confirmation must not offer a "Delete" button.
+    private let confirm: (String, String, String) -> Bool
     /// Tracks whether a scan has ever completed, independent of the transient
     /// `.scanning` state — `applyScanResult` uses this, not `scanState`, to
     /// decide whether to reconcile against a manual selection or seed the
@@ -42,7 +45,7 @@ final class WorktreeCleanupModel {
         scan: @escaping @Sendable () async -> Result<[WorktreeCleanupCandidate], Error>,
         deleteBatch: @escaping ([Worktree], Bool) async -> [WorktreeBatchResult],
         archiveBatch: @escaping ([Worktree]) -> [WorktreeBatchResult],
-        confirm: @escaping (String, String) -> Bool
+        confirm: @escaping (String, String, String) -> Bool
     ) {
         self.projectId = projectId
         self.keepBranches = keepBranches
@@ -134,12 +137,29 @@ final class WorktreeCleanupModel {
         """
     }
 
+    /// Archive-flavoured counterpart to `confirmationMessage()`: nothing is
+    /// removed from disk and no branch policy applies, but the tabs, terminals
+    /// and agent sessions of every archived worktree are torn down and are not
+    /// recreated when it is restored.
+    func archiveConfirmationMessage() -> String {
+        let branches = selectedWorktrees().map(\.branch)
+        let list = branches.map { "• \($0)" }.joined(separator: "\n")
+        return """
+        These worktrees will be hidden from the sidebar. Their files stay on \
+        disk and can be restored later, but open terminals and agent sessions \
+        will be closed:
+
+        \(list)
+        """
+    }
+
     func deleteSelected() async {
         let targets = selectedWorktrees()
         guard !targets.isEmpty, !isRunning else { return }
         guard confirm(
             "Delete \(targets.count) \(targets.count == 1 ? "worktree" : "worktrees")?",
-            confirmationMessage()
+            confirmationMessage(),
+            "Delete"
         ) else { return }
 
         isRunning = true
@@ -151,6 +171,12 @@ final class WorktreeCleanupModel {
     func archiveSelected() async {
         let targets = selectedWorktrees()
         guard !targets.isEmpty, !isRunning else { return }
+        guard confirm(
+            "Archive \(targets.count) \(targets.count == 1 ? "worktree" : "worktrees")?",
+            archiveConfirmationMessage(),
+            "Archive"
+        ) else { return }
+
         isRunning = true
         results = archiveBatch(targets)
         isRunning = false
@@ -190,7 +216,7 @@ extension WorktreeCleanupModel {
             scan: { .success(candidates) },
             deleteBatch: { _, _ in [] },
             archiveBatch: { _ in [] },
-            confirm: { _, _ in true }
+            confirm: { _, _, _ in true }
         )
         model.applyScanResult(candidates)
         return model

--- a/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
+++ b/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
@@ -29,6 +29,12 @@ final class WorktreeCleanupModel {
     private let deleteBatch: ([Worktree], Bool) async -> [WorktreeBatchResult]
     private let archiveBatch: ([Worktree]) -> [WorktreeBatchResult]
     private let confirm: (String, String) -> Bool
+    /// Tracks whether a scan has ever completed, independent of the transient
+    /// `.scanning` state — `applyScanResult` uses this, not `scanState`, to
+    /// decide whether to reconcile against a manual selection or seed the
+    /// default one, since `scanState` is already `.scanning` by the time a
+    /// rescan's result comes back.
+    private var hasCompletedAScan = false
 
     init(
         projectId: String,
@@ -50,7 +56,6 @@ final class WorktreeCleanupModel {
 
     func runScan() async {
         scanState = .scanning
-        results = []
         switch await scan() {
         case .success(let candidates):
             applyScanResult(candidates)
@@ -61,12 +66,24 @@ final class WorktreeCleanupModel {
         }
     }
 
-    /// Applies a fresh scan, keeping any manual selection that still refers to
-    /// a row present in the new result, and adding newly-qualifying candidates.
+    /// User-triggered rescan — the sheet's Refresh button, and the initial
+    /// load. Clears any results from a prior batch action, since starting a
+    /// fresh manual scan means the user is done reviewing that outcome.
+    func refresh() async {
+        results = []
+        await runScan()
+    }
+
+    /// Applies a fresh scan. If a scan has completed before, keeps any manual
+    /// selection that still refers to a row present in the new result and is
+    /// still selectable, and drops rows that disappeared or are no longer
+    /// selectable — it never auto-selects newly-qualifying rows. Otherwise
+    /// (the very first scan) seeds the default selection.
     func applyScanResult(_ candidates: [WorktreeCleanupCandidate]) {
         let previousSelection = selectedIds
-        let hadResults = !scanState.candidates.isEmpty
+        let hadResults = hasCompletedAScan
         scanState = .loaded(candidates)
+        hasCompletedAScan = true
         if hadResults {
             let selectable = Set(candidates.filter(\.isSelectable).map(\.id))
             selectedIds = previousSelection.intersection(selectable)

--- a/Alas/Sources/Dialogs/WorktreeCleanupSheet.swift
+++ b/Alas/Sources/Dialogs/WorktreeCleanupSheet.swift
@@ -1,0 +1,230 @@
+import SwiftUI
+
+struct WorktreeCleanupSheet: View {
+    @Bindable var model: WorktreeCleanupModel
+    let showKeepBranchOption: Bool
+    let onClose: () -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        DialogContainer(
+            title: "Clean Up Worktrees",
+            subtitle: subtitle,
+            width: DialogContainerLayout.projectWidth,
+            headerAccessory: {
+                DialogHeaderIconButton(
+                    icon: "arrow.clockwise",
+                    tooltip: "Rescan worktrees"
+                ) {
+                    Task { await model.refresh() }
+                }
+            },
+            content: { content },
+            cancelTitle: "Close",
+            confirmTitle: "Delete Selected…",
+            confirmStyle: .primary,
+            onCancel: onClose,
+            onConfirm: { Task { await model.deleteSelected() } },
+            confirmEnabled: !model.selectedIds.isEmpty && !model.isRunning
+        )
+    }
+
+    private var subtitle: String? {
+        switch model.scanState {
+        case .idle, .scanning:
+            return "Checking merge state, local changes, and activity…"
+        case .failed(let message):
+            return message
+        case .loaded(let candidates):
+            let count = candidates.filter(\.isSelectedByDefault).count
+            return count == 0
+                ? "Nothing looks ready to clean up."
+                : "\(count) of \(candidates.count) look ready to clean up."
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.scanState {
+        case .idle, .scanning:
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text("Scanning…")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(height: 220)
+
+        case .failed(let message):
+            VStack(alignment: .leading, spacing: 10) {
+                Text(message)
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-dim"))
+                AlasButton(title: "Retry", style: .normal) {
+                    Task { await model.refresh() }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(height: 220, alignment: .top)
+
+        case .loaded(let candidates):
+            VStack(alignment: .leading, spacing: 10) {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(candidates) { candidate in
+                            WorktreeCleanupRow(
+                                candidate: candidate,
+                                isSelected: model.selectedIds.contains(candidate.id),
+                                result: model.results.first { $0.worktreeId == candidate.id },
+                                onToggle: { model.toggle(candidate.id) }
+                            )
+                        }
+                    }
+                }
+                .frame(height: 320)
+
+                if showKeepBranchOption {
+                    Toggle("Keep local branches", isOn: $model.keepBranches)
+                        .font(.system(size: 12))
+                        .toggleStyle(.checkbox)
+                }
+
+                HStack(spacing: 8) {
+                    AlasButton(title: "Archive Selected", style: .normal) {
+                        Task { await model.archiveSelected() }
+                    }
+                    .disabled(model.selectedIds.isEmpty || model.isRunning)
+
+                    if !model.results.isEmpty {
+                        Text(WorktreeCleanupModel.summary(for: model.results))
+                            .font(.system(size: 11.5))
+                            .foregroundColor(theme.color("fg-dim"))
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct WorktreeCleanupRow: View {
+    let candidate: WorktreeCleanupCandidate
+    let isSelected: Bool
+    let result: WorktreeBatchResult?
+    let onToggle: () -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Toggle("", isOn: Binding(get: { isSelected }, set: { _ in onToggle() }))
+                .labelsHidden()
+                .toggleStyle(.checkbox)
+                .disabled(!candidate.isSelectable)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(candidate.worktree.branch)
+                        .font(.system(size: 12.5, weight: .medium))
+                        .foregroundColor(theme.color("fg"))
+                    Text(verdictLabel)
+                        .font(.system(size: 10.5, weight: .medium))
+                        .padding(.horizontal, 6).padding(.vertical, 1)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(theme.color(verdictColor).opacity(0.18))
+                        )
+                        .foregroundColor(theme.color(verdictColor))
+                }
+                ForEach(candidate.signals, id: \.self) { signal in
+                    HStack(spacing: 5) {
+                        Icon(
+                            name: signal.isBlocking ? "x" : "check",
+                            size: 9,
+                            color: theme.color(signal.isBlocking ? "fg-muted" : "add")
+                        )
+                        Text(signal.label)
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.color("fg-dim"))
+                    }
+                }
+                if let result, let text = resultLabel(result) {
+                    Text(text)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(theme.color("del"))
+                }
+            }
+            Spacer()
+        }
+        .padding(.vertical, 6).padding(.horizontal, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 6).fill(theme.color("bg-2"))
+        )
+        .opacity(candidate.isSelectable ? 1 : 0.6)
+    }
+
+    private var verdictLabel: String {
+        switch candidate.verdict {
+        case .candidate(.high):   return "Merged"
+        case .candidate(.medium): return "Merged locally"
+        case .candidate(.low):    return "Stale"
+        case .busy:               return "Busy"
+        case .dirty:              return "Has changes"
+        case .active:             return "Active"
+        case .excluded:           return "Excluded"
+        }
+    }
+
+    private var verdictColor: String {
+        switch candidate.verdict {
+        case .candidate: return "add"
+        case .busy:      return "mod"
+        case .dirty:     return "del"
+        case .active:    return "fg-muted"
+        case .excluded:  return "fg-muted"
+        }
+    }
+
+    private func resultLabel(_ result: WorktreeBatchResult) -> String? {
+        switch result.outcome {
+        case .deleted, .archived:      return nil
+        case .failed(let message):     return "Failed: \(message)"
+        case .needsForce:              return "Needs force delete — remove it individually"
+        case .skipped(let reason):     return "Skipped: \(reason)"
+        }
+    }
+}
+
+/// Owns the model for the lifetime of the sheet so a body re-evaluation does
+/// not rebuild it and restart the scan.
+struct WorktreeCleanupSheetHost: View {
+    let state: AppState
+    let projectId: String
+    let onClose: () -> Void
+
+    @State private var model: WorktreeCleanupModel?
+
+    var body: some View {
+        Group {
+            if let model {
+                WorktreeCleanupSheet(
+                    model: model,
+                    showKeepBranchOption: state.config.worktrees.deleteBranchOnRemove,
+                    onClose: onClose
+                )
+            } else {
+                ProgressView().controlSize(.small).padding(40)
+            }
+        }
+        .task {
+            guard model == nil else { return }
+            guard let built = state.makeWorktreeCleanupModel(projectId: projectId) else {
+                onClose()
+                return
+            }
+            model = built
+            await built.refresh()
+        }
+    }
+}

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupClassifier.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupClassifier.swift
@@ -28,6 +28,19 @@ enum WorktreeCleanupClassifier {
                 signals: [.remoteWorktree]
             )
         }
+        // A detached HEAD's commits are reachable only via that worktree's
+        // own HEAD. Removing it — even with git's own dirty-tree protections
+        // satisfied — makes those commits unreachable and eventually
+        // GC-eligible, unlike a branch's commits, which stay reachable via
+        // the branch ref regardless of unpushed status. Never offered, and
+        // never selectable via the per-item override.
+        if worktree.branch == "(detached)" {
+            return WorktreeCleanupCandidate(
+                worktree: worktree,
+                verdict: .excluded,
+                signals: [.detachedHead]
+            )
+        }
 
         var blocking: [WorktreeCleanupSignal] = []
         var qualifying: [WorktreeCleanupSignal] = []

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupClassifier.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupClassifier.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// Turns collected facts into a cleanup verdict. Pure and synchronous: given
+/// the same probe and clock it always produces the same answer, which is what
+/// makes the whole classification surface exhaustively testable.
+enum WorktreeCleanupClassifier {
+    static func classify(
+        worktree: Worktree,
+        probe: WorktreeCleanupProbe,
+        now: Date,
+        idleThresholdDays: Int
+    ) -> WorktreeCleanupCandidate {
+        let idleDays = daysSince(probe.lastActivity, now: now)
+
+        // Exclusion outranks everything: a main or remote worktree is never
+        // offered for cleanup regardless of how clean or idle it looks.
+        if worktree.isMainWorktree == true || probe.isMainWorktree {
+            return WorktreeCleanupCandidate(
+                worktree: worktree,
+                verdict: .excluded,
+                signals: [.mainWorktree]
+            )
+        }
+        if probe.isRemote {
+            return WorktreeCleanupCandidate(
+                worktree: worktree,
+                verdict: .excluded,
+                signals: [.remoteWorktree]
+            )
+        }
+
+        var blocking: [WorktreeCleanupSignal] = []
+        var qualifying: [WorktreeCleanupSignal] = []
+
+        // Busy
+        if probe.operationInFlight { blocking.append(.operationInFlight) }
+        if probe.activeSessionCount > 0 {
+            blocking.append(.activeSessions(count: probe.activeSessionCount))
+        } else {
+            qualifying.append(.noActiveSessions)
+        }
+        let isBusy = probe.operationInFlight || probe.activeSessionCount > 0
+
+        // Dirty
+        if probe.hasUncommittedChanges { blocking.append(.uncommittedChanges) }
+        if probe.hasUntrackedFiles { blocking.append(.untrackedFiles) }
+        if !probe.hasUncommittedChanges && !probe.hasUntrackedFiles {
+            qualifying.append(.noUncommittedChanges)
+        }
+        if probe.unpushedCommitCount > 0 {
+            blocking.append(.unpushedCommits(count: probe.unpushedCommitCount))
+        } else {
+            qualifying.append(.fullyPushed)
+        }
+        if probe.stashCount > 0 {
+            blocking.append(.stashes(count: probe.stashCount))
+        } else {
+            qualifying.append(.noStashes)
+        }
+        let isDirty = probe.hasUncommittedChanges
+            || probe.hasUntrackedFiles
+            || probe.unpushedCommitCount > 0
+            || probe.stashCount > 0
+
+        // Merge state
+        var mergeConfidence: WorktreeCleanupVerdict.Confidence?
+        switch probe.mergeState {
+        case .mergedOnForge(let identity, let url):
+            qualifying.append(.mergedOnForge(identity: identity, url: url))
+            mergeConfidence = .high
+        case .mergedLocally(let base):
+            qualifying.append(.mergedLocally(base: base))
+            mergeConfidence = .medium
+        case .unknown(let reason):
+            blocking.append(.mergeStateUnknown(reason: reason))
+            mergeConfidence = .low
+        case .notMerged:
+            blocking.append(.notMerged)
+            mergeConfidence = nil
+        }
+
+        // Staleness
+        let isIdle = idleDays >= idleThresholdDays
+        if isIdle {
+            qualifying.append(.idle(days: idleDays))
+        } else {
+            blocking.append(.recentActivity(days: idleDays))
+        }
+
+        let signals = orderedSignals(blocking: blocking, qualifying: qualifying)
+
+        // Precedence: busy, then dirty, then merged-and-idle decides.
+        let verdict: WorktreeCleanupVerdict
+        if isBusy {
+            verdict = .busy
+        } else if isDirty {
+            verdict = .dirty
+        } else if let confidence = mergeConfidence, isIdle {
+            verdict = .candidate(confidence: confidence)
+        } else {
+            verdict = .active
+        }
+
+        return WorktreeCleanupCandidate(
+            worktree: worktree,
+            verdict: verdict,
+            signals: signals
+        )
+    }
+
+    /// Whole days elapsed, floored, never negative — a worktree whose mtime is
+    /// in the future (clock skew, restored backup) reads as "active today"
+    /// rather than as absurdly stale.
+    static func daysSince(_ date: Date, now: Date) -> Int {
+        let seconds = now.timeIntervalSince(date)
+        guard seconds > 0 else { return 0 }
+        return Int(seconds / 86_400)
+    }
+
+    private static func orderedSignals(
+        blocking: [WorktreeCleanupSignal],
+        qualifying: [WorktreeCleanupSignal]
+    ) -> [WorktreeCleanupSignal] {
+        blocking + qualifying
+    }
+}

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
@@ -84,22 +84,35 @@ struct WorktreeCleanupScanner: Sendable {
         var candidates: [WorktreeCleanupCandidate] = []
         candidates.reserveCapacity(worktrees.count)
         for (offset, worktree) in worktrees.enumerated() {
+            let mergeState = Self.mergeState(
+                branch: worktree.branch,
+                baseBranch: baseBranch,
+                isMergedLocally: facts[offset].isMergedLocally,
+                indexResult: indexResult
+            )
+            // A branch the code host confirms is merged has its commits on the
+            // remote by definition. `unpushedCount` reports 1 whenever `@{u}`
+            // does not resolve, which is also what happens once the upstream
+            // has been pruned after a "delete branch on merge" — a stale
+            // local-tracking artifact, not unpublished work. It must not drive
+            // the dirty verdict the way a genuinely unpublished branch does.
+            let unpushedCommitCount: Int
+            if case .mergedOnForge = mergeState {
+                unpushedCommitCount = 0
+            } else {
+                unpushedCommitCount = facts[offset].unpushedCommitCount
+            }
             let probe = WorktreeCleanupProbe(
                 isMainWorktree: worktree.isMainWorktree == true,
                 isRemote: false,
                 hasUncommittedChanges: facts[offset].hasUncommittedChanges,
                 hasUntrackedFiles: facts[offset].hasUntrackedFiles,
-                unpushedCommitCount: facts[offset].unpushedCommitCount,
+                unpushedCommitCount: unpushedCommitCount,
                 stashCount: facts[offset].stashCount,
                 activeSessionCount: await dependencies.activeSessionCount(worktree.id),
                 operationInFlight: await dependencies.operationInFlight(worktree.id),
                 lastActivity: worktree.lastActivity,
-                mergeState: Self.mergeState(
-                    branch: worktree.branch,
-                    baseBranch: baseBranch,
-                    isMergedLocally: facts[offset].isMergedLocally,
-                    indexResult: indexResult
-                )
+                mergeState: mergeState
             )
             candidates.append(WorktreeCleanupClassifier.classify(
                 worktree: worktree,

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
@@ -204,11 +204,12 @@ extension WorktreeCleanupScanner {
     /// conservative direction rather than failing the scan.
     static func gitFacts(
         worktreePath: URL,
+        branch: String,
         baseBranch: String
     ) async -> WorktreeCleanupGitFacts {
         async let status = statusFacts(worktreePath: worktreePath)
         async let unpushed = unpushedCount(worktreePath: worktreePath)
-        async let stashes = stashCount(worktreePath: worktreePath)
+        async let stashes = stashCount(worktreePath: worktreePath, branch: branch)
         async let merged = isMergedLocally(
             worktreePath: worktreePath,
             baseBranch: baseBranch
@@ -263,22 +264,33 @@ extension WorktreeCleanupScanner {
             // branch has work that exists nowhere else, so treat it as unpushed.
             return 1
         }
-        return Int(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
+        // A successful command with unparseable output degrades the same way
+        // as a failed one: unpushed commits exist nowhere but this worktree,
+        // so a "we couldn't tell" case must not read as "nothing unpushed".
+        return Int(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 1
     }
 
-    private static func stashCount(worktreePath: URL) async -> Int {
-        // The stash stack is repository-wide, so filter to stashes whose
-        // recorded branch matches this worktree's branch.
-        guard let branch = try? await Process.git(
-            ["symbolic-ref", "--quiet", "--short", "HEAD"],
-            cwd: worktreePath
-        ), branch.exitCode == 0 else { return 0 }
-        let branchName = branch.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !branchName.isEmpty else { return 0 }
-
+    private static func stashCount(worktreePath: URL, branch: String) async -> Int {
+        // Unlike the unpushed-commit and status probes, a lookup failure here
+        // safely degrades to 0, not 1: the stash stack lives in the shared
+        // `.git` common directory, not this worktree's private state, so a
+        // stash survives `git worktree remove` regardless of whether this
+        // probe could read it. There is no way to lose a stash by
+        // under-counting it here — so 0 is the honest answer, and it avoids
+        // reporting a false "1 stash" blocker to a worktree that has none.
         guard let stashes = try? await GitService().stashes(worktreePath: worktreePath)
         else { return 0 }
-        return stashes.filter { $0.subject.contains(branchName) }.count
+        return stashes.filter { isStash($0, forBranch: branch) }.count
+    }
+
+    /// Matches a stash's `%gs` reflog subject against a branch name, anchored
+    /// on git's own subject shapes (`WIP on <branch>: ...` or
+    /// `On <branch>: ...`) rather than a bare substring — a bare
+    /// `subject.contains(branch)` would over-count branch `x` against a
+    /// stash actually belonging to `feature/x`.
+    static func isStash(_ stash: GitStash, forBranch branch: String) -> Bool {
+        stash.subject.hasPrefix("WIP on \(branch):")
+            || stash.subject.hasPrefix("On \(branch):")
     }
 
     private static func isMergedLocally(

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
@@ -126,7 +126,16 @@ struct WorktreeCleanupScanner: Sendable {
                 // does not update it. Prefer a freshly-read value so a
                 // worktree just touched and merged since that last refresh
                 // does not read as long-idle and get default-selected.
-                lastActivity: facts[offset].lastActivity ?? worktree.lastActivity,
+                //
+                // A freshly-read value can itself predate the checkout: it is
+                // derived from the branch ref's own history, so a worktree
+                // just created from an old merged branch would otherwise
+                // inherit that branch's age and read as idle immediately.
+                // The worktree cannot be idle before it existed.
+                lastActivity: max(
+                    facts[offset].lastActivity ?? worktree.lastActivity,
+                    worktree.createdAt
+                ),
                 mergeState: mergeState
             )
             candidates.append(WorktreeCleanupClassifier.classify(

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
@@ -15,25 +15,26 @@ struct WorktreeCleanupGitFacts: Equatable, Sendable {
     var headSHA: String?
 }
 
-/// Merged review requests for one repository, keyed by head branch.
+/// Merged review requests for one repository, keyed by head branch. A branch
+/// name can have multiple entries: it may have been reused across several
+/// merged reviews over time, and the caller must be able to check the local
+/// worktree's HEAD against any of them, not just the most recent — keeping
+/// only the newest would silently drop the exact "reused branch name" case
+/// SHA verification exists to handle.
 struct WorktreeForgeMergeIndex: Sendable {
-    let refsByHeadBranch: [String: MergedReviewRequestRef]
+    let refsByHeadBranch: [String: [MergedReviewRequestRef]]
 
-    init(refsByHeadBranch: [String: MergedReviewRequestRef]) {
+    init(refsByHeadBranch: [String: [MergedReviewRequestRef]]) {
         self.refsByHeadBranch = refsByHeadBranch
     }
 
     init(refs: [MergedReviewRequestRef]) {
-        // Newest first from both CLIs, so keep the first ref seen for a branch.
-        var byBranch: [String: MergedReviewRequestRef] = [:]
-        for ref in refs where byBranch[ref.headRefName] == nil {
-            byBranch[ref.headRefName] = ref
-        }
-        self.refsByHeadBranch = byBranch
+        self.refsByHeadBranch = Dictionary(grouping: refs, by: \.headRefName)
     }
 
-    func ref(forBranch branch: String) -> MergedReviewRequestRef? {
-        refsByHeadBranch[branch]
+    /// Every merged ref recorded for a branch name, oldest and newest alike.
+    func refs(forBranch branch: String) -> [MergedReviewRequestRef] {
+        refsByHeadBranch[branch] ?? []
     }
 }
 
@@ -149,8 +150,8 @@ struct WorktreeCleanupScanner: Sendable {
     ) -> WorktreeMergeState {
         switch indexResult {
         case .success(let index):
-            if let ref = index.ref(forBranch: branch),
-               let localHeadSHA, ref.headSHA == localHeadSHA {
+            if let localHeadSHA,
+               let ref = index.refs(forBranch: branch).first(where: { $0.headSHA == localHeadSHA }) {
                 return .mergedOnForge(identity: "#\(ref.number)", url: ref.url)
             }
             if isMergedLocally { return .mergedLocally(base: baseBranch) }

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
@@ -252,6 +252,7 @@ extension WorktreeCleanupScanner {
         async let stashes = stashCount(worktreePath: worktreePath, branch: branch)
         async let merged = isMergedLocally(
             worktreePath: worktreePath,
+            branch: branch,
             baseBranch: baseBranch
         )
         async let head = headSHA(worktreePath: worktreePath)
@@ -344,8 +345,17 @@ extension WorktreeCleanupScanner {
 
     private static func isMergedLocally(
         worktreePath: URL,
+        branch: String,
         baseBranch: String
     ) async -> Bool {
+        // A base-branch resolution that falls back past the configured
+        // default and past main/master/trunk can, in an unconventional repo,
+        // land on one of the very branches being scanned. Comparing a branch
+        // against itself as the base trivially "succeeds" (HEAD is always its
+        // own ancestor), which would misreport a genuinely unmerged worktree
+        // as merged locally. Guard the degenerate case directly rather than
+        // trusting the resolved base branch is never a scanned worktree.
+        guard branch != baseBranch else { return false }
         guard let result = try? await Process.git(
             ["merge-base", "--is-ancestor", "HEAD", baseBranch],
             cwd: worktreePath

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
@@ -9,6 +9,10 @@ struct WorktreeCleanupGitFacts: Equatable, Sendable {
     var unpushedCommitCount: Int
     var stashCount: Int
     var isMergedLocally: Bool
+    /// Current `HEAD` SHA, used to verify a forge-reported merge actually
+    /// applies to what is checked out here — a branch-name match alone is
+    /// not enough, since names get reused. `nil` when it could not be read.
+    var headSHA: String?
 }
 
 /// Merged review requests for one repository, keyed by head branch.
@@ -88,6 +92,7 @@ struct WorktreeCleanupScanner: Sendable {
                 branch: worktree.branch,
                 baseBranch: baseBranch,
                 isMergedLocally: facts[offset].isMergedLocally,
+                localHeadSHA: facts[offset].headSHA,
                 indexResult: indexResult
             )
             // A branch the code host confirms is merged has its commits on the
@@ -127,15 +132,25 @@ struct WorktreeCleanupScanner: Sendable {
     /// Resolves merge state, preserving the distinction the acceptance criteria
     /// require: forge-merged, locally merged, genuinely not merged, and
     /// "we could not find out". A forge failure never becomes `.notMerged`.
+    ///
+    /// A branch-name match against the forge index is not enough on its own:
+    /// branch names get reused after an old, unrelated PR on the same name
+    /// merged, and a stale name match would misreport the current, unrelated
+    /// commits as merged. `localHeadSHA` — this worktree's actual `HEAD` —
+    /// must equal the matched ref's recorded head SHA before the match is
+    /// trusted; otherwise this falls through to the local-merge check exactly
+    /// as if the forge had never reported a match at all.
     static func mergeState(
         branch: String,
         baseBranch: String,
         isMergedLocally: Bool,
+        localHeadSHA: String?,
         indexResult: Result<WorktreeForgeMergeIndex, Error>
     ) -> WorktreeMergeState {
         switch indexResult {
         case .success(let index):
-            if let ref = index.ref(forBranch: branch) {
+            if let ref = index.ref(forBranch: branch),
+               let localHeadSHA, ref.headSHA == localHeadSHA {
                 return .mergedOnForge(identity: "#\(ref.number)", url: ref.url)
             }
             if isMergedLocally { return .mergedLocally(base: baseBranch) }
@@ -205,7 +220,8 @@ struct WorktreeCleanupScanner: Sendable {
                     hasUntrackedFiles: false,
                     unpushedCommitCount: 0,
                     stashCount: 0,
-                    isMergedLocally: false
+                    isMergedLocally: false,
+                    headSHA: nil
                 )
             }
         }
@@ -227,16 +243,18 @@ extension WorktreeCleanupScanner {
             worktreePath: worktreePath,
             baseBranch: baseBranch
         )
+        async let head = headSHA(worktreePath: worktreePath)
 
-        let (statusFacts, unpushedCount, stashCount, mergedLocally) =
-            await (status, unpushed, stashes, merged)
+        let (statusFacts, unpushedCount, stashCount, mergedLocally, headSHA) =
+            await (status, unpushed, stashes, merged, head)
 
         return WorktreeCleanupGitFacts(
             hasUncommittedChanges: statusFacts.hasUncommittedChanges,
             hasUntrackedFiles: statusFacts.hasUntrackedFiles,
             unpushedCommitCount: unpushedCount,
             stashCount: stashCount,
-            isMergedLocally: mergedLocally
+            isMergedLocally: mergedLocally,
+            headSHA: headSHA
         )
     }
 
@@ -315,5 +333,14 @@ extension WorktreeCleanupScanner {
             cwd: worktreePath
         ) else { return false }
         return result.exitCode == 0
+    }
+
+    private static func headSHA(worktreePath: URL) async -> String? {
+        guard let result = try? await Process.git(
+            ["rev-parse", "HEAD"],
+            cwd: worktreePath
+        ), result.exitCode == 0 else { return nil }
+        let sha = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return sha.isEmpty ? nil : sha
     }
 }

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
@@ -13,6 +13,10 @@ struct WorktreeCleanupGitFacts: Equatable, Sendable {
     /// applies to what is checked out here — a branch-name match alone is
     /// not enough, since names get reused. `nil` when it could not be read.
     var headSHA: String?
+    /// Freshly-read activity timestamp, independent of the possibly-stale
+    /// `Worktree.lastActivity` the topology cache carries. `nil` when it
+    /// could not be read, in which case the cached value is used instead.
+    var lastActivity: Date?
 }
 
 /// Merged review requests for one repository, keyed by head branch. A branch
@@ -117,7 +121,12 @@ struct WorktreeCleanupScanner: Sendable {
                 stashCount: facts[offset].stashCount,
                 activeSessionCount: await dependencies.activeSessionCount(worktree.id),
                 operationInFlight: await dependencies.operationInFlight(worktree.id),
-                lastActivity: worktree.lastActivity,
+                // `worktree.lastActivity` is cached from the last topology
+                // refresh — ordinary commit activity while the app is open
+                // does not update it. Prefer a freshly-read value so a
+                // worktree just touched and merged since that last refresh
+                // does not read as long-idle and get default-selected.
+                lastActivity: facts[offset].lastActivity ?? worktree.lastActivity,
                 mergeState: mergeState
             )
             candidates.append(WorktreeCleanupClassifier.classify(
@@ -222,7 +231,8 @@ struct WorktreeCleanupScanner: Sendable {
                     unpushedCommitCount: 0,
                     stashCount: 0,
                     isMergedLocally: false,
-                    headSHA: nil
+                    headSHA: nil,
+                    lastActivity: nil
                 )
             }
         }
@@ -249,13 +259,20 @@ extension WorktreeCleanupScanner {
         let (statusFacts, unpushedCount, stashCount, mergedLocally, headSHA) =
             await (status, unpushed, stashes, merged, head)
 
+        // Synchronous file-attribute read, same mechanism that populates
+        // `Worktree.lastActivity` in the first place — reading it fresh here
+        // (rather than trusting that possibly-stale cached value) needs no
+        // subprocess and no extra concurrency.
+        let freshActivity = WorktreeService.lastActivity(forWorktreeAt: worktreePath)
+
         return WorktreeCleanupGitFacts(
             hasUncommittedChanges: statusFacts.hasUncommittedChanges,
             hasUntrackedFiles: statusFacts.hasUntrackedFiles,
             unpushedCommitCount: unpushedCount,
             stashCount: stashCount,
             isMergedLocally: mergedLocally,
-            headSHA: headSHA
+            headSHA: headSHA,
+            lastActivity: freshActivity
         )
     }
 

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
@@ -1,0 +1,294 @@
+import Foundation
+
+/// Git-derived facts for one worktree. Separate from `WorktreeCleanupProbe`
+/// because the scanner also folds in non-git facts (sessions, forge state)
+/// before classification.
+struct WorktreeCleanupGitFacts: Equatable, Sendable {
+    var hasUncommittedChanges: Bool
+    var hasUntrackedFiles: Bool
+    var unpushedCommitCount: Int
+    var stashCount: Int
+    var isMergedLocally: Bool
+}
+
+/// Merged review requests for one repository, keyed by head branch.
+struct WorktreeForgeMergeIndex: Sendable {
+    let refsByHeadBranch: [String: MergedReviewRequestRef]
+
+    init(refsByHeadBranch: [String: MergedReviewRequestRef]) {
+        self.refsByHeadBranch = refsByHeadBranch
+    }
+
+    init(refs: [MergedReviewRequestRef]) {
+        // Newest first from both CLIs, so keep the first ref seen for a branch.
+        var byBranch: [String: MergedReviewRequestRef] = [:]
+        for ref in refs where byBranch[ref.headRefName] == nil {
+            byBranch[ref.headRefName] = ref
+        }
+        self.refsByHeadBranch = byBranch
+    }
+
+    func ref(forBranch branch: String) -> MergedReviewRequestRef? {
+        refsByHeadBranch[branch]
+    }
+}
+
+/// Collects the facts the classifier needs. All I/O arrives through
+/// `Dependencies`, so tests drive the whole scan without a repository or a
+/// network.
+struct WorktreeCleanupScanner: Sendable {
+    struct Dependencies: Sendable {
+        var gitFacts: @Sendable (Worktree) async -> WorktreeCleanupGitFacts
+        /// `Result` rather than an optional so a failure can carry its reason
+        /// into the `unknown` merge state the user sees.
+        var mergeIndex: @Sendable (ProjectConfig) async -> Result<WorktreeForgeMergeIndex, Error>
+        /// Async because the live implementations read `@MainActor` app state
+        /// (open tabs, harness activity, in-flight operations) while the
+        /// scanner itself is not main-actor isolated.
+        var activeSessionCount: @Sendable (String) async -> Int
+        var operationInFlight: @Sendable (String) async -> Bool
+    }
+
+    /// Concurrent git probes in flight. Thirty worktrees must not mean thirty
+    /// simultaneous git processes.
+    static let probeConcurrency = 4
+
+    let dependencies: Dependencies
+
+    /// `baseBranch` must be the same branch the `gitFacts` probe compared
+    /// against, since it is what the `.mergedLocally` signal names back to the
+    /// user. Passing it explicitly keeps the label and the check from drifting.
+    func scan(
+        project: ProjectConfig,
+        worktrees: [Worktree],
+        baseBranch: String,
+        now: Date,
+        idleThresholdDays: Int
+    ) async -> [WorktreeCleanupCandidate] {
+        // Remote/SSH projects are out of scope for cleanup: excluded up front,
+        // with no probes run at all.
+        if project.host != nil {
+            return worktrees.map { worktree in
+                WorktreeCleanupClassifier.classify(
+                    worktree: worktree,
+                    probe: Self.remoteProbe(for: worktree),
+                    now: now,
+                    idleThresholdDays: idleThresholdDays
+                )
+            }
+        }
+
+        let indexResult = await dependencies.mergeIndex(project)
+        let facts = await collectGitFacts(for: worktrees)
+
+        var candidates: [WorktreeCleanupCandidate] = []
+        candidates.reserveCapacity(worktrees.count)
+        for (offset, worktree) in worktrees.enumerated() {
+            let probe = WorktreeCleanupProbe(
+                isMainWorktree: worktree.isMainWorktree == true,
+                isRemote: false,
+                hasUncommittedChanges: facts[offset].hasUncommittedChanges,
+                hasUntrackedFiles: facts[offset].hasUntrackedFiles,
+                unpushedCommitCount: facts[offset].unpushedCommitCount,
+                stashCount: facts[offset].stashCount,
+                activeSessionCount: await dependencies.activeSessionCount(worktree.id),
+                operationInFlight: await dependencies.operationInFlight(worktree.id),
+                lastActivity: worktree.lastActivity,
+                mergeState: Self.mergeState(
+                    branch: worktree.branch,
+                    baseBranch: baseBranch,
+                    isMergedLocally: facts[offset].isMergedLocally,
+                    indexResult: indexResult
+                )
+            )
+            candidates.append(WorktreeCleanupClassifier.classify(
+                worktree: worktree,
+                probe: probe,
+                now: now,
+                idleThresholdDays: idleThresholdDays
+            ))
+        }
+        return candidates
+    }
+
+    /// Resolves merge state, preserving the distinction the acceptance criteria
+    /// require: forge-merged, locally merged, genuinely not merged, and
+    /// "we could not find out". A forge failure never becomes `.notMerged`.
+    static func mergeState(
+        branch: String,
+        baseBranch: String,
+        isMergedLocally: Bool,
+        indexResult: Result<WorktreeForgeMergeIndex, Error>
+    ) -> WorktreeMergeState {
+        switch indexResult {
+        case .success(let index):
+            if let ref = index.ref(forBranch: branch) {
+                return .mergedOnForge(identity: "#\(ref.number)", url: ref.url)
+            }
+            if isMergedLocally { return .mergedLocally(base: baseBranch) }
+            return .notMerged
+        case .failure(let error):
+            // The local check is independent of the forge query, so a local
+            // merge still counts even when the forge could not be reached.
+            if isMergedLocally { return .mergedLocally(base: baseBranch) }
+            return .unknown(reason: Self.reason(for: error))
+        }
+    }
+
+    static func reason(for error: Error) -> String {
+        (error as? LocalizedError)?.errorDescription ?? "\(error)"
+    }
+
+    private static func remoteProbe(for worktree: Worktree) -> WorktreeCleanupProbe {
+        WorktreeCleanupProbe(
+            isMainWorktree: worktree.isMainWorktree == true,
+            isRemote: true,
+            hasUncommittedChanges: false,
+            hasUntrackedFiles: false,
+            unpushedCommitCount: 0,
+            stashCount: 0,
+            activeSessionCount: 0,
+            operationInFlight: false,
+            lastActivity: worktree.lastActivity,
+            mergeState: .unknown(reason: "remote worktree")
+        )
+    }
+
+    /// Probes run concurrently, bounded, and results are re-ordered to match
+    /// the input so callers can zip by index.
+    private func collectGitFacts(
+        for worktrees: [Worktree]
+    ) async -> [WorktreeCleanupGitFacts] {
+        await withTaskGroup(
+            of: (Int, WorktreeCleanupGitFacts).self
+        ) { group in
+            var results = [WorktreeCleanupGitFacts?](
+                repeating: nil,
+                count: worktrees.count
+            )
+            var next = 0
+
+            func addTask(_ index: Int) {
+                let worktree = worktrees[index]
+                let probe = dependencies.gitFacts
+                group.addTask { (index, await probe(worktree)) }
+            }
+
+            while next < worktrees.count && next < Self.probeConcurrency {
+                addTask(next)
+                next += 1
+            }
+            while let (index, facts) = await group.next() {
+                results[index] = facts
+                if next < worktrees.count {
+                    addTask(next)
+                    next += 1
+                }
+            }
+
+            return results.map {
+                $0 ?? WorktreeCleanupGitFacts(
+                    hasUncommittedChanges: true,
+                    hasUntrackedFiles: false,
+                    unpushedCommitCount: 0,
+                    stashCount: 0,
+                    isMergedLocally: false
+                )
+            }
+        }
+    }
+}
+
+extension WorktreeCleanupScanner {
+    /// Live git probe. Each failure degrades that single fact in the
+    /// conservative direction rather than failing the scan.
+    static func gitFacts(
+        worktreePath: URL,
+        baseBranch: String
+    ) async -> WorktreeCleanupGitFacts {
+        async let status = statusFacts(worktreePath: worktreePath)
+        async let unpushed = unpushedCount(worktreePath: worktreePath)
+        async let stashes = stashCount(worktreePath: worktreePath)
+        async let merged = isMergedLocally(
+            worktreePath: worktreePath,
+            baseBranch: baseBranch
+        )
+
+        let (statusFacts, unpushedCount, stashCount, mergedLocally) =
+            await (status, unpushed, stashes, merged)
+
+        return WorktreeCleanupGitFacts(
+            hasUncommittedChanges: statusFacts.hasUncommittedChanges,
+            hasUntrackedFiles: statusFacts.hasUntrackedFiles,
+            unpushedCommitCount: unpushedCount,
+            stashCount: stashCount,
+            isMergedLocally: mergedLocally
+        )
+    }
+
+    private static func statusFacts(
+        worktreePath: URL
+    ) async -> (hasUncommittedChanges: Bool, hasUntrackedFiles: Bool) {
+        guard let result = try? await Process.git(
+            ["status", "--porcelain", "--untracked-files=normal"],
+            cwd: worktreePath
+        ), result.exitCode == 0 else {
+            // Could not read status — assume dirty rather than offer deletion.
+            return (true, false)
+        }
+        return parseStatusPorcelain(result.stdout)
+    }
+
+    static func parseStatusPorcelain(
+        _ output: String
+    ) -> (hasUncommittedChanges: Bool, hasUntrackedFiles: Bool) {
+        var hasUncommittedChanges = false
+        var hasUntrackedFiles = false
+        for line in output.split(separator: "\n") where line.count >= 2 {
+            if line.hasPrefix("??") {
+                hasUntrackedFiles = true
+            } else {
+                hasUncommittedChanges = true
+            }
+        }
+        return (hasUncommittedChanges, hasUntrackedFiles)
+    }
+
+    private static func unpushedCount(worktreePath: URL) async -> Int {
+        guard let result = try? await Process.git(
+            ["rev-list", "--count", "@{u}..HEAD"],
+            cwd: worktreePath
+        ), result.exitCode == 0 else {
+            // No upstream configured (or the check failed). An unpublished
+            // branch has work that exists nowhere else, so treat it as unpushed.
+            return 1
+        }
+        return Int(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
+    }
+
+    private static func stashCount(worktreePath: URL) async -> Int {
+        // The stash stack is repository-wide, so filter to stashes whose
+        // recorded branch matches this worktree's branch.
+        guard let branch = try? await Process.git(
+            ["symbolic-ref", "--quiet", "--short", "HEAD"],
+            cwd: worktreePath
+        ), branch.exitCode == 0 else { return 0 }
+        let branchName = branch.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !branchName.isEmpty else { return 0 }
+
+        guard let stashes = try? await GitService().stashes(worktreePath: worktreePath)
+        else { return 0 }
+        return stashes.filter { $0.subject.contains(branchName) }.count
+    }
+
+    private static func isMergedLocally(
+        worktreePath: URL,
+        baseBranch: String
+    ) async -> Bool {
+        guard let result = try? await Process.git(
+            ["merge-base", "--is-ancestor", "HEAD", baseBranch],
+            cwd: worktreePath
+        ) else { return false }
+        return result.exitCode == 0
+    }
+}

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupTypes.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupTypes.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+/// How a worktree's branch relates to its base, and — critically — how
+/// confident we are in that answer. A code-host check that could not be
+/// performed yields `.unknown`, never `.notMerged`: "we could not ask GitHub"
+/// and "GitHub says this is not merged" are different facts and the UI must
+/// not conflate them.
+enum WorktreeMergeState: Equatable, Sendable {
+    /// The code host reports the branch's review request as merged.
+    case mergedOnForge(identity: String, url: URL)
+    /// `git merge-base --is-ancestor HEAD <base>` succeeded locally.
+    case mergedLocally(base: String)
+    /// Checked, and the branch is genuinely not merged.
+    case notMerged
+    /// The check could not be completed. `reason` is surfaced to the user.
+    case unknown(reason: String)
+}
+
+/// The raw facts about one worktree, collected by `WorktreeCleanupScanner`
+/// and consumed by `WorktreeCleanupClassifier`. Deliberately free of I/O and
+/// of any git or code-host type, so classification is a pure function.
+struct WorktreeCleanupProbe: Equatable, Sendable {
+    var isMainWorktree: Bool
+    var isRemote: Bool
+    var hasUncommittedChanges: Bool
+    var hasUntrackedFiles: Bool
+    var unpushedCommitCount: Int
+    var stashCount: Int
+    var activeSessionCount: Int
+    var operationInFlight: Bool
+    var lastActivity: Date
+    var mergeState: WorktreeMergeState
+}
+
+/// One reason a worktree does or does not qualify for cleanup. Signals carry
+/// their own user-facing copy so the "why not" text is testable data rather
+/// than logic buried in a view.
+enum WorktreeCleanupSignal: Equatable, Hashable, Sendable {
+    // Qualifying
+    case mergedOnForge(identity: String, url: URL)
+    case mergedLocally(base: String)
+    case noUncommittedChanges
+    case fullyPushed
+    case noStashes
+    case noActiveSessions
+    case idle(days: Int)
+
+    // Blocking
+    case uncommittedChanges
+    case untrackedFiles
+    case unpushedCommits(count: Int)
+    case stashes(count: Int)
+    case activeSessions(count: Int)
+    case recentActivity(days: Int)
+    case notMerged
+    case mergeStateUnknown(reason: String)
+
+    // Excluding
+    case mainWorktree
+    case remoteWorktree
+    case operationInFlight
+
+    /// True when this signal counts *against* cleanup. Drives both the row's
+    /// icon and its sort position — blocking signals render first so the user
+    /// reads the objection before the reassurance.
+    ///
+    /// Blocking is not the same as disqualifying. `.mergeStateUnknown` is
+    /// blocking (it is a caution, and must not be shown with a reassuring
+    /// checkmark) but a worktree carrying it can still be a low-confidence
+    /// candidate when it is otherwise clean and long idle. The verdict, not
+    /// this flag, decides candidacy.
+    var isBlocking: Bool {
+        switch self {
+        case .mergedOnForge, .mergedLocally, .noUncommittedChanges,
+             .fullyPushed, .noStashes, .noActiveSessions, .idle:
+            return false
+        case .uncommittedChanges, .untrackedFiles, .unpushedCommits,
+             .stashes, .activeSessions, .recentActivity, .notMerged,
+             .mergeStateUnknown, .mainWorktree, .remoteWorktree,
+             .operationInFlight:
+            return true
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .mergedOnForge(let identity, _):
+            return "Merged on the code host (\(identity))"
+        case .mergedLocally(let base):
+            return "Merged locally into \(base)"
+        case .noUncommittedChanges:
+            return "No uncommitted changes"
+        case .fullyPushed:
+            return "All commits pushed"
+        case .noStashes:
+            return "No stashes"
+        case .noActiveSessions:
+            return "No active sessions"
+        case .idle(let days):
+            return "Untouched for \(days) \(days == 1 ? "day" : "days")"
+        case .uncommittedChanges:
+            return "Has uncommitted changes"
+        case .untrackedFiles:
+            return "Has untracked files"
+        case .unpushedCommits(let count):
+            return "\(count) unpushed \(count == 1 ? "commit" : "commits")"
+        case .stashes(let count):
+            return "\(count) \(count == 1 ? "stash" : "stashes")"
+        case .activeSessions(let count):
+            return "\(count) active \(count == 1 ? "session" : "sessions")"
+        case .recentActivity(let days):
+            return days == 0
+                ? "Active today"
+                : "Active \(days) \(days == 1 ? "day" : "days") ago"
+        case .notMerged:
+            return "Not merged"
+        case .mergeStateUnknown(let reason):
+            return "Merge state unknown — \(reason)"
+        case .mainWorktree:
+            return "Main worktree — never removed"
+        case .remoteWorktree:
+            return "Remote worktree — cleanup is not supported yet"
+        case .operationInFlight:
+            return "Another operation is in progress"
+        }
+    }
+}
+
+/// The headline verdict for a worktree, collapsing its signal set.
+enum WorktreeCleanupVerdict: Equatable, Sendable {
+    /// Safe to clean up. Confidence tracks how the merge was established.
+    case candidate(confidence: Confidence)
+    /// Agent or terminal sessions are live, or an app operation is running.
+    case busy
+    /// Uncommitted changes, untracked files, unpushed commits, or stashes.
+    case dirty
+    /// Not merged, or merged but still being worked on.
+    case active
+    /// Structurally ineligible: the main worktree, or a remote/SSH one.
+    case excluded
+
+    enum Confidence: Equatable, Sendable {
+        /// The code host confirmed the merge.
+        case high
+        /// Only a local `merge-base` check confirmed it.
+        case medium
+        /// Merge state is unknown; the worktree simply looks abandoned.
+        case low
+    }
+}
+
+struct WorktreeCleanupCandidate: Identifiable, Equatable, Sendable {
+    let worktree: Worktree
+    let verdict: WorktreeCleanupVerdict
+    /// Blocking signals first, so the UI leads with the disqualifying reason.
+    let signals: [WorktreeCleanupSignal]
+
+    var id: String { worktree.id }
+
+    /// Pre-checked in the cleanup sheet.
+    var isSelectedByDefault: Bool {
+        if case .candidate = verdict { return true }
+        return false
+    }
+
+    /// Whether the user may override and select this row anyway. Dirty and
+    /// busy rows are selectable — that is the per-item override. Excluded
+    /// rows never are, which is what keeps bulk delete off a main worktree.
+    var isSelectable: Bool {
+        verdict != .excluded
+    }
+}

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupTypes.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupTypes.swift
@@ -59,6 +59,7 @@ enum WorktreeCleanupSignal: Equatable, Hashable, Sendable {
     case mainWorktree
     case remoteWorktree
     case operationInFlight
+    case detachedHead
 
     /// True when this signal counts *against* cleanup. Drives both the row's
     /// icon and its sort position — blocking signals render first so the user
@@ -77,7 +78,7 @@ enum WorktreeCleanupSignal: Equatable, Hashable, Sendable {
         case .uncommittedChanges, .untrackedFiles, .unpushedCommits,
              .stashes, .activeSessions, .recentActivity, .notMerged,
              .mergeStateUnknown, .mainWorktree, .remoteWorktree,
-             .operationInFlight:
+             .operationInFlight, .detachedHead:
             return true
         }
     }
@@ -122,6 +123,8 @@ enum WorktreeCleanupSignal: Equatable, Hashable, Sendable {
             return "Remote worktree — cleanup is not supported yet"
         case .operationInFlight:
             return "Another operation is in progress"
+        case .detachedHead:
+            return "Detached HEAD — its commits could become unreachable if removed"
         }
     }
 }
@@ -163,10 +166,15 @@ struct WorktreeCleanupCandidate: Identifiable, Equatable, Sendable {
         return false
     }
 
-    /// Whether the user may override and select this row anyway. Dirty and
-    /// busy rows are selectable — that is the per-item override. Excluded
-    /// rows never are, which is what keeps bulk delete off a main worktree.
+    /// Whether the user may override and select this row anyway. Dirty rows
+    /// are selectable — that is the per-item override, for files the user
+    /// might not care about. Busy rows are not: a live session or process
+    /// might belong to someone else entirely (another window), and both
+    /// batch actions unconditionally skip busy worktrees regardless of
+    /// selection — offering the checkbox anyway would promise an override
+    /// that never happens. Excluded rows never are either, which is what
+    /// keeps bulk delete off a main worktree.
     var isSelectable: Bool {
-        verdict != .excluded
+        verdict != .excluded && verdict != .busy
     }
 }

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -590,6 +590,16 @@ struct ReviewRequest: Identifiable, Equatable, Sendable {
     }
 }
 
+/// A minimal reference to a merged review request. Deliberately far smaller
+/// than `ReviewRequest`: worktree cleanup only needs to answer "was this head
+/// branch merged, and where can I link to it", and building a full
+/// `ReviewRequest` would mean per-item thread and check queries.
+struct MergedReviewRequestRef: Equatable, Sendable {
+    let number: Int
+    let headRefName: String
+    let url: URL
+}
+
 struct ReviewLoopLocalState: Equatable, Sendable {
     let branchName: String
     let headSHA: String

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -598,6 +598,13 @@ struct MergedReviewRequestRef: Equatable, Sendable {
     let number: Int
     let headRefName: String
     let url: URL
+    /// The head commit SHA the code host recorded for this merged review.
+    /// A branch name match alone is not enough to call a worktree
+    /// forge-merged: branch names get reused after an old, unrelated PR on
+    /// the same name merged, so the caller must also verify this SHA is
+    /// actually present in the worktree's current history before trusting
+    /// the match.
+    let headSHA: String
 }
 
 struct ReviewLoopLocalState: Equatable, Sendable {

--- a/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
@@ -243,6 +243,15 @@ protocol CodeHostProvider: Sendable {
 
     func publishReview(_ request: ProviderReviewPublishRequest) async throws -> ProviderReviewPublishResult
     func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult
+
+    /// Merged review requests for the repository, newest first, in one batched
+    /// query. Cleanup needs the whole set at once; asking per branch would be
+    /// one network round-trip per worktree.
+    func mergedReviewRequests(
+        remote: CodeHostRemote,
+        limit: Int,
+        cwd: URL
+    ) async throws -> [MergedReviewRequestRef]
 }
 
 extension CodeHostProvider {
@@ -433,6 +442,17 @@ extension CodeHostProvider {
 
     func mutateReviewThread(_ mutation: ProviderThreadMutation) async throws -> ProviderThreadMutationResult {
         throw CodeHostProviderError.unsupportedProvider(kind)
+    }
+
+    // Throwing rather than returning `[]` is deliberate: an empty list is
+    // indistinguishable from "nothing is merged", and the scanner must be able
+    // to tell those apart so it can report `unknown`.
+    func mergedReviewRequests(
+        remote: CodeHostRemote,
+        limit: Int,
+        cwd: URL
+    ) async throws -> [MergedReviewRequestRef] {
+        throw CodeHostProviderError.unsupportedProvider(remote.kind)
     }
 }
 

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -263,7 +263,7 @@ struct GitHubCLIProvider: CodeHostProvider, CodeHostIssueProviding {
                 "pr", "list",
                 "--state", "merged",
                 "--limit", "\(limit)",
-                "--json", "number,headRefName,url",
+                "--json", "number,headRefName,url,headRefOid",
                 "-R", Self.highLevelRepositorySelector(remote: remote),
             ],
             cwd: cwd
@@ -282,6 +282,7 @@ struct GitHubCLIProvider: CodeHostProvider, CodeHostIssueProviding {
             let number: Int
             let headRefName: String
             let url: URL
+            let headRefOid: String
         }
         do {
             return try JSONDecoder()
@@ -290,7 +291,8 @@ struct GitHubCLIProvider: CodeHostProvider, CodeHostIssueProviding {
                     MergedReviewRequestRef(
                         number: $0.number,
                         headRefName: $0.headRefName,
-                        url: $0.url
+                        url: $0.url,
+                        headSHA: $0.headRefOid
                     )
                 }
         } catch {

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -252,6 +252,54 @@ struct GitHubCLIProvider: CodeHostProvider, CodeHostIssueProviding {
         self.runner = runner
     }
 
+    func mergedReviewRequests(
+        remote: CodeHostRemote,
+        limit: Int,
+        cwd: URL
+    ) async throws -> [MergedReviewRequestRef] {
+        let result = try await runner.run(
+            "gh",
+            args: [
+                "pr", "list",
+                "--state", "merged",
+                "--limit", "\(limit)",
+                "--json", "number,headRefName,url",
+                "-R", Self.highLevelRepositorySelector(remote: remote),
+            ],
+            cwd: cwd
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(
+                command: "gh pr list",
+                stderr: result.stderr
+            )
+        }
+        return try Self.parseMergedPRList(result.stdout)
+    }
+
+    static func parseMergedPRList(_ json: String) throws -> [MergedReviewRequestRef] {
+        struct Item: Decodable {
+            let number: Int
+            let headRefName: String
+            let url: URL
+        }
+        do {
+            return try JSONDecoder()
+                .decode([Item].self, from: Data(json.utf8))
+                .map {
+                    MergedReviewRequestRef(
+                        number: $0.number,
+                        headRefName: $0.headRefName,
+                        url: $0.url
+                    )
+                }
+        } catch {
+            throw CodeHostProviderError.malformedOutput(
+                "Unable to parse gh pr list output"
+            )
+        }
+    }
+
     func isAvailable(cwd: URL) async -> Bool {
         do {
             let result = try await runner.run("gh", args: ["--version"], cwd: cwd)

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -17,6 +17,62 @@ struct GitLabCLIProvider: CodeHostProvider, CodeHostIssueProviding {
         self.runner = runner
     }
 
+    func mergedReviewRequests(
+        remote: CodeHostRemote,
+        limit: Int,
+        cwd: URL
+    ) async throws -> [MergedReviewRequestRef] {
+        let result = try await runner.run(
+            "glab",
+            args: [
+                // glab spells this `--merged`; there is no `--state` flag on
+                // `mr list` (verified against `glab mr list --help`).
+                "mr", "list",
+                "--merged",
+                "--per-page", "\(limit)",
+                "--output", "json",
+                "-R", remote.repositorySlug,
+            ],
+            cwd: cwd
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(
+                command: "glab mr list",
+                stderr: result.stderr
+            )
+        }
+        return try Self.parseMergedMRList(result.stdout)
+    }
+
+    static func parseMergedMRList(_ json: String) throws -> [MergedReviewRequestRef] {
+        struct Item: Decodable {
+            let iid: Int
+            let sourceBranch: String
+            let webURL: URL
+
+            enum CodingKeys: String, CodingKey {
+                case iid
+                case sourceBranch = "source_branch"
+                case webURL = "web_url"
+            }
+        }
+        do {
+            return try JSONDecoder()
+                .decode([Item].self, from: Data(json.utf8))
+                .map {
+                    MergedReviewRequestRef(
+                        number: $0.iid,
+                        headRefName: $0.sourceBranch,
+                        url: $0.webURL
+                    )
+                }
+        } catch {
+            throw CodeHostProviderError.malformedOutput(
+                "Unable to parse glab mr list output"
+            )
+        }
+    }
+
     func isAvailable(cwd: URL) async -> Bool {
         do {
             let result = try await runner.run("glab", args: ["--version"], cwd: cwd)

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -49,11 +49,17 @@ struct GitLabCLIProvider: CodeHostProvider, CodeHostIssueProviding {
             let iid: Int
             let sourceBranch: String
             let webURL: URL
+            // GitLab's merge request objects carry `sha`: the SHA of the
+            // most recent commit on the source branch as of the MR. `glab
+            // mr list --output json` has no field-selection flag, so this
+            // is already present in the full object without extra args.
+            let sha: String
 
             enum CodingKeys: String, CodingKey {
                 case iid
                 case sourceBranch = "source_branch"
                 case webURL = "web_url"
+                case sha
             }
         }
         do {
@@ -63,7 +69,8 @@ struct GitLabCLIProvider: CodeHostProvider, CodeHostIssueProviding {
                     MergedReviewRequestRef(
                         number: $0.iid,
                         headRefName: $0.sourceBranch,
-                        url: $0.webURL
+                        url: $0.webURL,
+                        headSHA: $0.sha
                     )
                 }
         } catch {

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -105,12 +105,14 @@ struct AppConfig: Codable, Equatable {
         var pruneStale: Bool
         var fetchRemoteBeforeCreate: Bool
         var defaultOrdering: WorktreeSortMode
+        /// Days a worktree must sit untouched before cleanup considers it idle.
+        var cleanupIdleDays: Int
 
         enum CodingKeys: String, CodingKey {
             case rootPath, pathTemplate, branchPrefix, baseBranch,
                  trackUpstream, deleteBranchOnRemove, autoFetch,
                  fetchIntervalMinutes, pruneStale, fetchRemoteBeforeCreate,
-                 defaultOrdering
+                 defaultOrdering, cleanupIdleDays
         }
 
         init(
@@ -124,7 +126,8 @@ struct AppConfig: Codable, Equatable {
             fetchIntervalMinutes: Int,
             pruneStale: Bool,
             fetchRemoteBeforeCreate: Bool = false,
-            defaultOrdering: WorktreeSortMode = .lastUpdateDesc
+            defaultOrdering: WorktreeSortMode = .lastUpdateDesc,
+            cleanupIdleDays: Int = 14
         ) {
             self.rootPath = rootPath
             self.pathTemplate = pathTemplate
@@ -137,6 +140,7 @@ struct AppConfig: Codable, Equatable {
             self.pruneStale = pruneStale
             self.fetchRemoteBeforeCreate = fetchRemoteBeforeCreate
             self.defaultOrdering = defaultOrdering
+            self.cleanupIdleDays = cleanupIdleDays
         }
 
         init(from decoder: Decoder) throws {
@@ -152,6 +156,7 @@ struct AppConfig: Codable, Equatable {
             pruneStale = try c.decode(Bool.self, forKey: .pruneStale)
             fetchRemoteBeforeCreate = (try? c.decode(Bool.self, forKey: .fetchRemoteBeforeCreate)) ?? false
             defaultOrdering = (try? c.decode(WorktreeSortMode.self, forKey: .defaultOrdering)) ?? .lastUpdateDesc
+            cleanupIdleDays = (try? c.decode(Int.self, forKey: .cleanupIdleDays)) ?? 14
         }
     }
 

--- a/Alas/Sources/Settings/WorktreesPane.swift
+++ b/Alas/Sources/Settings/WorktreesPane.swift
@@ -67,6 +67,14 @@ struct WorktreesPane: View {
                                 desc: "When removing a worktree, also delete its local branch if merged.") {
                         AlasToggle(on: bind(\.worktrees.deleteBranchOnRemove))
                     }
+                    SettingsRow(name: "Idle threshold",
+                                desc: "Days a worktree must sit untouched before cleanup treats it as idle.") {
+                        Stepper(
+                            "\(state.config.worktrees.cleanupIdleDays) days",
+                            value: idleThresholdBinding,
+                            in: 1...365
+                        )
+                    }
                 }
 
                 if hasAnyArchived {
@@ -102,6 +110,16 @@ struct WorktreesPane: View {
         Binding(
             get: { state.config.worktrees.defaultOrdering },
             set: { state.setDefaultWorktreeOrdering($0) }
+        )
+    }
+
+    private var idleThresholdBinding: Binding<Int> {
+        Binding(
+            get: { state.config.worktrees.cleanupIdleDays },
+            set: {
+                state.config.worktrees.cleanupIdleDays = $0
+                state.saveConfig()
+            }
         )
     }
 

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -34,6 +34,7 @@ struct RepoGroupView: View {
     let onCopyBranch: (Worktree) -> Void
     let onRevealInFinder: (Worktree) -> Void
     let onArchive: (Worktree) -> Void
+    let onCleanupWorktrees: () -> Void
     let onDelete: (Worktree) -> Void
     let onDeleteKeepBranch: (Worktree) -> Void
     let showKeepBranchOption: Bool
@@ -97,6 +98,7 @@ struct RepoGroupView: View {
                 }
                 Button("Reset Sort to Default", action: onResetSort)
                     .disabled(!project.worktreeOrderIsManual)
+                Button("Clean Up Worktrees…", action: onCleanupWorktrees)
                 Menu("Spaces") {
                     ForEach(spaces) { space in
                         let isMember = isProjectInSpace(space.id)

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -9,6 +9,7 @@ struct SidebarView: View {
     let onEditProject: (_ projectId: String) -> Void
     let onRemoveProject: (_ projectId: String) -> Void
     let onNewWorktree: (_ projectId: String?) -> Void
+    let onCleanupWorktrees: (_ projectId: String) -> Void
     let onHideSidebar: () -> Void
     @Environment(\.theme) var theme
     @State private var spaceTitleVisible = false
@@ -114,6 +115,7 @@ struct SidebarView: View {
                                     NSWorkspace.shared.activateFileViewerSelecting([wt.path])
                                 },
                                 onArchive: { wt in state.archiveWorktree(wt) },
+                                onCleanupWorktrees: { onCleanupWorktrees(project.id) },
                                 onDelete: { wt in state.deleteWorktree(wt) },
                                 onDeleteKeepBranch: { wt in state.deleteWorktree(wt, keepBranch: true) },
                                 showKeepBranchOption: state.config.worktrees.deleteBranchOnRemove,

--- a/AlasTests/AppStateWorktreeArchiveBatchTests.swift
+++ b/AlasTests/AppStateWorktreeArchiveBatchTests.swift
@@ -1,0 +1,90 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+struct AppStateWorktreeArchiveBatchTests {
+    @Test func batchArchiveHidesEveryItemWithoutTouchingDisk() async throws {
+        let fixture = try await makeCleanupFixture(worktreeCount: 3)
+        let targets = Array(fixture.worktrees.dropFirst())
+
+        let results = fixture.state.batchArchiveWorktrees(targets)
+
+        #expect(results.allSatisfy { $0.outcome == .archived })
+        #expect(fixture.state.projectsManager
+            .archivedWorktrees(projectId: fixture.project.id).count == targets.count)
+        #expect(fixture.state.projectsManager
+            .visibleWorktrees(projectId: fixture.project.id)
+            .allSatisfy { wt in !targets.contains { $0.id == wt.id } })
+        // Files are untouched.
+        for target in targets {
+            #expect(FileManager.default.fileExists(atPath: target.path.path))
+        }
+    }
+
+    @Test func batchArchiveSkipsMainWorktree() async throws {
+        let fixture = try await makeCleanupFixture(worktreeCount: 2)
+        let main = fixture.worktrees[0]
+
+        let results = fixture.state.batchArchiveWorktrees([main])
+
+        #expect(results[0].outcome == .skipped(reason: "Main worktree"))
+        #expect(fixture.state.projectsManager
+            .archivedWorktrees(projectId: fixture.project.id).isEmpty)
+    }
+
+    @Test func archiveRoundTripRestoresTheWorktree() async throws {
+        let fixture = try await makeCleanupFixture(worktreeCount: 2)
+        let target = fixture.worktrees[1]
+
+        _ = fixture.state.batchArchiveWorktrees([target])
+        #expect(fixture.state.projectsManager
+            .visibleWorktrees(projectId: fixture.project.id)
+            .contains { $0.id == target.id } == false)
+
+        fixture.state.unarchiveWorktree(
+            projectId: fixture.project.id,
+            path: target.path
+        )
+        #expect(fixture.state.projectsManager
+            .visibleWorktrees(projectId: fixture.project.id)
+            .contains { $0.id == target.id })
+        #expect(fixture.state.projectsManager
+            .archivedWorktrees(projectId: fixture.project.id).isEmpty)
+    }
+
+    /// Archive state lives in `ProjectConfig.hiddenWorktreePaths`, which is
+    /// what persists to disk — so a config round-trip is the relaunch test.
+    @Test func archivedStateSurvivesAConfigRoundTrip() throws {
+        var project = ProjectConfig(
+            id: "p",
+            name: "alas",
+            path: "/tmp/repo",
+            color: "blue",
+            addedAt: Date()
+        )
+        project.hiddenWorktreePaths = ["/tmp/wt-a", "/tmp/wt-b"]
+
+        let data = try JSONEncoder().encode(project)
+        let decoded = try JSONDecoder().decode(ProjectConfig.self, from: data)
+
+        #expect(decoded.hiddenWorktreePaths == ["/tmp/wt-a", "/tmp/wt-b"])
+    }
+
+    @Test func unarchivedStateSurvivesAConfigRoundTrip() throws {
+        var project = ProjectConfig(
+            id: "p",
+            name: "alas",
+            path: "/tmp/repo",
+            color: "blue",
+            addedAt: Date(),
+            hiddenWorktreePaths: ["/tmp/wt-a"]
+        )
+        project.hiddenWorktreePaths.removeAll { $0 == "/tmp/wt-a" }
+
+        let data = try JSONEncoder().encode(project)
+        let decoded = try JSONDecoder().decode(ProjectConfig.self, from: data)
+
+        #expect(decoded.hiddenWorktreePaths.isEmpty)
+    }
+}

--- a/AlasTests/AppStateWorktreeCleanupBatchTests.swift
+++ b/AlasTests/AppStateWorktreeCleanupBatchTests.swift
@@ -74,6 +74,26 @@ struct AppStateWorktreeCleanupBatchTests {
         #expect(fixture.state.pendingForceDeleteWorktree == nil)
     }
 
+    /// The batch skips per-item selection reconciliation (its list is still
+    /// stale mid-run) and reconciles once at the end. Without that final pass
+    /// the selection stays pinned to a worktree that no longer exists.
+    @Test func selectionIsReconciledAfterBatchDeletesTheSelectedWorktree() async throws {
+        let fixture = try await makeCleanupFixture(worktreeCount: 3)
+        let targets = Array(fixture.worktrees.dropFirst())
+        fixture.state.selectWorktree(id: targets[0].id)
+        #expect(fixture.state.selectedWorktreeId == targets[0].id)
+
+        _ = await fixture.state.batchDeleteWorktrees(targets, keepBranch: false)
+
+        #expect(fixture.state.selectedWorktreeId != targets[0].id)
+        #expect(fixture.state.selectedWorktreeId != targets[1].id)
+        if let selected = fixture.state.selectedWorktreeId {
+            #expect(fixture.state.projectsManager
+                .worktrees(projectId: fixture.project.id)
+                .contains { $0.id == selected })
+        }
+    }
+
     @Test func emptySelectionReturnsNoResultsAndTouchesNothing() async throws {
         let fixture = try await makeCleanupFixture(worktreeCount: 2)
         let before = fixture.state.projectsManager

--- a/AlasTests/AppStateWorktreeCleanupBatchTests.swift
+++ b/AlasTests/AppStateWorktreeCleanupBatchTests.swift
@@ -1,0 +1,88 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct AppStateWorktreeCleanupBatchTests {
+    @Test func mainWorktreeIsSkippedAndNeverDeleted() async throws {
+        let fixture = try await makeCleanupFixture(worktreeCount: 2)
+        let main = fixture.worktrees[0]   // fixture marks index 0 as main
+
+        let results = await fixture.state.batchDeleteWorktrees(
+            [main],
+            keepBranch: false
+        )
+
+        #expect(results.count == 1)
+        #expect(results[0].outcome == .skipped(reason: "Main worktree"))
+        #expect(fixture.state.projectsManager
+            .worktrees(projectId: fixture.project.id)
+            .contains { $0.id == main.id })
+    }
+
+    @Test func oneFailingItemDoesNotAbortTheBatch() async throws {
+        let fixture = try await makeCleanupFixture(worktreeCount: 3)
+        let targets = Array(fixture.worktrees.dropFirst())   // skip main
+
+        // Remove the second target's directory out from under git so its
+        // removal fails while its siblings succeed.
+        try FileManager.default.removeItem(at: targets[0].path)
+        try Process.corruptWorktreeRegistration(targets[0])
+
+        let results = await fixture.state.batchDeleteWorktrees(
+            targets,
+            keepBranch: false
+        )
+
+        #expect(results.count == targets.count)
+        #expect(results.contains { $0.outcome != .deleted })
+        #expect(results.contains { $0.outcome == .deleted })
+    }
+
+    @Test func everySelectedItemGetsItsOwnResult() async throws {
+        let fixture = try await makeCleanupFixture(worktreeCount: 3)
+        let targets = Array(fixture.worktrees.dropFirst())
+
+        let results = await fixture.state.batchDeleteWorktrees(
+            targets,
+            keepBranch: false
+        )
+
+        #expect(Set(results.map(\.worktreeId)) == Set(targets.map(\.id)))
+        #expect(results.map(\.branch) == targets.map(\.branch))
+    }
+
+    /// A batch must never pop a modal mid-run. A worktree git refuses to remove
+    /// without `--force` is reported back, not escalated into the app-wide
+    /// force-delete alert.
+    @Test func dirtyWorktreeReportsNeedsForceWithoutRaisingTheForceAlert() async throws {
+        let fixture = try await makeCleanupFixture(worktreeCount: 2)
+        let target = fixture.worktrees[1]
+        try "scratch".write(
+            to: target.path.appendingPathComponent("untracked.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let results = await fixture.state.batchDeleteWorktrees(
+            [target],
+            keepBranch: false
+        )
+
+        #expect(results[0].outcome == .needsForce)
+        #expect(fixture.state.pendingForceDeleteWorktree == nil)
+    }
+
+    @Test func emptySelectionReturnsNoResultsAndTouchesNothing() async throws {
+        let fixture = try await makeCleanupFixture(worktreeCount: 2)
+        let before = fixture.state.projectsManager
+            .worktrees(projectId: fixture.project.id).count
+
+        let results = await fixture.state.batchDeleteWorktrees([], keepBranch: false)
+
+        #expect(results.isEmpty)
+        #expect(fixture.state.projectsManager
+            .worktrees(projectId: fixture.project.id).count == before)
+    }
+}

--- a/AlasTests/AppStateWorktreeCleanupBatchTests.swift
+++ b/AlasTests/AppStateWorktreeCleanupBatchTests.swift
@@ -94,6 +94,27 @@ struct AppStateWorktreeCleanupBatchTests {
         }
     }
 
+    /// The scan that produced a worktree's cached `Worktree.branch` can be
+    /// stale by the time the batch actually runs. If something switches the
+    /// checkout to a detached HEAD in that window, deleting on the stale
+    /// cached branch name would remove a worktree whose commits are now
+    /// reachable only via that detached HEAD — orphaning them. The batch
+    /// must re-read the current branch immediately before removal.
+    @Test func batchSkipsAWorktreeWhoseBranchChangedSinceTheScan() async throws {
+        let fixture = try await makeCleanupFixture(worktreeCount: 2)
+        let target = fixture.worktrees[1]
+
+        // Simulate an external actor detaching HEAD in this worktree after
+        // the scan captured `target` as a named-branch `Worktree` value.
+        let detach = try await Process.git(["checkout", "--detach"], cwd: target.path)
+        #expect(detach.exitCode == 0)
+
+        let results = await fixture.state.batchDeleteWorktrees([target], keepBranch: false)
+
+        #expect(results[0].outcome == .skipped(reason: "Branch changed since this list was scanned"))
+        #expect(FileManager.default.fileExists(atPath: target.path.path))
+    }
+
     @Test func emptySelectionReturnsNoResultsAndTouchesNothing() async throws {
         let fixture = try await makeCleanupFixture(worktreeCount: 2)
         let before = fixture.state.projectsManager

--- a/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
+++ b/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
@@ -144,7 +144,7 @@ struct WorktreeCleanupModelTests {
             scan: { .success([a, b]) },
             deleteBatch: { _, _ in [] },
             archiveBatch: { _ in [] },
-            confirm: { _, _ in true }
+            confirm: { _, _, _ in true }
         )
         await model.runScan()
         #expect(model.selectedIds == ["/tmp/wt-a", "/tmp/wt-b"])
@@ -154,6 +154,89 @@ struct WorktreeCleanupModelTests {
 
         await model.runScan()       // a real rescan through the public API
         #expect(model.selectedIds == ["/tmp/wt-b"])
+    }
+
+    /// Bulk archive tears down tabs, terminals and agent sessions that are not
+    /// recreated on restore, so it must prompt exactly like bulk delete does.
+    @Test func archiveSelectedIsGatedOnConfirmation() async {
+        let a = candidate(branch: "a", verdict: .candidate(confidence: .high))
+        var confirmCalls: [(title: String, message: String, button: String)] = []
+        var archiveBatchCalls = 0
+        let model = WorktreeCleanupModel(
+            projectId: "p",
+            keepBranches: false,
+            scan: { .success([a]) },
+            deleteBatch: { _, _ in [] },
+            archiveBatch: { worktrees in
+                archiveBatchCalls += 1
+                return worktrees.map {
+                    WorktreeBatchResult(worktreeId: $0.id, branch: $0.branch, outcome: .archived)
+                }
+            },
+            confirm: { title, message, button in
+                confirmCalls.append((title, message, button))
+                return false   // decline — nothing should archive
+            }
+        )
+        model.applyScanResult([a])
+
+        await model.archiveSelected()
+
+        #expect(confirmCalls.count == 1)
+        #expect(confirmCalls[0].title.contains("Archive"))
+        #expect(confirmCalls[0].message.contains("a"))
+        #expect(confirmCalls[0].button == "Archive")
+        #expect(archiveBatchCalls == 0)
+        #expect(model.results.isEmpty)
+    }
+
+    @Test func archiveSelectedProceedsWhenConfirmed() async {
+        let a = candidate(branch: "a", verdict: .candidate(confidence: .high))
+        var archiveBatchCalls = 0
+        let model = WorktreeCleanupModel(
+            projectId: "p",
+            keepBranches: false,
+            scan: { .success([a]) },
+            deleteBatch: { _, _ in [] },
+            archiveBatch: { worktrees in
+                archiveBatchCalls += 1
+                return worktrees.map {
+                    WorktreeBatchResult(worktreeId: $0.id, branch: $0.branch, outcome: .archived)
+                }
+            },
+            confirm: { _, _, _ in true }
+        )
+        model.applyScanResult([a])
+
+        await model.archiveSelected()
+
+        #expect(archiveBatchCalls == 1)
+    }
+
+    @Test func deleteSelectedIsGatedOnConfirmation() async {
+        let a = candidate(branch: "a", verdict: .candidate(confidence: .high))
+        var deleteBatchCalls = 0
+        var confirmButtons: [String] = []
+        let model = WorktreeCleanupModel(
+            projectId: "p",
+            keepBranches: false,
+            scan: { .success([a]) },
+            deleteBatch: { _, _ in
+                deleteBatchCalls += 1
+                return []
+            },
+            archiveBatch: { _ in [] },
+            confirm: { _, _, button in
+                confirmButtons.append(button)
+                return false
+            }
+        )
+        model.applyScanResult([a])
+
+        await model.deleteSelected()
+
+        #expect(confirmButtons == ["Delete"])
+        #expect(deleteBatchCalls == 0)
     }
 
     @Test func selectedWorktreesFollowsDisplayOrder() {

--- a/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
+++ b/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
@@ -63,14 +63,17 @@ struct WorktreeCleanupModelTests {
     }
 
     @Test func confirmationNamesEveryWorktreeAndTheBranchPolicy() {
+        // Branch names deliberately avoid letters already present in the
+        // surrounding prose ("worktrees", "branches", "are removed") so the
+        // assertions can only pass if the bullet list is actually populated.
         let model = WorktreeCleanupModel.forTesting(candidates: [
-            candidate(branch: "a", verdict: .candidate(confidence: .high)),
-            candidate(branch: "b", verdict: .candidate(confidence: .medium)),
+            candidate(branch: "feature-alpha", verdict: .candidate(confidence: .high)),
+            candidate(branch: "feature-beta", verdict: .candidate(confidence: .medium)),
         ])
         model.keepBranches = false
         let message = model.confirmationMessage()
-        #expect(message.contains("a"))
-        #expect(message.contains("b"))
+        #expect(message.contains("feature-alpha"))
+        #expect(message.contains("feature-beta"))
         #expect(message.lowercased().contains("branch"))
 
         model.keepBranches = true
@@ -106,16 +109,51 @@ struct WorktreeCleanupModelTests {
 
     /// Rows that vanished from a rescan — typically because they were just
     /// deleted — must drop out of the selection rather than linger as ids
-    /// pointing at nothing.
+    /// pointing at nothing. Candidate "b" is `.dirty` — never in the default
+    /// selection — so its survival across the first rescan, and its absence
+    /// after the second, can only be explained by real intersection against
+    /// the manual selection, not by an implementation that always resets to
+    /// `defaultSelection`.
     @Test func rescanDropsSelectedRowsThatDisappeared() {
-        let model = WorktreeCleanupModel.forTesting(candidates: [
-            candidate(branch: "a", verdict: .candidate(confidence: .high)),
-            candidate(branch: "b", verdict: .candidate(confidence: .high)),
-        ])
+        let a = candidate(branch: "a", verdict: .candidate(confidence: .high))
+        let b = candidate(branch: "b", verdict: .dirty)
+        let model = WorktreeCleanupModel.forTesting(candidates: [a, b])
+        #expect(model.selectedIds == ["/tmp/wt-a"])
+
+        model.toggle("/tmp/wt-b")   // per-item override selects the dirty row
         #expect(model.selectedIds == ["/tmp/wt-a", "/tmp/wt-b"])
 
-        model.applyScanResult([candidate(branch: "a", verdict: .candidate(confidence: .high))])
+        model.applyScanResult([a, b])
+        #expect(model.selectedIds == ["/tmp/wt-a", "/tmp/wt-b"])
+
+        model.applyScanResult([a])
         #expect(model.selectedIds == ["/tmp/wt-a"])
+    }
+
+    /// Drives a rescan through `runScan()` itself, not `applyScanResult`
+    /// directly — this is the entry point the Refresh button and any
+    /// production rescan actually use, and `scanState` is `.scanning` for
+    /// the duration of the call, which is exactly what broke a prior
+    /// implementation that read `scanState` to decide whether to reconcile.
+    @Test func runScanThroughItsPublicEntryPointKeepsManualSelection() async {
+        let a = candidate(branch: "a", verdict: .candidate(confidence: .high))
+        let b = candidate(branch: "b", verdict: .candidate(confidence: .high))
+        let model = WorktreeCleanupModel(
+            projectId: "p",
+            keepBranches: false,
+            scan: { .success([a, b]) },
+            deleteBatch: { _, _ in [] },
+            archiveBatch: { _ in [] },
+            confirm: { _, _ in true }
+        )
+        await model.runScan()
+        #expect(model.selectedIds == ["/tmp/wt-a", "/tmp/wt-b"])
+
+        model.toggle("/tmp/wt-a")   // manual deselection, leaving only b
+        #expect(model.selectedIds == ["/tmp/wt-b"])
+
+        await model.runScan()       // a real rescan through the public API
+        #expect(model.selectedIds == ["/tmp/wt-b"])
     }
 
     @Test func selectedWorktreesFollowsDisplayOrder() {

--- a/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
+++ b/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
@@ -1,0 +1,129 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+struct WorktreeCleanupModelTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func candidate(
+        branch: String,
+        verdict: WorktreeCleanupVerdict,
+        signals: [WorktreeCleanupSignal] = []
+    ) -> WorktreeCleanupCandidate {
+        WorktreeCleanupCandidate(
+            worktree: Worktree(
+                id: "/tmp/wt-\(branch)",
+                projectId: "p",
+                name: branch,
+                branch: branch,
+                path: URL(fileURLWithPath: "/tmp/wt-\(branch)"),
+                isMainWorktree: verdict == .excluded,
+                status: .clean,
+                lastActivity: now
+            ),
+            verdict: verdict,
+            signals: signals
+        )
+    }
+
+    @Test func candidatesAreSelectedByDefaultAndOthersAreNot() {
+        let candidates = [
+            candidate(branch: "a", verdict: .candidate(confidence: .high)),
+            candidate(branch: "b", verdict: .dirty),
+            candidate(branch: "c", verdict: .busy),
+            candidate(branch: "d", verdict: .excluded),
+        ]
+        let selection = WorktreeCleanupModel.defaultSelection(from: candidates)
+        #expect(selection == ["/tmp/wt-a"])
+    }
+
+    @Test func togglingSelectsAndDeselectsAnOverridableRow() {
+        let model = WorktreeCleanupModel.forTesting(candidates: [
+            candidate(branch: "a", verdict: .candidate(confidence: .high)),
+            candidate(branch: "b", verdict: .dirty),
+        ])
+        #expect(model.selectedIds == ["/tmp/wt-a"])
+
+        model.toggle("/tmp/wt-b")
+        #expect(model.selectedIds == ["/tmp/wt-a", "/tmp/wt-b"])
+
+        model.toggle("/tmp/wt-a")
+        #expect(model.selectedIds == ["/tmp/wt-b"])
+    }
+
+    /// Per-item override may select a dirty or busy worktree, but never an
+    /// excluded one — that is what keeps bulk delete off a main worktree.
+    @Test func excludedRowsCannotBeSelected() {
+        let model = WorktreeCleanupModel.forTesting(candidates: [
+            candidate(branch: "main", verdict: .excluded, signals: [.mainWorktree]),
+        ])
+        model.toggle("/tmp/wt-main")
+        #expect(model.selectedIds.isEmpty)
+    }
+
+    @Test func confirmationNamesEveryWorktreeAndTheBranchPolicy() {
+        let model = WorktreeCleanupModel.forTesting(candidates: [
+            candidate(branch: "a", verdict: .candidate(confidence: .high)),
+            candidate(branch: "b", verdict: .candidate(confidence: .medium)),
+        ])
+        model.keepBranches = false
+        let message = model.confirmationMessage()
+        #expect(message.contains("a"))
+        #expect(message.contains("b"))
+        #expect(message.lowercased().contains("branch"))
+
+        model.keepBranches = true
+        #expect(model.confirmationMessage().lowercased().contains("kept"))
+    }
+
+    @Test func summaryCountsEachOutcomeKind() {
+        let results = [
+            WorktreeBatchResult(worktreeId: "1", branch: "a", outcome: .deleted),
+            WorktreeBatchResult(worktreeId: "2", branch: "b", outcome: .deleted),
+            WorktreeBatchResult(worktreeId: "3", branch: "c", outcome: .failed(message: "boom")),
+            WorktreeBatchResult(worktreeId: "4", branch: "d", outcome: .needsForce),
+            WorktreeBatchResult(worktreeId: "5", branch: "e", outcome: .skipped(reason: "Main worktree")),
+        ]
+        let summary = WorktreeCleanupModel.summary(for: results)
+        #expect(summary.contains("2 deleted"))
+        #expect(summary.contains("1 failed"))
+    }
+
+    /// A rescan must not silently undo the user's manual selection.
+    @Test func rescanKeepsManualSelectionForRowsThatStillExist() {
+        let all = [
+            candidate(branch: "a", verdict: .candidate(confidence: .high)),
+            candidate(branch: "b", verdict: .candidate(confidence: .high)),
+        ]
+        let model = WorktreeCleanupModel.forTesting(candidates: all)
+        model.toggle("/tmp/wt-a")   // deselect a, leaving b
+        #expect(model.selectedIds == ["/tmp/wt-b"])
+
+        model.applyScanResult(all)
+        #expect(model.selectedIds == ["/tmp/wt-b"])
+    }
+
+    /// Rows that vanished from a rescan — typically because they were just
+    /// deleted — must drop out of the selection rather than linger as ids
+    /// pointing at nothing.
+    @Test func rescanDropsSelectedRowsThatDisappeared() {
+        let model = WorktreeCleanupModel.forTesting(candidates: [
+            candidate(branch: "a", verdict: .candidate(confidence: .high)),
+            candidate(branch: "b", verdict: .candidate(confidence: .high)),
+        ])
+        #expect(model.selectedIds == ["/tmp/wt-a", "/tmp/wt-b"])
+
+        model.applyScanResult([candidate(branch: "a", verdict: .candidate(confidence: .high))])
+        #expect(model.selectedIds == ["/tmp/wt-a"])
+    }
+
+    @Test func selectedWorktreesFollowsDisplayOrder() {
+        let model = WorktreeCleanupModel.forTesting(candidates: [
+            candidate(branch: "a", verdict: .candidate(confidence: .high)),
+            candidate(branch: "b", verdict: .candidate(confidence: .high)),
+            candidate(branch: "c", verdict: .candidate(confidence: .high)),
+        ])
+        #expect(model.selectedWorktrees().map(\.branch) == ["a", "b", "c"])
+    }
+}

--- a/AlasTests/Git/WorktreeCleanupClassifierTests.swift
+++ b/AlasTests/Git/WorktreeCleanupClassifierTests.swift
@@ -154,6 +154,18 @@ struct WorktreeCleanupClassifierTests {
         #expect(Self.classify(probe).verdict == .busy)
     }
 
+    /// A busy row is never selectable — unlike dirty, which the user may
+    /// override. Both batch actions unconditionally skip busy worktrees
+    /// regardless of selection, so offering the checkbox would promise an
+    /// override that never actually happens.
+    @Test func busyWorktreeIsNotSelectable() {
+        var probe = Self.idealProbe()
+        probe.activeSessionCount = 1
+        let result = Self.classify(probe)
+        #expect(result.verdict == .busy)
+        #expect(!result.isSelectable)
+    }
+
     @Test func recentlyTouchedMergedWorktreeIsActiveNotACandidate() {
         let probe = Self.idealProbe(daysIdle: 2)
         let result = Self.classify(probe, idleThresholdDays: 14)
@@ -199,6 +211,34 @@ struct WorktreeCleanupClassifierTests {
         #expect(!result.isSelectable)
         #expect(WorktreeCleanupSignal.remoteWorktree.label
                 == "Remote worktree — cleanup is not supported yet")
+    }
+
+    /// A detached-HEAD worktree's commits are reachable only via that
+    /// worktree's own HEAD. Removing it — even a clean one, even with git's
+    /// own dirty-tree protections satisfied — makes those commits
+    /// unreachable and eventually GC-eligible, unlike a branch's commits,
+    /// which stay reachable via the branch ref. Never a candidate, and never
+    /// selectable via the per-item override that a merely-dirty row gets.
+    @Test func detachedHeadWorktreeIsExcludedAndUnselectable() {
+        let result = Self.classify(
+            Self.idealProbe(),
+            worktree: Self.worktree(branch: "(detached)")
+        )
+        #expect(result.verdict == .excluded)
+        #expect(result.signals.contains(.detachedHead))
+        #expect(!result.isSelectable)
+    }
+
+    @Test func detachedHeadExclusionOutranksBusyAndDirty() {
+        var probe = Self.idealProbe()
+        probe.activeSessionCount = 4
+        probe.hasUncommittedChanges = true
+        let result = Self.classify(
+            probe,
+            worktree: Self.worktree(branch: "(detached)")
+        )
+        #expect(result.verdict == .excluded)
+        #expect(!result.isSelectable)
     }
 
     @Test func blockingSignalsSortBeforeQualifyingOnes() {

--- a/AlasTests/Git/WorktreeCleanupClassifierTests.swift
+++ b/AlasTests/Git/WorktreeCleanupClassifierTests.swift
@@ -1,0 +1,224 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct WorktreeCleanupClassifierTests {
+    private static let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private static func worktree(
+        branch: String = "feature/x",
+        isMain: Bool = false
+    ) -> Worktree {
+        Worktree(
+            id: "/tmp/wt-\(branch)",
+            projectId: "p",
+            name: branch,
+            branch: branch,
+            path: URL(fileURLWithPath: "/tmp/wt-\(branch)"),
+            isMainWorktree: isMain,
+            status: .clean,
+            lastActivity: now
+        )
+    }
+
+    /// Baseline: merged on the forge, clean, pushed, idle, nothing running.
+    private static func idealProbe(daysIdle: Int = 30) -> WorktreeCleanupProbe {
+        WorktreeCleanupProbe(
+            isMainWorktree: false,
+            isRemote: false,
+            hasUncommittedChanges: false,
+            hasUntrackedFiles: false,
+            unpushedCommitCount: 0,
+            stashCount: 0,
+            activeSessionCount: 0,
+            operationInFlight: false,
+            lastActivity: now.addingTimeInterval(-Double(daysIdle) * 86_400),
+            mergeState: .mergedOnForge(
+                identity: "GitHub #42",
+                url: URL(string: "https://github.com/o/r/pull/42")!
+            )
+        )
+    }
+
+    private static func classify(
+        _ probe: WorktreeCleanupProbe,
+        worktree: Worktree = worktree(),
+        idleThresholdDays: Int = 14
+    ) -> WorktreeCleanupCandidate {
+        WorktreeCleanupClassifier.classify(
+            worktree: worktree,
+            probe: probe,
+            now: now,
+            idleThresholdDays: idleThresholdDays
+        )
+    }
+
+    @Test func forgeMergedIdleWorktreeIsHighConfidenceCandidate() {
+        let result = Self.classify(Self.idealProbe())
+        #expect(result.verdict == .candidate(confidence: .high))
+        #expect(result.isSelectedByDefault)
+        #expect(result.signals.contains {
+            if case .mergedOnForge = $0 { return true } else { return false }
+        })
+    }
+
+    @Test func locallyMergedWorktreeIsMediumConfidence() {
+        var probe = Self.idealProbe()
+        probe.mergeState = .mergedLocally(base: "main")
+        let result = Self.classify(probe)
+        #expect(result.verdict == .candidate(confidence: .medium))
+        #expect(result.signals.contains(.mergedLocally(base: "main")))
+    }
+
+    /// The acceptance criterion: a code-host check that failed must not be
+    /// presented the same way as a branch that genuinely is not merged.
+    @Test func unknownMergeStateIsNeverReportedAsNotMerged() {
+        var probe = Self.idealProbe()
+        probe.mergeState = .unknown(reason: "gh pr list failed")
+        let result = Self.classify(probe)
+        #expect(!result.signals.contains(.notMerged))
+        #expect(result.signals.contains(.mergeStateUnknown(reason: "gh pr list failed")))
+    }
+
+    @Test func unknownMergeStateWithLongIdleIsLowConfidenceCandidate() {
+        var probe = Self.idealProbe(daysIdle: 30)
+        probe.mergeState = .unknown(reason: "gh pr list failed")
+        #expect(Self.classify(probe).verdict == .candidate(confidence: .low))
+    }
+
+    /// `isBlocking` drives icon and sort order, not candidacy — a clean, long
+    /// idle worktree whose merge state could not be determined is still offered
+    /// (at low confidence) with the caution shown alongside it.
+    @Test func lowConfidenceCandidateIsStillSelectedDespiteACautionSignal() {
+        var probe = Self.idealProbe(daysIdle: 30)
+        probe.mergeState = .unknown(reason: "gh pr list failed")
+        let result = Self.classify(probe)
+        #expect(result.isSelectedByDefault)
+        #expect(result.signals.contains { $0.isBlocking })
+    }
+
+    @Test func notMergedWorktreeIsNeverACandidate() {
+        var probe = Self.idealProbe(daysIdle: 90)
+        probe.mergeState = .notMerged
+        let result = Self.classify(probe)
+        #expect(result.verdict == .active)
+        #expect(result.signals.contains(.notMerged))
+    }
+
+    @Test func uncommittedChangesBlockCandidacyWithVisibleReason() {
+        var probe = Self.idealProbe()
+        probe.hasUncommittedChanges = true
+        let result = Self.classify(probe)
+        #expect(result.verdict == .dirty)
+        #expect(result.signals.first == .uncommittedChanges)
+        #expect(!result.isSelectedByDefault)
+        #expect(result.isSelectable)
+    }
+
+    @Test func untrackedFilesBlockCandidacy() {
+        var probe = Self.idealProbe()
+        probe.hasUntrackedFiles = true
+        let result = Self.classify(probe)
+        #expect(result.verdict == .dirty)
+        #expect(result.signals.contains(.untrackedFiles))
+    }
+
+    @Test func unpushedCommitsBlockCandidacy() {
+        var probe = Self.idealProbe()
+        probe.unpushedCommitCount = 3
+        let result = Self.classify(probe)
+        #expect(result.verdict == .dirty)
+        #expect(result.signals.contains(.unpushedCommits(count: 3)))
+    }
+
+    @Test func stashesBlockCandidacy() {
+        var probe = Self.idealProbe()
+        probe.stashCount = 2
+        let result = Self.classify(probe)
+        #expect(result.verdict == .dirty)
+        #expect(result.signals.contains(.stashes(count: 2)))
+    }
+
+    @Test func activeSessionsBlockCandidacyAndOutrankDirtiness() {
+        var probe = Self.idealProbe()
+        probe.activeSessionCount = 1
+        probe.hasUncommittedChanges = true
+        let result = Self.classify(probe)
+        #expect(result.verdict == .busy)
+        #expect(result.signals.contains(.activeSessions(count: 1)))
+    }
+
+    @Test func inFlightOperationMakesWorktreeBusy() {
+        var probe = Self.idealProbe()
+        probe.operationInFlight = true
+        #expect(Self.classify(probe).verdict == .busy)
+    }
+
+    @Test func recentlyTouchedMergedWorktreeIsActiveNotACandidate() {
+        let probe = Self.idealProbe(daysIdle: 2)
+        let result = Self.classify(probe, idleThresholdDays: 14)
+        #expect(result.verdict == .active)
+        #expect(result.signals.contains(.recentActivity(days: 2)))
+    }
+
+    @Test func idleThresholdBoundaryIsInclusive() {
+        let probe = Self.idealProbe(daysIdle: 14)
+        #expect(Self.classify(probe, idleThresholdDays: 14).verdict
+                == .candidate(confidence: .high))
+    }
+
+    @Test func mainWorktreeIsExcludedAndUnselectable() {
+        let result = Self.classify(
+            Self.idealProbe(),
+            worktree: Self.worktree(branch: "main", isMain: true)
+        )
+        #expect(result.verdict == .excluded)
+        #expect(result.signals.contains(.mainWorktree))
+        #expect(!result.isSelectable)
+    }
+
+    @Test func mainWorktreeExclusionOutranksBusyAndDirty() {
+        var probe = Self.idealProbe()
+        probe.isMainWorktree = true
+        probe.activeSessionCount = 4
+        probe.hasUncommittedChanges = true
+        let result = Self.classify(
+            probe,
+            worktree: Self.worktree(branch: "main", isMain: true)
+        )
+        #expect(result.verdict == .excluded)
+        #expect(!result.isSelectable)
+    }
+
+    @Test func remoteWorktreeIsExcludedWithExplanation() {
+        var probe = Self.idealProbe()
+        probe.isRemote = true
+        let result = Self.classify(probe)
+        #expect(result.verdict == .excluded)
+        #expect(result.signals.contains(.remoteWorktree))
+        #expect(!result.isSelectable)
+        #expect(WorktreeCleanupSignal.remoteWorktree.label
+                == "Remote worktree — cleanup is not supported yet")
+    }
+
+    @Test func blockingSignalsSortBeforeQualifyingOnes() {
+        var probe = Self.idealProbe()
+        probe.hasUncommittedChanges = true
+        let signals = Self.classify(probe).signals
+        let firstQualifying = signals.firstIndex { !$0.isBlocking } ?? signals.count
+        let lastBlocking = signals.lastIndex { $0.isBlocking } ?? -1
+        #expect(lastBlocking < firstQualifying)
+    }
+
+    @Test func everySignalHasANonEmptyLabel() {
+        var probe = Self.idealProbe()
+        probe.hasUncommittedChanges = true
+        probe.hasUntrackedFiles = true
+        probe.unpushedCommitCount = 1
+        probe.stashCount = 1
+        probe.activeSessionCount = 1
+        for signal in Self.classify(probe).signals {
+            #expect(!signal.label.isEmpty)
+        }
+    }
+}

--- a/AlasTests/Git/WorktreeCleanupScannerTests.swift
+++ b/AlasTests/Git/WorktreeCleanupScannerTests.swift
@@ -29,12 +29,19 @@ struct WorktreeCleanupScannerTests {
         )
     }
 
+    /// Matches the `headSHA` on every `MergedReviewRequestRef` fixture below,
+    /// so tests that only care about the merged-on-forge path don't also have
+    /// to think about SHA verification — the dedicated mismatch test below
+    /// does that.
+    private static let localHeadSHA = "abc123"
+
     private static let cleanFacts = WorktreeCleanupGitFacts(
         hasUncommittedChanges: false,
         hasUntrackedFiles: false,
         unpushedCommitCount: 0,
         stashCount: 0,
-        isMergedLocally: false
+        isMergedLocally: false,
+        headSHA: localHeadSHA
     )
 
     private static func scanner(
@@ -73,7 +80,8 @@ struct WorktreeCleanupScannerTests {
         let ref = MergedReviewRequestRef(
             number: 42,
             headRefName: "feature/a",
-            url: URL(string: "https://github.com/o/r/pull/42")!
+            url: URL(string: "https://github.com/o/r/pull/42")!,
+            headSHA: Self.localHeadSHA
         )
         let scanner = Self.scanner(mergeIndex: { _ in
             .success(WorktreeForgeMergeIndex(refsByHeadBranch: ["feature/a": ref]))
@@ -86,6 +94,31 @@ struct WorktreeCleanupScannerTests {
         #expect(results[0].signals.contains(
             .mergedOnForge(identity: "#42", url: ref.url)
         ))
+    }
+
+    /// A branch-name match against the forge index is not enough on its own:
+    /// names get reused after an old, unrelated PR on the same name merged.
+    /// A recorded head SHA that does not match what is actually checked out
+    /// here must not be trusted as this branch's merge.
+    @Test func forgeMatchWithMismatchedSHAIsNotTrustedAsMergedOnForge() async {
+        let ref = MergedReviewRequestRef(
+            number: 42,
+            headRefName: "feature/a",
+            url: URL(string: "https://github.com/o/r/pull/42")!,
+            headSHA: "old-unrelated-sha"
+        )
+        let scanner = Self.scanner(mergeIndex: { _ in
+            .success(WorktreeForgeMergeIndex(refsByHeadBranch: ["feature/a": ref]))
+        })
+        let results = await Self.scan(
+            scanner,
+            worktrees: [Self.worktree(branch: "feature/a")]
+        )
+        #expect(!results[0].signals.contains { signal in
+            if case .mergedOnForge = signal { return true } else { return false }
+        })
+        #expect(results[0].signals.contains(.notMerged))
+        #expect(results[0].verdict == .active)
     }
 
     /// The core degradation rule: a forge failure must not manufacture a
@@ -143,7 +176,8 @@ struct WorktreeCleanupScannerTests {
         let ref = MergedReviewRequestRef(
             number: 42,
             headRefName: "feature/a",
-            url: URL(string: "https://github.com/o/r/pull/42")!
+            url: URL(string: "https://github.com/o/r/pull/42")!,
+            headSHA: Self.localHeadSHA
         )
         let scanner = Self.scanner(
             facts: { _ in facts },
@@ -190,7 +224,8 @@ struct WorktreeCleanupScannerTests {
         let ref = MergedReviewRequestRef(
             number: 42,
             headRefName: "feature/a",
-            url: URL(string: "https://github.com/o/r/pull/42")!
+            url: URL(string: "https://github.com/o/r/pull/42")!,
+            headSHA: Self.localHeadSHA
         )
         let scanner = Self.scanner(
             facts: { _ in facts },

--- a/AlasTests/Git/WorktreeCleanupScannerTests.swift
+++ b/AlasTests/Git/WorktreeCleanupScannerTests.swift
@@ -1,0 +1,192 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct WorktreeCleanupScannerTests {
+    private static let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private static func project(host: String? = nil) -> ProjectConfig {
+        ProjectConfig(
+            id: "p",
+            name: "alas",
+            path: "/tmp/repo",
+            color: "blue",
+            addedAt: now,
+            host: host
+        )
+    }
+
+    private static func worktree(branch: String, isMain: Bool = false) -> Worktree {
+        Worktree(
+            id: "/tmp/wt-\(branch)",
+            projectId: "p",
+            name: branch,
+            branch: branch,
+            path: URL(fileURLWithPath: "/tmp/wt-\(branch)"),
+            isMainWorktree: isMain,
+            status: .clean,
+            lastActivity: now.addingTimeInterval(-30 * 86_400)
+        )
+    }
+
+    private static let cleanFacts = WorktreeCleanupGitFacts(
+        hasUncommittedChanges: false,
+        hasUntrackedFiles: false,
+        unpushedCommitCount: 0,
+        stashCount: 0,
+        isMergedLocally: false
+    )
+
+    private static func scanner(
+        facts: @escaping @Sendable (Worktree) async -> WorktreeCleanupGitFacts = { _ in cleanFacts },
+        mergeIndex: @escaping @Sendable (ProjectConfig) async -> Result<WorktreeForgeMergeIndex, Error> = { _ in
+            .success(WorktreeForgeMergeIndex(refsByHeadBranch: [:]))
+        },
+        activeSessionCount: @escaping @Sendable (String) async -> Int = { _ in 0 },
+        operationInFlight: @escaping @Sendable (String) async -> Bool = { _ in false }
+    ) -> WorktreeCleanupScanner {
+        WorktreeCleanupScanner(
+            dependencies: WorktreeCleanupScanner.Dependencies(
+                gitFacts: facts,
+                mergeIndex: mergeIndex,
+                activeSessionCount: activeSessionCount,
+                operationInFlight: operationInFlight
+            )
+        )
+    }
+
+    private static func scan(
+        _ scanner: WorktreeCleanupScanner,
+        project: ProjectConfig = project(),
+        worktrees: [Worktree]
+    ) async -> [WorktreeCleanupCandidate] {
+        await scanner.scan(
+            project: project,
+            worktrees: worktrees,
+            baseBranch: "main",
+            now: now,
+            idleThresholdDays: 14
+        )
+    }
+
+    @Test func forgeIndexIsAppliedByHeadRefName() async {
+        let ref = MergedReviewRequestRef(
+            number: 42,
+            headRefName: "feature/a",
+            url: URL(string: "https://github.com/o/r/pull/42")!
+        )
+        let scanner = Self.scanner(mergeIndex: { _ in
+            .success(WorktreeForgeMergeIndex(refsByHeadBranch: ["feature/a": ref]))
+        })
+        let results = await Self.scan(
+            scanner,
+            worktrees: [Self.worktree(branch: "feature/a")]
+        )
+        #expect(results[0].verdict == .candidate(confidence: .high))
+        #expect(results[0].signals.contains(
+            .mergedOnForge(identity: "#42", url: ref.url)
+        ))
+    }
+
+    /// The core degradation rule: a forge failure must not manufacture a
+    /// "not merged" answer.
+    @Test func forgeFailureYieldsUnknownNotNotMerged() async {
+        let scanner = Self.scanner(mergeIndex: { _ in
+            .failure(CodeHostProviderError.cliMissing("gh"))
+        })
+        let results = await Self.scan(
+            scanner,
+            worktrees: [Self.worktree(branch: "feature/a")]
+        )
+        #expect(!results[0].signals.contains(.notMerged))
+        #expect(results[0].signals.contains { signal in
+            if case .mergeStateUnknown = signal { return true } else { return false }
+        })
+    }
+
+    /// A local merge-base check that succeeded is still reported, even when the
+    /// forge could not be reached — the two checks are independent.
+    @Test func localMergeSurvivesForgeFailure() async {
+        var facts = Self.cleanFacts
+        facts.isMergedLocally = true
+        let scanner = Self.scanner(
+            facts: { _ in facts },
+            mergeIndex: { _ in .failure(CodeHostProviderError.cliMissing("gh")) }
+        )
+        let results = await Self.scan(
+            scanner,
+            worktrees: [Self.worktree(branch: "feature/a")]
+        )
+        #expect(results[0].verdict == .candidate(confidence: .medium))
+        #expect(results[0].signals.contains(.mergedLocally(base: "main")))
+    }
+
+    @Test func branchAbsentFromForgeIndexIsNotMerged() async {
+        let scanner = Self.scanner(mergeIndex: { _ in
+            .success(WorktreeForgeMergeIndex(refsByHeadBranch: [:]))
+        })
+        let results = await Self.scan(
+            scanner,
+            worktrees: [Self.worktree(branch: "feature/a")]
+        )
+        #expect(results[0].signals.contains(.notMerged))
+        #expect(results[0].verdict == .active)
+    }
+
+    @Test func sshProjectShortCircuitsWithoutProbing() async {
+        let probeCount = ProbeCounter()
+        let scanner = Self.scanner(facts: { _ in
+            await probeCount.increment()
+            return Self.cleanFacts
+        })
+        let results = await Self.scan(
+            scanner,
+            project: Self.project(host: "devbox"),
+            worktrees: [Self.worktree(branch: "feature/a")]
+        )
+        #expect(results[0].verdict == .excluded)
+        #expect(results[0].signals.contains(.remoteWorktree))
+        #expect(await probeCount.value == 0)
+    }
+
+    @Test func activeSessionsAreCarriedIntoTheProbe() async {
+        let scanner = Self.scanner(activeSessionCount: { _ in 2 })
+        let results = await Self.scan(
+            scanner,
+            worktrees: [Self.worktree(branch: "feature/a")]
+        )
+        #expect(results[0].verdict == .busy)
+        #expect(results[0].signals.contains(.activeSessions(count: 2)))
+    }
+
+    @Test func resultsPreserveInputOrder() async {
+        let scanner = Self.scanner()
+        let worktrees = ["a", "b", "c"].map { Self.worktree(branch: "feature/\($0)") }
+        let results = await Self.scan(scanner, worktrees: worktrees)
+        #expect(results.map(\.worktree.branch)
+                == ["feature/a", "feature/b", "feature/c"])
+    }
+
+    @Test func statusPorcelainDistinguishesUntrackedFromModified() {
+        let modified = WorktreeCleanupScanner.parseStatusPorcelain(" M Sources/A.swift\n")
+        #expect(modified.hasUncommittedChanges)
+        #expect(!modified.hasUntrackedFiles)
+
+        let untracked = WorktreeCleanupScanner.parseStatusPorcelain("?? notes.txt\n")
+        #expect(!untracked.hasUncommittedChanges)
+        #expect(untracked.hasUntrackedFiles)
+
+        let both = WorktreeCleanupScanner.parseStatusPorcelain("M  A.swift\n?? B.swift\n")
+        #expect(both.hasUncommittedChanges)
+        #expect(both.hasUntrackedFiles)
+
+        let clean = WorktreeCleanupScanner.parseStatusPorcelain("")
+        #expect(!clean.hasUncommittedChanges)
+        #expect(!clean.hasUntrackedFiles)
+    }
+}
+
+private actor ProbeCounter {
+    private(set) var value = 0
+    func increment() { value += 1 }
+}

--- a/AlasTests/Git/WorktreeCleanupScannerTests.swift
+++ b/AlasTests/Git/WorktreeCleanupScannerTests.swift
@@ -184,6 +184,28 @@ struct WorktreeCleanupScannerTests {
         #expect(!clean.hasUncommittedChanges)
         #expect(!clean.hasUntrackedFiles)
     }
+
+    /// A bare substring match would let branch `x` claim a stash that
+    /// actually belongs to `feature/x`. The match must anchor on git's own
+    /// `%gs` subject shapes.
+    @Test func stashMatchDoesNotCollideOnBranchNameSubstrings() {
+        let stashOnFeatureX = GitStash(
+            ref: "stash@{0}",
+            subject: "WIP on feature/x: abc1234 message",
+            relativeTime: "2 days ago",
+            sha: "abc1234"
+        )
+        #expect(!WorktreeCleanupScanner.isStash(stashOnFeatureX, forBranch: "x"))
+        #expect(WorktreeCleanupScanner.isStash(stashOnFeatureX, forBranch: "feature/x"))
+
+        let stashOnX = GitStash(
+            ref: "stash@{1}",
+            subject: "On x: custom message",
+            relativeTime: "1 day ago",
+            sha: "def5678"
+        )
+        #expect(WorktreeCleanupScanner.isStash(stashOnX, forBranch: "x"))
+    }
 }
 
 private actor ProbeCounter {

--- a/AlasTests/Git/WorktreeCleanupScannerTests.swift
+++ b/AlasTests/Git/WorktreeCleanupScannerTests.swift
@@ -321,6 +321,30 @@ struct WorktreeCleanupScannerTests {
         #expect(results[0].signals.contains(.recentActivity(days: 0)))
     }
 
+    /// A worktree checked out today from an old, already-merged branch must
+    /// not read as idle for the branch's own age — the worktree itself did
+    /// not exist before it was created, regardless of what its branch's ref
+    /// history says.
+    @Test func idleClockNeverStartsBeforeTheWorktreeWasCreated() async {
+        var facts = Self.cleanFacts
+        facts.isMergedLocally = true
+        facts.lastActivity = Self.now.addingTimeInterval(-60 * 86_400)   // an old branch
+        let scanner = Self.scanner(facts: { _ in facts })
+        let freshWorktree = Worktree(
+            id: "/tmp/wt-feature-a",
+            projectId: "p",
+            name: "feature/a",
+            branch: "feature/a",
+            path: URL(fileURLWithPath: "/tmp/wt-feature-a"),
+            status: .clean,
+            lastActivity: Self.now.addingTimeInterval(-60 * 86_400),
+            createdAt: Self.now   // created just now
+        )
+        let results = await Self.scan(scanner, worktrees: [freshWorktree])
+        #expect(results[0].verdict == .active)
+        #expect(results[0].signals.contains(.recentActivity(days: 0)))
+    }
+
     @Test func resultsPreserveInputOrder() async {
         let scanner = Self.scanner()
         let worktrees = ["a", "b", "c"].map { Self.worktree(branch: "feature/\($0)") }

--- a/AlasTests/Git/WorktreeCleanupScannerTests.swift
+++ b/AlasTests/Git/WorktreeCleanupScannerTests.swift
@@ -84,7 +84,7 @@ struct WorktreeCleanupScannerTests {
             headSHA: Self.localHeadSHA
         )
         let scanner = Self.scanner(mergeIndex: { _ in
-            .success(WorktreeForgeMergeIndex(refsByHeadBranch: ["feature/a": ref]))
+            .success(WorktreeForgeMergeIndex(refsByHeadBranch: ["feature/a": [ref]]))
         })
         let results = await Self.scan(
             scanner,
@@ -108,7 +108,7 @@ struct WorktreeCleanupScannerTests {
             headSHA: "old-unrelated-sha"
         )
         let scanner = Self.scanner(mergeIndex: { _ in
-            .success(WorktreeForgeMergeIndex(refsByHeadBranch: ["feature/a": ref]))
+            .success(WorktreeForgeMergeIndex(refsByHeadBranch: ["feature/a": [ref]]))
         })
         let results = await Self.scan(
             scanner,
@@ -119,6 +119,41 @@ struct WorktreeCleanupScannerTests {
         })
         #expect(results[0].signals.contains(.notMerged))
         #expect(results[0].verdict == .active)
+    }
+
+    /// A branch name reused across two merged reviews must still match: the
+    /// index has to retain every ref for a branch, not just the newest, or a
+    /// worktree whose HEAD corresponds to the *older* merged review would be
+    /// compared only against the newer SHA and wrongly read as not merged.
+    @Test func olderRefForAReusedBranchNameStillMatches() async {
+        let olderRef = MergedReviewRequestRef(
+            number: 10,
+            headRefName: "feature/a",
+            url: URL(string: "https://github.com/o/r/pull/10")!,
+            headSHA: "old-commit-sha"
+        )
+        let newerRef = MergedReviewRequestRef(
+            number: 99,
+            headRefName: "feature/a",
+            url: URL(string: "https://github.com/o/r/pull/99")!,
+            headSHA: "new-commit-sha"
+        )
+        var facts = Self.cleanFacts
+        facts.headSHA = "old-commit-sha"
+        let scanner = Self.scanner(
+            facts: { _ in facts },
+            mergeIndex: { _ in
+                .success(WorktreeForgeMergeIndex(refsByHeadBranch: ["feature/a": [newerRef, olderRef]]))
+            }
+        )
+        let results = await Self.scan(
+            scanner,
+            worktrees: [Self.worktree(branch: "feature/a")]
+        )
+        #expect(results[0].verdict == .candidate(confidence: .high))
+        #expect(results[0].signals.contains(
+            .mergedOnForge(identity: "#10", url: olderRef.url)
+        ))
     }
 
     /// The core degradation rule: a forge failure must not manufacture a
@@ -182,7 +217,7 @@ struct WorktreeCleanupScannerTests {
         let scanner = Self.scanner(
             facts: { _ in facts },
             mergeIndex: { _ in
-                .success(WorktreeForgeMergeIndex(refsByHeadBranch: ["feature/a": ref]))
+                .success(WorktreeForgeMergeIndex(refsByHeadBranch: ["feature/a": [ref]]))
             }
         )
         let results = await Self.scan(
@@ -230,7 +265,7 @@ struct WorktreeCleanupScannerTests {
         let scanner = Self.scanner(
             facts: { _ in facts },
             mergeIndex: { _ in
-                .success(WorktreeForgeMergeIndex(refsByHeadBranch: ["feature/a": ref]))
+                .success(WorktreeForgeMergeIndex(refsByHeadBranch: ["feature/a": [ref]]))
             }
         )
         let results = await Self.scan(

--- a/AlasTests/Git/WorktreeCleanupScannerTests.swift
+++ b/AlasTests/Git/WorktreeCleanupScannerTests.swift
@@ -133,6 +133,79 @@ struct WorktreeCleanupScannerTests {
         #expect(results[0].verdict == .active)
     }
 
+    /// `unpushedCount` reports 1 when `@{u}` cannot be resolved, which is what
+    /// happens after the forge deletes the branch on merge and a local prune
+    /// drops the tracking ref. A branch the forge says is merged must not be
+    /// held back as dirty by that artifact.
+    @Test func mergedOnForgeSuppressesFalseUnpushedSignalFromPrunedUpstream() async {
+        var facts = Self.cleanFacts
+        facts.unpushedCommitCount = 1   // simulates a pruned/missing @{u}
+        let ref = MergedReviewRequestRef(
+            number: 42,
+            headRefName: "feature/a",
+            url: URL(string: "https://github.com/o/r/pull/42")!
+        )
+        let scanner = Self.scanner(
+            facts: { _ in facts },
+            mergeIndex: { _ in
+                .success(WorktreeForgeMergeIndex(refsByHeadBranch: ["feature/a": ref]))
+            }
+        )
+        let results = await Self.scan(
+            scanner,
+            worktrees: [Self.worktree(branch: "feature/a")]
+        )
+        #expect(results[0].verdict == .candidate(confidence: .high))
+        #expect(!results[0].signals.contains { signal in
+            if case .unpushedCommits = signal { return true } else { return false }
+        })
+    }
+
+    /// The suppression is scoped to the forge-merged case only: a branch that
+    /// is not merged still reports its real unpushed work.
+    @Test func notMergedWorktreeStillReportsRealUnpushedCommits() async {
+        var facts = Self.cleanFacts
+        facts.unpushedCommitCount = 3
+        let scanner = Self.scanner(
+            facts: { _ in facts },
+            mergeIndex: { _ in
+                .success(WorktreeForgeMergeIndex(refsByHeadBranch: [:]))
+            }
+        )
+        let results = await Self.scan(
+            scanner,
+            worktrees: [Self.worktree(branch: "feature/a")]
+        )
+        #expect(results[0].verdict == .dirty)
+        #expect(results[0].signals.contains(.unpushedCommits(count: 3)))
+    }
+
+    /// Uncommitted work is never excused by a forge merge — only the unpushed
+    /// signal is, and only because a pruned upstream cannot be told apart from
+    /// an unpublished branch.
+    @Test func mergedOnForgeStillBlocksOnUncommittedChanges() async {
+        var facts = Self.cleanFacts
+        facts.unpushedCommitCount = 1
+        facts.hasUncommittedChanges = true
+        let ref = MergedReviewRequestRef(
+            number: 42,
+            headRefName: "feature/a",
+            url: URL(string: "https://github.com/o/r/pull/42")!
+        )
+        let scanner = Self.scanner(
+            facts: { _ in facts },
+            mergeIndex: { _ in
+                .success(WorktreeForgeMergeIndex(refsByHeadBranch: ["feature/a": ref]))
+            }
+        )
+        let results = await Self.scan(
+            scanner,
+            worktrees: [Self.worktree(branch: "feature/a")]
+        )
+        #expect(results[0].verdict == .dirty)
+        #expect(results[0].signals.contains(.uncommittedChanges))
+    }
+
     @Test func sshProjectShortCircuitsWithoutProbing() async {
         let probeCount = ProbeCounter()
         let scanner = Self.scanner(facts: { _ in

--- a/AlasTests/Git/WorktreeCleanupScannerTests.swift
+++ b/AlasTests/Git/WorktreeCleanupScannerTests.swift
@@ -41,7 +41,8 @@ struct WorktreeCleanupScannerTests {
         unpushedCommitCount: 0,
         stashCount: 0,
         isMergedLocally: false,
-        headSHA: localHeadSHA
+        headSHA: localHeadSHA,
+        lastActivity: nil
     )
 
     private static func scanner(
@@ -300,6 +301,24 @@ struct WorktreeCleanupScannerTests {
         )
         #expect(results[0].verdict == .busy)
         #expect(results[0].signals.contains(.activeSessions(count: 2)))
+    }
+
+    /// `Worktree.lastActivity` is cached from the last topology refresh, not
+    /// updated by ordinary commit activity while the app is open. A merged,
+    /// freshly-touched worktree must not read as long-idle just because the
+    /// cache is stale.
+    @Test func freshActivityOverridesStaleCachedTimestamp() async {
+        var facts = Self.cleanFacts
+        facts.isMergedLocally = true
+        facts.lastActivity = Self.now   // fresh: touched right now
+        let scanner = Self.scanner(facts: { _ in facts })
+        // The cached worktree looks idle (30 days old by the fixture default).
+        let results = await Self.scan(
+            scanner,
+            worktrees: [Self.worktree(branch: "feature/a")]
+        )
+        #expect(results[0].verdict == .active)
+        #expect(results[0].signals.contains(.recentActivity(days: 0)))
     }
 
     @Test func resultsPreserveInputOrder() async {

--- a/AlasTests/Integrations/MergedReviewRequestTests.swift
+++ b/AlasTests/Integrations/MergedReviewRequestTests.swift
@@ -1,0 +1,181 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct MergedReviewRequestTests {
+    private static let remote = CodeHostRemote(
+        kind: .github,
+        host: "github.com",
+        owner: "mrmans0n",
+        repository: "alas",
+        remoteName: "origin",
+        webURL: URL(string: "https://github.com/mrmans0n/alas")!
+    )
+
+    @Test func parsesGitHubMergedPRList() throws {
+        let json = """
+        [
+          {"number": 42, "headRefName": "feature/a", "url": "https://github.com/mrmans0n/alas/pull/42"},
+          {"number": 43, "headRefName": "feature/b", "url": "https://github.com/mrmans0n/alas/pull/43"}
+        ]
+        """
+        let refs = try GitHubCLIProvider.parseMergedPRList(json)
+        #expect(refs.count == 2)
+        #expect(refs[0] == MergedReviewRequestRef(
+            number: 42,
+            headRefName: "feature/a",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/42")!
+        ))
+        #expect(refs[1].headRefName == "feature/b")
+    }
+
+    @Test func parsesEmptyGitHubList() throws {
+        #expect(try GitHubCLIProvider.parseMergedPRList("[]").isEmpty)
+    }
+
+    @Test func rejectsMalformedGitHubOutput() {
+        #expect(throws: CodeHostProviderError.self) {
+            _ = try GitHubCLIProvider.parseMergedPRList("not json")
+        }
+    }
+
+    @Test func parsesGitLabMergedMRList() throws {
+        let json = """
+        [
+          {"iid": 7, "source_branch": "feature/a", "web_url": "https://gitlab.com/o/r/-/merge_requests/7"}
+        ]
+        """
+        let refs = try GitLabCLIProvider.parseMergedMRList(json)
+        #expect(refs.count == 1)
+        #expect(refs[0].number == 7)
+        #expect(refs[0].headRefName == "feature/a")
+    }
+
+    @Test func gitHubProviderIssuesOneBatchedQuery() async throws {
+        let runner = RecordingRunner(stdout: """
+        [{"number": 42, "headRefName": "feature/a", "url": "https://github.com/mrmans0n/alas/pull/42"}]
+        """)
+        let provider = GitHubCLIProvider(runner: runner)
+        let refs = try await provider.mergedReviewRequests(
+            remote: Self.remote,
+            limit: 200,
+            cwd: URL(fileURLWithPath: "/tmp")
+        )
+        #expect(refs.count == 1)
+        let invocations = await runner.invocations
+        #expect(invocations.count == 1)
+        #expect(invocations[0].args.contains("--state"))
+        #expect(invocations[0].args.contains("merged"))
+        #expect(invocations[0].args.contains("200"))
+    }
+
+    @Test func gitHubProviderThrowsOnNonZeroExit() async {
+        let runner = RecordingRunner(stdout: "", stderr: "gh: not authenticated", exitCode: 1)
+        let provider = GitHubCLIProvider(runner: runner)
+        await #expect(throws: CodeHostProviderError.self) {
+            _ = try await provider.mergedReviewRequests(
+                remote: Self.remote,
+                limit: 200,
+                cwd: URL(fileURLWithPath: "/tmp")
+            )
+        }
+    }
+
+    /// The protocol default must fail loudly, not return an empty list — an
+    /// empty list would read as "nothing is merged", which is exactly the
+    /// silent degradation this feature must avoid.
+    @Test func protocolDefaultThrowsUnsupported() async {
+        let provider = MergeQueryUnsupportedProvider()
+        await #expect(throws: CodeHostProviderError.self) {
+            _ = try await provider.mergedReviewRequests(
+                remote: Self.remote,
+                limit: 10,
+                cwd: URL(fileURLWithPath: "/tmp")
+            )
+        }
+    }
+}
+
+private actor RecordingRunner: CodeHostCommandRunning {
+    struct Invocation: Sendable {
+        let executable: String
+        let args: [String]
+    }
+
+    private(set) var invocations: [Invocation] = []
+    private let stdout: String
+    private let stderr: String
+    private let exitCode: Int32
+
+    init(stdout: String, stderr: String = "", exitCode: Int32 = 0) {
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exitCode = exitCode
+    }
+
+    func run(
+        _ executable: String,
+        args: [String],
+        cwd: URL?,
+        stdin: String?
+    ) async throws -> ProcessResult {
+        invocations.append(Invocation(executable: executable, args: args))
+        return ProcessResult(exitCode: exitCode, stdout: stdout, stderr: stderr)
+    }
+
+    func runData(_ executable: String, args: [String], cwd: URL?) async throws -> ProcessResultData {
+        invocations.append(Invocation(executable: executable, args: args))
+        return ProcessResultData(exitCode: exitCode, stdout: Data(stdout.utf8), stderr: stderr)
+    }
+}
+
+/// Models a bare-bones `CodeHostProvider` that does not implement
+/// `mergedReviewRequests`, to exercise the protocol's default implementation.
+/// Mirrors the stub-method shape of `CodeHostProviderTests.FakeCodeHostProvider`.
+private struct MergeQueryUnsupportedProvider: CodeHostProvider {
+    let kind: CodeHostKind = .github
+    let capabilities: CodeHostProviderCapabilities = .readOnly
+
+    func isAvailable(cwd: URL) async -> Bool {
+        true
+    }
+
+    func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool {
+        true
+    }
+
+    func currentReviewRequest(
+        remote: CodeHostRemote,
+        branch: String,
+        headOwner: String?,
+        baseBranch: String,
+        cwd: URL
+    ) async throws -> ReviewRequest? {
+        nil
+    }
+
+    func createReviewRequest(
+        remote: CodeHostRemote,
+        branch: String,
+        headOwner: String?,
+        baseBranch: String,
+        title: String,
+        body: String,
+        isDraft: Bool,
+        cwd: URL
+    ) async throws -> URL {
+        remote.webURL
+    }
+
+    func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] {
+        []
+    }
+
+    func rerunFailedChecks(
+        remote: CodeHostRemote,
+        branch: String,
+        headSHA: String,
+        request: ReviewRequest?,
+        cwd: URL
+    ) async throws {}
+}

--- a/AlasTests/Integrations/MergedReviewRequestTests.swift
+++ b/AlasTests/Integrations/MergedReviewRequestTests.swift
@@ -15,8 +15,8 @@ struct MergedReviewRequestTests {
     @Test func parsesGitHubMergedPRList() throws {
         let json = """
         [
-          {"number": 42, "headRefName": "feature/a", "url": "https://github.com/mrmans0n/alas/pull/42"},
-          {"number": 43, "headRefName": "feature/b", "url": "https://github.com/mrmans0n/alas/pull/43"}
+          {"number": 42, "headRefName": "feature/a", "url": "https://github.com/mrmans0n/alas/pull/42", "headRefOid": "abc123"},
+          {"number": 43, "headRefName": "feature/b", "url": "https://github.com/mrmans0n/alas/pull/43", "headRefOid": "def456"}
         ]
         """
         let refs = try GitHubCLIProvider.parseMergedPRList(json)
@@ -24,9 +24,11 @@ struct MergedReviewRequestTests {
         #expect(refs[0] == MergedReviewRequestRef(
             number: 42,
             headRefName: "feature/a",
-            url: URL(string: "https://github.com/mrmans0n/alas/pull/42")!
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/42")!,
+            headSHA: "abc123"
         ))
         #expect(refs[1].headRefName == "feature/b")
+        #expect(refs[1].headSHA == "def456")
     }
 
     @Test func parsesEmptyGitHubList() throws {
@@ -42,18 +44,20 @@ struct MergedReviewRequestTests {
     @Test func parsesGitLabMergedMRList() throws {
         let json = """
         [
-          {"iid": 7, "source_branch": "feature/a", "web_url": "https://gitlab.com/o/r/-/merge_requests/7"}
+          {"iid": 7, "source_branch": "feature/a", "web_url": "https://gitlab.com/o/r/-/merge_requests/7", "sha": "abc123"}
         ]
         """
         let refs = try GitLabCLIProvider.parseMergedMRList(json)
         #expect(refs.count == 1)
         #expect(refs[0].number == 7)
         #expect(refs[0].headRefName == "feature/a")
+        #expect(refs[0].url == URL(string: "https://gitlab.com/o/r/-/merge_requests/7")!)
+        #expect(refs[0].headSHA == "abc123")
     }
 
     @Test func gitHubProviderIssuesOneBatchedQuery() async throws {
         let runner = RecordingRunner(stdout: """
-        [{"number": 42, "headRefName": "feature/a", "url": "https://github.com/mrmans0n/alas/pull/42"}]
+        [{"number": 42, "headRefName": "feature/a", "url": "https://github.com/mrmans0n/alas/pull/42", "headRefOid": "abc123"}]
         """)
         let provider = GitHubCLIProvider(runner: runner)
         let refs = try await provider.mergedReviewRequests(
@@ -62,11 +66,13 @@ struct MergedReviewRequestTests {
             cwd: URL(fileURLWithPath: "/tmp")
         )
         #expect(refs.count == 1)
+        #expect(refs[0].headSHA == "abc123")
         let invocations = await runner.invocations
         #expect(invocations.count == 1)
         #expect(invocations[0].args.contains("--state"))
         #expect(invocations[0].args.contains("merged"))
         #expect(invocations[0].args.contains("200"))
+        #expect(invocations[0].args.contains { $0.contains("headRefOid") })
     }
 
     @Test func gitHubProviderThrowsOnNonZeroExit() async {

--- a/AlasTests/Persistence/WorktreeCleanupConfigTests.swift
+++ b/AlasTests/Persistence/WorktreeCleanupConfigTests.swift
@@ -1,0 +1,60 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct WorktreeCleanupConfigTests {
+    @Test func cleanupIdleDaysDefaultsToFourteen() {
+        let worktrees = AppConfig.Worktrees(
+            rootPath: "/tmp",
+            pathTemplate: "{branch}",
+            branchPrefix: "",
+            baseBranch: "main",
+            trackUpstream: true,
+            deleteBranchOnRemove: false,
+            autoFetch: false,
+            fetchIntervalMinutes: 10,
+            pruneStale: false
+        )
+        #expect(worktrees.cleanupIdleDays == 14)
+    }
+
+    /// Config files written before this key existed must keep loading.
+    @Test func cleanupIdleDaysToleratesConfigThatPredatesTheKey() throws {
+        let json = """
+        {
+          "rootPath": "/tmp",
+          "pathTemplate": "{branch}",
+          "branchPrefix": "",
+          "baseBranch": "main",
+          "trackUpstream": true,
+          "deleteBranchOnRemove": false,
+          "autoFetch": false,
+          "fetchIntervalMinutes": 10,
+          "pruneStale": false
+        }
+        """
+        let decoded = try JSONDecoder().decode(
+            AppConfig.Worktrees.self,
+            from: Data(json.utf8)
+        )
+        #expect(decoded.cleanupIdleDays == 14)
+    }
+
+    @Test func cleanupIdleDaysRoundTrips() throws {
+        var worktrees = AppConfig.Worktrees(
+            rootPath: "/tmp",
+            pathTemplate: "{branch}",
+            branchPrefix: "",
+            baseBranch: "main",
+            trackUpstream: true,
+            deleteBranchOnRemove: false,
+            autoFetch: false,
+            fetchIntervalMinutes: 10,
+            pruneStale: false
+        )
+        worktrees.cleanupIdleDays = 30
+        let data = try JSONEncoder().encode(worktrees)
+        let decoded = try JSONDecoder().decode(AppConfig.Worktrees.self, from: data)
+        #expect(decoded.cleanupIdleDays == 30)
+    }
+}

--- a/AlasTests/RepoGroupViewLayoutTests.swift
+++ b/AlasTests/RepoGroupViewLayoutTests.swift
@@ -76,6 +76,7 @@ struct RepoGroupViewLayoutTests {
             onCopyBranch: { _ in },
             onRevealInFinder: { _ in },
             onArchive: { _ in },
+            onCleanupWorktrees: { },
             onDelete: { _ in },
             onDeleteKeepBranch: { _ in },
             showKeepBranchOption: false,

--- a/AlasTests/WorktreeCleanupFixtures.swift
+++ b/AlasTests/WorktreeCleanupFixtures.swift
@@ -1,0 +1,116 @@
+import Testing
+import Foundation
+@testable import Alas
+
+/// A temporary git repository, its `AppState`-registered project, and the
+/// worktrees git reports for it — ready to drive batch-cleanup tests without
+/// each test standing up its own repo.
+struct WorktreeCleanupFixture {
+    let state: AppState
+    let project: ProjectConfig
+    let worktrees: [Worktree]
+    let repoPath: URL
+}
+
+/// Builds a real temporary git repository with `worktreeCount` worktrees and
+/// an `AppState` with a project pointed at it. `sortedWorktrees` always pins
+/// the main worktree at position 0, so `fixture.worktrees[0]` is always main
+/// and the rest are ordinary feature worktrees named `feature-1`, `feature-2`, ….
+///
+/// Modeled on `WorktreeServiceTests.makeRepo` (repo + sibling worktrees) and
+/// `AppStateCleanupTests` (an `AppState` with a project registered against a
+/// real temporary repo).
+@MainActor
+func makeCleanupFixture(worktreeCount: Int) async throws -> WorktreeCleanupFixture {
+    precondition(worktreeCount >= 1, "a fixture needs at least the main worktree")
+
+    let repoPath = FileManager.default.temporaryDirectory
+        .appendingPathComponent("alas-cleanup-fixture-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: repoPath, withIntermediateDirectories: true)
+    _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repoPath)
+    _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: repoPath)
+
+    let root = repoPath.deletingLastPathComponent()
+    for index in 1..<worktreeCount {
+        let branch = "feature-\(index)"
+        _ = try await Process.git(["branch", branch, "main"], cwd: repoPath)
+        let destination = root.appendingPathComponent("\(repoPath.lastPathComponent)-wt\(index)")
+        _ = try await Process.git(["worktree", "add", "-q", destination.path, branch], cwd: repoPath)
+        WorktreeRegistrationLookup.shared.register(worktreePath: destination, repoPath: repoPath)
+    }
+
+    let state = AppState()
+    let project = try await state.projectsManager.addProject(
+        path: repoPath,
+        displayName: "cleanup-fixture",
+        color: "#5fb7c4"
+    )
+    try await state.projectsManager.refreshWorktrees(projectId: project.id)
+    let worktrees = state.projectsManager.worktrees(projectId: project.id)
+
+    return WorktreeCleanupFixture(state: state, project: project, worktrees: worktrees, repoPath: repoPath)
+}
+
+/// Thread-safe lookup from a worktree's on-disk path to the repository that
+/// registered it with git, so test helpers can still find the repository
+/// after the worktree's own directory (and the `.git` file inside it) has
+/// been deleted out from under it.
+///
+/// Keyed by a normalized path *string*, not `URL`: the destination URL built
+/// at registration time (via `appendingPathComponent`, before symlinks like
+/// `/var` → `/private/var` are resolved) and the path `WorktreeService`
+/// reports back (parsed from `git worktree list --porcelain`, which git
+/// reports already resolved) otherwise disagree even when they name the same
+/// file. Resolving only the *parent* directory keeps this correct even after
+/// the worktree's own leaf directory has been deleted, when the leaf itself
+/// can no longer be resolved.
+private final class WorktreeRegistrationLookup: @unchecked Sendable {
+    static let shared = WorktreeRegistrationLookup()
+
+    private let lock = NSLock()
+    private var repoPathsByWorktreePath: [String: URL] = [:]
+
+    private func normalizedKey(for worktreePath: URL) -> String {
+        worktreePath.deletingLastPathComponent()
+            .resolvingSymlinksInPath()
+            .appendingPathComponent(worktreePath.lastPathComponent)
+            .path
+    }
+
+    func register(worktreePath: URL, repoPath: URL) {
+        lock.lock()
+        defer { lock.unlock() }
+        repoPathsByWorktreePath[normalizedKey(for: worktreePath)] = repoPath
+    }
+
+    func repoPath(forWorktreePath worktreePath: URL) -> URL? {
+        lock.lock()
+        defer { lock.unlock() }
+        return repoPathsByWorktreePath[normalizedKey(for: worktreePath)]
+    }
+}
+
+extension Process {
+    /// Breaks worktree removal for `worktree` at the git-administrative
+    /// level, independent of whether the worktree's own directory still
+    /// exists on disk (deleting its directory alone leaves git able to
+    /// prune it silently — `git worktree remove` treats that as success).
+    /// Repoints the main repository's `worktrees/<name>/gitdir` registration
+    /// at a path that does not exist, so `git worktree remove` fails
+    /// validation instead.
+    static func corruptWorktreeRegistration(_ worktree: Worktree) throws {
+        guard let repoPath = WorktreeRegistrationLookup.shared.repoPath(forWorktreePath: worktree.path) else {
+            throw ProcessError.launchFailed("no repository registered for \(worktree.path.path)")
+        }
+        let adminDir = repoPath
+            .appendingPathComponent(".git")
+            .appendingPathComponent("worktrees")
+            .appendingPathComponent(worktree.path.lastPathComponent)
+        let gitdirFile = adminDir.appendingPathComponent("gitdir")
+        try "/nonexistent/\(UUID().uuidString)/.git\n".write(
+            to: gitdirFile,
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+}


### PR DESCRIPTION
Closes #1163

## Summary

Adds merged-and-idle worktree detection with a per-project cleanup sheet driving bulk delete and bulk archive.

- A pure classifier (`WorktreeCleanupClassifier`) turns collected facts about a worktree into a verdict (`candidate`, `busy`, `dirty`, `active`, `excluded`) plus the ordered reasons behind it.
- A scanner (`WorktreeCleanupScanner`) collects those facts from git and one batched merged-PR/MR query per repository (GitHub/GitLab), so the sheet costs one network round trip, not one per worktree.
- Bulk delete and bulk archive reuse the existing single-worktree deletion and archive machinery (`AppState.performDeleteWorktree`, `AppState.archiveWorktree`) rather than reimplementing worktree removal, so every existing protection — dirty checks, force handling, tab/session cleanup — applies automatically. A failure in one item never aborts the rest of the batch.
- A failed code-host merge check always renders as "merge state unknown", never as "not merged" — a local git check and a forge check are different facts, and this is the property most of the classifier and scanner tests exist to pin.
- Remote/SSH-backed projects are excluded from cleanup with an explanation, per the issue's own scope note.
- Archive already existed in this codebase (`hiddenWorktreePaths`, restore in Settings → Worktrees); this adds the bulk wrapper and closes the missing relaunch-persistence test coverage.

## Where things live

- `Alas/Sources/Git/WorktreeCleanup/` — classifier, scanner (new)
- `Alas/Sources/Dialogs/WorktreeCleanupModel.swift`, `WorktreeCleanupSheet.swift` — sheet + model (new)
- `Alas/Sources/App/AppState.swift` — `batchDeleteWorktrees`, `batchArchiveWorktrees`, `makeWorktreeCleanupModel`
- `Alas/Sources/Integrations/CodeHost/` — `mergedReviewRequests` on `CodeHostProvider`, implemented for both GitHub and GitLab
- "Clean Up Worktrees…" in the repo context menu opens the sheet

## Testing

131 tests across the feature's suites (classifier, scanner, provider, config, batch delete, batch archive, sheet model), plus the existing worktree/archive regression suites, all green. Full app build clean.

## Notes for reviewers

A few things intentionally deferred as follow-ups rather than expanding this PR further:

- No dedicated tests for the sheet/wiring layer (`WorktreeCleanupSheet.swift`, `makeWorktreeCleanupModel`) — its logic is thin glue over the classifier/scanner/model, all of which are covered.
- `glab mr list --merged --per-page 200` is silently clamped by GitLab's 100-item API cap; only affects repos with more than 100 merged MRs.
- A forge-merged branch that receives new local commits after the merge still reports as fully pushed (git's own `branch -d` still refuses to delete a branch holding unmerged commits, so this can't lose work — only the checkout directory would be removed).
- Config idle threshold changes while the sheet is open don't apply until the sheet is reopened.
