### PR TITLE
feat(worktree): Load worktree cleanup results progressively

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7885,6 +7885,7 @@ final class AppState {
     /// Returns nil when the project no longer exists.
     func makeWorktreeCleanupModel(projectId: String) -> WorktreeCleanupModel? {
         guard let project = projects.first(where: { $0.id == projectId }) else { return nil }
+        let initialWorktrees = projectsManager.visibleWorktrees(projectId: projectId)
         let idleThresholdDays = config.worktrees.cleanupIdleDays
         let repoPath = URL(fileURLWithPath: project.path)
         // `config.worktrees.baseBranch` is a global default across every
@@ -7896,12 +7897,13 @@ final class AppState {
 
         return WorktreeCleanupModel(
             projectId: projectId,
+            worktrees: initialWorktrees,
             keepBranches: !config.worktrees.deleteBranchOnRemove,
-            scan: { [weak self] in
+            loadWorktrees: { [weak self] in
+                self?.projectsManager.visibleWorktrees(projectId: projectId) ?? []
+            },
+            scan: { [weak self] worktrees, onUpdate in
                 guard let self else { return .success([]) }
-                let worktrees = await MainActor.run {
-                    self.projectsManager.visibleWorktrees(projectId: projectId)
-                }
                 let availableBranches = (try? await GitService().branches(at: repoPath)) ?? []
                 let baseBranch = NewWorktreeDialog.preferredBaseBranch(
                     availableBranches: availableBranches,
@@ -7957,7 +7959,8 @@ final class AppState {
                     worktrees: worktrees,
                     baseBranch: baseBranch,
                     now: Date(),
-                    idleThresholdDays: idleThresholdDays
+                    idleThresholdDays: idleThresholdDays,
+                    onUpdate: onUpdate
                 ))
             },
             deleteBatch: { [weak self] worktrees, keepBranch in

--- a/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
+++ b/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
@@ -218,7 +218,11 @@ final class WorktreeCleanupModel {
 
     func deleteSelected() async {
         let targets = selectedWorktrees()
-        guard !targets.isEmpty, !isRunning else { return }
+        guard !targets.isEmpty,
+              !isRunning,
+              !isScanning,
+              scanError == nil
+        else { return }
         guard confirm(
             "Delete \(targets.count) \(targets.count == 1 ? "worktree" : "worktrees")?",
             confirmationMessage(),
@@ -257,7 +261,11 @@ final class WorktreeCleanupModel {
 
     func archiveSelected() async {
         let targets = selectedWorktrees()
-        guard !targets.isEmpty, !isRunning else { return }
+        guard !targets.isEmpty,
+              !isRunning,
+              !isScanning,
+              scanError == nil
+        else { return }
         guard confirm(
             "Archive \(targets.count) \(targets.count == 1 ? "worktree" : "worktrees")?",
             archiveConfirmationMessage(),

--- a/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
+++ b/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
@@ -166,7 +166,8 @@ final class WorktreeCleanupModel {
     /// Per-item override. Excluded rows never become selectable, which is what
     /// keeps a main or remote worktree out of any batch.
     func toggle(_ id: String) {
-        guard let candidate = candidates.first(where: { $0.id == id }),
+        guard !isScanning,
+              let candidate = candidates.first(where: { $0.id == id }),
               candidate.isSelectable
         else { return }
         if selectedIds.contains(id) {

--- a/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
+++ b/Alas/Sources/Dialogs/WorktreeCleanupModel.swift
@@ -1,15 +1,16 @@
 import Foundation
 
-enum WorktreeCleanupScanState: Equatable {
-    case idle
-    case scanning
-    case loaded([WorktreeCleanupCandidate])
-    case failed(message: String)
+struct WorktreeCleanupScanProgress: Equatable {
+    let completed: Int
+    let total: Int
+}
 
-    var candidates: [WorktreeCleanupCandidate] {
-        if case .loaded(let candidates) = self { return candidates }
-        return []
-    }
+struct WorktreeCleanupRowState: Identifiable, Equatable {
+    let worktree: Worktree
+    var candidate: WorktreeCleanupCandidate?
+    var isScanning: Bool
+
+    var id: String { worktree.id }
 }
 
 /// Drives the cleanup sheet: runs scans, tracks selection and per-item results.
@@ -19,13 +20,20 @@ enum WorktreeCleanupScanState: Equatable {
 @Observable
 final class WorktreeCleanupModel {
     let projectId: String
-    private(set) var scanState: WorktreeCleanupScanState = .idle
+    private(set) var rows: [WorktreeCleanupRowState]
     private(set) var selectedIds: Set<String> = []
     private(set) var results: [WorktreeBatchResult] = []
     private(set) var isRunning = false
+    private(set) var isScanning = false
+    private(set) var scanProgress: WorktreeCleanupScanProgress?
+    private(set) var scanError: String?
     var keepBranches: Bool
 
-    private let scan: @Sendable () async -> Result<[WorktreeCleanupCandidate], Error>
+    private let loadWorktrees: () -> [Worktree]
+    private let scan: @Sendable (
+        [Worktree],
+        @escaping @Sendable (WorktreeCleanupScanUpdate) async -> Void
+    ) async -> Result<[WorktreeCleanupCandidate], Error>
     private let deleteBatch: ([Worktree], Bool) async -> [WorktreeBatchResult]
     private let archiveBatch: ([Worktree]) -> [WorktreeBatchResult]
     /// `(title, message, confirmButtonTitle) -> confirmed`. The button title is
@@ -33,39 +41,71 @@ final class WorktreeCleanupModel {
     /// prompt, and an archive confirmation must not offer a "Delete" button.
     private let confirm: (String, String, String) -> Bool
     /// Tracks whether a scan has ever completed, independent of the transient
-    /// `.scanning` state — `applyScanResult` uses this, not `scanState`, to
-    /// decide whether to reconcile against a manual selection or seed the
-    /// default one, since `scanState` is already `.scanning` by the time a
-    /// rescan's result comes back.
+    /// loading state, so rescans preserve manual selection while the first
+    /// successful scan seeds the default selection.
     private var hasCompletedAScan = false
 
     init(
         projectId: String,
+        worktrees: [Worktree],
         keepBranches: Bool,
-        scan: @escaping @Sendable () async -> Result<[WorktreeCleanupCandidate], Error>,
+        loadWorktrees: @escaping () -> [Worktree],
+        scan: @escaping @Sendable (
+            [Worktree],
+            @escaping @Sendable (WorktreeCleanupScanUpdate) async -> Void
+        ) async -> Result<[WorktreeCleanupCandidate], Error>,
         deleteBatch: @escaping ([Worktree], Bool) async -> [WorktreeBatchResult],
         archiveBatch: @escaping ([Worktree]) -> [WorktreeBatchResult],
         confirm: @escaping (String, String, String) -> Bool
     ) {
         self.projectId = projectId
+        self.rows = worktrees.map {
+            WorktreeCleanupRowState(worktree: $0, candidate: nil, isScanning: false)
+        }
         self.keepBranches = keepBranches
+        self.loadWorktrees = loadWorktrees
         self.scan = scan
         self.deleteBatch = deleteBatch
         self.archiveBatch = archiveBatch
         self.confirm = confirm
     }
 
-    var candidates: [WorktreeCleanupCandidate] { scanState.candidates }
+    var candidates: [WorktreeCleanupCandidate] {
+        rows.compactMap(\.candidate)
+    }
 
     func runScan() async {
-        scanState = .scanning
-        switch await scan() {
+        guard !isScanning else { return }
+
+        let worktrees = loadWorktrees()
+        let previousCandidates = Dictionary(
+            uniqueKeysWithValues: rows.compactMap { row in
+                row.candidate.map { (row.id, $0) }
+            }
+        )
+        rows = worktrees.map { worktree in
+            WorktreeCleanupRowState(
+                worktree: worktree,
+                candidate: previousCandidates[worktree.id],
+                isScanning: true
+            )
+        }
+        isScanning = true
+        scanProgress = .init(completed: 0, total: worktrees.count)
+        scanError = nil
+
+        switch await scan(worktrees, { [weak self] update in
+            await self?.applyScanUpdate(update)
+        }) {
         case .success(let candidates):
             applyScanResult(candidates)
         case .failure(let error):
-            scanState = .failed(
-                message: (error as? LocalizedError)?.errorDescription ?? "\(error)"
-            )
+            isScanning = false
+            scanProgress = nil
+            scanError = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+            for index in rows.indices {
+                rows[index].isScanning = false
+            }
         }
     }
 
@@ -73,8 +113,18 @@ final class WorktreeCleanupModel {
     /// load. Clears any results from a prior batch action, since starting a
     /// fresh manual scan means the user is done reviewing that outcome.
     func refresh() async {
+        guard !isScanning else { return }
         results = []
         await runScan()
+    }
+
+    private func applyScanUpdate(_ update: WorktreeCleanupScanUpdate) {
+        guard isScanning,
+              let index = rows.firstIndex(where: { $0.id == update.candidate.id })
+        else { return }
+        rows[index].candidate = update.candidate
+        rows[index].isScanning = false
+        scanProgress = .init(completed: update.completed, total: update.total)
     }
 
     /// Applies a fresh scan. If a scan has completed before, keeps any manual
@@ -85,7 +135,12 @@ final class WorktreeCleanupModel {
     func applyScanResult(_ candidates: [WorktreeCleanupCandidate]) {
         let previousSelection = selectedIds
         let hadResults = hasCompletedAScan
-        scanState = .loaded(candidates)
+        rows = candidates.map {
+            WorktreeCleanupRowState(worktree: $0.worktree, candidate: $0, isScanning: false)
+        }
+        isScanning = false
+        scanProgress = nil
+        scanError = nil
         hasCompletedAScan = true
         if hadResults {
             let selectable = Set(candidates.filter(\.isSelectable).map(\.id))
@@ -210,10 +265,13 @@ extension WorktreeCleanupModel {
     static func forTesting(
         candidates: [WorktreeCleanupCandidate]
     ) -> WorktreeCleanupModel {
+        let worktrees = candidates.map(\.worktree)
         let model = WorktreeCleanupModel(
             projectId: "p",
+            worktrees: worktrees,
             keepBranches: false,
-            scan: { .success(candidates) },
+            loadWorktrees: { worktrees },
+            scan: { _, _ in .success(candidates) },
             deleteBatch: { _, _ in [] },
             archiveBatch: { _ in [] },
             confirm: { _, _, _ in true }

--- a/Alas/Sources/Dialogs/WorktreeCleanupSheet.swift
+++ b/Alas/Sources/Dialogs/WorktreeCleanupSheet.swift
@@ -82,6 +82,7 @@ struct WorktreeCleanupSheet: View {
                         WorktreeCleanupRow(
                             row: row,
                             isSelected: model.selectedIds.contains(row.id),
+                            isSelectionDisabled: model.isScanning,
                             result: model.results.first { $0.worktreeId == row.id },
                             onToggle: { model.toggle(row.id) }
                         )
@@ -120,6 +121,7 @@ struct WorktreeCleanupSheet: View {
 private struct WorktreeCleanupRow: View {
     let row: WorktreeCleanupRowState
     let isSelected: Bool
+    let isSelectionDisabled: Bool
     let result: WorktreeBatchResult?
     let onToggle: () -> Void
 
@@ -130,7 +132,7 @@ private struct WorktreeCleanupRow: View {
             Toggle("", isOn: Binding(get: { isSelected }, set: { _ in onToggle() }))
                 .labelsHidden()
                 .toggleStyle(.checkbox)
-                .disabled(row.isScanning || row.candidate?.isSelectable != true)
+                .disabled(isSelectionDisabled || row.candidate?.isSelectable != true)
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {

--- a/Alas/Sources/Dialogs/WorktreeCleanupSheet.swift
+++ b/Alas/Sources/Dialogs/WorktreeCleanupSheet.swift
@@ -19,6 +19,7 @@ struct WorktreeCleanupSheet: View {
                 ) {
                     Task { await model.refresh() }
                 }
+                .disabled(model.isScanning || model.isRunning)
             },
             content: { content },
             cancelTitle: "Close",
@@ -26,82 +27,90 @@ struct WorktreeCleanupSheet: View {
             confirmStyle: .primary,
             onCancel: onClose,
             onConfirm: { Task { await model.deleteSelected() } },
-            confirmEnabled: !model.selectedIds.isEmpty && !model.isRunning
+            confirmEnabled: !model.selectedIds.isEmpty
+                && !model.isRunning
+                && !model.isScanning
+                && model.scanError == nil
         )
     }
 
     private var subtitle: String? {
-        switch model.scanState {
-        case .idle, .scanning:
-            return "Checking merge state, local changes, and activity…"
-        case .failed(let message):
-            return message
-        case .loaded(let candidates):
-            let count = candidates.filter(\.isSelectedByDefault).count
-            return count == 0
-                ? "Nothing looks ready to clean up."
-                : "\(count) of \(candidates.count) look ready to clean up."
+        if model.isScanning {
+            guard let progress = model.scanProgress, progress.total > 0 else {
+                return "Checking worktrees…"
+            }
+            return "Checking \(progress.completed) of \(progress.total) worktrees…"
         }
+        if let error = model.scanError {
+            return error
+        }
+        let candidates = model.candidates
+        let count = candidates.filter(\.isSelectedByDefault).count
+        return count == 0
+            ? "Nothing looks ready to clean up."
+            : "\(count) of \(candidates.count) look ready to clean up."
     }
 
-    @ViewBuilder
     private var content: some View {
-        switch model.scanState {
-        case .idle, .scanning:
-            HStack(spacing: 8) {
-                ProgressView().controlSize(.small)
-                Text("Scanning…")
-                    .font(.system(size: 12))
-                    .foregroundColor(theme.color("fg-dim"))
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .frame(height: 220)
-
-        case .failed(let message):
-            VStack(alignment: .leading, spacing: 10) {
-                Text(message)
-                    .font(.system(size: 12))
-                    .foregroundColor(theme.color("fg-dim"))
-                AlasButton(title: "Retry", style: .normal) {
-                    Task { await model.refresh() }
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .frame(height: 220, alignment: .top)
-
-        case .loaded(let candidates):
-            VStack(alignment: .leading, spacing: 10) {
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 6) {
-                        ForEach(candidates) { candidate in
-                            WorktreeCleanupRow(
-                                candidate: candidate,
-                                isSelected: model.selectedIds.contains(candidate.id),
-                                result: model.results.first { $0.worktreeId == candidate.id },
-                                onToggle: { model.toggle(candidate.id) }
-                            )
-                        }
-                    }
-                }
-                .frame(height: 320)
-
-                if showKeepBranchOption {
-                    Toggle("Keep local branches", isOn: $model.keepBranches)
-                        .font(.system(size: 12))
-                        .toggleStyle(.checkbox)
-                }
-
+        VStack(alignment: .leading, spacing: 10) {
+            if let error = model.scanError {
                 HStack(spacing: 8) {
-                    AlasButton(title: "Archive Selected", style: .normal) {
-                        Task { await model.archiveSelected() }
+                    Text(error)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.color("fg-dim"))
+                    Spacer()
+                    AlasButton(title: "Retry", style: .normal) {
+                        Task { await model.refresh() }
                     }
-                    .disabled(model.selectedIds.isEmpty || model.isRunning)
+                }
+                .padding(8)
+                .background(
+                    RoundedRectangle(cornerRadius: 6).fill(theme.color("bg-2"))
+                )
+            }
 
-                    if !model.results.isEmpty {
-                        Text(WorktreeCleanupModel.summary(for: model.results))
-                            .font(.system(size: 11.5))
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 6) {
+                    if model.rows.isEmpty {
+                        Text(model.isScanning ? "Looking for worktrees…" : "No worktrees found.")
+                            .font(.system(size: 12))
                             .foregroundColor(theme.color("fg-dim"))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.vertical, 8)
                     }
+                    ForEach(model.rows) { row in
+                        WorktreeCleanupRow(
+                            row: row,
+                            isSelected: model.selectedIds.contains(row.id),
+                            result: model.results.first { $0.worktreeId == row.id },
+                            onToggle: { model.toggle(row.id) }
+                        )
+                    }
+                }
+            }
+            .frame(height: 320)
+
+            if showKeepBranchOption {
+                Toggle("Keep local branches", isOn: $model.keepBranches)
+                    .font(.system(size: 12))
+                    .toggleStyle(.checkbox)
+            }
+
+            HStack(spacing: 8) {
+                AlasButton(title: "Archive Selected", style: .normal) {
+                    Task { await model.archiveSelected() }
+                }
+                .disabled(
+                    model.selectedIds.isEmpty
+                        || model.isRunning
+                        || model.isScanning
+                        || model.scanError != nil
+                )
+
+                if !model.results.isEmpty {
+                    Text(WorktreeCleanupModel.summary(for: model.results))
+                        .font(.system(size: 11.5))
+                        .foregroundColor(theme.color("fg-dim"))
                 }
             }
         }
@@ -109,7 +118,7 @@ struct WorktreeCleanupSheet: View {
 }
 
 private struct WorktreeCleanupRow: View {
-    let candidate: WorktreeCleanupCandidate
+    let row: WorktreeCleanupRowState
     let isSelected: Bool
     let result: WorktreeBatchResult?
     let onToggle: () -> Void
@@ -121,34 +130,53 @@ private struct WorktreeCleanupRow: View {
             Toggle("", isOn: Binding(get: { isSelected }, set: { _ in onToggle() }))
                 .labelsHidden()
                 .toggleStyle(.checkbox)
-                .disabled(!candidate.isSelectable)
+                .disabled(row.isScanning || row.candidate?.isSelectable != true)
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {
-                    Text(candidate.worktree.branch)
+                    Text(row.worktree.branch)
                         .font(.system(size: 12.5, weight: .medium))
                         .foregroundColor(theme.color("fg"))
-                    Text(verdictLabel)
-                        .font(.system(size: 10.5, weight: .medium))
-                        .padding(.horizontal, 6).padding(.vertical, 1)
-                        .background(
-                            RoundedRectangle(cornerRadius: 4)
-                                .fill(theme.color(verdictColor).opacity(0.18))
-                        )
-                        .foregroundColor(theme.color(verdictColor))
-                }
-                ForEach(candidate.signals, id: \.self) { signal in
-                    HStack(spacing: 5) {
-                        Icon(
-                            name: signal.isBlocking ? "x" : "check",
-                            size: 9,
-                            color: theme.color(signal.isBlocking ? "fg-muted" : "add")
-                        )
-                        Text(signal.label)
-                            .font(.system(size: 11))
-                            .foregroundColor(theme.color("fg-dim"))
+                    if let candidate = row.candidate {
+                        Text(verdictLabel(candidate.verdict))
+                            .font(.system(size: 10.5, weight: .medium))
+                            .padding(.horizontal, 6).padding(.vertical, 1)
+                            .background(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .fill(theme.color(verdictColor(candidate.verdict)).opacity(0.18))
+                            )
+                            .foregroundColor(theme.color(verdictColor(candidate.verdict)))
+                    }
+                    if row.isScanning {
+                        Spinner(lineWidth: 1.4, duration: 0.8)
+                            .frame(width: 11, height: 11)
                     }
                 }
+                Text(row.worktree.path.path)
+                    .font(.system(size: 10.5, design: .monospaced))
+                    .foregroundColor(theme.color("fg-faint"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                if let candidate = row.candidate {
+                    ForEach(candidate.signals, id: \.self) { signal in
+                        HStack(spacing: 5) {
+                            Icon(
+                                name: signal.isBlocking ? "x" : "check",
+                                size: 9,
+                                color: theme.color(signal.isBlocking ? "fg-muted" : "add")
+                            )
+                            Text(signal.label)
+                                .font(.system(size: 11))
+                                .foregroundColor(theme.color("fg-dim"))
+                        }
+                    }
+                } else {
+                    Text(row.isScanning ? "Checking merge state, changes, and activity…" : "Details unavailable")
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.color("fg-dim"))
+                }
+
                 if let result, let text = resultLabel(result) {
                     Text(text)
                         .font(.system(size: 11, weight: .medium))
@@ -161,11 +189,11 @@ private struct WorktreeCleanupRow: View {
         .background(
             RoundedRectangle(cornerRadius: 6).fill(theme.color("bg-2"))
         )
-        .opacity(candidate.isSelectable ? 1 : 0.6)
+        .opacity(row.candidate?.isSelectable == false ? 0.6 : 1)
     }
 
-    private var verdictLabel: String {
-        switch candidate.verdict {
+    private func verdictLabel(_ verdict: WorktreeCleanupVerdict) -> String {
+        switch verdict {
         case .candidate(.high):   return "Merged"
         case .candidate(.medium): return "Merged locally"
         case .candidate(.low):    return "Stale"
@@ -176,8 +204,8 @@ private struct WorktreeCleanupRow: View {
         }
     }
 
-    private var verdictColor: String {
-        switch candidate.verdict {
+    private func verdictColor(_ verdict: WorktreeCleanupVerdict) -> String {
+        switch verdict {
         case .candidate: return "add"
         case .busy:      return "mod"
         case .dirty:     return "del"

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
@@ -134,7 +134,11 @@ struct WorktreeCleanupScanner: Sendable {
                         activeSessionCount,
                         operationInFlight
                     )
-                    let indexResult = await mergeIndexTask.value
+                    let indexResult = await withTaskCancellationHandler {
+                        await mergeIndexTask.value
+                    } onCancel: {
+                        mergeIndexTask.cancel()
+                    }
                     return (
                         index,
                         Self.candidate(

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
@@ -122,7 +122,7 @@ struct WorktreeCleanupScanner: Sendable {
 
             func addTask(_ index: Int) {
                 let worktree = worktrees[index]
-                group.addTask {
+                _ = group.addTaskUnlessCancelled {
                     async let facts = dependencies.gitFacts(worktree)
                     async let activeSessionCount =
                         dependencies.activeSessionCount(worktree.id)

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
@@ -19,6 +19,12 @@ struct WorktreeCleanupGitFacts: Equatable, Sendable {
     var lastActivity: Date?
 }
 
+struct WorktreeCleanupScanUpdate: Equatable, Sendable {
+    let candidate: WorktreeCleanupCandidate
+    let completed: Int
+    let total: Int
+}
+
 /// Merged review requests for one repository, keyed by head branch. A branch
 /// name can have multiple entries: it may have been reused across several
 /// merged reviews over time, and the caller must be able to check the local
@@ -72,12 +78,13 @@ struct WorktreeCleanupScanner: Sendable {
         worktrees: [Worktree],
         baseBranch: String,
         now: Date,
-        idleThresholdDays: Int
+        idleThresholdDays: Int,
+        onUpdate: @escaping @Sendable (WorktreeCleanupScanUpdate) async -> Void = { _ in }
     ) async -> [WorktreeCleanupCandidate] {
         // Remote/SSH projects are out of scope for cleanup: excluded up front,
         // with no probes run at all.
         if project.host != nil {
-            return worktrees.map { worktree in
+            let candidates = worktrees.map { worktree in
                 WorktreeCleanupClassifier.classify(
                     worktree: worktree,
                     probe: Self.remoteProbe(for: worktree),
@@ -85,67 +92,85 @@ struct WorktreeCleanupScanner: Sendable {
                     idleThresholdDays: idleThresholdDays
                 )
             }
-        }
-
-        let indexResult = await dependencies.mergeIndex(project)
-        let facts = await collectGitFacts(for: worktrees)
-
-        var candidates: [WorktreeCleanupCandidate] = []
-        candidates.reserveCapacity(worktrees.count)
-        for (offset, worktree) in worktrees.enumerated() {
-            let mergeState = Self.mergeState(
-                branch: worktree.branch,
-                baseBranch: baseBranch,
-                isMergedLocally: facts[offset].isMergedLocally,
-                localHeadSHA: facts[offset].headSHA,
-                indexResult: indexResult
-            )
-            // A branch the code host confirms is merged has its commits on the
-            // remote by definition. `unpushedCount` reports 1 whenever `@{u}`
-            // does not resolve, which is also what happens once the upstream
-            // has been pruned after a "delete branch on merge" — a stale
-            // local-tracking artifact, not unpublished work. It must not drive
-            // the dirty verdict the way a genuinely unpublished branch does.
-            let unpushedCommitCount: Int
-            if case .mergedOnForge = mergeState {
-                unpushedCommitCount = 0
-            } else {
-                unpushedCommitCount = facts[offset].unpushedCommitCount
+            for (offset, candidate) in candidates.enumerated() {
+                await onUpdate(.init(
+                    candidate: candidate,
+                    completed: offset + 1,
+                    total: candidates.count
+                ))
             }
-            let probe = WorktreeCleanupProbe(
-                isMainWorktree: worktree.isMainWorktree == true,
-                isRemote: false,
-                hasUncommittedChanges: facts[offset].hasUncommittedChanges,
-                hasUntrackedFiles: facts[offset].hasUntrackedFiles,
-                unpushedCommitCount: unpushedCommitCount,
-                stashCount: facts[offset].stashCount,
-                activeSessionCount: await dependencies.activeSessionCount(worktree.id),
-                operationInFlight: await dependencies.operationInFlight(worktree.id),
-                // `worktree.lastActivity` is cached from the last topology
-                // refresh — ordinary commit activity while the app is open
-                // does not update it. Prefer a freshly-read value so a
-                // worktree just touched and merged since that last refresh
-                // does not read as long-idle and get default-selected.
-                //
-                // A freshly-read value can itself predate the checkout: it is
-                // derived from the branch ref's own history, so a worktree
-                // just created from an old merged branch would otherwise
-                // inherit that branch's age and read as idle immediately.
-                // The worktree cannot be idle before it existed.
-                lastActivity: max(
-                    facts[offset].lastActivity ?? worktree.lastActivity,
-                    worktree.createdAt
-                ),
-                mergeState: mergeState
-            )
-            candidates.append(WorktreeCleanupClassifier.classify(
-                worktree: worktree,
-                probe: probe,
-                now: now,
-                idleThresholdDays: idleThresholdDays
-            ))
+            return candidates
         }
-        return candidates
+
+        // The forge query and bounded per-worktree probes are independent.
+        // Start them together so network latency does not sit in front of all
+        // local git work, then publish each row as soon as both inputs exist.
+        let mergeIndexTask = Task {
+            await dependencies.mergeIndex(project)
+        }
+        defer { mergeIndexTask.cancel() }
+
+        return await withTaskGroup(
+            of: (Int, WorktreeCleanupCandidate).self
+        ) { group in
+            var results = [WorktreeCleanupCandidate?](
+                repeating: nil,
+                count: worktrees.count
+            )
+            var next = 0
+            var completed = 0
+
+            func addTask(_ index: Int) {
+                let worktree = worktrees[index]
+                group.addTask {
+                    async let facts = dependencies.gitFacts(worktree)
+                    async let activeSessionCount =
+                        dependencies.activeSessionCount(worktree.id)
+                    async let operationInFlight =
+                        dependencies.operationInFlight(worktree.id)
+
+                    let inputs = await (
+                        facts,
+                        activeSessionCount,
+                        operationInFlight
+                    )
+                    let indexResult = await mergeIndexTask.value
+                    return (
+                        index,
+                        Self.candidate(
+                            worktree: worktree,
+                            facts: inputs.0,
+                            activeSessionCount: inputs.1,
+                            operationInFlight: inputs.2,
+                            baseBranch: baseBranch,
+                            indexResult: indexResult,
+                            now: now,
+                            idleThresholdDays: idleThresholdDays
+                        )
+                    )
+                }
+            }
+
+            while next < worktrees.count && next < Self.probeConcurrency {
+                addTask(next)
+                next += 1
+            }
+            while let (index, candidate) = await group.next() {
+                results[index] = candidate
+                completed += 1
+                await onUpdate(.init(
+                    candidate: candidate,
+                    completed: completed,
+                    total: worktrees.count
+                ))
+                if next < worktrees.count {
+                    addTask(next)
+                    next += 1
+                }
+            }
+
+            return results.compactMap { $0 }
+        }
     }
 
     /// Resolves merge state, preserving the distinction the acceptance criteria
@@ -201,50 +226,56 @@ struct WorktreeCleanupScanner: Sendable {
         )
     }
 
-    /// Probes run concurrently, bounded, and results are re-ordered to match
-    /// the input so callers can zip by index.
-    private func collectGitFacts(
-        for worktrees: [Worktree]
-    ) async -> [WorktreeCleanupGitFacts] {
-        await withTaskGroup(
-            of: (Int, WorktreeCleanupGitFacts).self
-        ) { group in
-            var results = [WorktreeCleanupGitFacts?](
-                repeating: nil,
-                count: worktrees.count
-            )
-            var next = 0
-
-            func addTask(_ index: Int) {
-                let worktree = worktrees[index]
-                let probe = dependencies.gitFacts
-                group.addTask { (index, await probe(worktree)) }
-            }
-
-            while next < worktrees.count && next < Self.probeConcurrency {
-                addTask(next)
-                next += 1
-            }
-            while let (index, facts) = await group.next() {
-                results[index] = facts
-                if next < worktrees.count {
-                    addTask(next)
-                    next += 1
-                }
-            }
-
-            return results.map {
-                $0 ?? WorktreeCleanupGitFacts(
-                    hasUncommittedChanges: true,
-                    hasUntrackedFiles: false,
-                    unpushedCommitCount: 0,
-                    stashCount: 0,
-                    isMergedLocally: false,
-                    headSHA: nil,
-                    lastActivity: nil
-                )
-            }
+    private static func candidate(
+        worktree: Worktree,
+        facts: WorktreeCleanupGitFacts,
+        activeSessionCount: Int,
+        operationInFlight: Bool,
+        baseBranch: String,
+        indexResult: Result<WorktreeForgeMergeIndex, Error>,
+        now: Date,
+        idleThresholdDays: Int
+    ) -> WorktreeCleanupCandidate {
+        let mergeState = mergeState(
+            branch: worktree.branch,
+            baseBranch: baseBranch,
+            isMergedLocally: facts.isMergedLocally,
+            localHeadSHA: facts.headSHA,
+            indexResult: indexResult
+        )
+        // A branch the code host confirms is merged has its commits on the
+        // remote by definition. A missing upstream after branch pruning is
+        // not unpublished work.
+        let unpushedCommitCount: Int
+        if case .mergedOnForge = mergeState {
+            unpushedCommitCount = 0
+        } else {
+            unpushedCommitCount = facts.unpushedCommitCount
         }
+        let probe = WorktreeCleanupProbe(
+            isMainWorktree: worktree.isMainWorktree == true,
+            isRemote: false,
+            hasUncommittedChanges: facts.hasUncommittedChanges,
+            hasUntrackedFiles: facts.hasUntrackedFiles,
+            unpushedCommitCount: unpushedCommitCount,
+            stashCount: facts.stashCount,
+            activeSessionCount: activeSessionCount,
+            operationInFlight: operationInFlight,
+            // The cached activity can be stale, while branch history can
+            // predate the checkout. The worktree cannot be idle before it
+            // existed.
+            lastActivity: max(
+                facts.lastActivity ?? worktree.lastActivity,
+                worktree.createdAt
+            ),
+            mergeState: mergeState
+        )
+        return WorktreeCleanupClassifier.classify(
+            worktree: worktree,
+            probe: probe,
+            now: now,
+            idleThresholdDays: idleThresholdDays
+        )
     }
 }
 

--- a/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
+++ b/Alas/Sources/Git/WorktreeCleanup/WorktreeCleanupScanner.swift
@@ -25,6 +25,13 @@ struct WorktreeCleanupScanUpdate: Equatable, Sendable {
     let total: Int
 }
 
+private struct WorktreeCleanupProbeResult: Sendable {
+    let index: Int
+    let facts: WorktreeCleanupGitFacts
+    let activeSessionCount: Int
+    let operationInFlight: Bool
+}
+
 /// Merged review requests for one repository, keyed by head branch. A branch
 /// name can have multiple entries: it may have been reused across several
 /// merged reviews over time, and the caller must be able to check the local
@@ -102,79 +109,106 @@ struct WorktreeCleanupScanner: Sendable {
             return candidates
         }
 
-        // The forge query and bounded per-worktree probes are independent.
-        // Start them together so network latency does not sit in front of all
-        // local git work, then publish each row as soon as both inputs exist.
+        guard !worktrees.isEmpty else { return [] }
+
+        // Local probes and the forge query are independent. Stream bounded
+        // probe results into a buffer while the network request runs, then
+        // publish buffered and future rows as soon as forge evidence exists.
+        let (probeResults, probeTask) = localProbeResults(for: worktrees)
         let mergeIndexTask = Task {
             await dependencies.mergeIndex(project)
         }
-        defer { mergeIndexTask.cancel() }
+        defer {
+            probeTask.cancel()
+            mergeIndexTask.cancel()
+        }
 
-        return await withTaskGroup(
-            of: (Int, WorktreeCleanupCandidate).self
-        ) { group in
+        return await withTaskCancellationHandler {
+            let indexResult = await mergeIndexTask.value
             var results = [WorktreeCleanupCandidate?](
                 repeating: nil,
                 count: worktrees.count
             )
-            var next = 0
             var completed = 0
 
-            func addTask(_ index: Int) {
-                let worktree = worktrees[index]
-                _ = group.addTaskUnlessCancelled {
-                    async let facts = dependencies.gitFacts(worktree)
-                    async let activeSessionCount =
-                        dependencies.activeSessionCount(worktree.id)
-                    async let operationInFlight =
-                        dependencies.operationInFlight(worktree.id)
-
-                    let inputs = await (
-                        facts,
-                        activeSessionCount,
-                        operationInFlight
-                    )
-                    let indexResult = await withTaskCancellationHandler {
-                        await mergeIndexTask.value
-                    } onCancel: {
-                        mergeIndexTask.cancel()
-                    }
-                    return (
-                        index,
-                        Self.candidate(
-                            worktree: worktree,
-                            facts: inputs.0,
-                            activeSessionCount: inputs.1,
-                            operationInFlight: inputs.2,
-                            baseBranch: baseBranch,
-                            indexResult: indexResult,
-                            now: now,
-                            idleThresholdDays: idleThresholdDays
-                        )
-                    )
-                }
-            }
-
-            while next < worktrees.count && next < Self.probeConcurrency {
-                addTask(next)
-                next += 1
-            }
-            while let (index, candidate) = await group.next() {
-                results[index] = candidate
+            for await probe in probeResults {
+                guard !Task.isCancelled else { break }
+                let worktree = worktrees[probe.index]
+                let candidate = Self.candidate(
+                    worktree: worktree,
+                    facts: probe.facts,
+                    activeSessionCount: probe.activeSessionCount,
+                    operationInFlight: probe.operationInFlight,
+                    baseBranch: baseBranch,
+                    indexResult: indexResult,
+                    now: now,
+                    idleThresholdDays: idleThresholdDays
+                )
+                results[probe.index] = candidate
                 completed += 1
                 await onUpdate(.init(
                     candidate: candidate,
                     completed: completed,
                     total: worktrees.count
                 ))
-                if next < worktrees.count {
-                    addTask(next)
-                    next += 1
-                }
             }
 
             return results.compactMap { $0 }
+        } onCancel: {
+            probeTask.cancel()
+            mergeIndexTask.cancel()
         }
+    }
+
+    private func localProbeResults(
+        for worktrees: [Worktree]
+    ) -> (
+        stream: AsyncStream<WorktreeCleanupProbeResult>,
+        task: Task<Void, Never>
+    ) {
+        let (stream, continuation) = AsyncStream<WorktreeCleanupProbeResult>.makeStream()
+        let task = Task {
+            await withTaskGroup(of: WorktreeCleanupProbeResult.self) { group in
+                var next = 0
+
+                func addTask(_ index: Int) {
+                    let worktree = worktrees[index]
+                    _ = group.addTaskUnlessCancelled {
+                        async let facts = dependencies.gitFacts(worktree)
+                        async let activeSessionCount =
+                            dependencies.activeSessionCount(worktree.id)
+                        async let operationInFlight =
+                            dependencies.operationInFlight(worktree.id)
+
+                        let inputs = await (
+                            facts,
+                            activeSessionCount,
+                            operationInFlight
+                        )
+                        return WorktreeCleanupProbeResult(
+                            index: index,
+                            facts: inputs.0,
+                            activeSessionCount: inputs.1,
+                            operationInFlight: inputs.2
+                        )
+                    }
+                }
+
+                while next < worktrees.count && next < Self.probeConcurrency {
+                    addTask(next)
+                    next += 1
+                }
+                while let result = await group.next() {
+                    continuation.yield(result)
+                    if next < worktrees.count {
+                        addTask(next)
+                        next += 1
+                    }
+                }
+            }
+            continuation.finish()
+        }
+        return (stream, task)
     }
 
     /// Resolves merge state, preserving the distinction the acceptance criteria

--- a/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
+++ b/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
@@ -190,6 +190,49 @@ struct WorktreeCleanupModelTests {
         #expect(model.selectedIds == [a.id])
     }
 
+    @Test func batchActionsAreBlockedWhileScanning() async {
+        let candidate = candidate(branch: "a", verdict: .candidate(confidence: .high))
+        let worktrees = [candidate.worktree]
+        let gate = WorktreeCleanupScanGate()
+        var confirmationCount = 0
+        var deleteBatchCount = 0
+        var archiveBatchCount = 0
+        let model = WorktreeCleanupModel(
+            projectId: "p",
+            worktrees: worktrees,
+            keepBranches: false,
+            loadWorktrees: { worktrees },
+            scan: { _, _ in
+                await gate.pause()
+                return .success([candidate])
+            },
+            deleteBatch: { _, _, _ in
+                deleteBatchCount += 1
+                return []
+            },
+            archiveBatch: { _ in
+                archiveBatchCount += 1
+                return []
+            },
+            confirm: { _, _, _ in
+                confirmationCount += 1
+                return true
+            }
+        )
+        model.applyScanResult([candidate])
+        let scanTask = Task { await model.runScan() }
+        await gate.waitUntilPaused()
+
+        await model.deleteSelected()
+        await model.archiveSelected()
+
+        #expect(confirmationCount == 0)
+        #expect(deleteBatchCount == 0)
+        #expect(archiveBatchCount == 0)
+        await gate.resume()
+        await scanTask.value
+    }
+
     /// Drives a rescan through `runScan()` itself, not `applyScanResult`
     /// directly — this is the entry point the Refresh button and any
     /// production rescan actually use. The model is already marked as scanning

--- a/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
+++ b/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
@@ -180,11 +180,14 @@ struct WorktreeCleanupModelTests {
         #expect(!model.rows[0].isScanning)
         #expect(model.rows[1].candidate == nil)
         #expect(model.rows[1].isScanning)
+        model.toggle(a.id)
+        #expect(model.selectedIds.isEmpty)
 
         await gate.resume()
         await scanTask.value
         #expect(!model.isScanning)
         #expect(model.candidates == [a, b])
+        #expect(model.selectedIds == [a.id])
     }
 
     /// Drives a rescan through `runScan()` itself, not `applyScanResult`

--- a/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
+++ b/AlasTests/Dialogs/WorktreeCleanupModelTests.swift
@@ -130,18 +130,77 @@ struct WorktreeCleanupModelTests {
         #expect(model.selectedIds == ["/tmp/wt-a"])
     }
 
+    @Test func worktreeRowsAreAvailableBeforeTheScanStarts() {
+        let a = candidate(branch: "a", verdict: .candidate(confidence: .high))
+        let b = candidate(branch: "b", verdict: .dirty)
+        let worktrees = [a.worktree, b.worktree]
+        let model = WorktreeCleanupModel(
+            projectId: "p",
+            worktrees: worktrees,
+            keepBranches: false,
+            loadWorktrees: { worktrees },
+            scan: { _, _ in .success([a, b]) },
+            deleteBatch: { _, _ in [] },
+            archiveBatch: { _ in [] },
+            confirm: { _, _, _ in true }
+        )
+
+        #expect(model.rows.map(\.worktree.branch) == ["a", "b"])
+        #expect(model.rows.allSatisfy { $0.candidate == nil })
+        #expect(!model.isScanning)
+    }
+
+    @Test func scanPublishesCompletedRowsWhileOtherRowsAreStillLoading() async {
+        let a = candidate(branch: "a", verdict: .candidate(confidence: .high))
+        let b = candidate(branch: "b", verdict: .dirty)
+        let worktrees = [a.worktree, b.worktree]
+        let gate = WorktreeCleanupScanGate()
+        let model = WorktreeCleanupModel(
+            projectId: "p",
+            worktrees: worktrees,
+            keepBranches: false,
+            loadWorktrees: { worktrees },
+            scan: { _, onUpdate in
+                await onUpdate(.init(candidate: a, completed: 1, total: 2))
+                await gate.pause()
+                await onUpdate(.init(candidate: b, completed: 2, total: 2))
+                return .success([a, b])
+            },
+            deleteBatch: { _, _ in [] },
+            archiveBatch: { _ in [] },
+            confirm: { _, _, _ in true }
+        )
+
+        let scanTask = Task { await model.runScan() }
+        await gate.waitUntilPaused()
+
+        #expect(model.isScanning)
+        #expect(model.scanProgress == .init(completed: 1, total: 2))
+        #expect(model.rows[0].candidate == a)
+        #expect(!model.rows[0].isScanning)
+        #expect(model.rows[1].candidate == nil)
+        #expect(model.rows[1].isScanning)
+
+        await gate.resume()
+        await scanTask.value
+        #expect(!model.isScanning)
+        #expect(model.candidates == [a, b])
+    }
+
     /// Drives a rescan through `runScan()` itself, not `applyScanResult`
     /// directly — this is the entry point the Refresh button and any
-    /// production rescan actually use, and `scanState` is `.scanning` for
-    /// the duration of the call, which is exactly what broke a prior
-    /// implementation that read `scanState` to decide whether to reconcile.
+    /// production rescan actually use. The model is already marked as scanning
+    /// while results arrive, so selection reconciliation must use the durable
+    /// completed-scan flag rather than transient loading state.
     @Test func runScanThroughItsPublicEntryPointKeepsManualSelection() async {
         let a = candidate(branch: "a", verdict: .candidate(confidence: .high))
         let b = candidate(branch: "b", verdict: .candidate(confidence: .high))
         let model = WorktreeCleanupModel(
             projectId: "p",
+            worktrees: [a.worktree, b.worktree],
             keepBranches: false,
-            scan: { .success([a, b]) },
+            loadWorktrees: { [a.worktree, b.worktree] },
+            scan: { _, _ in .success([a, b]) },
             deleteBatch: { _, _ in [] },
             archiveBatch: { _ in [] },
             confirm: { _, _, _ in true }
@@ -164,8 +223,10 @@ struct WorktreeCleanupModelTests {
         var archiveBatchCalls = 0
         let model = WorktreeCleanupModel(
             projectId: "p",
+            worktrees: [a.worktree],
             keepBranches: false,
-            scan: { .success([a]) },
+            loadWorktrees: { [a.worktree] },
+            scan: { _, _ in .success([a]) },
             deleteBatch: { _, _ in [] },
             archiveBatch: { worktrees in
                 archiveBatchCalls += 1
@@ -195,8 +256,10 @@ struct WorktreeCleanupModelTests {
         var archiveBatchCalls = 0
         let model = WorktreeCleanupModel(
             projectId: "p",
+            worktrees: [a.worktree],
             keepBranches: false,
-            scan: { .success([a]) },
+            loadWorktrees: { [a.worktree] },
+            scan: { _, _ in .success([a]) },
             deleteBatch: { _, _ in [] },
             archiveBatch: { worktrees in
                 archiveBatchCalls += 1
@@ -219,8 +282,10 @@ struct WorktreeCleanupModelTests {
         var confirmButtons: [String] = []
         let model = WorktreeCleanupModel(
             projectId: "p",
+            worktrees: [a.worktree],
             keepBranches: false,
-            scan: { .success([a]) },
+            loadWorktrees: { [a.worktree] },
+            scan: { _, _ in .success([a]) },
             deleteBatch: { _, _ in
                 deleteBatchCalls += 1
                 return []
@@ -246,5 +311,32 @@ struct WorktreeCleanupModelTests {
             candidate(branch: "c", verdict: .candidate(confidence: .high)),
         ])
         #expect(model.selectedWorktrees().map(\.branch) == ["a", "b", "c"])
+    }
+}
+
+private actor WorktreeCleanupScanGate {
+    private var isPaused = false
+    private var pauseWaiters: [CheckedContinuation<Void, Never>] = []
+    private var resumeContinuation: CheckedContinuation<Void, Never>?
+
+    func pause() async {
+        isPaused = true
+        pauseWaiters.forEach { $0.resume() }
+        pauseWaiters.removeAll()
+        await withCheckedContinuation { continuation in
+            resumeContinuation = continuation
+        }
+    }
+
+    func waitUntilPaused() async {
+        if isPaused { return }
+        await withCheckedContinuation { continuation in
+            pauseWaiters.append(continuation)
+        }
+    }
+
+    func resume() {
+        resumeContinuation?.resume()
+        resumeContinuation = nil
     }
 }

--- a/AlasTests/Git/WorktreeCleanupScannerTests.swift
+++ b/AlasTests/Git/WorktreeCleanupScannerTests.swift
@@ -374,6 +374,31 @@ struct WorktreeCleanupScannerTests {
         #expect(Set(updates.map(\.candidate.id)) == Set(worktrees.map(\.id)))
     }
 
+    @Test func cancellingScanCancelsMergeIndexLookup() async {
+        let probe = WorktreeCleanupCancellationProbe()
+        let scanner = Self.scanner(mergeIndex: { _ in
+            await probe.markStarted()
+            do {
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+            } catch is CancellationError {
+                await probe.markCancelled()
+            } catch {}
+            return .failure(CancellationError())
+        })
+        let scanTask = Task {
+            await Self.scan(
+                scanner,
+                worktrees: [Self.worktree(branch: "feature/a")]
+            )
+        }
+        await probe.waitUntilStarted()
+
+        scanTask.cancel()
+        _ = await scanTask.value
+
+        #expect(await probe.didObserveCancellation)
+    }
+
     @Test func statusPorcelainDistinguishesUntrackedFromModified() {
         let modified = WorktreeCleanupScanner.parseStatusPorcelain(" M Sources/A.swift\n")
         #expect(modified.hasUncommittedChanges)
@@ -425,5 +450,28 @@ private actor WorktreeCleanupUpdateRecorder {
 
     func append(_ update: WorktreeCleanupScanUpdate) {
         updates.append(update)
+    }
+}
+
+private actor WorktreeCleanupCancellationProbe {
+    private(set) var didObserveCancellation = false
+    private var started = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func markStarted() {
+        started = true
+        startWaiters.forEach { $0.resume() }
+        startWaiters.removeAll()
+    }
+
+    func waitUntilStarted() async {
+        if started { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+        }
+    }
+
+    func markCancelled() {
+        didObserveCancellation = true
     }
 }

--- a/AlasTests/Git/WorktreeCleanupScannerTests.swift
+++ b/AlasTests/Git/WorktreeCleanupScannerTests.swift
@@ -374,6 +374,35 @@ struct WorktreeCleanupScannerTests {
         #expect(Set(updates.map(\.candidate.id)) == Set(worktrees.map(\.id)))
     }
 
+    @Test func localProbesContinueWhileForgeLookupIsPending() async {
+        let forgeGate = WorktreeCleanupForgeGate()
+        let recorder = WorktreeCleanupProbeStartRecorder()
+        let scanner = Self.scanner(
+            facts: { _ in
+                await recorder.recordStart()
+                return Self.cleanFacts
+            },
+            mergeIndex: { _ in
+                await forgeGate.pause()
+                return .success(WorktreeForgeMergeIndex(refsByHeadBranch: [:]))
+            }
+        )
+        let worktrees = (0..<8).map {
+            Self.worktree(branch: "feature/\($0)")
+        }
+        let scanTask = Task {
+            await Self.scan(scanner, worktrees: worktrees)
+        }
+        await forgeGate.waitUntilPaused()
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        let probesStartedBeforeForgeCompleted = await recorder.count
+
+        await forgeGate.resume()
+        _ = await scanTask.value
+
+        #expect(probesStartedBeforeForgeCompleted == worktrees.count)
+    }
+
     @Test func cancellingScanCancelsMergeIndexLookup() async {
         let probe = WorktreeCleanupCancellationProbe()
         let scanner = Self.scanner(mergeIndex: { _ in
@@ -523,5 +552,32 @@ private actor WorktreeCleanupProbeStartRecorder {
         await withCheckedContinuation { continuation in
             waitContinuation = continuation
         }
+    }
+}
+
+private actor WorktreeCleanupForgeGate {
+    private var isPaused = false
+    private var pauseWaiters: [CheckedContinuation<Void, Never>] = []
+    private var resumeContinuation: CheckedContinuation<Void, Never>?
+
+    func pause() async {
+        isPaused = true
+        pauseWaiters.forEach { $0.resume() }
+        pauseWaiters.removeAll()
+        await withCheckedContinuation { continuation in
+            resumeContinuation = continuation
+        }
+    }
+
+    func waitUntilPaused() async {
+        if isPaused { return }
+        await withCheckedContinuation { continuation in
+            pauseWaiters.append(continuation)
+        }
+    }
+
+    func resume() {
+        resumeContinuation?.resume()
+        resumeContinuation = nil
     }
 }

--- a/AlasTests/Git/WorktreeCleanupScannerTests.swift
+++ b/AlasTests/Git/WorktreeCleanupScannerTests.swift
@@ -399,6 +399,34 @@ struct WorktreeCleanupScannerTests {
         #expect(await probe.didObserveCancellation)
     }
 
+    @Test func cancellingScanDoesNotStartQueuedWorktreeProbes() async {
+        let concurrencyLimit = 4
+        let recorder = WorktreeCleanupProbeStartRecorder()
+        let scanner = Self.scanner(
+            facts: { _ in
+                await recorder.recordStart()
+                try? await Task.sleep(nanoseconds: 10_000_000_000)
+                return Self.cleanFacts
+            },
+            mergeIndex: { _ in
+                try? await Task.sleep(nanoseconds: 10_000_000_000)
+                return .failure(CancellationError())
+            }
+        )
+        let worktrees = (0..<8).map {
+            Self.worktree(branch: "feature/\($0)")
+        }
+        let scanTask = Task {
+            await Self.scan(scanner, worktrees: worktrees)
+        }
+        await recorder.waitUntilStarted(concurrencyLimit)
+
+        scanTask.cancel()
+        _ = await scanTask.value
+
+        #expect(await recorder.count == concurrencyLimit)
+    }
+
     @Test func statusPorcelainDistinguishesUntrackedFromModified() {
         let modified = WorktreeCleanupScanner.parseStatusPorcelain(" M Sources/A.swift\n")
         #expect(modified.hasUncommittedChanges)
@@ -473,5 +501,27 @@ private actor WorktreeCleanupCancellationProbe {
 
     func markCancelled() {
         didObserveCancellation = true
+    }
+}
+
+private actor WorktreeCleanupProbeStartRecorder {
+    private(set) var count = 0
+    private var waitTarget: Int?
+    private var waitContinuation: CheckedContinuation<Void, Never>?
+
+    func recordStart() {
+        count += 1
+        guard let waitTarget, count >= waitTarget else { return }
+        self.waitTarget = nil
+        waitContinuation?.resume()
+        waitContinuation = nil
+    }
+
+    func waitUntilStarted(_ target: Int) async {
+        if count >= target { return }
+        waitTarget = target
+        await withCheckedContinuation { continuation in
+            waitContinuation = continuation
+        }
     }
 }

--- a/AlasTests/Git/WorktreeCleanupScannerTests.swift
+++ b/AlasTests/Git/WorktreeCleanupScannerTests.swift
@@ -353,6 +353,27 @@ struct WorktreeCleanupScannerTests {
                 == ["feature/a", "feature/b", "feature/c"])
     }
 
+    @Test func scanPublishesProgressForEveryWorktree() async {
+        let scanner = Self.scanner()
+        let worktrees = ["a", "b", "c"].map { Self.worktree(branch: "feature/\($0)") }
+        let recorder = WorktreeCleanupUpdateRecorder()
+
+        let results = await scanner.scan(
+            project: Self.project(),
+            worktrees: worktrees,
+            baseBranch: "main",
+            now: Self.now,
+            idleThresholdDays: 14,
+            onUpdate: { update in await recorder.append(update) }
+        )
+        let updates = await recorder.updates
+
+        #expect(results.map(\.worktree.branch) == ["feature/a", "feature/b", "feature/c"])
+        #expect(updates.map(\.completed) == [1, 2, 3])
+        #expect(updates.allSatisfy { $0.total == 3 })
+        #expect(Set(updates.map(\.candidate.id)) == Set(worktrees.map(\.id)))
+    }
+
     @Test func statusPorcelainDistinguishesUntrackedFromModified() {
         let modified = WorktreeCleanupScanner.parseStatusPorcelain(" M Sources/A.swift\n")
         #expect(modified.hasUncommittedChanges)
@@ -397,4 +418,12 @@ struct WorktreeCleanupScannerTests {
 private actor ProbeCounter {
     private(set) var value = 0
     func increment() { value += 1 }
+}
+
+private actor WorktreeCleanupUpdateRecorder {
+    private(set) var updates: [WorktreeCleanupScanUpdate] = []
+
+    func append(_ update: WorktreeCleanupScanUpdate) {
+        updates.append(update)
+    }
 }


### PR DESCRIPTION
## Summary

- render known worktrees immediately when the cleanup sheet opens
- stream scan results into individual rows with per-row and aggregate progress
- overlap forge merge lookup with bounded local worktree probes
- keep destructive actions disabled while scanning or after scan errors

## Verification

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet -only-testing:AlasTests/WorktreeCleanupModelTests -only-testing:AlasTests/WorktreeCleanupScannerTests test`
- manual app smoke test: the initial `Checking 0 of 3 worktrees…` state rendered all known branches and paths before scan details completed

The full test suite was also invoked and reported 13 failures outside the `WorktreeCleanupModelTests` and `WorktreeCleanupScannerTests` suites.