### PR TITLE
feat(agent): Add agent tab to right sidebar

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -279,6 +279,7 @@
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
 		28D41D400C04EF69F8A31A26 /* WorkspacesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71562064227F929B0906048A /* WorkspacesManager.swift */; };
 		28D8C1BBA0B577679782AA68 /* ACPMarkdownInlineTextViewMeasurementCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D73156DBE6DB95469D4D80 /* ACPMarkdownInlineTextViewMeasurementCacheTests.swift */; };
+		28F0C140D930388611F34BCE /* AgentSidebarRollupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC853E34EAA7644C6893FBEF /* AgentSidebarRollupTests.swift */; };
 		28F42E0137436A3B5F72CB85 /* ACPImageEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */; };
 		2908D330D59E98775E26C688 /* MarkdownPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */; };
 		292E443F13B06303EAF8E24B /* CreatingWorktreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3AC3A1F7C5649E75015293 /* CreatingWorktreeView.swift */; };
@@ -304,6 +305,7 @@
 		2CEFCA2E399E7EADBFE3A064 /* ProjectMCPServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792BD8DAE4AAED201252C9E2 /* ProjectMCPServerTests.swift */; };
 		2D313A7E99C93242DD35AA8E /* CursorInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948BA9EC461BA2E3617FBF0 /* CursorInstaller.swift */; };
 		2D3E3F75B6CBDF63A3FF2CD7 /* ACPStarterPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C6D6594CCA4EBC83BDF264 /* ACPStarterPrompt.swift */; };
+		2D428B399E48ED859E4D0797 /* AgentSidebarRollup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0440E0CF2FCB4EF89EF53DC2 /* AgentSidebarRollup.swift */; };
 		2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */; };
 		2D63742A552F72DC6BEBF7DC /* WorktreeCreationCompletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3CA4AD69CDACE0D41821742 /* WorktreeCreationCompletion.swift */; };
 		2D80BC255AB24FA274617553 /* ReviewRequestPromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A17183B064CAB5EB5D5C11 /* ReviewRequestPromptEditorWindow.swift */; };
@@ -1736,6 +1738,7 @@
 		03A8831DA4C093678F8B158E /* WorkspaceCheckoutLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCheckoutLifecycleTests.swift; sourceTree = "<group>"; };
 		03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreQueueTests.swift; sourceTree = "<group>"; };
 		03E54D3FBA0EB8B5DCF52179 /* RemoteHelperACPTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperACPTransport.swift; sourceTree = "<group>"; };
+		0440E0CF2FCB4EF89EF53DC2 /* AgentSidebarRollup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSidebarRollup.swift; sourceTree = "<group>"; };
 		0452819DD42784CF60D466A4 /* AlasApplicationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasApplicationDelegate.swift; sourceTree = "<group>"; };
 		04601C00F293AAB0EE4209E1 /* RunScriptStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunScriptStore.swift; sourceTree = "<group>"; };
 		04B44F1DD775D2543439D508 /* ACPTranscriptMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMarkdown.swift; sourceTree = "<group>"; };
@@ -3122,6 +3125,7 @@
 		DC3814D8B30EBB9991F3388A /* ACPMarkdownInlineRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownInlineRenderer.swift; sourceTree = "<group>"; };
 		DC73B8AC6AC57FB3A3253F40 /* ReviewScopeSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewScopeSelectionTests.swift; sourceTree = "<group>"; };
 		DC76F9150CC29A324D785C29 /* ACPDelayedHoverVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDelayedHoverVisibilityTests.swift; sourceTree = "<group>"; };
+		DC853E34EAA7644C6893FBEF /* AgentSidebarRollupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSidebarRollupTests.swift; sourceTree = "<group>"; };
 		DCD333CD0765908F6657E824 /* WorktreePathTemplateRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreePathTemplateRenderer.swift; sourceTree = "<group>"; };
 		DCD3E9F5573DA60B2DDECF3B /* IssueAutocompleteField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueAutocompleteField.swift; sourceTree = "<group>"; };
 		DD1F34E025D235A5CECCE36E /* ACPSessionUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUpdate.swift; sourceTree = "<group>"; };
@@ -3627,6 +3631,7 @@
 				2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */,
 				9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */,
 				E267334F2224961856D20BD8 /* AgentRunnerParseTests.swift */,
+				DC853E34EAA7644C6893FBEF /* AgentSidebarRollupTests.swift */,
 				CB5E3661944CDA65ABCCB826 /* AgentsPaneTests.swift */,
 				11C3EC94DBE871DFC45C7D25 /* AgentTerminalLaunchTests.swift */,
 				1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */,
@@ -4384,6 +4389,7 @@
 		413E432DDAAAE618029482C3 /* Right */ = {
 			isa = PBXGroup;
 			children = (
+				0440E0CF2FCB4EF89EF53DC2 /* AgentSidebarRollup.swift */,
 				002C8D5C52466955E0A90606 /* BaseBranchSelector.swift */,
 				FF68BCA1222E7C06DA4AC595 /* BaseResolutionMapping.swift */,
 				6BAD20759A17B6EFE3AC0C81 /* BranchOpsMenu.swift */,
@@ -6629,6 +6635,7 @@
 				5D2A45DB652AD797E2276A7A /* AgentRegistry.swift in Sources */,
 				2584552219DE6987E1E6AF36 /* AgentRunError.swift in Sources */,
 				0BA997A903C1DC2A41D64E22 /* AgentRunner.swift in Sources */,
+				2D428B399E48ED859E4D0797 /* AgentSidebarRollup.swift in Sources */,
 				55C7881F382ACCEBCDB7D157 /* AgentsPane.swift in Sources */,
 				59EFDD354514B21BBA4206AD /* AiSplitButton.swift in Sources */,
 				E6426E94A57602E76D401D21 /* AlasActionService.swift in Sources */,
@@ -7502,6 +7509,7 @@
 				659B9DBE590DCF6C395C64B3 /* AgentRegistryTests.swift in Sources */,
 				D51AC3D5B34A566A90C923BB /* AgentRunnerInvocationTests.swift in Sources */,
 				0E2D69C181ECD5233770BC01 /* AgentRunnerParseTests.swift in Sources */,
+				28F0C140D930388611F34BCE /* AgentSidebarRollupTests.swift in Sources */,
 				13E762EA8D84EFE6F0228806 /* AgentTerminalLaunchTests.swift in Sources */,
 				C653712419D5B5A78AA53E84 /* AgentsPaneTests.swift in Sources */,
 				026C8FB815E41D31C8E9421B /* AlasCLICommandRouterTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1390,6 +1390,7 @@
 		D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */; };
 		D2D5D79EE8DE82FC44C2D36A /* CompletionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D510DACCD80A328B2DFABDC0 /* CompletionFeature.swift */; };
 		D2DBD17549E31DAAF87EE4A9 /* ACPDictationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF5F310D158323C328E56929 /* ACPDictationServiceTests.swift */; };
+		D2F62FD2AC838FFDC305206D /* AgentTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1AD121323EC19D333DC2556 /* AgentTabView.swift */; };
 		D36A33178D064DBD5DFD9B6D /* PairedAuthoredContentSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBB557833D3939208D75FB7 /* PairedAuthoredContentSurfaceTests.swift */; };
 		D397C3E94E3F00F012CBE5AE /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27595490B7D883CF5D9FFD5 /* Tab.swift */; };
 		D3A67696B13E8F9E31B10DC0 /* DiffReviewRailThreadCountsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E933EFC52B5E3D12133B1306 /* DiffReviewRailThreadCountsTests.swift */; };
@@ -2734,6 +2735,7 @@
 		A107DA120039DD59C4F5CDD7 /* MermaidRenderServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MermaidRenderServiceTests.swift; sourceTree = "<group>"; };
 		A1503D1CB549B39E499EFAB8 /* DiffInlineAnnotationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffInlineAnnotationCard.swift; sourceTree = "<group>"; };
 		A172B476A5BF7E4016431E6A /* DiffReviewModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewModelsTests.swift; sourceTree = "<group>"; };
+		A1AD121323EC19D333DC2556 /* AgentTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTabView.swift; sourceTree = "<group>"; };
 		A1BC298112812E38C99E0B71 /* ACPAdapterUpdateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterUpdateStoreTests.swift; sourceTree = "<group>"; };
 		A203964F9055BEF3F6142684 /* CodexACPInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexACPInstallerTests.swift; sourceTree = "<group>"; };
 		A218B5125FC963339E40605E /* TabsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManager.swift; sourceTree = "<group>"; };
@@ -4390,6 +4392,7 @@
 			isa = PBXGroup;
 			children = (
 				0440E0CF2FCB4EF89EF53DC2 /* AgentSidebarRollup.swift */,
+				A1AD121323EC19D333DC2556 /* AgentTabView.swift */,
 				002C8D5C52466955E0A90606 /* BaseBranchSelector.swift */,
 				FF68BCA1222E7C06DA4AC595 /* BaseResolutionMapping.swift */,
 				6BAD20759A17B6EFE3AC0C81 /* BranchOpsMenu.swift */,
@@ -6636,6 +6639,7 @@
 				2584552219DE6987E1E6AF36 /* AgentRunError.swift in Sources */,
 				0BA997A903C1DC2A41D64E22 /* AgentRunner.swift in Sources */,
 				2D428B399E48ED859E4D0797 /* AgentSidebarRollup.swift in Sources */,
