### PR TITLE
style(queue): unify queue split-button color

### DIFF
--- a/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
@@ -175,9 +175,9 @@ struct ACPComposerActionButton: View {
                 )
                 .overlay(alignment: .topTrailing) { badgeOverlay }
                 .overlay(alignment: .trailing) {
-                    Divider()
-                        .background(theme.color("line"))
-                        .frame(height: 16)
+                    Rectangle()
+                        .fill(theme.color("line"))
+                        .frame(width: 1, height: 16)
                 }
             }
             .buttonStyle(.plain)

--- a/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
@@ -151,7 +151,7 @@ struct ACPComposerActionButton: View {
     // MARK: - Queue (split capsule, primary + chevron menu)
 
     private func queueSplitCapsule(menu: [ComposerMenuItem]) -> some View {
-        HStack(spacing: 1) {
+        HStack(spacing: 0) {
             Button(action: onPrimary) {
                 HStack(spacing: 5) {
                     Image(systemName: "arrow.up")
@@ -177,6 +177,10 @@ struct ACPComposerActionButton: View {
             }
             .buttonStyle(.plain)
             .help("Queue (⏎). Hold ⌥ to steer.")
+
+            Divider()
+                .background(theme.color("line"))
+                .frame(height: 16)
 
             Menu {
                 ForEach(menu, id: \.self) { item in

--- a/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
@@ -174,13 +174,14 @@ struct ACPComposerActionButton: View {
                     .fill(theme.color("bg-3"))
                 )
                 .overlay(alignment: .topTrailing) { badgeOverlay }
+                .overlay(alignment: .trailing) {
+                    Divider()
+                        .background(theme.color("line"))
+                        .frame(height: 16)
+                }
             }
             .buttonStyle(.plain)
             .help("Queue (⏎). Hold ⌥ to steer.")
-
-            Divider()
-                .background(theme.color("line"))
-                .frame(height: 16)
 
             Menu {
                 ForEach(menu, id: \.self) { item in


### PR DESCRIPTION
## Summary

Make the ACP Queue split button read as one control: both halves share the same background, separated by an inset vertical divider.

## Testing

The full test battery is running in CI.