### PR TITLE
style(run): polish run failure notifications

### DIFF
--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -702,9 +702,11 @@ struct CenterPaneView: View {
                                 onDismiss: { state.dismissRunScriptFailure(id: failure.id, worktreeID: worktree.id) }
                             )
                             .frame(width: 360)
+                            .transition(.move(edge: .bottom).combined(with: .opacity))
                         }
                     }
                     .padding(12)
+                    .animation(.easeOut(duration: 0.2), value: runScriptFailures.map(\.id))
                 }
             }
         }

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -693,8 +693,8 @@ struct CenterPaneView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .overlay(alignment: .bottomTrailing) {
-                if !runScriptFailures.isEmpty {
-                    VStack(alignment: .trailing, spacing: 8) {
+                VStack(alignment: .trailing, spacing: 8) {
+                    if !runScriptFailures.isEmpty {
                         ForEach(runScriptFailures, id: \.id) { failure in
                             RunScriptFailureBanner(
                                 presentation: RunScriptFailureBannerPresentation(failure: failure),
@@ -705,9 +705,9 @@ struct CenterPaneView: View {
                             .transition(.move(edge: .bottom).combined(with: .opacity))
                         }
                     }
-                    .padding(12)
-                    .animation(.easeOut(duration: 0.2), value: runScriptFailures.map(\.id))
                 }
+                .padding(12)
+                .animation(.easeOut(duration: 0.2), value: runScriptFailures.map(\.id))
             }
         }
         .onAppear {

--- a/Alas/Sources/RunScripts/RunScriptFailureViews.swift
+++ b/Alas/Sources/RunScripts/RunScriptFailureViews.swift
@@ -66,6 +66,8 @@ struct RunScriptFailureBanner: View {
                     Text(presentation.title)
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(theme.color("fg"))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
                     if let overflowText = presentation.overflowText {
                         Text(overflowText)
                             .font(.system(size: 12))

--- a/Alas/Sources/RunScripts/RunScriptFailureViews.swift
+++ b/Alas/Sources/RunScripts/RunScriptFailureViews.swift
@@ -61,19 +61,19 @@ struct RunScriptFailureBanner: View {
             Button(action: onOpen) {
                 HStack(spacing: 8) {
                     Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.system(size: 13, weight: .semibold))
                         .foregroundStyle(theme.color("del"))
                     Text(presentation.title)
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(theme.color("fg"))
                     if let overflowText = presentation.overflowText {
                         Text(overflowText)
-                            .font(.system(size: 11))
+                            .font(.system(size: 12))
                             .foregroundStyle(theme.color("fg-muted"))
                     }
                     Spacer(minLength: 0)
                     Text("Show output")
-                        .font(.system(size: 11))
+                        .font(.system(size: 12))
                         .foregroundStyle(theme.color("accent"))
                 }
                 .contentShape(Rectangle())
@@ -85,15 +85,20 @@ struct RunScriptFailureBanner: View {
                 Image(systemName: "xmark")
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundStyle(theme.color("fg-muted"))
-                    .frame(width: 18, height: 18)
+                    .frame(width: 32, height: 32)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Dismiss run script failure")
         }
         .padding(.horizontal, 12)
-        .frame(height: 30)
+        .padding(.vertical, 6)
         .background(theme.color("del").opacity(0.12))
-        .overlay(Rectangle().fill(theme.color("line")).frame(height: 0.5), alignment: .bottom)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(theme.color("del").opacity(0.3), lineWidth: 0.75)
+        )
+        .clipShape(.rect(cornerRadius: 8))
         .accessibilityIdentifier("run-script-failure-banner")
     }
 }


### PR DESCRIPTION
## Summary

Run-script failures were easy to miss and dismiss. This updates the center-pane notification to match the app's outlined error treatment and makes its controls easier to use.

## Changes

- Add rounded red outlines and increase banner typography.
- Expand the dismiss button hit target to 32 by 32 points.
- Animate banner insertion and removal from the bottom edge.

## Verification

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n\nLocal tests were blocked by unrelated long-running Xcode build database locks.