### PR TITLE
feat(omp): Add OMP agent support

### DIFF
--- a/Alas/Resources/Assets.xcassets/AgentLogos/agent-omp.imageset/Contents.json
+++ b/Alas/Resources/Assets.xcassets/AgentLogos/agent-omp.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images": [
+    {
+      "idiom": "universal",
+      "filename": "agent-omp.svg",
+      "scale": "1x"
+    },
+    {
+      "idiom": "universal",
+      "scale": "2x"
+    },
+    {
+      "idiom": "universal",
+      "scale": "3x"
+    }
+  ],
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}

--- a/Alas/Resources/Assets.xcassets/AgentLogos/agent-omp.imageset/agent-omp.svg
+++ b/Alas/Resources/Assets.xcassets/AgentLogos/agent-omp.imageset/agent-omp.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="pi-mark-2-grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="oklch(0.7 0.24 340)"/>
+      <stop offset=".5" stop-color="oklch(0.62 0.21 295)"/>
+      <stop offset="1" stop-color="oklch(0.81 0.14 200)"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#pi-mark-2-grad)" d="M10 14h44v9H43v33h-9V23h-9v22h-9V23H10z"/>
+</svg>

--- a/Alas/Sources/ACP/ACPHarnessBridge.swift
+++ b/Alas/Sources/ACP/ACPHarnessBridge.swift
@@ -104,6 +104,7 @@ final class ACPHarnessBridge {
         case "gemini":       return .gemini
         case "opencode":     return .opencode
         case "pi":           return .pi
+        case "omp":          return .omp
         case "copilot":      return .copilot
         default:             return .claude
         }

--- a/Alas/Sources/ACP/Adapter/ACPLaunchCatalog.swift
+++ b/Alas/Sources/ACP/Adapter/ACPLaunchCatalog.swift
@@ -100,6 +100,16 @@ enum ACPLaunchCatalog {
             supportsModelSelection: false,
             supportsModeSelection: false,
             mcpInjection: .external(hint: "Pi ignores ACP MCP config. Alas tools work via the alas CLI; other MCP servers need the pi-mcp-adapter extension.")),
+
+        // OMP ships a native ACP server.
+        ACPLaunchSpec(
+            agentID: "omp",
+            command: "omp",
+            arguments: ["acp"],
+            extraEnv: [:],
+            setupCheck: .binaryOnPath(name: "omp"),
+            supportsModelSelection: true,
+            supportsModeSelection: true),
     ]
 
     static func spec(for agentID: String) -> ACPLaunchSpec? {

--- a/Alas/Sources/Agents/AgentBuiltins.swift
+++ b/Alas/Sources/Agents/AgentBuiltins.swift
@@ -66,6 +66,19 @@ enum AgentBuiltins {
             isEnabled: true,
             builtinLogoAssetName: "agent-pi"
         ),
+        // Verified against `omp --help` v18.1.17 (2026-09-11).
+        AgentDefinition(
+            id: "omp",
+            displayName: "OMP",
+            binary: "omp",
+            binaryOverride: nil,
+            promptModeArgs: ["-p"],
+            bypassPermissionsFlag: "--auto-approve",
+            extraTerminalArgs: nil,
+            isBuiltin: true,
+            isEnabled: true,
+            builtinLogoAssetName: "agent-omp"
+        ),
         // Verified against `opencode run --help` v1.15.1 (2026-05-16). The
         // `run` subcommand is the non-interactive entry point. There is
         // NO top-level "skip permissions" flag — `--dangerously-skip-permissions`

--- a/Alas/Sources/Harness/AgentKind.swift
+++ b/Alas/Sources/Harness/AgentKind.swift
@@ -8,6 +8,7 @@ enum AgentKind: String, CaseIterable, Sendable, Codable, Identifiable {
     case gemini
     case opencode
     case pi
+    case omp
     case copilot
 
     var id: String { rawValue }
@@ -20,6 +21,7 @@ enum AgentKind: String, CaseIterable, Sendable, Codable, Identifiable {
         case .gemini: return "Gemini CLI"
         case .opencode: return "opencode"
         case .pi: return "Pi"
+        case .omp: return "OMP"
         case .copilot: return "Copilot"
         }
     }
@@ -32,6 +34,7 @@ enum AgentKind: String, CaseIterable, Sendable, Codable, Identifiable {
         case .gemini:   return "agent-gemini"
         case .opencode: return "agent-opencode"
         case .pi:       return "agent-pi"
+        case .omp:      return "agent-omp"
         case .copilot:  return "agent-copilot"
         }
     }

