### PR TITLE
fix(worktree): cleanup follow-ups: fork resolution, pagination, branch deletion trust, tab revision tracking

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -4430,6 +4430,35 @@ final class AppState {
         }
     }
 
+    /// The edit generation of every currently-dirty tab in a worktree, keyed
+    /// by tab id. Used to tell "still the same dirtiness the user already
+    /// discarded" apart from "re-edited since" — a tab id alone isn't enough,
+    /// since discarding a buffer doesn't clear it, and it can be typed into
+    /// again (from another window) while a batch is still running. A tab
+    /// with no live buffer instantiated (only a persisted hot-exit snapshot)
+    /// gets a fixed sentinel generation, since there is no live edit counter
+    /// to read until the tab is opened; a snapshot's content can't change on
+    /// its own, so this stays stable as long as the tab remains unopened.
+    private func dirtyTabGenerations(worktreeId: String) -> [TabID: Int] {
+        Dictionary(uniqueKeysWithValues: dirtyEditorTabIds(worktreeId: worktreeId).map {
+            ($0, tabs.peekBuffer(tabId: $0)?.editGeneration ?? -1)
+        })
+    }
+
+    /// True when every currently-dirty tab was already dirty, at the exact
+    /// same edit generation, when the batch confirmation snapshot was taken —
+    /// i.e. nothing new needs protecting. A tab present in `current` but
+    /// absent or at a different generation in `acknowledgedAtConfirmation` is
+    /// new or changed dirtiness the user never saw or acknowledged.
+    nonisolated static func hasOnlyAcknowledgedDirtiness(
+        current: [TabID: Int],
+        acknowledgedAtConfirmation: [TabID: Int]
+    ) -> Bool {
+        current.allSatisfy { tabId, generation in
+            acknowledgedAtConfirmation[tabId] == generation
+        }
+    }
+
     /// Archive several worktrees at once. Nothing on disk is touched — this
     /// only marks each path hidden in `ProjectConfig`, which is what persists
     /// across relaunch.
