### PR TITLE
feat(sidebar): adapt right pane tab labels when narrow

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		241C661965785076CB3442DA /* ACPGoalPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FAB28A45A3606C316044F3 /* ACPGoalPill.swift */; };
 		2434A66A45EDF2609BA9F1D3 /* session-update-config-options.json in Resources */ = {isa = PBXBuildFile; fileRef = 97DA8F50DDCDAA15CCEA2004 /* session-update-config-options.json */; };
 		2472561EEB7160C90085B4C3 /* ACPTranscriptVisibleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46D97A89C40731455D9EC2DA /* ACPTranscriptVisibleRow.swift */; };
+		24916B243B32BA9DB9444BD6 /* RightPaneTabBarLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76808E76F12DB79DFDC119C /* RightPaneTabBarLayoutTests.swift */; };
 		249E943D5C46A84496390B31 /* StagedDiffSelectionBridgingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3DCDC9F76F91CE1071471C /* StagedDiffSelectionBridgingTests.swift */; };
 		24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E6D61B213F3378243B4A26 /* AlasField.swift */; };
 		24F8FC4320CB8B8EA19809F6 /* IssueWorktreeLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0479721D1BC95DC664D4CB /* IssueWorktreeLaunchTests.swift */; };
@@ -3313,6 +3314,7 @@
 		F6F598D32E08FFED3E45351D /* ACPBrokerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPBrokerProtocol.swift; sourceTree = "<group>"; };
 		F721FB733081A583D4053DDA /* FileTypeIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconView.swift; sourceTree = "<group>"; };
 		F748F06725644571785BF658 /* PendingStashDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingStashDrop.swift; sourceTree = "<group>"; };
+		F76808E76F12DB79DFDC119C /* RightPaneTabBarLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneTabBarLayoutTests.swift; sourceTree = "<group>"; };
 		F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRowView.swift; sourceTree = "<group>"; };
 		F83370751580C42D5DE93F80 /* GitInvocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitInvocation.swift; sourceTree = "<group>"; };
 		F84BC1A10866A165EA321719 /* ACPTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptTests.swift; sourceTree = "<group>"; };
@@ -3912,6 +3914,7 @@
 				1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */,
 				0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */,
 				8451C5BCEE50F118F07CDD83 /* RightPaneStoreBaseBranchTests.swift */,
+				F76808E76F12DB79DFDC119C /* RightPaneTabBarLayoutTests.swift */,
 				1352DFCDFF4769EAF89B75CF /* RightPaneTabTests.swift */,
 				B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */,
 				184A8668BB2C00AB8D1BB1C4 /* RunEndpointTests.swift */,
@@ -7960,6 +7963,7 @@
 				DCACB5B624BFFE7C50DA6C61 /* RightPaneStateSyncStatusTests.swift in Sources */,
 				57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */,
 				4186372EBF16A9C7CB38F558 /* RightPaneStoreBaseBranchTests.swift in Sources */,
+				24916B243B32BA9DB9444BD6 /* RightPaneTabBarLayoutTests.swift in Sources */,
 				D84D5F836F828349114F2D3C /* RightPaneTabTests.swift in Sources */,
 				4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */,
 				6EDBC8B0F9284ABF9796A4F0 /* RunEndpointTests.swift in Sources */,

--- a/Alas/Sources/Right/RightPaneTabBar.swift
+++ b/Alas/Sources/Right/RightPaneTabBar.swift
@@ -1,5 +1,26 @@
 import SwiftUI
 