--- a/Alas/Sources/Harness/HarnessKind.swift
+++ b/Alas/Sources/Harness/HarnessKind.swift
@@ -7,6 +7,7 @@ enum HarnessKind: String, Codable, CaseIterable, Identifiable, Sendable {
     case gemini     = "gemini"
     case opencode   = "opencode"
     case pi         = "pi"
+    case omp        = "omp"
     case copilot    = "copilot"
 
     var id: String { rawValue }
@@ -19,6 +20,7 @@ enum HarnessKind: String, Codable, CaseIterable, Identifiable, Sendable {
         case .gemini:     return "Gemini CLI"
         case .opencode:   return "opencode"
         case .pi:         return "Pi"
+        case .omp:        return "OMP"
         case .copilot:    return "Copilot"
         }
     }
@@ -31,6 +33,7 @@ enum HarnessKind: String, Codable, CaseIterable, Identifiable, Sendable {
         case .gemini:     return ["gemini"]
         case .opencode:   return ["opencode"]
         case .pi:         return ["pi"]
+        case .omp:        return ["omp"]
         case .copilot:    return ["copilot"]
         }
     }
@@ -46,6 +49,7 @@ enum HarnessKind: String, Codable, CaseIterable, Identifiable, Sendable {
         case .gemini:     return .gemini
         case .opencode:   return .opencode
         case .pi:         return .pi
+        case .omp:        return .omp
         case .copilot:    return .copilot
         }
     }
@@ -60,6 +64,7 @@ extension AgentKind {
         case .gemini:   return .gemini
         case .opencode: return .opencode
         case .pi:       return .pi
+        case .omp:      return .omp
         case .copilot:  return .copilot
         }
     }

--- a/AlasTests/ACP/ACPHarnessBridgeTests.swift
+++ b/AlasTests/ACP/ACPHarnessBridgeTests.swift
@@ -83,6 +83,17 @@ struct ACPHarnessBridgeTests {
         #expect(harness.activityBySession["s1"]?.agent == .cursor)
     }
 
+    @Test("omp agentId maps to .omp AgentKind")
+    func ompAgentMaps() async {
+        let harness = makeHarness()
+        let bridge = ACPHarnessBridge(harness: harness)
+        let session = ACPSession(id: "s1", agentId: "omp", worktreeId: "wt", title: "t")
+        bridge.observe(session: session)
+        session.transcript.streamingState = .streaming
+        await Task.yield()
+        #expect(harness.activityBySession["s1"]?.agent == .omp)
+    }
+
     @Test("unknown agentId falls back to .claude")
     func unknownAgentFallsBack() async {
         let harness = makeHarness()

--- a/AlasTests/ACP/Adapter/ACPLaunchCatalogTests.swift
+++ b/AlasTests/ACP/Adapter/ACPLaunchCatalogTests.swift
@@ -12,7 +12,7 @@ struct ACPLaunchCatalogTests {
         }
     }
 