+				D2F62FD2AC838FFDC305206D /* AgentTabView.swift in Sources */,
 				55C7881F382ACCEBCDB7D157 /* AgentsPane.swift in Sources */,
 				59EFDD354514B21BBA4206AD /* AiSplitButton.swift in Sources */,
 				E6426E94A57602E76D401D21 /* AlasActionService.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -87,6 +87,8 @@ final class AppState {
     /// separate from `tabs`: a run's outcome outlives its terminal shell, and a
     /// live shell never implies a live command.
     var runRecords = RunRecordStore()
+    /// Follow-up composers outlive the conditional Agent pane and worktree navigation.
+    var agentSidebarFollowUps: [String: [ACPSession.ID: AgentSidebarFollowUpDraft]] = [:]
     var selectedRunScriptFailure: RunScriptFailure?
     @ObservationIgnored var runScriptCompletionTasks: [String: (worktreeID: String, sessionID: String, location: RunScriptCaptureLocation, task: Task<Void, Never>)] = [:]
     @ObservationIgnored let runScriptCompletionWaiter: RunScriptCompletionWaiter
@@ -8921,6 +8923,31 @@ final class AppState {
             }) else { return }
             selectWorktree(id: worktree.id)
             activateWorktreeCenterTab(worktreeId: worktree.id, tabId: tabID)
+        }
+    }
+
+    func sendAgentSidebarFollowUp(for sessionID: ACPSession.ID, worktreeID: String, text: String) {
+        guard let complete = beginAgentSidebarFollowUp(for: sessionID, worktreeID: worktreeID, text: text) else { return }
+        Task {
+            await sendPrompt(for: sessionID, worktreeID: worktreeID, text: text, attachments: [], onResult: complete)
+        }
+    }
+
+    /// Own completion in AppState so a hidden pane cannot lose a failed message.
+    func beginAgentSidebarFollowUp(
+        for sessionID: ACPSession.ID,
+        worktreeID: String,
+        text: String
+    ) -> (@MainActor (Bool) -> Void)? {
+        guard agentSidebarFollowUps[worktreeID]?[sessionID]?.delivery != .sending,
+              !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        agentSidebarFollowUps[worktreeID, default: [:]][sessionID] = .init(text: text, delivery: .sending)
+        return { [weak self] succeeded in
+            guard let self else { return }
+            self.agentSidebarFollowUps[worktreeID, default: [:]][sessionID]?.delivery = succeeded ? .sent : .failed
+            if succeeded, self.agentSidebarFollowUps[worktreeID]?[sessionID]?.text == text {
+                self.agentSidebarFollowUps[worktreeID, default: [:]][sessionID]?.text = ""
+            }
         }
     }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -8882,6 +8882,48 @@ final class AppState {
         acpManagers[.worktree(id)]
     }
 
+    /// The manager owns persisted history; center tabs only supply terminal rows.
+    func agentSidebarRollup(for worktree: Worktree) -> AgentSidebarRollup {
+        let manager = acpManager(forWorktreeId: worktree.id)
+        let terminalTabs = tabs.tabs(forWorktree: worktree.id).compactMap { tab -> TerminalTabState? in
+            guard case .terminal(let terminal) = tab else { return nil }
+            return terminal
+        }
+        let liveSessions = manager?.sessions.values.filter { session in
+            manager?.sessionRows.first(where: { $0.id == session.id })?.archived != true
+        } ?? []
+        return AgentSidebarRollupBuilder.build(.init(
+            worktreeID: worktree.id,
+            persistedACP: manager?.sessionRows.filter { !$0.archived } ?? [],
+            liveACP: liveSessions.sorted {
+                if $0.createdAt != $1.createdAt { return $0.createdAt > $1.createdAt }
+                return $0.id < $1.id
+            },
+            terminalTabs: terminalTabs,
+            harnessActivity: harness.activityBySession,
+            remoteHost: projectAndWorktree(withWorktreeId: worktree.id)?.project.host
+        ))
+    }
+
+    func focusAgentSidebarRow(_ rowID: AgentSidebarRowID, in worktree: Worktree) async {
+        switch rowID {
+        case .acp(let sessionID):
+            guard let manager = acpManager(forWorktreeId: worktree.id),
+                  manager.liveSession(for: sessionID) != nil
+                    || manager.sessionRows.contains(where: { $0.id == sessionID && !$0.archived })
+            else { return }
+            selectWorktree(id: worktree.id)
+            await openExistingACPSession(sessionId: sessionID, worktree: worktree)
+        case .terminal(let tabID, _):
+            guard tabs.tabs(forWorktree: worktree.id).contains(where: {
+                guard case .terminal = $0 else { return false }
+                return $0.id == tabID
+            }) else { return }
+            selectWorktree(id: worktree.id)
+            activateWorktreeCenterTab(worktreeId: worktree.id, tabId: tabID)
+        }
+    }
+
     func acpManager(for owner: SessionOwnerID) -> ACPSessionManager? {
         acpManagers[owner]
     }
@@ -9810,6 +9852,11 @@ final class AppState {
     func openExistingACPSession(sessionId: ACPSession.ID) async {
         guard let worktreeId = selectedWorktreeId,
               let worktree = worktree(withId: worktreeId) else { return }
+        await openExistingACPSession(sessionId: sessionId, worktree: worktree)
+    }
+
+    /// Pins the owner before suspension, including when sidebar focus reopens history.
+    func openExistingACPSession(sessionId: ACPSession.ID, worktree: Worktree) async {
         await awaitPendingACPDetach(owner: .worktree(worktree.id), sessionId: sessionId)
         guard let mgr = acpManager(for: worktree) else { return }
         cancelRetainedACPSessionCleanup(owner: .worktree(worktree.id), sessionId: sessionId)
@@ -10959,6 +11006,21 @@ extension AppState: RemoteSessionsProvider {
         onResult(false)
     }
 
+    func sendPrompt(
+        for id: String,
+        worktreeID: String,
+        text: String,
+        attachments: [ACPMessage.Attachment],
+        onResult: @escaping @MainActor (Bool) -> Void
+    ) async {
+        guard let manager = acpManager(forWorktreeId: worktreeID),
+              manager.liveSession(for: id) != nil else {
+            onResult(false)
+            return
+        }
+        await manager.sendPrompt(for: id, text: text, attachments: attachments, onResult: onResult)
+    }
+
     func writeAttachment(_ data: Data, mimeType: String, name: String?, for id: String) -> URL? {
         guard let mgr = acpManagers.values.first(where: { $0.liveSession(for: id) != nil }),
               let session = mgr.liveSession(for: id) else { return nil }
@@ -10975,6 +11037,11 @@ extension AppState: RemoteSessionsProvider {
             await mgr.interruptBypassingLease(for: id)
             return
         }
+    }
+
+    func stop(for id: String, worktreeID: String) async {
+        guard let manager = acpManager(forWorktreeId: worktreeID) else { return }
+        await manager.interrupt(for: id)
     }
 
     func queueForceSend(for id: String, itemId: UUID) async {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -8916,12 +8916,17 @@ final class AppState {
             else { return }
             selectWorktree(id: worktree.id)
             await openExistingACPSession(sessionId: sessionID, worktree: worktree)
-        case .terminal(let tabID, _):
-            guard tabs.tabs(forWorktree: worktree.id).contains(where: {
-                guard case .terminal = $0 else { return false }
-                return $0.id == tabID
-            }) else { return }
+        case .terminal(let tabID, let sessionID):
+            let matchingLeafID = tabs.tabs(forWorktree: worktree.id).compactMap { tab -> String? in
+                guard tab.id == tabID,
+                      case .terminal(let terminal) = tab,
+                      let leaf = terminal.root.leaves().first(where: { $0.sessionId == sessionID })
+                else { return nil }
+                return leaf.id
+            }.first
+            guard let matchingLeafID else { return }
             selectWorktree(id: worktree.id)
+            _ = tabs.setFocusedLeaf(worktreeId: worktree.id, tabId: tabID, leafId: matchingLeafID)
             activateWorktreeCenterTab(worktreeId: worktree.id, tabId: tabID)
         }
     }

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -47,6 +47,9 @@ struct AppConfig: Codable, Equatable {
     /// Preview gate for the worktree Run tab. This remains off until the
     /// command lifecycle UI has completed preview testing.
     var runTabEnabled: Bool = false
+    /// Preview gate for the worktree Agent tab. This remains off until the
+    /// per-worktree rollup has completed preview testing.
+    var agentTabEnabled: Bool = false
     var recentProjectIds: [String] = []
     var recentWorktreeIdsByProject: [String: [String]] = [:]
     var recentWorktreeRefs: [RepoSelectorRecents.RecentWorktreeRef] = []
@@ -509,6 +512,7 @@ struct AppConfig: Codable, Equatable {
         files: Files(showIgnored: true),
         workspacesEnabled: false,
         runTabEnabled: false,
+        agentTabEnabled: false,
         recentProjectIds: [],
         recentWorktreeIdsByProject: [:],
         recentWorktreeRefs: [],
@@ -602,6 +606,7 @@ extension AppConfig {
              remote,
              workspacesEnabled,
              runTabEnabled,
+             agentTabEnabled,
              recentProjectIds, recentWorktreeIdsByProject, recentWorktreeRefs,
              collapsedProjectIds,
              sidebarChromeOverrides,
@@ -840,6 +845,9 @@ extension AppConfig {
         // The Run tab preview is opt-in. Configs written before it existed
         // continue to load without exposing unfinished command controls.
         runTabEnabled = (try? c.decode(Bool.self, forKey: .runTabEnabled)) ?? false
+        // The Agent tab preview is opt-in. Configs written before it existed
+        // continue to load without exposing the sidebar rollup.
+        agentTabEnabled = (try? c.decode(Bool.self, forKey: .agentTabEnabled)) ?? false
         recentProjectIds = (try? c.decode([String].self, forKey: .recentProjectIds)) ?? []
         recentWorktreeIdsByProject =
             (try? c.decode([String: [String]].self, forKey: .recentWorktreeIdsByProject)) ?? [:]

--- a/Alas/Sources/Right/AgentSidebarRollup.swift
+++ b/Alas/Sources/Right/AgentSidebarRollup.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+enum AgentSidebarState: Equatable {
+    case running
+    case awaitingInput
+    case permissionRequest
+    case idle
+    case detached
+    case unknown
+}
+
+struct AgentSidebarPlanProgress: Equatable {
+    let completed: Int
+    let total: Int
+    let currentStep: String?
+}
+
+struct AgentSidebarRow: Identifiable, Equatable {
+    enum ID: Hashable {
+        case acp(ACPSession.ID)
+        case terminal(tabID: TabID, sessionID: String)
+    }
+
+    let id: ID
+    let agentID: String
+    let title: String
+    let model: String?
+    let state: AgentSidebarState
+    let contextUsage: ACPUsageInfo?
+    let plan: AgentSidebarPlanProgress?
+    let host: String?
+    let createdAt: Date
+    let isLiveACP: Bool
+
+    static func acp(
+        id: ACPSession.ID,
+        agentID: String,
+        title: String,
+        model: String?,
+        state: AgentSidebarState,
+        contextUsage: ACPUsageInfo? = nil,
+        plan: AgentSidebarPlanProgress? = nil,
+        host: String? = nil,
+        createdAt: Date,
+        isLive: Bool
+    ) -> Self {
+        Self(
+            id: .acp(id),
+            agentID: agentID,
+            title: title,
+            model: model,
+            state: state,
+            contextUsage: contextUsage,
+            plan: plan,
+            host: host,
+            createdAt: createdAt,
+            isLiveACP: isLive
+        )
+    }
+
+    static func terminal(
+        tabID: TabID,
+        sessionID: String,
+        agentID: String,
+        title: String,
+        state: AgentSidebarState
+    ) -> Self {
+        Self(
+            id: .terminal(tabID: tabID, sessionID: sessionID),
+            agentID: agentID,
+            title: title,
+            model: nil,
+            state: state,
+            contextUsage: nil,
+            plan: nil,
+            host: nil,
+            createdAt: .distantPast,
+            isLiveACP: false
+        )
+    }
+}
+
+typealias AgentSidebarRowID = AgentSidebarRow.ID
+
+struct AgentSidebarRollup: Equatable {
+    let rows: [AgentSidebarRow]
+
+    var active: [AgentSidebarRow] {
+        rows.filter { $0.state != .detached }
+    }
+
+    var history: [AgentSidebarRow] {
+        rows.filter { $0.state == .detached }
+    }
+}
+
+@MainActor
+struct AgentSidebarRollupBuilder {
+    struct Input {
+        let worktreeID: String
+        let persistedACP: [ACPSessionRow]
+        let liveACP: [ACPSession]
+        let terminalTabs: [TerminalTabState]
+        let harnessActivity: [String: HarnessService.HarnessActivityState]
+        let remoteHost: String?
+    }
+
+    static func build(_ input: Input) -> AgentSidebarRollup {
+        let liveSessions = input.liveACP.filter { $0.worktreeId == input.worktreeID }
+        let liveIDs = Set(liveSessions.map(\.id))
+
+        let liveRows = liveSessions.map { liveRow(for: $0, remoteHost: input.remoteHost) }
+        let persistedRows = input.persistedACP
+            .filter { !liveIDs.contains($0.id) }
+            .map(persistedRow)
+        let terminalRows = input.terminalTabs.map { terminalRow(for: $0, activity: input.harnessActivity) }
+
+        return AgentSidebarRollup(rows: liveRows + persistedRows + terminalRows)
+    }
+
+    private static func liveRow(for session: ACPSession, remoteHost: String?) -> AgentSidebarRow {
+        .acp(
+            id: session.id,
+            agentID: session.agentId,
+            title: session.title,
+            model: session.currentModel,
+            state: state(for: session),
+            contextUsage: session.contextUsage,
+            plan: planProgress(for: session.transcript.currentPlan),
+            host: remoteHost,
+            createdAt: session.createdAt,
+            isLive: true
+        )
+    }
+
+    private static func persistedRow(_ row: ACPSessionRow) -> AgentSidebarRow {
+        .acp(
+            id: row.id,
+            agentID: row.agentId,
+            title: row.title,
+            model: row.currentModel,
+            state: .detached,
+            createdAt: Date(timeIntervalSince1970: TimeInterval(row.createdAt)),
+            isLive: false
+        )
+    }
+
+    private static func terminalRow(
+        for tab: TerminalTabState,
+        activity: [String: HarnessService.HarnessActivityState]
+    ) -> AgentSidebarRow {
+        let leaf = tab.root.find(leafId: tab.focusedLeafId)?.leaf ?? tab.root.firstLeaf()
+        let hook = activity[leaf.sessionId]
+        return .terminal(
+            tabID: tab.id,
+            sessionID: leaf.sessionId,
+            agentID: hook?.agent.rawValue ?? "terminal",
+            title: tab.title,
+            state: hook.map { state(for: $0.state) } ?? .unknown
+        )
+    }
+
+    private static func state(for session: ACPSession) -> AgentSidebarState {
+        switch session.transcript.streamingState {
+        case .sending, .streaming:
+            return .running
+        case .awaitingInput:
+            return .awaitingInput
+        case .awaitingPermission:
+            return .permissionRequest
+        case .idle:
+            switch session.agentState {
+            case .spawning:
+                return .running
+            case .idle, .ready:
+                return .idle
+            case .disconnected:
+                return .detached
+            case .failed:
+                return .unknown
+            }
+        }
+    }
+
+    private static func state(for activity: ActivityState) -> AgentSidebarState {
+        switch activity {
+        case .busy:
+            return .running
+        case .awaitingInput:
+            return .awaitingInput
+        case .permissionRequest:
+            return .permissionRequest
+        case .idle:
+            return .idle
+        }
+    }
+
+    private static func planProgress(for plan: [ACPMessage.PlanItem]?) -> AgentSidebarPlanProgress? {
+        guard let plan, !plan.isEmpty else { return nil }
+        return AgentSidebarPlanProgress(
+            completed: plan.count { $0.status == "completed" },
+            total: plan.count,
+            currentStep: plan.first(where: { $0.status == "in_progress" })?.content
+        )
+    }
+}

--- a/Alas/Sources/Right/AgentSidebarRollup.swift
+++ b/Alas/Sources/Right/AgentSidebarRollup.swift
@@ -196,11 +196,11 @@ struct AgentSidebarRollupBuilder {
     }
 
     private static func planProgress(for plan: [ACPMessage.PlanItem]?) -> AgentSidebarPlanProgress? {
-        guard let plan, !plan.isEmpty else { return nil }
+        guard let state = ACPPlanPillState(items: plan) else { return nil }
         return AgentSidebarPlanProgress(
-            completed: plan.count { $0.status == "completed" },
-            total: plan.count,
-            currentStep: plan.first(where: { $0.status == "in_progress" })?.content
+            completed: state.done,
+            total: state.total,
+            currentStep: state.currentStep
         )
     }
 }

--- a/Alas/Sources/Right/AgentSidebarRollup.swift
+++ b/Alas/Sources/Right/AgentSidebarRollup.swift
@@ -63,7 +63,8 @@ struct AgentSidebarRow: Identifiable, Equatable {
         sessionID: String,
         agentID: String,
         title: String,
-        state: AgentSidebarState
+        state: AgentSidebarState,
+        host: String? = nil
     ) -> Self {
         Self(
             id: .terminal(tabID: tabID, sessionID: sessionID),
@@ -73,7 +74,7 @@ struct AgentSidebarRow: Identifiable, Equatable {
             state: state,
             contextUsage: nil,
             plan: nil,
-            host: nil,
+            host: host,
             createdAt: .distantPast,
             isLiveACP: false
         )
@@ -112,10 +113,12 @@ struct AgentSidebarRollupBuilder {
         let liveRows = liveSessions.map { liveRow(for: $0, remoteHost: input.remoteHost) }
         let persistedRows = input.persistedACP
             .filter { !liveIDs.contains($0.id) }
-            .map(persistedRow)
-        let terminalRows = input.terminalTabs.map { terminalRow(for: $0, activity: input.harnessActivity) }
+            .map { persistedRow($0, remoteHost: input.remoteHost) }
+        let terminalRowsList = input.terminalTabs.flatMap {
+            terminalRows(for: $0, activity: input.harnessActivity, remoteHost: input.remoteHost)
+        }
 
-        return AgentSidebarRollup(rows: liveRows + persistedRows + terminalRows)
+        return AgentSidebarRollup(rows: liveRows + persistedRows + terminalRowsList)
     }
 
     private static func liveRow(for session: ACPSession, remoteHost: String?) -> AgentSidebarRow {
@@ -133,30 +136,47 @@ struct AgentSidebarRollupBuilder {
         )
     }
 
-    private static func persistedRow(_ row: ACPSessionRow) -> AgentSidebarRow {
+    private static func persistedRow(_ row: ACPSessionRow, remoteHost: String?) -> AgentSidebarRow {
         .acp(
             id: row.id,
             agentID: row.agentId,
             title: row.title,
             model: row.currentModel,
             state: .detached,
+            host: remoteHost,
             createdAt: Date(timeIntervalSince1970: TimeInterval(row.createdAt)),
             isLive: false
         )
     }
 
+    private static func terminalRows(
+        for tab: TerminalTabState,
+        activity: [String: HarnessService.HarnessActivityState],
+        remoteHost: String?
+    ) -> [AgentSidebarRow] {
+        tab.root.leaves()
+            .sorted { lhs, rhs in
+                if lhs.id == tab.focusedLeafId { return true }
+                if rhs.id == tab.focusedLeafId { return false }
+                return lhs.id < rhs.id
+            }
+            .map { terminalRow(for: tab, leaf: $0, activity: activity, remoteHost: remoteHost) }
+    }
+
     private static func terminalRow(
         for tab: TerminalTabState,
-        activity: [String: HarnessService.HarnessActivityState]
+        leaf: PaneLeaf,
+        activity: [String: HarnessService.HarnessActivityState],
+        remoteHost: String?
     ) -> AgentSidebarRow {
-        let leaf = tab.root.find(leafId: tab.focusedLeafId)?.leaf ?? tab.root.firstLeaf()
         let hook = activity[leaf.sessionId]
         return .terminal(
             tabID: tab.id,
             sessionID: leaf.sessionId,
             agentID: hook?.agent.rawValue ?? "terminal",
             title: tab.title,
-            state: hook.map { state(for: $0.state) } ?? .unknown
+            state: hook.map { state(for: $0.state) } ?? .unknown,
+            host: remoteHost
         )
     }
 

--- a/Alas/Sources/Right/AgentTabView.swift
+++ b/Alas/Sources/Right/AgentTabView.swift
@@ -1,0 +1,246 @@
+import SwiftUI
+import Combine
+
+struct AgentSidebarActions {
+    let onFocus: (AgentSidebarRowID) -> Void
+    let onInterrupt: (ACPSession.ID) -> Void
+    let onFollowUp: (ACPSession.ID, String) -> Void
+    let onDelegate: ((ACPSession.ID) -> Void)?
+}
+
+enum AgentSidebarFollowUpDelivery: Equatable {
+    case sending
+    case sent
+    case failed
+}
+
+/// Observes the manager and its nested Combine models for this worktree only.
+struct AgentWorktreeTabView: View {
+    let state: AppState
+    let worktree: Worktree
+    @ObservedObject var manager: ACPSessionManager
+    @State private var sessionRevision = 0
+    @State private var deliveries: [ACPSession.ID: AgentSidebarFollowUpDelivery] = [:]
+
+    var body: some View {
+        let _ = sessionRevision
+        AgentTabView(
+            rollup: state.agentSidebarRollup(for: worktree),
+            actions: AgentSidebarActions(
+                onFocus: { rowID in
+                    Task { await state.focusAgentSidebarRow(rowID, in: worktree) }
+                },
+                onInterrupt: { sessionID in
+                    Task { await state.stop(for: sessionID, worktreeID: worktree.id) }
+                },
+                onFollowUp: { sessionID, text in
+                    deliveries[sessionID] = .sending
+                    Task {
+                        await state.sendPrompt(
+                            for: sessionID, worktreeID: worktree.id,
+                            text: text, attachments: []
+                        ) { succeeded in
+                            deliveries[sessionID] = succeeded ? .sent : .failed
+                        }
+                    }
+                },
+                onDelegate: nil
+            ),
+            controllableSessionIDs: Set(manager.sessions.keys.filter { manager.isWriter(for: $0) }),
+            followUpDelivery: deliveries
+        )
+        .onReceive(sessionUpdates) { _ in sessionRevision &+= 1 }
+        .task { await manager.refreshRecentNow() }
+    }
+
+    private var sessionUpdates: AnyPublisher<Void, Never> {
+        Publishers.MergeMany(manager.sessions.values.flatMap { session in
+            [session.objectWillChange.eraseToAnyPublisher(),
+             session.transcript.objectWillChange.eraseToAnyPublisher()]
+        })
+        // Published notifications arrive before mutation; deliver after the
+        // update and coalesce streaming events into one sidebar refresh.
+        .throttle(for: .milliseconds(100), scheduler: RunLoop.main, latest: true)
+        .receive(on: RunLoop.main)
+        .eraseToAnyPublisher()
+    }
+}
+
+struct AgentTabView: View {
+    let rollup: AgentSidebarRollup
+    let actions: AgentSidebarActions
+    var controllableSessionIDs: Set<ACPSession.ID> = []
+    var followUpDelivery: [ACPSession.ID: AgentSidebarFollowUpDelivery] = [:]
+    @State private var drafts: [AgentSidebarRowID: String] = [:]
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                if rollup.rows.isEmpty {
+                    Text("No agent sessions or terminals in this worktree.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(theme.color("fg-muted"))
+                        .padding(16)
+                } else {
+                    section(title: "Active", rows: rollup.active)
+                    section(title: "History", rows: rollup.history)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .onChange(of: followUpDelivery) { previous, current in
+            // Handle completion even when the lazy stack has unloaded the row.
+            for (sessionID, delivery) in current where delivery == .sent && previous[sessionID] != .sent {
+                drafts[.acp(sessionID)] = nil
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func section(title: String, rows: [AgentSidebarRow]) -> some View {
+        if !rows.isEmpty {
+            HStack {
+                Text(title)
+                Spacer()
+                Text("\(rows.count)").monospacedDigit()
+            }
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(theme.color("fg-muted"))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            ForEach(rows) { row in
+                AgentSidebarRowView(
+                    row: row,
+                    actions: actions,
+                    canControl: row.sessionID.map { controllableSessionIDs.contains($0) } ?? false,
+                    delivery: row.sessionID.flatMap { followUpDelivery[$0] },
+                    draft: Binding(
+                        get: { drafts[row.id, default: ""] },
+                        set: { drafts[row.id] = $0 }
+                    )
+                )
+            }
+        }
+    }
+}
+
+private struct AgentSidebarRowView: View {
+    let row: AgentSidebarRow
+    let actions: AgentSidebarActions
+    let canControl: Bool
+    let delivery: AgentSidebarFollowUpDelivery?
+    @Binding var draft: String
+    @State private var isEditing = false
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Button { actions.onFocus(row.id) } label: {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(alignment: .firstTextBaseline) {
+                        Text(row.title).font(.system(size: 12, weight: .medium)).lineLimit(2)
+                        Spacer(minLength: 4)
+                        Text(row.state.label)
+                            .font(.system(size: 10))
+                            .foregroundStyle(theme.color("fg-muted"))
+                    }
+                    HStack(spacing: 5) {
+                        Text(row.agentID)
+                        if let model = row.model { Text("· \(model)") }
+                    }
+                    .font(.system(size: 10))
+                    .foregroundStyle(theme.color("fg-muted"))
+                    .lineLimit(1)
+                    if let host = row.host {
+                        Label(host, systemImage: "network")
+                            .font(.system(size: 10))
+                            .foregroundStyle(theme.color("fg-muted"))
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Focus \(row.title)")
+
+            if let plan = row.plan {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Tasks \(plan.completed)/\(plan.total)")
+                        .font(.system(size: 10, weight: .medium))
+                    if let step = plan.currentStep {
+                        Text(step).font(.system(size: 10)).lineLimit(2)
+                    }
+                    ProgressView(value: Double(plan.completed), total: Double(plan.total))
+                }
+                .foregroundStyle(theme.color("fg-muted"))
+            }
+            if row.contextUsage != nil || canControl {
+                HStack(spacing: 8) {
+                    ACPContextUsageButton(usage: row.contextUsage, modelName: row.model)
+                    Spacer(minLength: 0)
+                    if let sessionID = row.sessionID, row.isLiveACP, canControl {
+                        if row.state == .running || row.state == .awaitingInput || row.state == .permissionRequest {
+                            Button("Interrupt") { actions.onInterrupt(sessionID) }
+                        }
+                        Button("Follow up") { isEditing.toggle() }
+                        if let onDelegate = actions.onDelegate {
+                            Button("Delegate") { onDelegate(sessionID) }
+                        }
+                    }
+                }
+                .controlSize(.small)
+            }
+            if let sessionID = row.sessionID,
+               isEditing || !draft.isEmpty || delivery == .failed {
+                VStack(alignment: .leading, spacing: 5) {
+                    TextField("Follow-up message", text: $draft, axis: .vertical)
+                        .lineLimit(2...5)
+                        .textFieldStyle(.roundedBorder)
+                        .disabled(delivery == .sending)
+                    HStack {
+                        if delivery == .failed {
+                            Text("Could not send. Your message is kept here.")
+                                .font(.system(size: 10))
+                                .foregroundStyle(theme.color("fg-muted"))
+                        }
+                        Spacer(minLength: 0)
+                        Button(delivery == .sending ? "Sending…" : "Send") {
+                            actions.onFollowUp(sessionID, draft)
+                        }
+                        .disabled(!canControl || delivery == .sending || draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        .controlSize(.small)
+                    }
+                }
+            }
+        }
+        .foregroundStyle(theme.color("fg"))
+        .padding(12)
+        .overlay(alignment: .bottom) { Divider() }
+        .onChange(of: delivery) {
+            if delivery == .sent {
+                isEditing = false
+            }
+        }
+    }
+}
+
+private extension AgentSidebarRow {
+    var sessionID: ACPSession.ID? {
+        guard case .acp(let sessionID) = id else { return nil }
+        return sessionID
+    }
+}
+
+private extension AgentSidebarState {
+    var label: String {
+        switch self {
+        case .running: "Running"
+        case .awaitingInput: "Awaiting input"
+        case .permissionRequest: "Permission requested"
+        case .idle: "Idle"
+        case .detached: "Detached"
+        case .unknown: "Unknown"
+        }
+    }
+}

--- a/Alas/Sources/Right/AgentTabView.swift
+++ b/Alas/Sources/Right/AgentTabView.swift
@@ -14,13 +14,24 @@ enum AgentSidebarFollowUpDelivery: Equatable {
     case failed
 }
 
+struct AgentSidebarFollowUpDraft: Equatable {
+    var text = ""
+    var delivery: AgentSidebarFollowUpDelivery?
+}
+
 /// Observes the manager and its nested Combine models for this worktree only.
 struct AgentWorktreeTabView: View {
     let state: AppState
     let worktree: Worktree
     @ObservedObject var manager: ACPSessionManager
     @State private var sessionRevision = 0
-    @State private var deliveries: [ACPSession.ID: AgentSidebarFollowUpDelivery] = [:]
+
+    var followUps: Binding<[ACPSession.ID: AgentSidebarFollowUpDraft]> {
+        Binding(
+            get: { state.agentSidebarFollowUps[worktree.id, default: [:]] },
+            set: { state.agentSidebarFollowUps[worktree.id] = $0 }
+        )
+    }
 
     var body: some View {
         let _ = sessionRevision
@@ -34,20 +45,12 @@ struct AgentWorktreeTabView: View {
                     Task { await state.stop(for: sessionID, worktreeID: worktree.id) }
                 },
                 onFollowUp: { sessionID, text in
-                    deliveries[sessionID] = .sending
-                    Task {
-                        await state.sendPrompt(
-                            for: sessionID, worktreeID: worktree.id,
-                            text: text, attachments: []
-                        ) { succeeded in
-                            deliveries[sessionID] = succeeded ? .sent : .failed
-                        }
-                    }
+                    state.sendAgentSidebarFollowUp(for: sessionID, worktreeID: worktree.id, text: text)
                 },
                 onDelegate: nil
             ),
             controllableSessionIDs: Set(manager.sessions.keys.filter { manager.isWriter(for: $0) }),
-            followUpDelivery: deliveries
+            followUps: followUps
         )
         .onReceive(sessionUpdates) { _ in sessionRevision &+= 1 }
         .task { await manager.refreshRecentNow() }
@@ -70,8 +73,7 @@ struct AgentTabView: View {
     let rollup: AgentSidebarRollup
     let actions: AgentSidebarActions
     var controllableSessionIDs: Set<ACPSession.ID> = []
-    var followUpDelivery: [ACPSession.ID: AgentSidebarFollowUpDelivery] = [:]
-    @State private var drafts: [AgentSidebarRowID: String] = [:]
+    @Binding var followUps: [ACPSession.ID: AgentSidebarFollowUpDraft]
     @Environment(\.theme) private var theme
 
     var body: some View {
@@ -89,12 +91,6 @@ struct AgentTabView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .onChange(of: followUpDelivery) { previous, current in
-            // Handle completion even when the lazy stack has unloaded the row.
-            for (sessionID, delivery) in current where delivery == .sent && previous[sessionID] != .sent {
-                drafts[.acp(sessionID)] = nil
-            }
-        }
     }
 
     @ViewBuilder
@@ -114,10 +110,14 @@ struct AgentTabView: View {
                     row: row,
                     actions: actions,
                     canControl: row.sessionID.map { controllableSessionIDs.contains($0) } ?? false,
-                    delivery: row.sessionID.flatMap { followUpDelivery[$0] },
+                    delivery: row.sessionID.flatMap { followUps[$0]?.delivery },
                     draft: Binding(
-                        get: { drafts[row.id, default: ""] },
-                        set: { drafts[row.id] = $0 }
+                        get: { row.sessionID.flatMap { followUps[$0]?.text } ?? "" },
+                        set: { text in
+                            if let sessionID = row.sessionID {
+                                followUps[sessionID, default: .init()].text = text
+                            }
+                        }
                     )
                 )
             }

--- a/Alas/Sources/Right/AgentTabView.swift
+++ b/Alas/Sources/Right/AgentTabView.swift
@@ -148,6 +148,10 @@ private struct AgentSidebarRowView: View {
                     HStack(spacing: 5) {
                         Text(row.agentID)
                         if let model = row.model { Text("· \(model)") }
+                        if row.createdAt != .distantPast {
+                            Text("·")
+                            Text(row.createdAt, style: .relative)
+                        }
                     }
                     .font(.system(size: 10))
                     .foregroundStyle(theme.color("fg-muted"))

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -4,10 +4,10 @@ import Observation
 import os
 
 enum RightPaneTab: String {
-    case changes, files, run
+    case changes, files, agent, run
 
     static func available(runTabEnabled: Bool) -> [Self] {
-        runTabEnabled ? [.changes, .files, .run] : [.changes, .files]
+        runTabEnabled ? [.changes, .files, .agent, .run] : [.changes, .files, .agent]
     }
 
     static func visible(_ tab: Self, runTabEnabled: Bool) -> Self {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -6,12 +6,15 @@ import os
 enum RightPaneTab: String {
     case changes, files, agent, run
 
-    static func available(runTabEnabled: Bool) -> [Self] {
-        runTabEnabled ? [.changes, .files, .agent, .run] : [.changes, .files, .agent]
+    static func available(agentTabEnabled: Bool, runTabEnabled: Bool) -> [Self] {
+        var tabs: [Self] = [.changes, .files]
+        if agentTabEnabled { tabs.append(.agent) }
+        if runTabEnabled { tabs.append(.run) }
+        return tabs
     }
 
-    static func visible(_ tab: Self, runTabEnabled: Bool) -> Self {
-        tab == .run && !runTabEnabled ? .changes : tab
+    static func visible(_ tab: Self, agentTabEnabled: Bool, runTabEnabled: Bool) -> Self {
+        available(agentTabEnabled: agentTabEnabled, runTabEnabled: runTabEnabled).contains(tab) ? tab : .changes
     }
 }
 

--- a/Alas/Sources/Right/RightPaneTabBar.swift
+++ b/Alas/Sources/Right/RightPaneTabBar.swift
@@ -8,6 +8,7 @@ struct RightPaneTabBar: View {
     let onHidePane: () -> Void
     let showIgnored: Bool
     let onToggleShowIgnored: () -> Void
+    var showAgentTab: Bool = false
     var showRunTab: Bool = false
     /// Number of commands currently starting or running in this worktree.
     var activeRunCount: Int = 0
@@ -45,13 +46,15 @@ struct RightPaneTabBar: View {
                         set: { _ in onToggleShowIgnored() }
                     ))
                 }
-            segment(
-                .agent,
-                icon: "person.crop.circle",
-                label: "Agent",
-                count: activeAgentCount > 0 ? activeAgentCount : nil,
-                compact: compact
-            )
+            if showAgentTab {
+                segment(
+                    .agent,
+                    icon: "person.crop.circle",
+                    label: "Agent",
+                    count: activeAgentCount > 0 ? activeAgentCount : nil,
+                    compact: compact
+                )
+            }
             if showRunTab {
                 segment(
                     .run,

--- a/Alas/Sources/Right/RightPaneTabBar.swift
+++ b/Alas/Sources/Right/RightPaneTabBar.swift
@@ -11,6 +11,8 @@ struct RightPaneTabBar: View {
     var showRunTab: Bool = false
     /// Number of commands currently starting or running in this worktree.
     var activeRunCount: Int = 0
+    /// Number of non-detached Agent sidebar rows in this worktree.
+    var activeAgentCount: Int = 0
 
     @Environment(\.theme) private var theme
 
@@ -43,6 +45,13 @@ struct RightPaneTabBar: View {
                         set: { _ in onToggleShowIgnored() }
                     ))
                 }
+            segment(
+                .agent,
+                icon: "person.crop.circle",
+                label: "Agent",
+                count: activeAgentCount > 0 ? activeAgentCount : nil,
+                compact: compact
+            )
             if RightPaneTab.available(runTabEnabled: showRunTab).contains(.run) {
                 segment(
                     .run,
@@ -124,7 +133,7 @@ struct RightPaneTabBar: View {
                 .font(.system(size: 11, design: .monospaced))
                 .padding(.trailing, 4)
             }
-        case .files, .run:
+        case .files, .agent, .run:
             EmptyView()
         }
     }

--- a/Alas/Sources/Right/RightPaneTabBar.swift
+++ b/Alas/Sources/Right/RightPaneTabBar.swift
@@ -23,8 +23,9 @@ struct RightPaneTabBar: View {
             // at the pane's 240pt minimum, so fall back to icon-only rather
             // than truncating every label to an ellipsis.
             ViewThatFits(in: .horizontal) {
-                segments(compact: false)
-                segments(compact: true)
+                segments(compact: false, includeCounts: true)
+                segments(compact: true, includeCounts: true)
+                segments(compact: true, includeCounts: false)
             }
 
             Spacer(minLength: 8)
@@ -36,9 +37,9 @@ struct RightPaneTabBar: View {
         .windowDragHandle()
     }
 
-    private func segments(compact: Bool) -> some View {
+    private func segments(compact: Bool, includeCounts: Bool) -> some View {
         HStack(spacing: 2) {
-            segment(.changes, icon: "diff", label: "Changes", count: changesCount, compact: compact)
+            segment(.changes, icon: "diff", label: "Changes", count: includeCounts ? changesCount : nil, compact: compact)
             segment(.files, icon: "folder", label: "Files", count: nil, compact: compact)
                 .contextMenu {
                     Toggle("Show ignored or excluded files", isOn: Binding(
@@ -51,7 +52,7 @@ struct RightPaneTabBar: View {
                     .agent,
                     icon: "person.crop.circle",
                     label: "Agent",
-                    count: activeAgentCount > 0 ? activeAgentCount : nil,
+                    count: includeCounts && activeAgentCount > 0 ? activeAgentCount : nil,
                     compact: compact
                 )
             }
@@ -60,7 +61,7 @@ struct RightPaneTabBar: View {
                     .run,
                     icon: "play",
                     label: "Run",
-                    count: activeRunCount > 0 ? activeRunCount : nil,
+                    count: includeCounts && activeRunCount > 0 ? activeRunCount : nil,
                     compact: compact
                 )
             }

--- a/Alas/Sources/Right/RightPaneTabBar.swift
+++ b/Alas/Sources/Right/RightPaneTabBar.swift
@@ -52,7 +52,7 @@ struct RightPaneTabBar: View {
                 count: activeAgentCount > 0 ? activeAgentCount : nil,
                 compact: compact
             )
-            if RightPaneTab.available(runTabEnabled: showRunTab).contains(.run) {
+            if showRunTab {
                 segment(
                     .run,
                     icon: "play",
@@ -78,8 +78,48 @@ struct RightPaneTabBar: View {
         count: Int?,
         compact: Bool = false
     ) -> some View {
-        let isOn = activeTab == tab
-        return Button {
+        RightPaneSegmentButton(
+            activeTab: $activeTab,
+            tab: tab,
+            icon: icon,
+            label: label,
+            count: count,
+            compact: compact
+        )
+    }
+
+    @ViewBuilder
+    private var trailing: some View {
+        switch activeTab {
+        case .changes:
+            if shouldShowChangeSummary(additions: totalAdd, deletions: totalDel) {
+                HStack(spacing: 6) {
+                    Text("+\(totalAdd)").foregroundColor(theme.color("add"))
+                    Text("−\(totalDel)").foregroundColor(theme.color("del"))
+                }
+                .font(.system(size: 11, design: .monospaced))
+                .padding(.trailing, 4)
+            }
+        case .files, .agent, .run:
+            EmptyView()
+        }
+    }
+}
+
+private struct RightPaneSegmentButton: View {
+    @Binding var activeTab: RightPaneTab
+    let tab: RightPaneTab
+    let icon: String
+    let label: String
+    let count: Int?
+    let compact: Bool
+
+    @Environment(\.theme) private var theme
+
+    private var isOn: Bool { activeTab == tab }
+
+    var body: some View {
+        Button {
             activeTab = tab
         } label: {
             HStack(spacing: 5) {
@@ -101,17 +141,7 @@ struct RightPaneTabBar: View {
             }
             .padding(.horizontal, 9)
             .frame(height: 22)
-            .background(
-                ZStack {
-                    if isOn {
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(theme.color("bg-3"))
-                        RoundedRectangle(cornerRadius: 4)
-                            .stroke(Color.white.opacity(0.04), lineWidth: 1)
-                            .blendMode(.plusLighter)
-                    }
-                }
-            )
+            .background(selectionBackground)
             .clipShape(RoundedRectangle(cornerRadius: 4))
             .shadow(color: isOn ? Color.black.opacity(0.25) : .clear, radius: 1, x: 0, y: 1)
             .contentShape(Rectangle())
@@ -122,19 +152,13 @@ struct RightPaneTabBar: View {
     }
 
     @ViewBuilder
-    private var trailing: some View {
-        switch activeTab {
-        case .changes:
-            if shouldShowChangeSummary(additions: totalAdd, deletions: totalDel) {
-                HStack(spacing: 6) {
-                    Text("+\(totalAdd)").foregroundColor(theme.color("add"))
-                    Text("−\(totalDel)").foregroundColor(theme.color("del"))
-                }
-                .font(.system(size: 11, design: .monospaced))
-                .padding(.trailing, 4)
-            }
-        case .files, .agent, .run:
-            EmptyView()
+    private var selectionBackground: some View {
+        if isOn {
+            RoundedRectangle(cornerRadius: 4)
+                .fill(theme.color("bg-3"))
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(Color.white.opacity(0.04), lineWidth: 1)
+                .blendMode(.plusLighter)
         }
     }
 }

--- a/Alas/Sources/Right/RightPaneTransitionalView.swift
+++ b/Alas/Sources/Right/RightPaneTransitionalView.swift
@@ -38,6 +38,8 @@ struct RightPaneTransitionalView: View {
                     onHidePane: {},
                     showIgnored: state.config.files.showIgnored,
                     onToggleShowIgnored: {},
+                    showAgentTab: state.config.agentTabEnabled,
+                    showRunTab: state.config.runTabEnabled,
                     activeAgentCount: state.agentSidebarRollup(for: worktree).active.count
                 )
                 .disabled(true)

--- a/Alas/Sources/Right/RightPaneTransitionalView.swift
+++ b/Alas/Sources/Right/RightPaneTransitionalView.swift
@@ -37,7 +37,8 @@ struct RightPaneTransitionalView: View {
                     totalDel: 0,
                     onHidePane: {},
                     showIgnored: state.config.files.showIgnored,
-                    onToggleShowIgnored: {}
+                    onToggleShowIgnored: {},
+                    activeAgentCount: state.agentSidebarRollup(for: worktree).active.count
                 )
                 .disabled(true)
 

--- a/Alas/Sources/Right/RightPaneTransitionalView.swift
+++ b/Alas/Sources/Right/RightPaneTransitionalView.swift
@@ -100,7 +100,7 @@ struct RightPaneLoadingSkeletonView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
-        case .files, .run:
+        case .files, .agent, .run:
             VStack(alignment: .leading, spacing: 6) {
                 SkeletonRow(widthFraction: 0.6,  leadingInset: 0)
                 SkeletonRow(widthFraction: 0.5,  leadingInset: 16)

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -269,9 +269,14 @@ private struct AgentSidebarManagerObserver: View {
     let onChange: () -> Void
 
     var body: some View {
+        let sessionChanges = Publishers.MergeMany(manager.sessions.values.map(\.objectWillChange))
+
         Color.clear
             .frame(width: 0, height: 0)
             .onReceive(manager.objectWillChange) { _ in
+                onChange()
+            }
+            .onReceive(sessionChanges) { _ in
                 onChange()
             }
     }

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -114,6 +114,8 @@ struct RightPaneView: View {
                                 onClearReveal: { rps.clearReveal() },
                                 worktreeRoot: rps.worktree.path
                             )
+                        case .agent:
+                            EmptyView()
                         case .run:
                             RunTabView(state: state, worktree: worktree)
                         }

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -68,7 +68,8 @@ struct RightPaneView: View {
                         showRunTab: state.config.runTabEnabled,
                         activeRunCount: state.runRecords
                             .records(worktreeID: worktree.id)
-                            .count { $0.status.isActive }
+                            .count { $0.status.isActive },
+                        activeAgentCount: state.agentSidebarRollup(for: worktree).active.count
                     )
 
                     if rps.hasLoadedSnapshot || rps.activeTab == .agent {

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -36,6 +36,7 @@ struct RightPaneView: View {
         let initialState = state.rightPaneStore.activeState(worktreeId: worktree.id)
         initialState?.activeTab = RightPaneTab.visible(
             initialState?.activeTab ?? .changes,
+            agentTabEnabled: state.config.agentTabEnabled,
             runTabEnabled: state.config.runTabEnabled
         )
         _rps = State(initialValue: initialState)
@@ -68,6 +69,7 @@ struct RightPaneView: View {
                             state.config.files.showIgnored.toggle()
                             state.saveConfig()
                         },
+                        showAgentTab: state.config.agentTabEnabled,
                         showRunTab: state.config.runTabEnabled,
                         activeRunCount: state.runRecords
                             .records(worktreeID: worktree.id)
@@ -75,7 +77,7 @@ struct RightPaneView: View {
                         activeAgentCount: state.agentSidebarRollup(for: worktree).active.count
                     )
 
-                    if rps.hasLoadedSnapshot || rps.activeTab == .agent {
+                    if rps.hasLoadedSnapshot || (rps.activeTab == .agent && state.config.agentTabEnabled) {
                         switch rps.activeTab {
                         case .changes:
                             ChangesTabView(
@@ -150,6 +152,14 @@ struct RightPaneView: View {
                 .onChange(of: state.config.runTabEnabled) {
                     rps.activeTab = RightPaneTab.visible(
                         rps.activeTab,
+                        agentTabEnabled: state.config.agentTabEnabled,
+                        runTabEnabled: state.config.runTabEnabled
+                    )
+                }
+                .onChange(of: state.config.agentTabEnabled) {
+                    rps.activeTab = RightPaneTab.visible(
+                        rps.activeTab,
+                        agentTabEnabled: state.config.agentTabEnabled,
                         runTabEnabled: state.config.runTabEnabled
                     )
                 }

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 struct RightPaneView: View {
     @Bindable var state: AppState
@@ -11,6 +12,7 @@ struct RightPaneView: View {
     @Environment(\.theme) var theme
     @State private var rps: RightPaneState?
     @State private var agentManager: ACPSessionManager?
+    @State private var agentSidebarRevision = 0
 
     init(
         state: AppState,
@@ -40,6 +42,7 @@ struct RightPaneView: View {
     }
 
     var body: some View {
+        let _ = agentSidebarRevision
         let override = state.config.sidebarChromeOverride(forThemeId: state.themeStore.current.id)
         ZStack {
             SidebarMaterialBackground(
@@ -126,9 +129,6 @@ struct RightPaneView: View {
                                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                                 }
                             }
-                            .task(id: worktree.id) {
-                                agentManager = state.acpManager(for: worktree)
-                            }
                         case .run:
                             RunTabView(state: state, worktree: worktree)
                         }
@@ -137,6 +137,16 @@ struct RightPaneView: View {
                     }
                 }
                 .sidebarChromeTheme(textContrast: override.textContrast)
+                .task(id: worktree.id) {
+                    agentManager = state.acpManager(for: worktree)
+                }
+                .background {
+                    if let agentManager, agentManager.worktreeId == worktree.id {
+                        AgentSidebarManagerObserver(manager: agentManager) {
+                            agentSidebarRevision &+= 1
+                        }
+                    }
+                }
                 .onChange(of: state.config.runTabEnabled) {
                     rps.activeTab = RightPaneTab.visible(
                         rps.activeTab,
@@ -251,5 +261,18 @@ struct RightPaneView: View {
         .onDisappear {
             state.rightPaneStore.deactivate()
         }
+    }
+}
+
+private struct AgentSidebarManagerObserver: View {
+    @ObservedObject var manager: ACPSessionManager
+    let onChange: () -> Void
+
+    var body: some View {
+        Color.clear
+            .frame(width: 0, height: 0)
+            .onReceive(manager.objectWillChange) { _ in
+                onChange()
+            }
     }
 }

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -10,6 +10,7 @@ struct RightPaneView: View {
     let onReviewCommit: (CommitInfo) -> Void
     @Environment(\.theme) var theme
     @State private var rps: RightPaneState?
+    @State private var agentManager: ACPSessionManager?
 
     init(
         state: AppState,
@@ -70,7 +71,7 @@ struct RightPaneView: View {
                             .count { $0.status.isActive }
                     )
 
-                    if rps.hasLoadedSnapshot {
+                    if rps.hasLoadedSnapshot || rps.activeTab == .agent {
                         switch rps.activeTab {
                         case .changes:
                             ChangesTabView(
@@ -115,7 +116,18 @@ struct RightPaneView: View {
                                 worktreeRoot: rps.worktree.path
                             )
                         case .agent:
-                            EmptyView()
+                            Group {
+                                if let agentManager, agentManager.worktreeId == worktree.id {
+                                    AgentWorktreeTabView(state: state, worktree: worktree, manager: agentManager)
+                                        .id(worktree.id)
+                                } else {
+                                    ProgressView("Loading sessions…")
+                                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                }
+                            }
+                            .task(id: worktree.id) {
+                                agentManager = state.acpManager(for: worktree)
+                            }
                         case .run:
                             RunTabView(state: state, worktree: worktree)
                         }

--- a/Alas/Sources/Settings/AdvancedPane.swift
+++ b/Alas/Sources/Settings/AdvancedPane.swift
@@ -30,6 +30,18 @@ struct AdvancedPane: View {
                         ))
                     }
                     SettingsRow(
+                        name: "Agent tab preview",
+                        desc: "Shows the worktree Agent tab for preview testing."
+                    ) {
+                        AlasToggle(on: Binding(
+                            get: { state.config.agentTabEnabled },
+                            set: { enabled in
+                                state.config.agentTabEnabled = enabled
+                                state.saveConfig()
+                            }
+                        ))
+                    }
+                    SettingsRow(
                         name: "Run tab preview",
                         desc: "Shows the worktree Run tab for preview testing."
                     ) {

--- a/AlasTests/AgentSidebarRollupTests.swift
+++ b/AlasTests/AgentSidebarRollupTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Agent sidebar rollup")
+struct AgentSidebarRollupTests {
+    @Test @MainActor
+    func liveACPRowOverridesPersistedHistoryAndBindsUsageAndPlan() {
+        let session = makeLiveSession(id: "acp-a", worktreeID: "worktree-a")
+        session.currentModel = "gpt-5"
+        session.contextUsage = ACPUsageInfo(used: 45_000, size: 128_000, cost: nil)
+        _ = session.apply(.plan([
+            .init(content: "Ship sidebar", status: "completed"),
+            .init(content: "Test isolation", status: "in_progress"),
+        ]))
+
+        let rollup = AgentSidebarRollupBuilder.build(.init(
+            worktreeID: "worktree-a", persistedACP: [makeRow(id: "acp-a")],
+            liveACP: [session], terminalTabs: [], harnessActivity: [:], remoteHost: "builder.example"
+        ))
+
+        let row = try! #require(rollup.active.first)
+        #expect(row.id == .acp("acp-a"))
+        #expect(row.model == "gpt-5")
+        #expect(row.contextUsage?.used == 45_000)
+        #expect(row.plan == .init(completed: 1, total: 2, currentStep: "Test isolation"))
+        #expect(row.host == "builder.example")
+    }
+
+    @Test @MainActor
+    func builderFiltersOtherWorktreesAndUsesUnknownForUnhookedTerminal() {
+        let rollup = AgentSidebarRollupBuilder.build(.init(
+            worktreeID: "worktree-a", persistedACP: [makeRow(id: "a")],
+            liveACP: [makeLiveSession(id: "b", worktreeID: "worktree-b")],
+            terminalTabs: [makeTerminal(id: "terminal-a", sessionID: "shell-a")],
+            harnessActivity: [:], remoteHost: nil
+        ))
+
+        #expect(rollup.rows.map(\.id) == [.acp("a"), .terminal(tabID: "terminal-a", sessionID: "shell-a")])
+        #expect(rollup.rows.last?.state == .unknown)
+    }
+
+    @Test @MainActor
+    func hookStateOverridesTerminalFallbackAndActionsKeepExactTargets() {
+        let activity = HarnessService.HarnessActivityState(
+            agent: .codex, state: .permissionRequest, pid: nil, lastBody: nil, updatedAt: .now
+        )
+        let rollup = AgentSidebarRollupBuilder.build(.init(
+            worktreeID: "worktree-a", persistedACP: [], liveACP: [],
+            terminalTabs: [makeTerminal(id: "terminal-a", sessionID: "shell-a")],
+            harnessActivity: ["shell-a": activity], remoteHost: nil
+        ))
+
+        let row = try! #require(rollup.rows.first)
+        #expect(row.state == .permissionRequest)
+        #expect(row.id == .terminal(tabID: "terminal-a", sessionID: "shell-a"))
+    }
+
+    @MainActor
+    private func makeLiveSession(id: String, worktreeID: String) -> ACPSession {
+        ACPSession(id: id, agentId: "codex", worktreeId: worktreeID, title: "Session \(id)")
+    }
+
+    private func makeRow(id: String) -> ACPSessionRow {
+        ACPSessionRow(
+            id: id,
+            agentId: "codex",
+            title: "Session \(id)",
+            currentModel: "persisted-model",
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        )
+    }
+
+    private func makeTerminal(id: TabID, sessionID: String) -> TerminalTabState {
+        TerminalTabState(id: id, title: "Terminal \(id)", sessionId: sessionID)
+    }
+}

--- a/AlasTests/AgentSidebarRollupTests.swift
+++ b/AlasTests/AgentSidebarRollupTests.swift
@@ -218,6 +218,81 @@ struct AgentSidebarRollupTests {
         #expect(target.queue.isEmpty)
     }
 
+    @Test @MainActor
+    func unsentFollowUpSurvivesWorktreeNavigationWithoutLeakingToMatchingSessionID() {
+        let (state, first, second) = makeAppFixture()
+        state.selectWorktree(id: first.id)
+        state.agentSidebarFollowUps[first.id, default: [:]]["same-id"] = .init(text: "Unsent draft")
+        state.selectWorktree(id: second.id)
+        state.agentSidebarFollowUps[second.id, default: [:]]["same-id"] = .init(text: "Other worktree")
+        state.selectWorktree(id: first.id)
+
+        #expect(state.agentSidebarFollowUps[first.id]?["same-id"]?.text == "Unsent draft")
+        #expect(state.agentSidebarFollowUps[first.id]?["same-id"]?.delivery == nil)
+        #expect(state.agentSidebarFollowUps[second.id]?["same-id"]?.text == "Other worktree")
+    }
+
+    @Test @MainActor
+    func pendingAndFailedFollowUpSurviveNavigationUntilDeliverySucceeds() throws {
+        let (state, first, second) = makeAppFixture()
+        state.selectWorktree(id: first.id)
+        let complete = try #require(state.beginAgentSidebarFollowUp(
+            for: "same-id", worktreeID: first.id, text: "Keep this after failure"
+        ))
+        state.selectWorktree(id: second.id)
+        #expect(state.agentSidebarFollowUps[first.id]?["same-id"]?.text == "Keep this after failure")
+        #expect(state.agentSidebarFollowUps[first.id]?["same-id"]?.delivery == .sending)
+        #expect(state.agentSidebarFollowUps[second.id]?["same-id"] == nil)
+
+        complete(false)
+        state.selectWorktree(id: first.id)
+        #expect(state.agentSidebarFollowUps[first.id]?["same-id"]?.text == "Keep this after failure")
+        #expect(state.agentSidebarFollowUps[first.id]?["same-id"]?.delivery == .failed)
+
+        let completeRetry = try #require(state.beginAgentSidebarFollowUp(
+            for: "same-id", worktreeID: first.id, text: "Keep this after failure"
+        ))
+        state.selectWorktree(id: second.id)
+        completeRetry(true)
+        state.selectWorktree(id: first.id)
+        #expect(state.agentSidebarFollowUps[first.id]?["same-id"]?.text == "")
+        #expect(state.agentSidebarFollowUps[first.id]?["same-id"]?.delivery == .sent)
+    }
+
+    @Test @MainActor
+    func pendingFollowUpRejectsDuplicateSubmissionAndPreservesItsDraft() throws {
+        let (state, first, _) = makeAppFixture()
+        _ = try #require(state.beginAgentSidebarFollowUp(for: "session", worktreeID: first.id, text: "Original"))
+
+        let duplicate = state.beginAgentSidebarFollowUp(for: "session", worktreeID: first.id, text: "Replacement")
+
+        #expect(duplicate == nil)
+        #expect(state.agentSidebarFollowUps[first.id]?["session"]?.text == "Original")
+        #expect(state.agentSidebarFollowUps[first.id]?["session"]?.delivery == .sending)
+    }
+
+    @Test @MainActor
+    func recreatingAgentPaneRestoresPendingDraftAndLaterFailure() throws {
+        let (state, worktree, _) = makeAppFixture()
+        let manager = try #require(state.acpManager(for: worktree))
+        var pane: AgentWorktreeTabView? = AgentWorktreeTabView(state: state, worktree: worktree, manager: manager)
+        pane?.followUps.wrappedValue["session"] = .init(text: "Draft from the row")
+        let complete = try #require(state.beginAgentSidebarFollowUp(
+            for: "session", worktreeID: worktree.id, text: "Draft from the row"
+        ))
+
+        pane = nil
+        pane = AgentWorktreeTabView(state: state, worktree: worktree, manager: manager)
+        #expect(pane?.followUps.wrappedValue["session"]?.text == "Draft from the row")
+        #expect(pane?.followUps.wrappedValue["session"]?.delivery == .sending)
+
+        pane = nil
+        complete(false)
+        pane = AgentWorktreeTabView(state: state, worktree: worktree, manager: manager)
+        #expect(pane?.followUps.wrappedValue["session"]?.text == "Draft from the row")
+        #expect(pane?.followUps.wrappedValue["session"]?.delivery == .failed)
+    }
+
     private struct MemoryStore: PersistenceStoreProtocol {
         func write<T: Encodable>(_: T, to _: URL) throws {}
         func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }

--- a/AlasTests/AgentSidebarRollupTests.swift
+++ b/AlasTests/AgentSidebarRollupTests.swift
@@ -5,13 +5,36 @@ import Testing
 @Suite("Agent sidebar rollup")
 struct AgentSidebarRollupTests {
     @Test @MainActor
+    func actionsExposeTheRowIdentityAfterHistoryBecomesLive() {
+        var focused: [AgentSidebarRowID] = []
+        let actions = AgentSidebarActions(
+            onFocus: { focused.append($0) }, onInterrupt: { _ in },
+            onFollowUp: { _, _ in }, onDelegate: nil
+        )
+        let history = AgentSidebarRollupBuilder.build(.init(
+            worktreeID: "worktree-a", persistedACP: [makeRow(id: "acp-a")],
+            liveACP: [], terminalTabs: [], harnessActivity: [:], remoteHost: nil
+        ))
+        let live = AgentSidebarRollupBuilder.build(.init(
+            worktreeID: "worktree-a", persistedACP: [makeRow(id: "acp-a")],
+            liveACP: [makeLiveSession(id: "acp-a", worktreeID: "worktree-a")],
+            terminalTabs: [], harnessActivity: [:], remoteHost: nil
+        ))
+
+        actions.onFocus(history.rows[0].id)
+        actions.onFocus(live.rows[0].id)
+
+        #expect(focused == [.acp("acp-a"), .acp("acp-a")])
+    }
+
+    @Test @MainActor
     func liveACPRowOverridesPersistedHistoryAndBindsUsageAndPlan() {
         let session = makeLiveSession(id: "acp-a", worktreeID: "worktree-a")
         session.currentModel = "gpt-5"
         session.contextUsage = ACPUsageInfo(used: 45_000, size: 128_000, cost: nil)
         _ = session.apply(.plan([
-            .init(content: "Ship sidebar", status: "completed"),
-            .init(content: "Test isolation", status: "in_progress"),
+            .init(content: "Ship sidebar", priority: nil, status: "completed"),
+            .init(content: "Test isolation", priority: nil, status: "in_progress"),
         ]))
 
         let rollup = AgentSidebarRollupBuilder.build(.init(
@@ -78,5 +101,145 @@ struct AgentSidebarRollupTests {
 
     private func makeTerminal(id: TabID, sessionID: String) -> TerminalTabState {
         TerminalTabState(id: id, title: "Terminal \(id)", sessionId: sessionID)
+    }
+
+    @Test @MainActor
+    func snapshotKeepsPersistedRowsInTheirOwningWorktree() async throws {
+        let (state, first, second) = makeAppFixture()
+        let firstManager = try #require(state.acpManager(for: first))
+        let secondManager = try #require(state.acpManager(for: second))
+        let session = firstManager.createSession(id: "first-session", agentId: "sidebar-test-agent")
+        _ = secondManager.createSession(id: "second-session", agentId: "sidebar-test-agent")
+        await firstManager.flushAllPersistence()
+        firstManager.closeSession(id: session.id)
+        await firstManager.refreshRecentNow()
+        let terminal = state.tabs.appendTerminal(worktreeId: first.id, title: "First", sessionId: "shell-a")
+        state.tabs.appendTerminal(worktreeId: second.id, title: "Second", sessionId: "shell-b")
+
+        let rollup = state.agentSidebarRollup(for: first)
+
+        #expect(rollup.rows.map(\.id) == [.acp("first-session"), .terminal(tabID: terminal.id, sessionID: "shell-a")])
+        #expect(rollup.history.map(\.id) == [.acp("first-session")])
+    }
+
+    @Test @MainActor
+    func focusReopensHistoryInItsWorktreeAndReusesTheNewTab() async throws {
+        let (state, first, second) = makeAppFixture()
+        let manager = try #require(state.acpManager(for: first))
+        let session = manager.createSession(id: "reopened-session", agentId: "sidebar-test-agent")
+        await manager.flushAllPersistence()
+        manager.closeSession(id: session.id)
+        await manager.refreshRecentNow()
+        state.selectWorktree(id: second.id)
+
+        await state.focusAgentSidebarRow(.acp("reopened-session"), in: first)
+        let reopenedID = try #require(state.tabs.activeTabId(forWorktree: first.id))
+        await state.focusAgentSidebarRow(.acp("reopened-session"), in: first)
+
+        #expect(state.tabs.tabs(forWorktree: first.id).count == 1)
+        #expect(state.tabs.activeTabId(forWorktree: first.id) == reopenedID)
+        #expect(state.tabs.tabs(forWorktree: second.id).isEmpty)
+        #expect(state.selectedWorktreeId == first.id)
+    }
+
+    @Test @MainActor
+    func terminalFocusUsesExactTabAndRejectsOtherWorktreeRows() async {
+        let (state, first, second) = makeAppFixture()
+        let terminal = state.tabs.appendTerminal(worktreeId: first.id, title: "First", sessionId: "shell-a")
+        state.tabs.appendTerminal(worktreeId: first.id, title: "Second", sessionId: "shell-b")
+        state.selectWorktree(id: second.id)
+
+        await state.focusAgentSidebarRow(.terminal(tabID: terminal.id, sessionID: "shell-a"), in: first)
+        #expect(state.tabs.activeTabId(forWorktree: first.id) == terminal.id)
+        await state.focusAgentSidebarRow(.terminal(tabID: terminal.id, sessionID: "shell-a"), in: second)
+        #expect(state.tabs.activeTabId(forWorktree: second.id) == nil)
+        #expect(state.selectedWorktreeId == first.id)
+    }
+
+    @Test @MainActor
+    func sidebarPlanUsesExistingPendingAndCompletedStepSemantics() {
+        let session = makeLiveSession(id: "acp-a", worktreeID: "worktree-a")
+        _ = session.apply(.plan([.init(content: "Pending task", priority: nil, status: "pending")]))
+        let pending = AgentSidebarRollupBuilder.build(.init(
+            worktreeID: "worktree-a", persistedACP: [], liveACP: [session],
+            terminalTabs: [], harnessActivity: [:], remoteHost: nil
+        ))
+        #expect(pending.rows.first?.plan?.currentStep == "Pending task")
+        _ = session.apply(.plan([.init(content: "Pending task", priority: nil, status: "completed")]))
+        let completed = AgentSidebarRollupBuilder.build(.init(
+            worktreeID: "worktree-a", persistedACP: [], liveACP: [session],
+            terminalTabs: [], harnessActivity: [:], remoteHost: nil
+        ))
+        #expect(completed.rows.first?.plan?.currentStep == "All steps complete")
+    }
+
+    @Test @MainActor
+    func followUpTargetsItsWorktreeSessionWhenAnotherTabIsActive() async throws {
+        let (state, first, second) = makeAppFixture()
+        let firstManager = try #require(state.acpManager(for: first))
+        let secondManager = try #require(state.acpManager(for: second))
+        let target = firstManager.createSession(id: "shared-session-id", agentId: "sidebar-test-agent")
+        let other = secondManager.createSession(id: "shared-session-id", agentId: "sidebar-test-agent")
+        target.agentState = .spawning
+        other.agentState = .spawning
+        #expect(await firstManager.acquireWriterLease(sessionId: target.id))
+        #expect(await secondManager.acquireWriterLease(sessionId: other.id))
+        state.tabs.append(acpSession: ACPSessionTabState(sessionId: other.id, title: "Other"), to: second.id)
+        state.selectWorktree(id: second.id)
+
+        let accepted = await withCheckedContinuation { continuation in
+            Task { @MainActor in
+                await state.sendPrompt(for: target.id, worktreeID: first.id, text: "Continue here", attachments: []) {
+                    continuation.resume(returning: $0)
+                }
+            }
+        }
+
+        #expect(accepted)
+        #expect(target.queue.first?.blocks == [.text("Continue here")])
+        #expect(other.queue.isEmpty)
+        #expect(state.selectedWorktreeId == second.id)
+        await firstManager.releaseWriterLease(sessionId: target.id)
+        await secondManager.releaseWriterLease(sessionId: other.id)
+    }
+
+    @Test @MainActor
+    func followUpRefusalReportsFailureWithoutChangingTheQueue() async throws {
+        let (state, first, _) = makeAppFixture()
+        let manager = try #require(state.acpManager(for: first))
+        let target = manager.createSession(id: "read-only-session", agentId: "sidebar-test-agent")
+        var accepted: Bool?
+
+        await state.sendPrompt(for: target.id, worktreeID: first.id, text: "Keep this draft", attachments: []) {
+            accepted = $0
+        }
+
+        #expect(accepted == false)
+        #expect(target.queue.isEmpty)
+    }
+
+    private struct MemoryStore: PersistenceStoreProtocol {
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    }
+
+    @MainActor
+    private func makeAppFixture() -> (AppState, Worktree, Worktree) {
+        let state = AppState(store: MemoryStore())
+        let fixtureID = UUID().uuidString
+        let project = ProjectConfig(
+            id: fixtureID, name: "Agent Sidebar", path: "/tmp/\(fixtureID)",
+            color: "blue", addedAt: .distantPast
+        )
+        let worktrees = ["first", "second"].map { name in
+            Worktree(
+                id: "\(fixtureID)-\(name)", projectId: fixtureID, name: name, branch: name,
+                path: URL(fileURLWithPath: "/tmp/\(fixtureID)/\(name)"),
+                status: .clean, lastActivity: .distantPast
+            )
+        }
+        state.projectsManager = ProjectsManager(persistedProjects: [project])
+        for worktree in worktrees { state.projectsManager.insertOptimisticWorktree(worktree) }
+        return (state, worktrees[0], worktrees[1])
     }
 }

--- a/AlasTests/AgentSidebarRollupTests.swift
+++ b/AlasTests/AgentSidebarRollupTests.swift
@@ -56,11 +56,12 @@ struct AgentSidebarRollupTests {
             worktreeID: "worktree-a", persistedACP: [makeRow(id: "a")],
             liveACP: [makeLiveSession(id: "b", worktreeID: "worktree-b")],
             terminalTabs: [makeTerminal(id: "terminal-a", sessionID: "shell-a")],
-            harnessActivity: [:], remoteHost: nil
+            harnessActivity: [:], remoteHost: "builder.example"
         ))
 
         #expect(rollup.rows.map(\.id) == [.acp("a"), .terminal(tabID: "terminal-a", sessionID: "shell-a")])
         #expect(rollup.rows.last?.state == .unknown)
+        #expect(rollup.rows.map(\.host) == ["builder.example", "builder.example"])
     }
 
     @Test @MainActor
@@ -77,6 +78,40 @@ struct AgentSidebarRollupTests {
         let row = try! #require(rollup.rows.first)
         #expect(row.state == .permissionRequest)
         #expect(row.id == .terminal(tabID: "terminal-a", sessionID: "shell-a"))
+    }
+
+    @Test @MainActor
+    func splitTerminalTabEmitsRowsForEveryLeafWithFocusedLeafFirst() {
+        let terminal = TerminalTabState(
+            id: "terminal-a",
+            title: "Terminal",
+            root: .split(PaneSplit(
+                id: "split",
+                axis: .vertical,
+                fraction: 0.5,
+                children: [
+                    .leaf(PaneLeaf(id: "left-leaf", sessionId: "left-session", lastCwd: nil)),
+                    .leaf(PaneLeaf(id: "right-leaf", sessionId: "right-session", lastCwd: nil)),
+                ]
+            )),
+            focusedLeafId: "right-leaf"
+        )
+        let rollup = AgentSidebarRollupBuilder.build(.init(
+            worktreeID: "worktree-a", persistedACP: [], liveACP: [],
+            terminalTabs: [terminal],
+            harnessActivity: [
+                "left-session": .init(agent: .claude, state: .busy, pid: nil, lastBody: nil, updatedAt: .now),
+                "right-session": .init(agent: .codex, state: .awaitingInput, pid: nil, lastBody: nil, updatedAt: .now),
+            ],
+            remoteHost: nil
+        ))
+
+        #expect(rollup.rows.map(\.id) == [
+            .terminal(tabID: "terminal-a", sessionID: "right-session"),
+            .terminal(tabID: "terminal-a", sessionID: "left-session"),
+        ])
+        #expect(rollup.rows.map(\.state) == [.awaitingInput, .running])
+        #expect(rollup.rows.map(\.agentID) == ["codex", "claude"])
     }
 
     @MainActor
@@ -154,6 +189,33 @@ struct AgentSidebarRollupTests {
         await state.focusAgentSidebarRow(.terminal(tabID: terminal.id, sessionID: "shell-a"), in: second)
         #expect(state.tabs.activeTabId(forWorktree: second.id) == nil)
         #expect(state.selectedWorktreeId == first.id)
+    }
+
+    @Test @MainActor
+    func terminalFocusTargetsLeafSessionAndRejectsStaleRows() async {
+        let (state, first, _) = makeAppFixture()
+        let terminal = state.tabs.appendTerminal(worktreeId: first.id, title: "Split", sessionId: "left-session")
+        _ = state.tabs.splitFocusedLeaf(
+            worktreeId: first.id,
+            tabId: terminal.id,
+            axis: .vertical,
+            newLeafId: "right-session",
+            newSessionId: "right-session"
+        )
+
+        await state.focusAgentSidebarRow(.terminal(tabID: terminal.id, sessionID: "left-session"), in: first)
+        let focusedLeft = try! #require(state.tabs.tabs(forWorktree: first.id).compactMap { tab -> String? in
+            guard tab.id == terminal.id, case .terminal(let terminal) = tab else { return nil }
+            return terminal.focusedLeafId
+        }.first)
+        #expect(focusedLeft == "left-session")
+
+        await state.focusAgentSidebarRow(.terminal(tabID: terminal.id, sessionID: "missing-session"), in: first)
+        let focusedAfterStaleAction = try! #require(state.tabs.tabs(forWorktree: first.id).compactMap { tab -> String? in
+            guard tab.id == terminal.id, case .terminal(let terminal) = tab else { return nil }
+            return terminal.focusedLeafId
+        }.first)
+        #expect(focusedAfterStaleAction == "left-session")
     }
 
     @Test @MainActor

--- a/AlasTests/AppConfigTests.swift
+++ b/AlasTests/AppConfigTests.swift
@@ -30,6 +30,7 @@ struct AppConfigTests {
         #expect(cfg.worktrees.rootPath == "~/.alas/worktrees")
         #expect(cfg.worktrees.branchPrefix == "feature/")
         #expect(cfg.workspacesEnabled == false)
+        #expect(cfg.agentTabEnabled == false)
         #expect(cfg.runTabEnabled == false)
     }
 
@@ -53,6 +54,17 @@ struct AppConfigTests {
         let decoded = try JSONDecoder().decode(AppConfig.self, from: oldConfig)
 
         #expect(decoded.runTabEnabled == false)
+    }
+
+    @Test func decodeOldConfigDefaultsAgentTabDisabled() throws {
+        let data = try JSONEncoder().encode(AppConfig.defaults)
+        var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        object.removeValue(forKey: "agentTabEnabled")
+
+        let oldConfig = try JSONSerialization.data(withJSONObject: object)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: oldConfig)
+
+        #expect(decoded.agentTabEnabled == false)
     }
 
     @Test func decodeOldHarnessConfigDefaultsAwaitingPingOn() throws {

--- a/AlasTests/RightPaneTabTests.swift
+++ b/AlasTests/RightPaneTabTests.swift
@@ -2,13 +2,12 @@ import Testing
 @testable import Alas
 
 struct RightPaneTabTests {
-    @Test func runTabIsUnavailableUntilPreviewIsEnabled() {
-        #expect(RightPaneTab.available(runTabEnabled: false) == [.changes, .files])
-        #expect(RightPaneTab.available(runTabEnabled: true) == [.changes, .files, .run])
+    @Test func agentTabRemainsAvailableWhenRunTabIsDisabled() {
+        #expect(RightPaneTab.available(runTabEnabled: false) == [.changes, .files, .agent])
+        #expect(RightPaneTab.visible(.agent, runTabEnabled: false) == .agent)
     }
 
-    @Test func hidingRunTabMovesItsSelectionToChanges() {
+    @Test func disablingRunOnlyFallsBackFromRun() {
         #expect(RightPaneTab.visible(.run, runTabEnabled: false) == .changes)
-        #expect(RightPaneTab.visible(.files, runTabEnabled: false) == .files)
     }
 }

--- a/AlasTests/RightPaneTabTests.swift
+++ b/AlasTests/RightPaneTabTests.swift
@@ -2,12 +2,14 @@ import Testing
 @testable import Alas
 
 struct RightPaneTabTests {
-    @Test func agentTabRemainsAvailableWhenRunTabIsDisabled() {
-        #expect(RightPaneTab.available(runTabEnabled: false) == [.changes, .files, .agent])
-        #expect(RightPaneTab.visible(.agent, runTabEnabled: false) == .agent)
+    @Test func agentTabRequiresPreviewFlag() {
+        #expect(RightPaneTab.available(agentTabEnabled: false, runTabEnabled: false) == [.changes, .files])
+        #expect(RightPaneTab.available(agentTabEnabled: true, runTabEnabled: false) == [.changes, .files, .agent])
+        #expect(RightPaneTab.visible(.agent, agentTabEnabled: false, runTabEnabled: false) == .changes)
+        #expect(RightPaneTab.visible(.agent, agentTabEnabled: true, runTabEnabled: false) == .agent)
     }
 
     @Test func disablingRunOnlyFallsBackFromRun() {
-        #expect(RightPaneTab.visible(.run, runTabEnabled: false) == .changes)
+        #expect(RightPaneTab.visible(.run, agentTabEnabled: true, runTabEnabled: false) == .changes)
     }
 }


### PR DESCRIPTION
## Summary

- Add an Agent tab to the right sidebar with a worktree-scoped rollup of ACP and terminal sessions.
- Surface session state, agent/model, elapsed time, host attribution, ACP context usage, plan progress, and scoped history.
- Route existing session actions from the rollup: focus, interrupt where supported, follow-up prompt delivery, and resume/focus for history.
- Keep terminal-only sessions honest by showing hook-backed state when available and `unknown` when unsupported.

## Testing

- `xcodegen` passed.
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build` passed.
- Focused Agent sidebar regression tests passed.
- Full local suite currently fails on tests that appear unrelated to this branch, including stale `RemoteWebAssetTests` asset-version expectations/crashes and a few existing ACP/AppState timing/state tests. Leaving this visible so CI can give the clean repository verdict.

Fixes #1161