+enum RightPaneTabBarLayout {
+    case regular
+    case compact
+    case iconOnly
+
+    func showsLabel(for tab: RightPaneTab, activeTab: RightPaneTab) -> Bool {
+        self == .regular || (self == .compact && tab == activeTab)
+    }
+
+    func showsCount(for tab: RightPaneTab, activeTab: RightPaneTab) -> Bool {
+        self == .regular || (self == .compact && tab == activeTab)
+    }
+
+    func accessibilityLabel(_ label: String, count: Int?, for tab: RightPaneTab, activeTab: RightPaneTab) -> String {
+        guard let count, showsCount(for: tab, activeTab: activeTab) else {
+            return label
+        }
+        return "\(label), \(count)"
+    }
+}
+
 struct RightPaneTabBar: View {
     @Binding var activeTab: RightPaneTab
     let changesCount: Int
@@ -15,28 +36,30 @@ struct RightPaneTabBar: View {
     @Environment(\.theme) private var theme
 
     var body: some View {
+        header
+        .padding(.horizontal, 10).padding(.vertical, 6)
+        .overlay(Divider().opacity(0.5), alignment: .bottom)
+        .windowDragHandle()
+    }
+
+    private var header: some View {
         HStack(spacing: 8) {
-            // Three segments no longer fit beside the summary and hide button
-            // at the pane's 240pt minimum, so fall back to icon-only rather
-            // than truncating every label to an ellipsis.
             ViewThatFits(in: .horizontal) {
-                segments(compact: false)
-                segments(compact: true)
+                segments(layout: .regular)
+                segments(layout: .compact)
+                segments(layout: .iconOnly)
             }
 
             Spacer(minLength: 8)
             trailing
             ToolbarBtn(icon: "sidebar.right", tooltip: "Hide changes pane", action: onHidePane)
         }
-        .padding(.horizontal, 10).padding(.vertical, 6)
-        .overlay(Divider().opacity(0.5), alignment: .bottom)
-        .windowDragHandle()
     }
 
-    private func segments(compact: Bool) -> some View {
+    private func segments(layout: RightPaneTabBarLayout) -> some View {
         HStack(spacing: 2) {
-            segment(.changes, icon: "diff", label: "Changes", count: changesCount, compact: compact)
-            segment(.files, icon: "folder", label: "Files", count: nil, compact: compact)
+            segment(.changes, icon: "diff", label: "Changes", count: changesCount, layout: layout)
+            segment(.files, icon: "folder", label: "Files", count: nil, layout: layout)
                 .contextMenu {
                     Toggle("Show ignored or excluded files", isOn: Binding(
                         get: { showIgnored },
@@ -49,7 +72,7 @@ struct RightPaneTabBar: View {
                     icon: "play",
                     label: "Run",
                     count: activeRunCount > 0 ? activeRunCount : nil,
-                    compact: compact
+                    layout: layout
                 )
             }
         }
@@ -67,7 +90,7 @@ struct RightPaneTabBar: View {
         icon: String,
         label: String,
         count: Int?,
-        compact: Bool = false
+        layout: RightPaneTabBarLayout
     ) -> some View {
         let isOn = activeTab == tab
         return Button {
@@ -75,12 +98,12 @@ struct RightPaneTabBar: View {
         } label: {
             HStack(spacing: 5) {
                 Icon(name: icon, size: 11, color: isOn ? theme.color("fg") : theme.color("fg-muted"))
-                if !compact {
+                if layout.showsLabel(for: tab, activeTab: activeTab) {
                     Text(label)
                         .font(.system(size: 11.5, weight: isOn ? .semibold : .medium))
                         .foregroundColor(isOn ? theme.color("fg") : theme.color("fg-muted"))
                 }
-                if let count {
+                if let count, layout.showsCount(for: tab, activeTab: activeTab) {
                     Text("\(count)")
                         .font(.system(size: 10, weight: .semibold))
                         .frame(minWidth: 16, minHeight: 14)
@@ -108,8 +131,9 @@ struct RightPaneTabBar: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(layout.accessibilityLabel(label, count: count, for: tab, activeTab: activeTab))
+        .accessibilityAddTraits(isOn ? .isSelected : [])
         .help(label)
-        .accessibilityLabel(label)
     }
 
     @ViewBuilder

--- a/AlasTests/RightPaneTabBarLayoutTests.swift
+++ b/AlasTests/RightPaneTabBarLayoutTests.swift
@@ -1,0 +1,30 @@
+import Testing
+@testable import Alas
+
+struct RightPaneTabBarLayoutTests {
+    @Test func compactRailShowsTheActiveTabLabelOnly() {
+        #expect(RightPaneTabBarLayout.compact.showsLabel(for: .changes, activeTab: .changes))
+        #expect(!RightPaneTabBarLayout.compact.showsLabel(for: .files, activeTab: .changes))
+        #expect(!RightPaneTabBarLayout.compact.showsLabel(for: .changes, activeTab: .files))
+        #expect(RightPaneTabBarLayout.compact.showsLabel(for: .files, activeTab: .files))
+        #expect(!RightPaneTabBarLayout.iconOnly.showsLabel(for: .changes, activeTab: .changes))
+        #expect(!RightPaneTabBarLayout.iconOnly.showsLabel(for: .files, activeTab: .files))
+    }
+
+    @Test func compactRailShowsCountsOnlyForTheActiveTab() {
+        #expect(RightPaneTabBarLayout.compact.showsCount(for: .changes, activeTab: .changes))
+        #expect(!RightPaneTabBarLayout.compact.showsCount(for: .changes, activeTab: .files))
+        #expect(RightPaneTabBarLayout.compact.showsCount(for: .run, activeTab: .run))
+        #expect(!RightPaneTabBarLayout.compact.showsCount(for: .run, activeTab: .changes))
+        #expect(!RightPaneTabBarLayout.iconOnly.showsCount(for: .changes, activeTab: .changes))
+        #expect(!RightPaneTabBarLayout.iconOnly.showsCount(for: .run, activeTab: .run))
+    }
+
+    @Test func accessibilityLabelIncludesCountOnlyWhenTheCountIsVisible() {
+        #expect(RightPaneTabBarLayout.regular.accessibilityLabel("Changes", count: 3, for: .changes, activeTab: .files) == "Changes, 3")
+        #expect(RightPaneTabBarLayout.compact.accessibilityLabel("Changes", count: 3, for: .changes, activeTab: .changes) == "Changes, 3")
+        #expect(RightPaneTabBarLayout.compact.accessibilityLabel("Changes", count: 3, for: .changes, activeTab: .files) == "Changes")
+        #expect(RightPaneTabBarLayout.iconOnly.accessibilityLabel("Changes", count: 3, for: .changes, activeTab: .changes) == "Changes")
+        #expect(RightPaneTabBarLayout.compact.accessibilityLabel("Files", count: nil, for: .files, activeTab: .files) == "Files")
+    }
+}


### PR DESCRIPTION
## Summary
- Adapt the right pane tab bar to fall back to compact labels when horizontal space is tight
- Keep text visible only for the selected tab in compact mode
- Add Swift Testing coverage for the compact tab-label rules

## Verification
- rtk xcodegen
- rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-ij-like-tabs-deriveddata -only-testing:AlasTests/RightPaneTabBarLayoutTests test -quiet
- swiftformat Alas/Sources/Right/RightPaneTabBar.swift AlasTests/RightPaneTabBarLayoutTests.swift --lint
- git diff --check
- rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /private/tmp/alas-ij-like-tabs-deriveddata -quiet build