-    @Test("claude, gemini, opencode, cursor-agent, codex, copilot, pi are configured")
+    @Test("built-in ACP agents are configured")
     func catalogCoverage() {
         let ids = Set(ACPLaunchCatalog.specs.map(\.agentID))
         #expect(ids.contains("claude"))
@@ -22,6 +22,16 @@ struct ACPLaunchCatalogTests {
         #expect(ids.contains("codex"))
         #expect(ids.contains("copilot"))
         #expect(ids.contains("pi"))
+        #expect(ids.contains("omp"))
+    }
+
+    @Test("omp launches its native ACP server")
+    func ompUsesNativeACP() throws {
+        let omp = try #require(ACPLaunchCatalog.spec(for: "omp"))
+        #expect(omp.command == "omp")
+        #expect(omp.arguments == ["acp"])
+        #expect(omp.setupCheck == .binaryOnPath(name: "omp"))
+        #expect(omp.mcpInjection == .sessionNew)
     }
 
     @Test("pi is the only external MCP-injection adapter")

--- a/AlasTests/AgentBuiltinsTests.swift
+++ b/AlasTests/AgentBuiltinsTests.swift
@@ -3,9 +3,9 @@ import Testing
 @testable import Alas
 
 struct AgentBuiltinsTests {
-    @Test func catalogHasExactlySevenEntriesInDeterministicOrder() {
+    @Test func catalogHasExactlyEightEntriesInDeterministicOrder() {
         let ids = AgentBuiltins.catalog.map(\.id)
-        #expect(ids == ["claude", "codex", "cursor-agent", "pi", "opencode", "gemini", "copilot"])
+        #expect(ids == ["claude", "codex", "cursor-agent", "pi", "omp", "opencode", "gemini", "copilot"])
     }
 
     @Test func everyEntryIsMarkedBuiltin() {
@@ -52,6 +52,15 @@ struct AgentBuiltinsTests {
         #expect(e?.isBuiltin == true)
         #expect(e?.isEnabled == true)
         #expect(e?.builtinLogoAssetName == "agent-copilot")
+    }
+
+    @Test func ompBuiltinUsesItsNativeCLI() {
+        let e = AgentBuiltins.entry(id: "omp")
+        #expect(e?.displayName == "OMP")
+        #expect(e?.binary == "omp")
+        #expect(e?.promptModeArgs == ["-p"])
+        #expect(e?.bypassPermissionsFlag == "--auto-approve")
+        #expect(e?.builtinLogoAssetName == "agent-omp")
     }
 
     @Test func entryLookupReturnsNilForUnknownId() {

--- a/AlasTests/AgentRegistryTests.swift
+++ b/AlasTests/AgentRegistryTests.swift
@@ -58,7 +58,7 @@ struct AgentRegistryTests {
         let r = AgentRegistry(builtinState: [:], customs: [custom], installedIds: [])
         let ids = r.agents.map(\.id)
         #expect(ids.last == "custom-uuid")
-        #expect(ids.count == 8)
+        #expect(ids.count == AgentBuiltins.catalog.count + 1)
     }
 
     @Test func installedFiltersToDetectedAgentsAcrossBuiltinsAndCustoms() {

--- a/AlasTests/HarnessDetectorTests.swift
+++ b/AlasTests/HarnessDetectorTests.swift
@@ -16,6 +16,7 @@ struct HarnessDetectorTests {
         #expect(HarnessDetector.matchKind(processName: "gemini") == .gemini)
         #expect(HarnessDetector.matchKind(processName: "opencode") == .opencode)
         #expect(HarnessDetector.matchKind(processName: "pi") == .pi)
+        #expect(HarnessDetector.matchKind(processName: "omp") == .omp)
         #expect(HarnessDetector.matchKind(processName: "copilot") == .copilot)
     }
     @Test func unknownReturnsNil() {

--- a/AlasTests/HarnessServiceTests.swift
+++ b/AlasTests/HarnessServiceTests.swift
@@ -266,6 +266,7 @@ struct HarnessServiceTests {
         #expect(AgentKind.gemini.asHarnessKind == .gemini)
         #expect(AgentKind.opencode.asHarnessKind == .opencode)
         #expect(AgentKind.pi.asHarnessKind == .pi)
+        #expect(AgentKind.omp.asHarnessKind == .omp)
         #expect(AgentKind.copilot.asHarnessKind == .copilot)
     }
 
@@ -276,6 +277,7 @@ struct HarnessServiceTests {
         #expect(HarnessKind.gemini.asAgentKind == .gemini)
         #expect(HarnessKind.opencode.asAgentKind == .opencode)
         #expect(HarnessKind.pi.asAgentKind == .pi)
+        #expect(HarnessKind.omp.asAgentKind == .omp)
         #expect(HarnessKind.copilot.asAgentKind == .copilot)
     }
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ that loop end to end: every agent, every worktree, one window.
   over [ACP](https://agentclientprotocol.com) — same worktree, your call. Tool
   calls, plans, and permission prompts render inline, and past sessions can be
   browsed and resumed. Works with Claude Code, Codex, Cursor, Gemini, OpenCode,
-  Pi, and Copilot.
+  Pi, OMP, and Copilot.
 
 - **Parallel worktrees, one window.** Every repo lives in the sidebar with its
   linked worktrees underneath. Switching is instant; terminal sessions, tabs, and


### PR DESCRIPTION
## Summary

Adds OMP as a distinct native provider rather than conflating it with Pi. Alas launches OMP with its own terminal flags and native ACP server, preserves normal ACP MCP injection, and uses the website gradient Pi mark to keep the picker unambiguous.

## Changes

- Add OMP to built-in agent, terminal activity, and process detection catalogs.
- Launch ACP sessions with `omp acp` and terminal prompts with `omp -p`.
- Add the official OMP gradient logo and focused regression coverage.

## Verification

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Focused provider, registry, ACP, and harness tests: 94 passed.

## Notes for reviewers

- The full repository suite currently has unrelated existing failures in remote-web assets, workspace storage, and timing-sensitive UI/ACP tests.