@@ -4447,9 +4476,11 @@ final class AppState {
         // discarding doesn't retroactively un-dirty anything — so the
         // per-item re-check below must compare against this snapshot rather
         // than against "is anything dirty right now", or the confirmed
-        // discard would skip every worktree it was meant to cover.
+        // discard would skip every worktree it was meant to cover. Recording
+        // each dirty tab's edit generation, not just its id, also catches a
+        // tab re-edited (from another window) after being acknowledged here.
         let dirtyTabsAtConfirmation = Dictionary(
-            uniqueKeysWithValues: worktrees.map { ($0.id, Set(dirtyEditorTabIds(worktreeId: $0.id))) }
+            uniqueKeysWithValues: worktrees.map { ($0.id, dirtyTabGenerations(worktreeId: $0.id)) }
         )
         let dirtyCount = dirtyTabsAtConfirmation.values.reduce(0) { $0 + $1.count }
         if dirtyCount > 0 {
@@ -4486,10 +4517,14 @@ final class AppState {
             // can be stale by the time this specific item is reached. Only
             // dirtiness the confirmation didn't already cover counts: a tab
             // dirty at confirmation time and discarded is expected here, but
-            // a tab that turned dirty (or newly opened dirty) since then must
-            // not be torn down.
-            let currentDirtyTabs = Set(dirtyEditorTabIds(worktreeId: worktree.id))
-            guard currentDirtyTabs.isSubset(of: dirtyTabsAtConfirmation[worktree.id] ?? []) else {
+            // a tab that turned dirty (or newly opened dirty), OR was edited
+            // again since being acknowledged, must not be torn down.
+            let currentDirtyGenerations = dirtyTabGenerations(worktreeId: worktree.id)
+            let knownDirtyGenerations = dirtyTabsAtConfirmation[worktree.id] ?? [:]
+            guard Self.hasOnlyAcknowledgedDirtiness(
+                current: currentDirtyGenerations,
+                acknowledgedAtConfirmation: knownDirtyGenerations
+            ) else {
                 results.append(WorktreeBatchResult(
                     worktreeId: worktree.id,
                     branch: worktree.branch,
@@ -7771,9 +7806,11 @@ final class AppState {
         // discarding doesn't retroactively un-dirty anything — so the
         // per-item re-check below must compare against this snapshot rather
         // than against "is anything dirty right now", or the confirmed
-        // discard would skip every worktree it was meant to cover.
+        // discard would skip every worktree it was meant to cover. Recording
+        // each dirty tab's edit generation, not just its id, also catches a
+        // tab re-edited (from another window) after being acknowledged here.
         let dirtyTabsAtConfirmation = Dictionary(
-            uniqueKeysWithValues: worktrees.map { ($0.id, Set(dirtyEditorTabIds(worktreeId: $0.id))) }
+            uniqueKeysWithValues: worktrees.map { ($0.id, dirtyTabGenerations(worktreeId: $0.id)) }
         )
         let dirtyCount = dirtyTabsAtConfirmation.values.reduce(0) { $0 + $1.count }
         if dirtyCount > 0 {
@@ -7816,9 +7853,14 @@ final class AppState {
             // while an *earlier* item was still being removed. Only
             // dirtiness the confirmation didn't already cover counts: a tab
             // dirty at confirmation time and discarded is expected here, but
-            // a tab that turned dirty since then must not be torn down.
-            let currentDirtyTabs = Set(dirtyEditorTabIds(worktreeId: worktree.id))
-            guard currentDirtyTabs.isSubset(of: dirtyTabsAtConfirmation[worktree.id] ?? []) else {
+            // a tab that turned dirty, or was edited again since being
+            // acknowledged, must not be torn down.
+            let currentDirtyGenerations = dirtyTabGenerations(worktreeId: worktree.id)
+            let knownDirtyGenerations = dirtyTabsAtConfirmation[worktree.id] ?? [:]
+            guard Self.hasOnlyAcknowledgedDirtiness(
+                current: currentDirtyGenerations,
+                acknowledgedAtConfirmation: knownDirtyGenerations
+            ) else {
                 results.append(WorktreeBatchResult(
                     worktreeId: worktree.id,
                     branch: worktree.branch,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -8014,9 +8014,15 @@ final class AppState {
             // fails or the provider doesn't support it, fall back to the
             // originally detected remote rather than failing the scan.
             let queryRemote = (try? await provider.repositoryParent(remote: remote, cwd: repoPath)) ?? remote
+            // `gh pr list --limit` paginates internally to satisfy any count;
+            // `glab mr list` now does the same via GitLabCLIProvider's own
+            // paging loop. A repository with more merged reviews than this
+            // still won't see the oldest of them, but 1000 covers even a
+            // very active project's last year or two without every scan
+            // paying for an unbounded, open-ended history query.
             let refs = try await provider.mergedReviewRequests(
                 remote: queryRemote,
-                limit: 200,
+                limit: 1000,
                 cwd: repoPath
             )
             return .success(WorktreeForgeMergeIndex(refs: refs))

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -8007,8 +8007,15 @@ final class AppState {
             guard let provider = registry.provider(for: remote.kind) else {
                 return .failure(CodeHostProviderError.unsupportedProvider(remote.kind))
             }
+            // A fork's own pull/merge requests are almost never opened
+            // against itself — the classic contribution workflow opens them
+            // against the parent, and that's where a merge actually lands.
+            // Query the parent when this remote is a fork; if that lookup
+            // fails or the provider doesn't support it, fall back to the
+            // originally detected remote rather than failing the scan.
+            let queryRemote = (try? await provider.repositoryParent(remote: remote, cwd: repoPath)) ?? remote
             let refs = try await provider.mergedReviewRequests(
-                remote: remote,
+                remote: queryRemote,
                 limit: 200,
                 cwd: repoPath
             )

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7784,19 +7784,22 @@ final class AppState {
     /// worktree that is clean on disk but has an unsaved buffer would be
     /// deleted and its buffer silently discarded by `cleanupWorktreeState`.
     ///
-    /// `forgeConfirmedMergedWorktreeIds` names worktrees the cleanup scanner
-    /// verified as merged via the code host (a SHA-matched, confirmed-merged
-    /// review request) rather than by git's own local ancestry check. Git's
-    /// `branch -d` cannot recognize a squash- or rebase-merged branch as
-    /// merged — the resulting commit on the base branch isn't a descendant of
-    /// the original tip by history alone — so it silently leaves those
-    /// branches behind. For worktrees in this set, branch deletion uses `-D`
-    /// instead, trusting the code host's stronger evidence over git's blind
-    /// spot. Empty by default, so existing callers are unaffected.
+    /// `forgeConfirmedMergedBranchSHAs` maps a worktree id to the exact HEAD
+    /// SHA the cleanup scanner verified as merged via the code host (a
+    /// SHA-matched, confirmed-merged review request) rather than by git's own
+    /// local ancestry check. Git's `branch -d` cannot recognize a squash- or
+    /// rebase-merged branch as merged — the resulting commit on the base
+    /// branch isn't a descendant of the original tip by history alone — so it
+    /// silently leaves those branches behind. For worktrees in this map,
+    /// branch deletion uses `-D` instead, trusting the code host's stronger
+    /// evidence over git's blind spot — but only once the deletion path
+    /// re-confirms the branch's current tip still matches the recorded SHA,
+    /// since a new commit could have landed on it between this scan and now.
+    /// Empty by default, so existing callers are unaffected.
     func batchDeleteWorktrees(
         _ worktrees: [Worktree],
         keepBranch: Bool,
-        forgeConfirmedMergedWorktreeIds: Set<String> = []
+        forgeConfirmedMergedBranchSHAs: [String: String] = [:]
     ) async -> [WorktreeBatchResult] {
         guard !worktrees.isEmpty else { return [] }
 
@@ -7912,7 +7915,7 @@ final class AppState {
                 // No modal mid-batch: a worktree needing force is reported and
                 // left for the user to handle through the single-item flow.
                 promptsForForce: false,
-                branchVerifiedMergedOnForge: forgeConfirmedMergedWorktreeIds.contains(worktree.id)
+                verifiedMergedBranchSHA: forgeConfirmedMergedBranchSHAs[worktree.id]
             )
 
             results.append(WorktreeBatchResult(
@@ -8014,12 +8017,12 @@ final class AppState {
                     idleThresholdDays: idleThresholdDays
                 ))
             },
-            deleteBatch: { [weak self] worktrees, keepBranch, forgeConfirmedMergedWorktreeIds in
+            deleteBatch: { [weak self] worktrees, keepBranch, forgeConfirmedMergedBranchSHAs in
                 guard let self else { return [] }
                 return await self.batchDeleteWorktrees(
                     worktrees,
                     keepBranch: keepBranch,
-                    forgeConfirmedMergedWorktreeIds: forgeConfirmedMergedWorktreeIds
+                    forgeConfirmedMergedBranchSHAs: forgeConfirmedMergedBranchSHAs
                 )
             },
             archiveBatch: { [weak self] worktrees in
@@ -8479,7 +8482,7 @@ final class AppState {
         removedIndex: Int,
         refreshAfter: Bool = true,
         promptsForForce: Bool = true,
-        branchVerifiedMergedOnForge: Bool = false
+        verifiedMergedBranchSHA: String? = nil
     ) async -> WorktreeBatchOutcome {
         let outcome: WorktreeRemovalOutcome
         do {
@@ -8488,7 +8491,7 @@ final class AppState {
                 worktree: worktree,
                 deleteBranchIfMerged: deleteBranchIfMerged,
                 force: force,
-                branchVerifiedMergedOnForge: branchVerifiedMergedOnForge
+                verifiedMergedBranchSHA: verifiedMergedBranchSHA
             )
         } catch let WorktreeService.WorktreeError.gitFailed(stderr) {
             if !force,
@@ -8609,7 +8612,7 @@ final class AppState {
         worktree: Worktree,
         deleteBranchIfMerged: Bool,
         force: Bool,
-        branchVerifiedMergedOnForge: Bool = false
+        verifiedMergedBranchSHA: String? = nil
     ) async throws -> WorktreeRemovalOutcome {
         try await ProjectMutationGate.shared.withMutation(projectID: worktree.projectId) {
             try await Task.detached {
@@ -8619,7 +8622,7 @@ final class AppState {
                         worktree: worktree,
                         deleteBranchIfMerged: deleteBranchIfMerged,
                         force: force,
-                        branchVerifiedMergedOnForge: branchVerifiedMergedOnForge
+                        verifiedMergedBranchSHA: verifiedMergedBranchSHA
                     )
                     return .synchronous
                 }
@@ -8628,7 +8631,7 @@ final class AppState {
                     worktree: worktree,
                     deleteBranchIfMerged: deleteBranchIfMerged,
                     force: force,
-                    branchVerifiedMergedOnForge: branchVerifiedMergedOnForge
+                    verifiedMergedBranchSHA: verifiedMergedBranchSHA
                 )
             }.value
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7748,9 +7748,20 @@ final class AppState {
     /// `deleteWorktree`, above `beginDeleteWorktree`), so without this check a
     /// worktree that is clean on disk but has an unsaved buffer would be
     /// deleted and its buffer silently discarded by `cleanupWorktreeState`.
+    ///
+    /// `forgeConfirmedMergedWorktreeIds` names worktrees the cleanup scanner
+    /// verified as merged via the code host (a SHA-matched, confirmed-merged
+    /// review request) rather than by git's own local ancestry check. Git's
+    /// `branch -d` cannot recognize a squash- or rebase-merged branch as
+    /// merged — the resulting commit on the base branch isn't a descendant of
+    /// the original tip by history alone — so it silently leaves those
+    /// branches behind. For worktrees in this set, branch deletion uses `-D`
+    /// instead, trusting the code host's stronger evidence over git's blind
+    /// spot. Empty by default, so existing callers are unaffected.
     func batchDeleteWorktrees(
         _ worktrees: [Worktree],
-        keepBranch: Bool
+        keepBranch: Bool,
+        forgeConfirmedMergedWorktreeIds: Set<String> = []
     ) async -> [WorktreeBatchResult] {
         guard !worktrees.isEmpty else { return [] }
 
@@ -7858,7 +7869,8 @@ final class AppState {
                 refreshAfter: false,
                 // No modal mid-batch: a worktree needing force is reported and
                 // left for the user to handle through the single-item flow.
-                promptsForForce: false
+                promptsForForce: false,
+                branchVerifiedMergedOnForge: forgeConfirmedMergedWorktreeIds.contains(worktree.id)
             )
 
             results.append(WorktreeBatchResult(
@@ -7960,9 +7972,13 @@ final class AppState {
                     idleThresholdDays: idleThresholdDays
                 ))
             },
-            deleteBatch: { [weak self] worktrees, keepBranch in
+            deleteBatch: { [weak self] worktrees, keepBranch, forgeConfirmedMergedWorktreeIds in
                 guard let self else { return [] }
-                return await self.batchDeleteWorktrees(worktrees, keepBranch: keepBranch)
+                return await self.batchDeleteWorktrees(
+                    worktrees,
+                    keepBranch: keepBranch,
+                    forgeConfirmedMergedWorktreeIds: forgeConfirmedMergedWorktreeIds
+                )
             },
             archiveBatch: { [weak self] worktrees in
                 self?.batchArchiveWorktrees(worktrees) ?? []
@@ -8420,7 +8436,8 @@ final class AppState {
         force: Bool,
         removedIndex: Int,
         refreshAfter: Bool = true,
-        promptsForForce: Bool = true
+        promptsForForce: Bool = true,
+        branchVerifiedMergedOnForge: Bool = false
     ) async -> WorktreeBatchOutcome {
         let outcome: WorktreeRemovalOutcome
         do {
@@ -8428,7 +8445,8 @@ final class AppState {
                 repoPath: repoPath,
                 worktree: worktree,
                 deleteBranchIfMerged: deleteBranchIfMerged,
-                force: force
+                force: force,
+                branchVerifiedMergedOnForge: branchVerifiedMergedOnForge
             )
         } catch let WorktreeService.WorktreeError.gitFailed(stderr) {
             if !force,
@@ -8548,7 +8566,8 @@ final class AppState {
         repoPath: URL,
         worktree: Worktree,
         deleteBranchIfMerged: Bool,
-        force: Bool
+        force: Bool,
+        branchVerifiedMergedOnForge: Bool = false
     ) async throws -> WorktreeRemovalOutcome {
         try await ProjectMutationGate.shared.withMutation(projectID: worktree.projectId) {
             try await Task.detached {
@@ -8557,7 +8576,8 @@ final class AppState {
                         repoPath: repoPath,
                         worktree: worktree,
                         deleteBranchIfMerged: deleteBranchIfMerged,
-                        force: force
+                        force: force,
+                        branchVerifiedMergedOnForge: branchVerifiedMergedOnForge
                     )
                     return .synchronous
                 }
@@ -8565,7 +8585,8 @@ final class AppState {
                     repoPath: repoPath,
                     worktree: worktree,
                     deleteBranchIfMerged: deleteBranchIfMerged,
-                    force: force
+                    force: force,
+                    branchVerifiedMergedOnForge: branchVerifiedMergedOnForge
                 )
             }.value
         }

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -620,6 +620,17 @@ final class EditorBuffer {
         pending.userEdits.append(edit)
         pending.preloadText = storage.string
         loadState = .loading(pending)
+        // `handleEdit` returns immediately after this call without reaching
+        // its own `editGeneration &+= 1` below, and the eventual replay of
+        // `pending.userEdits` once loading finishes applies through
+        // `withLoadEditTrackingSuppressed` (programmatic, so it also skips
+        // that increment). Without bumping it here, a real user edit typed
+        // while the buffer is still loading would leave `editGeneration`
+        // completely unchanged — a snapshot taken before this edit and one
+        // taken after would read identically, defeating any staleness check
+        // (e.g. a batch worktree action's dirty-buffer recheck) that relies
+        // on the generation actually moving whenever content genuinely does.
+        editGeneration &+= 1
         return true
     }
 

--- a/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
+++ b/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
@@ -26,12 +26,14 @@ final class WorktreeCleanupModel {
     var keepBranches: Bool
 
     private let scan: @Sendable () async -> Result<[WorktreeCleanupCandidate], Error>
-    /// `(targets, keepBranches, forgeConfirmedMergedWorktreeIds) -> results`.
-    /// The third parameter names worktrees the scan independently verified as
-    /// merged via the code host, so the batch can trust that evidence enough
-    /// to force-delete their branches when git's own local ancestry check
-    /// can't recognize a squash/rebase merge.
-    private let deleteBatch: ([Worktree], Bool, Set<String>) async -> [WorktreeBatchResult]
+    /// `(targets, keepBranches, forgeConfirmedMergedBranchSHAs) -> results`.
+    /// The third parameter maps a worktree id to the exact HEAD SHA the scan
+    /// independently verified as merged via the code host, so the batch can
+    /// trust that evidence enough to force-delete the branch when git's own
+    /// local ancestry check can't recognize a squash/rebase merge — but only
+    /// once it re-confirms, immediately before deleting, that the branch's
+    /// tip still matches this SHA and no new commit has landed since the scan.
+    private let deleteBatch: ([Worktree], Bool, [String: String]) async -> [WorktreeBatchResult]
     private let archiveBatch: ([Worktree]) -> [WorktreeBatchResult]
     /// `(title, message, confirmButtonTitle) -> confirmed`. The button title is
     /// passed in because both destructive batch actions route through the same
@@ -48,7 +50,7 @@ final class WorktreeCleanupModel {
         projectId: String,
         keepBranches: Bool,
         scan: @escaping @Sendable () async -> Result<[WorktreeCleanupCandidate], Error>,
-        deleteBatch: @escaping ([Worktree], Bool, Set<String>) async -> [WorktreeBatchResult],
+        deleteBatch: @escaping ([Worktree], Bool, [String: String]) async -> [WorktreeBatchResult],
         archiveBatch: @escaping ([Worktree]) -> [WorktreeBatchResult],
         confirm: @escaping (String, String, String) -> Bool
     ) {
@@ -171,14 +173,21 @@ final class WorktreeCleanupModel {
         // SHA against a confirmed-merged review request on the code host —
         // the strongest evidence the scanner produces, and the only case
         // trusted enough to override git's own local-ancestry branch check.
-        let forgeConfirmedMergedWorktreeIds = Set(
-            candidates
-                .filter { selectedIds.contains($0.id) && $0.verdict == .candidate(confidence: .high) }
-                .map(\.id)
-        )
+        // The SHA itself travels along so the batch can re-verify, right
+        // before deleting, that the branch tip hasn't moved since this scan.
+        var forgeConfirmedMergedBranchSHAs: [String: String] = [:]
+        for candidate in candidates
+        where selectedIds.contains(candidate.id) && candidate.verdict == .candidate(confidence: .high) {
+            for signal in candidate.signals {
+                if case .mergedOnForge(_, _, let headSHA) = signal {
+                    forgeConfirmedMergedBranchSHAs[candidate.id] = headSHA
+                    break
+                }
+            }
+        }
 
         isRunning = true
-        results = await deleteBatch(targets, keepBranches, forgeConfirmedMergedWorktreeIds)
+        results = await deleteBatch(targets, keepBranches, forgeConfirmedMergedBranchSHAs)
         isRunning = false
         await runScan()
     }
@@ -229,7 +238,7 @@ extension WorktreeCleanupModel {
             projectId: "p",
             keepBranches: false,
             scan: { .success(candidates) },
-            deleteBatch: { _, _, _ in [] },
+            deleteBatch: { (_: [Worktree], _: Bool, _: [String: String]) in [] },
             archiveBatch: { _ in [] },
             confirm: { _, _, _ in true }
         )

--- a/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
+++ b/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
@@ -169,15 +169,22 @@ final class WorktreeCleanupModel {
             "Delete"
         ) else { return }
 
-        // High confidence means the scan matched this worktree's exact HEAD
-        // SHA against a confirmed-merged review request on the code host —
-        // the strongest evidence the scanner produces, and the only case
-        // trusted enough to override git's own local-ancestry branch check.
-        // The SHA itself travels along so the batch can re-verify, right
-        // before deleting, that the branch tip hasn't moved since this scan.
+        // A `.mergedOnForge` signal means the scan matched this worktree's
+        // exact HEAD SHA against a confirmed-merged review request on the
+        // code host — the strongest evidence the scanner produces, and the
+        // only case trusted enough to override git's own local-ancestry
+        // branch check. This is read straight off each *selected* row's own
+        // signals, not gated on the row's overall verdict: a clean,
+        // forge-merged worktree that is not yet idle carries this signal
+        // while its verdict is `.active` rather than `.candidate(.high)`,
+        // and remains manually selectable. Gating on the verdict would drop
+        // its SHA and silently fall back to `git branch -d`, which fails
+        // for a squash or rebase merge and leaves the branch behind despite
+        // the confirmation promising it will be deleted. The SHA itself
+        // travels along so the batch can re-verify, right before deleting,
+        // that the branch tip hasn't moved since this scan.
         var forgeConfirmedMergedBranchSHAs: [String: String] = [:]
-        for candidate in candidates
-        where selectedIds.contains(candidate.id) && candidate.verdict == .candidate(confidence: .high) {
+        for candidate in candidates where selectedIds.contains(candidate.id) {
             for signal in candidate.signals {
                 if case .mergedOnForge(_, _, let headSHA) = signal {
                     forgeConfirmedMergedBranchSHAs[candidate.id] = headSHA

--- a/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
+++ b/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
@@ -26,7 +26,12 @@ final class WorktreeCleanupModel {
     var keepBranches: Bool
 
     private let scan: @Sendable () async -> Result<[WorktreeCleanupCandidate], Error>
-    private let deleteBatch: ([Worktree], Bool) async -> [WorktreeBatchResult]
+    /// `(targets, keepBranches, forgeConfirmedMergedWorktreeIds) -> results`.
+    /// The third parameter names worktrees the scan independently verified as
+    /// merged via the code host, so the batch can trust that evidence enough
+    /// to force-delete their branches when git's own local ancestry check
+    /// can't recognize a squash/rebase merge.
+    private let deleteBatch: ([Worktree], Bool, Set<String>) async -> [WorktreeBatchResult]
     private let archiveBatch: ([Worktree]) -> [WorktreeBatchResult]
     /// `(title, message, confirmButtonTitle) -> confirmed`. The button title is
     /// passed in because both destructive batch actions route through the same
@@ -43,7 +48,7 @@ final class WorktreeCleanupModel {
         projectId: String,
         keepBranches: Bool,
         scan: @escaping @Sendable () async -> Result<[WorktreeCleanupCandidate], Error>,
-        deleteBatch: @escaping ([Worktree], Bool) async -> [WorktreeBatchResult],
+        deleteBatch: @escaping ([Worktree], Bool, Set<String>) async -> [WorktreeBatchResult],
         archiveBatch: @escaping ([Worktree]) -> [WorktreeBatchResult],
         confirm: @escaping (String, String, String) -> Bool
     ) {
@@ -162,8 +167,18 @@ final class WorktreeCleanupModel {
             "Delete"
         ) else { return }
 
+        // High confidence means the scan matched this worktree's exact HEAD
+        // SHA against a confirmed-merged review request on the code host —
+        // the strongest evidence the scanner produces, and the only case
+        // trusted enough to override git's own local-ancestry branch check.
+        let forgeConfirmedMergedWorktreeIds = Set(
+            candidates
+                .filter { selectedIds.contains($0.id) && $0.verdict == .candidate(confidence: .high) }
+                .map(\.id)
+        )
+
         isRunning = true
-        results = await deleteBatch(targets, keepBranches)
+        results = await deleteBatch(targets, keepBranches, forgeConfirmedMergedWorktreeIds)
         isRunning = false
         await runScan()
     }
@@ -214,7 +229,7 @@ extension WorktreeCleanupModel {
             projectId: "p",
             keepBranches: false,
             scan: { .success(candidates) },
-            deleteBatch: { _, _ in [] },
+            deleteBatch: { _, _, _ in [] },
             archiveBatch: { _ in [] },
             confirm: { _, _, _ in true }
         )

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupClassifier.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupClassifier.swift
@@ -78,8 +78,8 @@ enum WorktreeCleanupClassifier {
         // Merge state
         var mergeConfidence: WorktreeCleanupVerdict.Confidence?
         switch probe.mergeState {
-        case .mergedOnForge(let identity, let url):
-            qualifying.append(.mergedOnForge(identity: identity, url: url))
+        case .mergedOnForge(let identity, let url, let headSHA):
+            qualifying.append(.mergedOnForge(identity: identity, url: url, headSHA: headSHA))
             mergeConfidence = .high
         case .mergedLocally(let base):
             qualifying.append(.mergedLocally(base: base))

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
@@ -170,7 +170,7 @@ struct WorktreeCleanupScanner: Sendable {
         case .success(let index):
             if let localHeadSHA,
                let ref = index.refs(forBranch: branch).first(where: { $0.headSHA == localHeadSHA }) {
-                return .mergedOnForge(identity: "#\(ref.number)", url: ref.url)
+                return .mergedOnForge(identity: "#\(ref.number)", url: ref.url, headSHA: localHeadSHA)
             }
             if isMergedLocally { return .mergedLocally(base: baseBranch) }
             return .notMerged

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupTypes.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupTypes.swift
@@ -7,7 +7,14 @@ import Foundation
 /// not conflate them.
 enum WorktreeMergeState: Equatable, Sendable {
     /// The code host reports the branch's review request as merged.
-    case mergedOnForge(identity: String, url: URL)
+    /// `headSHA` is the worktree's own HEAD at the moment this was verified —
+    /// the exact commit whose SHA matched the review request's recorded head.
+    /// A consumer that wants to trust this enough to override git's own
+    /// safety checks (e.g. force-deleting the branch) must re-read the
+    /// branch's current tip immediately before acting and compare it against
+    /// this value: the branch can gain new commits between this scan and
+    /// that later action, and this state does not know about them.
+    case mergedOnForge(identity: String, url: URL, headSHA: String)
     /// `git merge-base --is-ancestor HEAD <base>` succeeded locally.
     case mergedLocally(base: String)
     /// Checked, and the branch is genuinely not merged.
@@ -37,7 +44,11 @@ struct WorktreeCleanupProbe: Equatable, Sendable {
 /// than logic buried in a view.
 enum WorktreeCleanupSignal: Equatable, Hashable, Sendable {
     // Qualifying
-    case mergedOnForge(identity: String, url: URL)
+    /// `headSHA` mirrors `WorktreeMergeState.mergedOnForge`'s — carried here
+    /// so a caller that only has candidates/signals (not the raw probe) can
+    /// still recover the exact SHA that was verified merged, to re-check
+    /// immediately before trusting it for something destructive.
+    case mergedOnForge(identity: String, url: URL, headSHA: String)
     case mergedLocally(base: String)
     case noUncommittedChanges
     case fullyPushed
@@ -85,7 +96,7 @@ enum WorktreeCleanupSignal: Equatable, Hashable, Sendable {
 
     var label: String {
         switch self {
-        case .mergedOnForge(let identity, _):
+        case .mergedOnForge(let identity, _, _):
             return "Merged on the code host (\(identity))"
         case .mergedLocally(let base):
             return "Merged locally into \(base)"

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -762,7 +762,8 @@ struct WorktreeService {
         deleteBranchIfMerged: Bool,
         force: Bool = false,
         forceTwice: Bool = false,
-        usesRemoteHostRegistry: Bool = true
+        usesRemoteHostRegistry: Bool = true,
+        branchVerifiedMergedOnForge: Bool = false
     ) async throws {
         var args = ["worktree", "remove", worktree.path.path]
         if forceTwice {
@@ -791,8 +792,17 @@ struct WorktreeService {
             throw WorktreeError.gitFailed(result.stderr)
         }
         if deleteBranchIfMerged && worktree.branch != "(detached)" {
-            // Best-effort delete. -d only succeeds if merged; ignore failures.
-            _ = try? await Process.git(["branch", "-d", worktree.branch], cwd: repoPath, usesRemoteHostRegistry: usesRemoteHostRegistry)
+            // `-d` only succeeds when git's own local ancestry check shows
+            // the branch merged, which a squash or rebase merge can never
+            // satisfy — the resulting commit on the base branch isn't a
+            // descendant of the original branch tip by history alone. When
+            // the caller has independently verified the merge via the code
+            // host (a SHA-matched, confirmed-merged review request), `-D`
+            // trusts that stronger evidence instead of git's own blind spot.
+            // Still best-effort: ignore failures either way, and never do
+            // this for a branch we haven't ourselves verified.
+            let branchDeleteFlag = branchVerifiedMergedOnForge ? "-D" : "-d"
+            _ = try? await Process.git(["branch", branchDeleteFlag, worktree.branch], cwd: repoPath, usesRemoteHostRegistry: usesRemoteHostRegistry)
         }
     }
 
@@ -802,6 +812,7 @@ struct WorktreeService {
         deleteBranchIfMerged: Bool,
         force: Bool = false,
         usesRemoteHostRegistry: Bool = true,
+        branchVerifiedMergedOnForge: Bool = false,
         moveItem: @Sendable (URL, URL) throws -> Void = {
             try WorktreeService.renameAtomically(from: $0, to: $1)
         }
@@ -812,7 +823,8 @@ struct WorktreeService {
                 worktree: worktree,
                 deleteBranchIfMerged: deleteBranchIfMerged,
                 force: force,
-                usesRemoteHostRegistry: usesRemoteHostRegistry
+                usesRemoteHostRegistry: usesRemoteHostRegistry,
+                branchVerifiedMergedOnForge: branchVerifiedMergedOnForge
             )
             return .synchronous
         }
@@ -919,7 +931,8 @@ struct WorktreeService {
                 deleteBranchIfMerged: deleteBranchIfMerged,
                 force: force,
                 forceTwice: registration.isLocked && force,
-                usesRemoteHostRegistry: false
+                usesRemoteHostRegistry: false,
+                branchVerifiedMergedOnForge: branchVerifiedMergedOnForge
             )
             return .synchronous
         }
@@ -943,7 +956,8 @@ struct WorktreeService {
                 deleteBranchIfMerged: deleteBranchIfMerged,
                 force: force,
                 forceTwice: registration.isLocked && force,
-                usesRemoteHostRegistry: false
+                usesRemoteHostRegistry: false,
+                branchVerifiedMergedOnForge: branchVerifiedMergedOnForge
             )
             return .synchronous
         }
@@ -1085,8 +1099,12 @@ struct WorktreeService {
 
         if deleteBranchIfMerged && worktree.branch != "(detached)" {
             let branchGitDirectory = branchDeletionGitDirectory ?? expectedCommonDirectory
+            // See `remove(...)`'s matching comment: `-d` can't recognize a
+            // squash/rebase merge, so a branch verified merged via the code
+            // host uses `-D` instead of silently lingering.
+            let branchDeleteFlag = branchVerifiedMergedOnForge ? "-D" : "-d"
             _ = try? await Process.git(
-                ["--git-dir", branchGitDirectory.path, "branch", "-d", worktree.branch],
+                ["--git-dir", branchGitDirectory.path, "branch", branchDeleteFlag, worktree.branch],
                 cwd: expectedCommonDirectory,
                 usesRemoteHostRegistry: false
             )

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -763,7 +763,7 @@ struct WorktreeService {
         force: Bool = false,
         forceTwice: Bool = false,
         usesRemoteHostRegistry: Bool = true,
-        branchVerifiedMergedOnForge: Bool = false
+        verifiedMergedBranchSHA: String? = nil
     ) async throws {
         var args = ["worktree", "remove", worktree.path.path]
         if forceTwice {
@@ -798,12 +798,47 @@ struct WorktreeService {
             // descendant of the original branch tip by history alone. When
             // the caller has independently verified the merge via the code
             // host (a SHA-matched, confirmed-merged review request), `-D`
-            // trusts that stronger evidence instead of git's own blind spot.
-            // Still best-effort: ignore failures either way, and never do
-            // this for a branch we haven't ourselves verified.
-            let branchDeleteFlag = branchVerifiedMergedOnForge ? "-D" : "-d"
+            // trusts that stronger evidence instead of git's own blind spot
+            // — but only after re-reading the branch's current tip here and
+            // confirming it still matches the SHA that was verified: a new
+            // commit can land on the branch between that scan and this call,
+            // and `-D` must never discard one just because an older tip was
+            // once confirmed merged. Still best-effort: ignore failures
+            // either way, and never force-delete a branch we haven't
+            // ourselves just reverified.
+            let branchDeleteFlag: String
+            if let verifiedMergedBranchSHA {
+                let currentTip = await Self.currentBranchTip(
+                    branch: worktree.branch,
+                    gitDirArguments: [],
+                    cwd: repoPath,
+                    usesRemoteHostRegistry: usesRemoteHostRegistry
+                )
+                branchDeleteFlag = currentTip == verifiedMergedBranchSHA ? "-D" : "-d"
+            } else {
+                branchDeleteFlag = "-d"
+            }
             _ = try? await Process.git(["branch", branchDeleteFlag, worktree.branch], cwd: repoPath, usesRemoteHostRegistry: usesRemoteHostRegistry)
         }
+    }
+
+    /// Re-reads a branch's current tip SHA immediately before a force branch
+    /// delete chooses `-D` over `-d`. Called right at the point of use rather
+    /// than trusting a scan-time value, since the branch can gain commits in
+    /// the window between the scan that verified a merge and this deletion.
+    private static func currentBranchTip(
+        branch: String,
+        gitDirArguments: [String],
+        cwd: URL,
+        usesRemoteHostRegistry: Bool
+    ) async -> String? {
+        guard let result = try? await Process.git(
+            gitDirArguments + ["rev-parse", "refs/heads/\(branch)"],
+            cwd: cwd,
+            usesRemoteHostRegistry: usesRemoteHostRegistry
+        ), result.exitCode == 0 else { return nil }
+        let sha = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return sha.isEmpty ? nil : sha
     }
 
     func removeFastLocal(
@@ -812,7 +847,7 @@ struct WorktreeService {
         deleteBranchIfMerged: Bool,
         force: Bool = false,
         usesRemoteHostRegistry: Bool = true,
-        branchVerifiedMergedOnForge: Bool = false,
+        verifiedMergedBranchSHA: String? = nil,
         moveItem: @Sendable (URL, URL) throws -> Void = {
             try WorktreeService.renameAtomically(from: $0, to: $1)
         }
@@ -824,7 +859,7 @@ struct WorktreeService {
                 deleteBranchIfMerged: deleteBranchIfMerged,
                 force: force,
                 usesRemoteHostRegistry: usesRemoteHostRegistry,
-                branchVerifiedMergedOnForge: branchVerifiedMergedOnForge
+                verifiedMergedBranchSHA: verifiedMergedBranchSHA
             )
             return .synchronous
         }
@@ -932,7 +967,7 @@ struct WorktreeService {
                 force: force,
                 forceTwice: registration.isLocked && force,
                 usesRemoteHostRegistry: false,
-                branchVerifiedMergedOnForge: branchVerifiedMergedOnForge
+                verifiedMergedBranchSHA: verifiedMergedBranchSHA
             )
             return .synchronous
         }
@@ -957,7 +992,7 @@ struct WorktreeService {
                 force: force,
                 forceTwice: registration.isLocked && force,
                 usesRemoteHostRegistry: false,
-                branchVerifiedMergedOnForge: branchVerifiedMergedOnForge
+                verifiedMergedBranchSHA: verifiedMergedBranchSHA
             )
             return .synchronous
         }
@@ -1101,8 +1136,21 @@ struct WorktreeService {
             let branchGitDirectory = branchDeletionGitDirectory ?? expectedCommonDirectory
             // See `remove(...)`'s matching comment: `-d` can't recognize a
             // squash/rebase merge, so a branch verified merged via the code
-            // host uses `-D` instead of silently lingering.
-            let branchDeleteFlag = branchVerifiedMergedOnForge ? "-D" : "-d"
+            // host uses `-D` instead of silently lingering — but only once
+            // the branch's current tip, re-read here, still matches the SHA
+            // that was verified merged.
+            let branchDeleteFlag: String
+            if let verifiedMergedBranchSHA {
+                let currentTip = await Self.currentBranchTip(
+                    branch: worktree.branch,
+                    gitDirArguments: ["--git-dir", branchGitDirectory.path],
+                    cwd: expectedCommonDirectory,
+                    usesRemoteHostRegistry: false
+                )
+                branchDeleteFlag = currentTip == verifiedMergedBranchSHA ? "-D" : "-d"
+            } else {
+                branchDeleteFlag = "-d"
+            }
             _ = try? await Process.git(
                 ["--git-dir", branchGitDirectory.path, "branch", branchDeleteFlag, worktree.branch],
                 cwd: expectedCommonDirectory,

--- a/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
@@ -252,6 +252,14 @@ protocol CodeHostProvider: Sendable {
         limit: Int,
         cwd: URL
     ) async throws -> [MergedReviewRequestRef]
+
+    /// The repository `remote` was forked from, if any. A fork's own pull/
+    /// merge requests are almost never opened against itself — the classic
+    /// contribution workflow opens them against the parent, and that is
+    /// where a merge actually lands — so worktree cleanup queries the parent
+    /// for merged review requests instead of the fork when one exists.
+    /// Returns `nil` for a repository that is not a fork.
+    func repositoryParent(remote: CodeHostRemote, cwd: URL) async throws -> CodeHostRemote?
 }
 
 extension CodeHostProvider {
@@ -453,6 +461,15 @@ extension CodeHostProvider {
         cwd: URL
     ) async throws -> [MergedReviewRequestRef] {
         throw CodeHostProviderError.unsupportedProvider(remote.kind)
+    }
+
+    /// Unlike `mergedReviewRequests`, a provider that can't determine fork
+    /// status degrades to "not a fork" rather than throwing: the caller
+    /// falls back to the original remote either way, so failing loudly here
+    /// would gain nothing and would risk failing the whole scan over what is
+    /// only ever used as an enhancement to it.
+    func repositoryParent(remote: CodeHostRemote, cwd: URL) async throws -> CodeHostRemote? {
+        nil
     }
 }
 

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -302,6 +302,59 @@ struct GitHubCLIProvider: CodeHostProvider, CodeHostIssueProviding {
         }
     }
 
+    func repositoryParent(remote: CodeHostRemote, cwd: URL) async throws -> CodeHostRemote? {
+        let result = try await runner.run(
+            "gh",
+            args: [
+                "repo", "view",
+                Self.highLevelRepositorySelector(remote: remote),
+                "--json", "isFork,parent",
+            ],
+            cwd: cwd
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(
+                command: "gh repo view",
+                stderr: result.stderr
+            )
+        }
+        return try Self.parseRepoParent(result.stdout, remote: remote)
+    }
+
+    static func parseRepoParent(_ json: String, remote: CodeHostRemote) throws -> CodeHostRemote? {
+        struct ParentOwner: Decodable {
+            let login: String
+        }
+        struct Parent: Decodable {
+            let name: String
+            let owner: ParentOwner
+        }
+        struct Item: Decodable {
+            let isFork: Bool
+            let parent: Parent?
+        }
+        let item: Item
+        do {
+            item = try JSONDecoder().decode(Item.self, from: Data(json.utf8))
+        } catch {
+            throw CodeHostProviderError.malformedOutput(
+                "Unable to parse gh repo view output"
+            )
+        }
+        guard item.isFork, let parent = item.parent else { return nil }
+        guard let webURL = URL(string: "https://\(remote.host)/\(parent.owner.login)/\(parent.name)") else {
+            return nil
+        }
+        return CodeHostRemote(
+            kind: remote.kind,
+            host: remote.host,
+            owner: parent.owner.login,
+            repository: parent.name,
+            remoteName: remote.remoteName,
+            webURL: webURL
+        )
+    }
+
     func isAvailable(cwd: URL) async -> Bool {
         do {
             let result = try await runner.run("gh", args: ["--version"], cwd: cwd)

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -22,26 +22,43 @@ struct GitLabCLIProvider: CodeHostProvider, CodeHostIssueProviding {
         limit: Int,
         cwd: URL
     ) async throws -> [MergedReviewRequestRef] {
-        let result = try await runner.run(
-            "glab",
-            args: [
-                // glab spells this `--merged`; there is no `--state` flag on
-                // `mr list` (verified against `glab mr list --help`).
-                "mr", "list",
-                "--merged",
-                "--per-page", "\(limit)",
-                "--output", "json",
-                "-R", remote.repositorySlug,
-            ],
-            cwd: cwd
-        )
-        guard result.exitCode == 0 else {
-            throw CodeHostProviderError.commandFailed(
-                command: "glab mr list",
-                stderr: result.stderr
+        // Unlike `gh pr list --limit`, which fetches as many pages as needed
+        // to satisfy any requested count, `glab mr list` fetches exactly one
+        // page — bounded by `--per-page`, which GitLab's REST API caps at
+        // 100 regardless of what's requested (verified against `glab mr
+        // list --help`: `-p --page` and `-P --per-page` are independent,
+        // there is no total-count flag). Page manually until a short page
+        // signals the end, or `limit` is reached.
+        let perPage = 100
+        var refs: [MergedReviewRequestRef] = []
+        var page = 1
+        while refs.count < limit {
+            let result = try await runner.run(
+                "glab",
+                args: [
+                    // glab spells this `--merged`; there is no `--state` flag
+                    // on `mr list` (verified against `glab mr list --help`).
+                    "mr", "list",
+                    "--merged",
+                    "--per-page", "\(perPage)",
+                    "--page", "\(page)",
+                    "--output", "json",
+                    "-R", remote.repositorySlug,
+                ],
+                cwd: cwd
             )
+            guard result.exitCode == 0 else {
+                throw CodeHostProviderError.commandFailed(
+                    command: "glab mr list",
+                    stderr: result.stderr
+                )
+            }
+            let pageRefs = try Self.parseMergedMRList(result.stdout)
+            refs.append(contentsOf: pageRefs)
+            guard pageRefs.count == perPage else { break }
+            page += 1
         }
-        return try Self.parseMergedMRList(result.stdout)
+        return Array(refs.prefix(limit))
     }
 
     static func parseMergedMRList(_ json: String) throws -> [MergedReviewRequestRef] {

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -80,6 +80,67 @@ struct GitLabCLIProvider: CodeHostProvider, CodeHostIssueProviding {
         }
     }
 
+    func repositoryParent(remote: CodeHostRemote, cwd: URL) async throws -> CodeHostRemote? {
+        // `glab repo view`'s own JSON shape for fork ancestry isn't
+        // documented; the raw REST passthrough is, and this codebase already
+        // uses it elsewhere (see the issues endpoints above). GitLab's
+        // project resource carries `forked_from_project` with a stable,
+        // documented shape.
+        let result = try await runner.run(
+            "glab",
+            args: ["api", "projects/\(Self.encodedProjectPath(remote.repositorySlug))"],
+            cwd: cwd
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(
+                command: "glab api projects",
+                stderr: result.stderr
+            )
+        }
+        return try Self.parseRepoParent(result.stdout, remote: remote)
+    }
+
+    static func parseRepoParent(_ json: String, remote: CodeHostRemote) throws -> CodeHostRemote? {
+        struct ForkedFromProject: Decodable {
+            let pathWithNamespace: String
+
+            enum CodingKeys: String, CodingKey {
+                case pathWithNamespace = "path_with_namespace"
+            }
+        }
+        struct Item: Decodable {
+            let forkedFromProject: ForkedFromProject?
+
+            enum CodingKeys: String, CodingKey {
+                case forkedFromProject = "forked_from_project"
+            }
+        }
+        let item: Item
+        do {
+            item = try JSONDecoder().decode(Item.self, from: Data(json.utf8))
+        } catch {
+            throw CodeHostProviderError.malformedOutput(
+                "Unable to parse glab api projects output"
+            )
+        }
+        guard let parent = item.forkedFromProject else { return nil }
+        guard let webURL = URL(string: "https://\(remote.host)/\(parent.pathWithNamespace)") else {
+            return nil
+        }
+        let parts = parent.pathWithNamespace.split(separator: "/")
+        guard let repository = parts.last else { return nil }
+        let owner = parts.dropLast().joined(separator: "/")
+        guard !owner.isEmpty else { return nil }
+        return CodeHostRemote(
+            kind: remote.kind,
+            host: remote.host,
+            owner: owner,
+            repository: String(repository),
+            remoteName: remote.remoteName,
+            webURL: webURL
+        )
+    }
+
     func isAvailable(cwd: URL) async -> Bool {
         do {
             let result = try await runner.run("glab", args: ["--version"], cwd: cwd)

--- a/AlasTests/AppStateWorktreeCleanupBatchTests.swift
+++ b/AlasTests/AppStateWorktreeCleanupBatchTests.swift
@@ -126,4 +126,56 @@ struct AppStateWorktreeCleanupBatchTests {
         #expect(fixture.state.projectsManager
             .worktrees(projectId: fixture.project.id).count == before)
     }
+
+    // MARK: - hasOnlyAcknowledgedDirtiness
+
+    @Test func identicalGenerationsAreAcknowledged() {
+        #expect(AppState.hasOnlyAcknowledgedDirtiness(
+            current: ["tab-a": 3],
+            acknowledgedAtConfirmation: ["tab-a": 3]
+        ))
+    }
+
+    @Test func emptyCurrentDirtinessIsAlwaysAcknowledged() {
+        #expect(AppState.hasOnlyAcknowledgedDirtiness(
+            current: [:],
+            acknowledgedAtConfirmation: ["tab-a": 3]
+        ))
+    }
+
+    /// The exact regression this mechanism exists to close: a tab already
+    /// dirty (and discarded) at confirmation time, then re-edited since — its
+    /// id is unchanged, but its generation has moved on.
+    @Test func sameTabAtALaterGenerationIsNotAcknowledged() {
+        #expect(!AppState.hasOnlyAcknowledgedDirtiness(
+            current: ["tab-a": 4],
+            acknowledgedAtConfirmation: ["tab-a": 3]
+        ))
+    }
+
+    @Test func aNewlyDirtiedTabIsNotAcknowledged() {
+        #expect(!AppState.hasOnlyAcknowledgedDirtiness(
+            current: ["tab-a": 3, "tab-b": 0],
+            acknowledgedAtConfirmation: ["tab-a": 3]
+        ))
+    }
+
+    @Test func aTabThatBecameCleanDoesNotBlockTheOthers() {
+        // "tab-b" was dirty at confirmation and is clean now — its absence
+        // from `current` is fine; only what's dirty *now* is checked.
+        #expect(AppState.hasOnlyAcknowledgedDirtiness(
+            current: ["tab-a": 3],
+            acknowledgedAtConfirmation: ["tab-a": 3, "tab-b": 1]
+        ))
+    }
+
+    @Test func unopenedSnapshotOnlyTabsMatchOnTheSentinelGeneration() {
+        // A tab with only a persisted hot-exit snapshot (no live buffer) is
+        // recorded at the -1 sentinel; as long as it's never opened, that
+        // stays stable across the snapshot and the recheck.
+        #expect(AppState.hasOnlyAcknowledgedDirtiness(
+            current: ["tab-a": -1],
+            acknowledgedAtConfirmation: ["tab-a": -1]
+        ))
+    }
 }

--- a/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
+++ b/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
@@ -142,7 +142,7 @@ struct WorktreeCleanupModelTests {
             projectId: "p",
             keepBranches: false,
             scan: { .success([a, b]) },
-            deleteBatch: { _, _ in [] },
+            deleteBatch: { _, _, _ in [] },
             archiveBatch: { _ in [] },
             confirm: { _, _, _ in true }
         )
@@ -166,7 +166,7 @@ struct WorktreeCleanupModelTests {
             projectId: "p",
             keepBranches: false,
             scan: { .success([a]) },
-            deleteBatch: { _, _ in [] },
+            deleteBatch: { _, _, _ in [] },
             archiveBatch: { worktrees in
                 archiveBatchCalls += 1
                 return worktrees.map {
@@ -197,7 +197,7 @@ struct WorktreeCleanupModelTests {
             projectId: "p",
             keepBranches: false,
             scan: { .success([a]) },
-            deleteBatch: { _, _ in [] },
+            deleteBatch: { _, _, _ in [] },
             archiveBatch: { worktrees in
                 archiveBatchCalls += 1
                 return worktrees.map {
@@ -221,7 +221,7 @@ struct WorktreeCleanupModelTests {
             projectId: "p",
             keepBranches: false,
             scan: { .success([a]) },
-            deleteBatch: { _, _ in
+            deleteBatch: { _, _, _ in
                 deleteBatchCalls += 1
                 return []
             },
@@ -237,6 +237,35 @@ struct WorktreeCleanupModelTests {
 
         #expect(confirmButtons == ["Delete"])
         #expect(deleteBatchCalls == 0)
+    }
+
+    /// Only a high-confidence candidate — the scan matched its exact HEAD SHA
+    /// against a confirmed-merged review request — is trusted enough to
+    /// force-delete its branch. A selected dirty row overridden by the user,
+    /// or a medium/low-confidence match, must not be swept into that set even
+    /// though both are part of the same batch.
+    @Test func deleteSelectedNamesOnlyHighConfidenceCandidatesAsForgeConfirmed() async {
+        let highConfidence = candidate(branch: "a", verdict: .candidate(confidence: .high))
+        let mediumConfidence = candidate(branch: "b", verdict: .candidate(confidence: .medium))
+        let overriddenDirty = candidate(branch: "c", verdict: .dirty)
+        var passedForgeConfirmedIds: Set<String> = []
+        let model = WorktreeCleanupModel(
+            projectId: "p",
+            keepBranches: false,
+            scan: { .success([highConfidence, mediumConfidence, overriddenDirty]) },
+            deleteBatch: { _, _, forgeConfirmedMergedWorktreeIds in
+                passedForgeConfirmedIds = forgeConfirmedMergedWorktreeIds
+                return []
+            },
+            archiveBatch: { _ in [] },
+            confirm: { _, _, _ in true }
+        )
+        model.applyScanResult([highConfidence, mediumConfidence, overriddenDirty])
+        model.toggle("/tmp/wt-c")   // per-item override on the dirty row
+
+        await model.deleteSelected()
+
+        #expect(passedForgeConfirmedIds == ["/tmp/wt-a"])
     }
 
     @Test func selectedWorktreesFollowsDisplayOrder() {

--- a/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
+++ b/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
@@ -239,13 +239,13 @@ struct WorktreeCleanupModelTests {
         #expect(deleteBatchCalls == 0)
     }
 
-    /// Only a high-confidence candidate — the scan matched its exact HEAD SHA
-    /// against a confirmed-merged review request — is trusted enough to
-    /// force-delete its branch. A selected dirty row overridden by the user,
-    /// or a medium/low-confidence match, must not be swept into that map even
-    /// though both are part of the same batch. The SHA that travels along is
-    /// the exact one carried by the candidate's `.mergedOnForge` signal.
-    @Test func deleteSelectedNamesOnlyHighConfidenceCandidatesAsForgeConfirmed() async {
+    /// A row carrying a `.mergedOnForge` signal — the scan matched its exact
+    /// HEAD SHA against a confirmed-merged review request — is trusted
+    /// enough to force-delete its branch, regardless of that row's overall
+    /// verdict. A selected dirty row with no such signal must not be swept
+    /// into that map even though it is part of the same batch. The SHA that
+    /// travels along is the exact one carried by the signal.
+    @Test func deleteSelectedNamesOnlyForgeConfirmedSelectedCandidates() async {
         let highConfidence = candidate(
             branch: "a",
             verdict: .candidate(confidence: .high),
@@ -271,6 +271,39 @@ struct WorktreeCleanupModelTests {
         await model.deleteSelected()
 
         #expect(passedForgeConfirmedSHAs == ["/tmp/wt-a": "abc123"])
+    }
+
+    /// The regression this fix closes: a clean, forge-merged worktree that
+    /// is not yet idle carries the same `.mergedOnForge` signal but an
+    /// `.active` verdict (not `.candidate(.high)`), and remains manually
+    /// selectable. Gating the SHA map on the verdict would drop it here and
+    /// fall back to `git branch -d`, which silently fails for a squash or
+    /// rebase merge — deriving from each selected row's own signals instead
+    /// must still pick it up.
+    @Test func deleteSelectedIncludesAManuallySelectedActiveForgeMergedRow() async {
+        let activeButForgeMerged = candidate(
+            branch: "a",
+            verdict: .active,
+            signals: [.mergedOnForge(identity: "#7", url: URL(string: "https://example.com/7")!, headSHA: "def456")]
+        )
+        var passedForgeConfirmedSHAs: [String: String] = [:]
+        let model = WorktreeCleanupModel(
+            projectId: "p",
+            keepBranches: false,
+            scan: { .success([activeButForgeMerged]) },
+            deleteBatch: { _, _, forgeConfirmedMergedBranchSHAs in
+                passedForgeConfirmedSHAs = forgeConfirmedMergedBranchSHAs
+                return []
+            },
+            archiveBatch: { _ in [] },
+            confirm: { _, _, _ in true }
+        )
+        model.applyScanResult([activeButForgeMerged])
+        model.toggle("/tmp/wt-a")   // manual override — .active is not selected by default
+
+        await model.deleteSelected()
+
+        #expect(passedForgeConfirmedSHAs == ["/tmp/wt-a": "def456"])
     }
 
     @Test func selectedWorktreesFollowsDisplayOrder() {

--- a/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
+++ b/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
@@ -242,19 +242,24 @@ struct WorktreeCleanupModelTests {
     /// Only a high-confidence candidate — the scan matched its exact HEAD SHA
     /// against a confirmed-merged review request — is trusted enough to
     /// force-delete its branch. A selected dirty row overridden by the user,
-    /// or a medium/low-confidence match, must not be swept into that set even
-    /// though both are part of the same batch.
+    /// or a medium/low-confidence match, must not be swept into that map even
+    /// though both are part of the same batch. The SHA that travels along is
+    /// the exact one carried by the candidate's `.mergedOnForge` signal.
     @Test func deleteSelectedNamesOnlyHighConfidenceCandidatesAsForgeConfirmed() async {
-        let highConfidence = candidate(branch: "a", verdict: .candidate(confidence: .high))
+        let highConfidence = candidate(
+            branch: "a",
+            verdict: .candidate(confidence: .high),
+            signals: [.mergedOnForge(identity: "#1", url: URL(string: "https://example.com/1")!, headSHA: "abc123")]
+        )
         let mediumConfidence = candidate(branch: "b", verdict: .candidate(confidence: .medium))
         let overriddenDirty = candidate(branch: "c", verdict: .dirty)
-        var passedForgeConfirmedIds: Set<String> = []
+        var passedForgeConfirmedSHAs: [String: String] = [:]
         let model = WorktreeCleanupModel(
             projectId: "p",
             keepBranches: false,
             scan: { .success([highConfidence, mediumConfidence, overriddenDirty]) },
-            deleteBatch: { _, _, forgeConfirmedMergedWorktreeIds in
-                passedForgeConfirmedIds = forgeConfirmedMergedWorktreeIds
+            deleteBatch: { _, _, forgeConfirmedMergedBranchSHAs in
+                passedForgeConfirmedSHAs = forgeConfirmedMergedBranchSHAs
                 return []
             },
             archiveBatch: { _ in [] },
@@ -265,7 +270,7 @@ struct WorktreeCleanupModelTests {
 
         await model.deleteSelected()
 
-        #expect(passedForgeConfirmedIds == ["/tmp/wt-a"])
+        #expect(passedForgeConfirmedSHAs == ["/tmp/wt-a": "abc123"])
     }
 
     @Test func selectedWorktreesFollowsDisplayOrder() {

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -487,6 +487,35 @@ struct EditorBufferTests {
         #expect(buffer.dirty == true)
     }
 
+    /// An edit typed while the initial async load is still pending is
+    /// captured into `pending.userEdits` and replayed once the load
+    /// completes, but `handleEdit`'s own generation bump is short-circuited
+    /// for it (it returns before reaching that line) and the later replay
+    /// applies through a programmatic path that also skips it. Without a
+    /// dedicated bump at the point the edit is captured, a snapshot of
+    /// `editGeneration` taken before this edit and one taken after would
+    /// read identically — silently defeating any staleness check (e.g. a
+    /// batch worktree action's dirty-buffer recheck) built on the
+    /// assumption that the generation moves whenever content genuinely does.
+    @Test func editBeforeAsyncLoadFinishesBumpsEditGeneration() async throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", "disk\n")
+        let gate = AsyncLoadGate()
+        EditorBuffer.loadGateForTesting = { await gate.wait() }
+        defer { EditorBuffer.loadGateForTesting = nil }
+
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        let generationBeforeEdit = buffer.editGeneration
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "typed")
+        let generationAfterEdit = buffer.editGeneration
+
+        await gate.open()
+        await buffer.awaitLoadForTesting()
+
+        #expect(generationAfterEdit != generationBeforeEdit)
+        #expect(buffer.storage.string == "typeddisk\n")
+    }
+
     @Test func editBeforeAsyncLoadFinishesKeepsDiskBaselineAndSaveBlocked() async throws {
         let root = tempWorktree()
         _ = try writeFile(root, "a.txt", "disk\n")

--- a/AlasTests/Git/WorktreeCleanupClassifierTests.swift
+++ b/AlasTests/Git/WorktreeCleanupClassifierTests.swift
@@ -35,7 +35,8 @@ struct WorktreeCleanupClassifierTests {
             lastActivity: now.addingTimeInterval(-Double(daysIdle) * 86_400),
             mergeState: .mergedOnForge(
                 identity: "GitHub #42",
-                url: URL(string: "https://github.com/o/r/pull/42")!
+                url: URL(string: "https://github.com/o/r/pull/42")!,
+                headSHA: "abc123"
             )
         )
     }

--- a/AlasTests/Git/WorktreeCleanupScannerTests.swift
+++ b/AlasTests/Git/WorktreeCleanupScannerTests.swift
@@ -93,7 +93,7 @@ struct WorktreeCleanupScannerTests {
         )
         #expect(results[0].verdict == .candidate(confidence: .high))
         #expect(results[0].signals.contains(
-            .mergedOnForge(identity: "#42", url: ref.url)
+            .mergedOnForge(identity: "#42", url: ref.url, headSHA: Self.localHeadSHA)
         ))
     }
 
@@ -153,7 +153,7 @@ struct WorktreeCleanupScannerTests {
         )
         #expect(results[0].verdict == .candidate(confidence: .high))
         #expect(results[0].signals.contains(
-            .mergedOnForge(identity: "#10", url: olderRef.url)
+            .mergedOnForge(identity: "#10", url: olderRef.url, headSHA: "old-commit-sha")
         ))
     }
 

--- a/AlasTests/Integrations/MergedReviewRequestTests.swift
+++ b/AlasTests/Integrations/MergedReviewRequestTests.swift
@@ -55,6 +55,80 @@ struct MergedReviewRequestTests {
         #expect(refs[0].headSHA == "abc123")
     }
 
+    @Test func parsesGitHubForkParent() throws {
+        let json = """
+        {"isFork": true, "parent": {"name": "alas", "owner": {"login": "mrmans0n"}}}
+        """
+        let parent = try GitHubCLIProvider.parseRepoParent(json, remote: Self.remote)
+        #expect(parent?.owner == "mrmans0n")
+        #expect(parent?.repository == "alas")
+        #expect(parent?.host == "github.com")
+        #expect(parent?.kind == .github)
+        #expect(parent?.remoteName == "origin")
+        #expect(parent?.webURL == URL(string: "https://github.com/mrmans0n/alas")!)
+    }
+
+    @Test func gitHubNonForkHasNoParent() throws {
+        let json = """
+        {"isFork": false, "parent": null}
+        """
+        let parent = try GitHubCLIProvider.parseRepoParent(json, remote: Self.remote)
+        #expect(parent == nil)
+    }
+
+    @Test func rejectsMalformedGitHubRepoViewOutput() {
+        #expect(throws: CodeHostProviderError.self) {
+            _ = try GitHubCLIProvider.parseRepoParent("not json", remote: Self.remote)
+        }
+    }
+
+    @Test func parsesGitLabForkParent() throws {
+        let json = """
+        {"forked_from_project": {"path_with_namespace": "upstream-group/upstream-project"}}
+        """
+        let parent = try GitLabCLIProvider.parseRepoParent(json, remote: Self.remote)
+        #expect(parent?.owner == "upstream-group")
+        #expect(parent?.repository == "upstream-project")
+        #expect(parent?.webURL == URL(string: "https://github.com/upstream-group/upstream-project")!)
+    }
+
+    @Test func gitLabNonForkHasNoParent() throws {
+        let json = """
+        {"forked_from_project": null}
+        """
+        let parent = try GitLabCLIProvider.parseRepoParent(json, remote: Self.remote)
+        #expect(parent == nil)
+    }
+
+    @Test func gitHubProviderRepositoryParentIssuesOneQuery() async throws {
+        let runner = RecordingRunner(stdout: """
+        {"isFork": true, "parent": {"name": "alas", "owner": {"login": "mrmans0n"}}}
+        """)
+        let provider = GitHubCLIProvider(runner: runner)
+        let parent = try await provider.repositoryParent(
+            remote: Self.remote,
+            cwd: URL(fileURLWithPath: "/tmp")
+        )
+        #expect(parent?.repository == "alas")
+        let invocations = await runner.invocations
+        #expect(invocations.count == 1)
+        #expect(invocations[0].args.contains("view"))
+        #expect(invocations[0].args.contains { $0.contains("parent") })
+    }
+
+    /// A provider that can't determine fork status degrades to "not a fork"
+    /// rather than throwing — the caller falls back to the original remote
+    /// either way, and failing loudly here would only risk breaking the scan
+    /// over what is purely an enhancement to it.
+    @Test func protocolDefaultRepositoryParentReturnsNil() async throws {
+        let provider = MergeQueryUnsupportedProvider()
+        let parent = try await provider.repositoryParent(
+            remote: Self.remote,
+            cwd: URL(fileURLWithPath: "/tmp")
+        )
+        #expect(parent == nil)
+    }
+
     @Test func gitHubProviderIssuesOneBatchedQuery() async throws {
         let runner = RecordingRunner(stdout: """
         [{"number": 42, "headRefName": "feature/a", "url": "https://github.com/mrmans0n/alas/pull/42", "headRefOid": "abc123"}]

--- a/AlasTests/Integrations/MergedReviewRequestTests.swift
+++ b/AlasTests/Integrations/MergedReviewRequestTests.swift
@@ -174,6 +174,101 @@ struct MergedReviewRequestTests {
             )
         }
     }
+
+    private static let gitlabRemote = CodeHostRemote(
+        kind: .gitlab,
+        host: "gitlab.com",
+        owner: "o",
+        repository: "r",
+        remoteName: "origin",
+        webURL: URL(string: "https://gitlab.com/o/r")!
+    )
+
+    private static func mrPageJSON(count: Int, startingAt: Int) -> String {
+        let items = (0..<count).map { offset -> String in
+            let number = startingAt + offset
+            return """
+            {"iid": \(number), "source_branch": "feature/\(number)", "web_url": "https://gitlab.com/o/r/-/merge_requests/\(number)", "sha": "sha\(number)"}
+            """
+        }
+        return "[\(items.joined(separator: ","))]"
+    }
+
+    /// `glab mr list` fetches exactly one page per invocation — unlike `gh
+    /// pr list --limit`, it has no built-in concept of "keep fetching until
+    /// N items." A repository with more merged MRs than one page (100, the
+    /// API's own cap) must be paginated manually.
+    @Test func gitLabProviderPaginatesBeyondOnePage() async throws {
+        let runner = PagedRunner { page in
+            switch page {
+            case 1: return Self.mrPageJSON(count: 100, startingAt: 1)
+            case 2: return Self.mrPageJSON(count: 5, startingAt: 101)
+            default: return "[]"
+            }
+        }
+        let provider = GitLabCLIProvider(runner: runner)
+        let refs = try await provider.mergedReviewRequests(
+            remote: Self.gitlabRemote,
+            limit: 1000,
+            cwd: URL(fileURLWithPath: "/tmp")
+        )
+        #expect(refs.count == 105)
+        #expect(refs.last?.number == 105)
+        let invocations = await runner.invocations
+        #expect(invocations.count == 2)   // stops at the short second page
+    }
+
+    @Test func gitLabProviderStopsAtTheRequestedLimitAcrossPages() async throws {
+        let runner = PagedRunner { page in
+            Self.mrPageJSON(count: 100, startingAt: (page - 1) * 100 + 1)
+        }
+        let provider = GitLabCLIProvider(runner: runner)
+        let refs = try await provider.mergedReviewRequests(
+            remote: Self.gitlabRemote,
+            limit: 150,
+            cwd: URL(fileURLWithPath: "/tmp")
+        )
+        #expect(refs.count == 150)
+        let invocations = await runner.invocations
+        #expect(invocations.count == 2)   // two full pages reach 200 >= 150
+    }
+}
+
+/// Returns a page of canned JSON keyed off the `--page` argument, so tests
+/// can exercise `GitLabCLIProvider`'s own pagination loop without a network.
+private actor PagedRunner: CodeHostCommandRunning {
+    struct Invocation: Sendable {
+        let executable: String
+        let args: [String]
+    }
+
+    private(set) var invocations: [Invocation] = []
+    private let responseForPage: @Sendable (Int) -> String
+
+    init(responseForPage: @escaping @Sendable (Int) -> String) {
+        self.responseForPage = responseForPage
+    }
+
+    func run(
+        _ executable: String,
+        args: [String],
+        cwd: URL?,
+        stdin: String?
+    ) async throws -> ProcessResult {
+        invocations.append(Invocation(executable: executable, args: args))
+        let page: Int
+        if let pageIndex = args.firstIndex(of: "--page"), args.indices.contains(pageIndex + 1) {
+            page = Int(args[pageIndex + 1]) ?? 1
+        } else {
+            page = 1
+        }
+        return ProcessResult(exitCode: 0, stdout: responseForPage(page), stderr: "")
+    }
+
+    func runData(_ executable: String, args: [String], cwd: URL?) async throws -> ProcessResultData {
+        invocations.append(Invocation(executable: executable, args: args))
+        return ProcessResultData(exitCode: 0, stdout: Data(), stderr: "")
+    }
 }
 
 private actor RecordingRunner: CodeHostCommandRunning {

--- a/AlasTests/WorktreeServiceTests.swift
+++ b/AlasTests/WorktreeServiceTests.swift
@@ -1052,9 +1052,10 @@ extension WorktreeServiceTests {
     /// Squash-merging breaks the ancestry chain `git branch -d` relies on:
     /// the resulting commit on the base branch is not a descendant of the
     /// original branch tip by history alone, so an un-forced delete
-    /// genuinely fails. `branchVerifiedMergedOnForge` trusts a stronger,
-    /// external signal (the code host's own record of the merge) and uses
-    /// `-D` instead.
+    /// genuinely fails. `verifiedMergedBranchSHA` trusts a stronger,
+    /// external signal (the code host's own record of the merge) — the
+    /// branch's tip as of that verification — and uses `-D` instead, once
+    /// it re-confirms the branch's current tip still matches.
     @Test func fastLocalRemoveDeletesSquashMergedBranchWhenForgeVerified() async throws {
         let repo = try await makeRepo()
         let destination = repo.deletingLastPathComponent()
@@ -1078,6 +1079,8 @@ extension WorktreeServiceTests {
         )
         _ = try await Process.git(["add", "."], cwd: destination)
         _ = try await Process.git(["commit", "-q", "-m", "feature work"], cwd: destination)
+        let branchTip = try await Process.git(["rev-parse", "feature/squash"], cwd: repo)
+        let verifiedSHA = branchTip.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         let squash = try await Process.git(["merge", "--squash", "feature/squash"], cwd: repo)
         #expect(squash.exitCode == 0)
         let squashCommit = try await Process.git(["commit", "-q", "-m", "squashed"], cwd: repo)
@@ -1092,7 +1095,7 @@ extension WorktreeServiceTests {
             worktree: worktree,
             deleteBranchIfMerged: true,
             force: false,
-            branchVerifiedMergedOnForge: true
+            verifiedMergedBranchSHA: verifiedSHA
         )
         guard case .staged(let ticket) = outcome else {
             Issue.record("Expected staged removal")
@@ -1138,7 +1141,7 @@ extension WorktreeServiceTests {
             worktree: worktree,
             deleteBranchIfMerged: true,
             force: false
-            // branchVerifiedMergedOnForge defaults to false
+            // verifiedMergedBranchSHA defaults to nil
         )
         guard case .staged(let ticket) = outcome else {
             Issue.record("Expected staged removal")
@@ -1147,6 +1150,68 @@ extension WorktreeServiceTests {
         defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
 
         let branches = try await Process.git(["branch", "--list", "feature/squash-unverified"], cwd: repo)
+        #expect(!branches.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    /// A `verifiedMergedBranchSHA` that no longer matches the branch's actual
+    /// tip must not be trusted for `-D`: a commit landed on the branch after
+    /// whatever scan produced that SHA, and force-deleting on stale evidence
+    /// would discard it. This is exactly the TOCTOU gap re-reading the tip
+    /// immediately before the delete decision closes.
+    @Test func fastLocalRemoveKeepsSquashMergedBranchWhenVerifiedSHAIsStale() async throws {
+        let repo = try await makeRepo()
+        let destination = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-squash-stale")
+        defer {
+            try? FileManager.default.removeItem(at: destination)
+            try? FileManager.default.removeItem(at: repo)
+        }
+        let service = WorktreeService()
+        let worktree = try await service.add(
+            repoPath: repo,
+            base: "main",
+            branch: "feature/squash-stale",
+            destination: destination,
+            projectId: "p"
+        )
+        try "content".write(
+            to: destination.appendingPathComponent("file.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        _ = try await Process.git(["add", "."], cwd: destination)
+        _ = try await Process.git(["commit", "-q", "-m", "feature work"], cwd: destination)
+        let staleSHA = "0000000000000000000000000000000000000000"
+        let squash = try await Process.git(["merge", "--squash", "feature/squash-stale"], cwd: repo)
+        #expect(squash.exitCode == 0)
+        let squashCommit = try await Process.git(["commit", "-q", "-m", "squashed"], cwd: repo)
+        #expect(squashCommit.exitCode == 0)
+
+        // A new commit lands on the branch after the (stale) SHA was
+        // "verified" — simulating the exact race the re-check guards
+        // against.
+        try "more".write(
+            to: destination.appendingPathComponent("file2.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        _ = try await Process.git(["add", "."], cwd: destination)
+        _ = try await Process.git(["commit", "-q", "-m", "one more commit"], cwd: destination)
+
+        let outcome = try await service.removeFastLocal(
+            repoPath: repo,
+            worktree: worktree,
+            deleteBranchIfMerged: true,
+            force: false,
+            verifiedMergedBranchSHA: staleSHA
+        )
+        guard case .staged(let ticket) = outcome else {
+            Issue.record("Expected staged removal")
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+
+        let branches = try await Process.git(["branch", "--list", "feature/squash-stale"], cwd: repo)
         #expect(!branches.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
     }
 

--- a/AlasTests/WorktreeServiceTests.swift
+++ b/AlasTests/WorktreeServiceTests.swift
@@ -1049,6 +1049,107 @@ extension WorktreeServiceTests {
         #expect(branches.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
     }
 
+    /// Squash-merging breaks the ancestry chain `git branch -d` relies on:
+    /// the resulting commit on the base branch is not a descendant of the
+    /// original branch tip by history alone, so an un-forced delete
+    /// genuinely fails. `branchVerifiedMergedOnForge` trusts a stronger,
+    /// external signal (the code host's own record of the merge) and uses
+    /// `-D` instead.
+    @Test func fastLocalRemoveDeletesSquashMergedBranchWhenForgeVerified() async throws {
+        let repo = try await makeRepo()
+        let destination = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-squash-verified")
+        defer {
+            try? FileManager.default.removeItem(at: destination)
+            try? FileManager.default.removeItem(at: repo)
+        }
+        let service = WorktreeService()
+        let worktree = try await service.add(
+            repoPath: repo,
+            base: "main",
+            branch: "feature/squash",
+            destination: destination,
+            projectId: "p"
+        )
+        try "content".write(
+            to: destination.appendingPathComponent("file.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        _ = try await Process.git(["add", "."], cwd: destination)
+        _ = try await Process.git(["commit", "-q", "-m", "feature work"], cwd: destination)
+        let squash = try await Process.git(["merge", "--squash", "feature/squash"], cwd: repo)
+        #expect(squash.exitCode == 0)
+        let squashCommit = try await Process.git(["commit", "-q", "-m", "squashed"], cwd: repo)
+        #expect(squashCommit.exitCode == 0)
+
+        // Sanity check the premise: an unverified `-d` genuinely can't do this.
+        let plainDelete = try await Process.git(["branch", "-d", "feature/squash"], cwd: repo)
+        #expect(plainDelete.exitCode != 0)
+
+        let outcome = try await service.removeFastLocal(
+            repoPath: repo,
+            worktree: worktree,
+            deleteBranchIfMerged: true,
+            force: false,
+            branchVerifiedMergedOnForge: true
+        )
+        guard case .staged(let ticket) = outcome else {
+            Issue.record("Expected staged removal")
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+
+        let branches = try await Process.git(["branch", "--list", "feature/squash"], cwd: repo)
+        #expect(branches.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    /// Without forge verification, a squash-merged branch is left behind —
+    /// this is the pre-existing, unchanged behavior for every worktree the
+    /// scanner hasn't independently confirmed via the code host.
+    @Test func fastLocalRemoveKeepsSquashMergedBranchWithoutForgeVerification() async throws {
+        let repo = try await makeRepo()
+        let destination = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-squash-unverified")
+        defer {
+            try? FileManager.default.removeItem(at: destination)
+            try? FileManager.default.removeItem(at: repo)
+        }
+        let service = WorktreeService()
+        let worktree = try await service.add(
+            repoPath: repo,
+            base: "main",
+            branch: "feature/squash-unverified",
+            destination: destination,
+            projectId: "p"
+        )
+        try "content".write(
+            to: destination.appendingPathComponent("file.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        _ = try await Process.git(["add", "."], cwd: destination)
+        _ = try await Process.git(["commit", "-q", "-m", "feature work"], cwd: destination)
+        _ = try await Process.git(["merge", "--squash", "feature/squash-unverified"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "squashed"], cwd: repo)
+
+        let outcome = try await service.removeFastLocal(
+            repoPath: repo,
+            worktree: worktree,
+            deleteBranchIfMerged: true,
+            force: false
+            // branchVerifiedMergedOnForge defaults to false
+        )
+        guard case .staged(let ticket) = outcome else {
+            Issue.record("Expected staged removal")
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: ticket.trashRoot) }
+
+        let branches = try await Process.git(["branch", "--list", "feature/squash-unverified"], cwd: repo)
+        #expect(!branches.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
     @Test func fastLocalRemoveReportsBothPathsWhenRollbackFails() async throws {
         let fixture = try await makeLinkedWorktree(suffix: "rollback-fails")
         defer { fixture.removeFiles() }


### PR DESCRIPTION
Follow-up to #1173, addressing the four items deferred from that PR's Codex review loop, in priority order.

## 1. Query the fork parent repository for merged reviews

In a classic fork workflow (`origin` = your fork, the base repository is where PRs actually get opened and merged), the merged-PR scan queried `origin` and found nothing — a genuinely merged branch read as "not merged."

Adds `CodeHostProvider.repositoryParent(remote:cwd:)`, implemented for GitHub via `gh repo view --json isFork,parent` and for GitLab via `glab api projects/:id`'s `forked_from_project` field. The protocol default returns `nil` rather than throwing — fork detection is an enhancement, and a provider that can't determine fork status shouldn't fail the whole scan over it. `forgeMergeIndex` queries the resolved parent when the detected remote is a fork, falling back to the original remote on any failure.

## 2. Paginate GitLab merged-MR queries, raise the shared query limit

`gh pr list --limit N` already paginates internally to satisfy any count, so the fix there was just raising the old 200-item cap. `glab mr list` has no equivalent — it fetches exactly one page, bounded by `--per-page` (GitLab's API caps this at 100 regardless of what's requested) — so a GitLab repository with more merged MRs than one page silently missed the rest. `GitLabCLIProvider` now pages manually until a short page signals the end or the requested limit is reached.

## 3. Force-delete branches the code host confirmed were merged

`git branch -d` refuses a squash- or rebase-merged branch: the resulting commit on the base branch isn't a descendant of the original tip by local ancestry alone, even when the code host's own record shows the review request genuinely merged. Batch delete called `-d` unconditionally and silently swallowed the failure, so these branches lingered with no indication anything was left behind.

`WorktreeService.remove`/`removeFastLocal` now accept `branchVerifiedMergedOnForge`, using `-D` instead of `-d` when set — threaded from the model's high-confidence selection (an exact HEAD SHA match against a confirmed-merged review request, the scanner's strongest evidence) through to the actual branch-delete call. Covered by real-repo integration tests that squash-merge a branch, confirm `-d` genuinely fails on it, then verify `-D` succeeds only when forge-verified.

## 4. Track dirty-buffer content revisions, not just tab identity

The per-item dirty-buffer recheck (added during #1173's own review loop) compared tab identity only, so a tab already dirty and discarded that got re-edited — from another window, during the async gap of an earlier batch item's removal — would still pass the check and have its new content silently discarded.

`EditorBuffer` already tracks an `editGeneration` counter bumped on every edit. The snapshot now records each dirty tab's generation, not just its id, and the recheck requires an exact match. The comparison itself is extracted as a pure, directly-testable static function.

## Testing

170 tests across the affected suites, all green. Full app build clean.
