### PR TITLE
fix(omp): logo colors

### DIFF
--- a/Alas/Resources/Assets.xcassets/AgentLogos/agent-omp.imageset/agent-omp.svg
+++ b/Alas/Resources/Assets.xcassets/AgentLogos/agent-omp.imageset/agent-omp.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
     <linearGradient id="pi-mark-2-grad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="oklch(0.7 0.24 340)"/>
-      <stop offset=".5" stop-color="oklch(0.62 0.21 295)"/>
-      <stop offset="1" stop-color="oklch(0.81 0.14 200)"/>
+      <stop offset="0" stop-color="#F84FCC"/>
+      <stop offset=".5" stop-color="#9362F4"/>
+      <stop offset="1" stop-color="#00DBE4"/>
     </linearGradient>
   </defs>
   <path fill="url(#pi-mark-2-grad)" d="M10 14h44v9H43v33h-9V23h-9v22h-9V23H10z"/>


### PR DESCRIPTION
## Summary

Fixes the OMP logo rendering as black in the app. AppKit's SVG renderer does not support CSS `oklch()` gradient stops, so the asset now uses equivalent sRGB hex colors.

## Verification

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` ran 2,190 tests and reported 12 unrelated existing failures; none were logo-related.
- Native AppKit SVG render check detected 158 colors after the fix.