### PR TITLE
style(agents): Polish agent sidebar cards

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1426,6 +1426,7 @@
 		D7BBE05B1EECE01D43EE48B0 /* WorkspaceModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38AA6E00C56FC42ABDCBB329 /* WorkspaceModels.swift */; };
 		D7C0F02B7A62097E3EF21160 /* FileSearchRanker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FABF9037326B7EE23FCC040 /* FileSearchRanker.swift */; };
 		D7D45D387EEF0436834DF7AD /* ThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EE713DD3CACF29F206553C /* ThemeStore.swift */; };
+		D7DC1DB58494BFCCDB5732CA /* AgentTabPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCFA9964097ABAFEDD64ECA /* AgentTabPresentation.swift */; };
 		D8254D678C89FC54678A1A88 /* RemoteHelperInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFB9832AA15DF6888553C7E /* RemoteHelperInstallerTests.swift */; };
 		D84D5F836F828349114F2D3C /* RightPaneTabTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1352DFCDFF4769EAF89B75CF /* RightPaneTabTests.swift */; };
 		D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */; };
@@ -2011,6 +2012,7 @@
 		2F7E37886988A6F285BEA163 /* ReviewSessionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSessionModels.swift; sourceTree = "<group>"; };
 		2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadReaderTests.swift; sourceTree = "<group>"; };
 		2FACC9A36AFADFB92DC240BD /* ACPTranscriptRowContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptRowContent.swift; sourceTree = "<group>"; };
+		2FCFA9964097ABAFEDD64ECA /* AgentTabPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTabPresentation.swift; sourceTree = "<group>"; };
 		2FD28E0005DE3A33A974A511 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 		2FE3A300CA2284FF5EEEF102 /* StashRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StashRows.swift; sourceTree = "<group>"; };
 		2FE4396C610C7714AFDD6B41 /* DiffReviewImageState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewImageState.swift; sourceTree = "<group>"; };
@@ -4395,6 +4397,7 @@
 			isa = PBXGroup;
 			children = (
 				0440E0CF2FCB4EF89EF53DC2 /* AgentSidebarRollup.swift */,
+				2FCFA9964097ABAFEDD64ECA /* AgentTabPresentation.swift */,
 				A1AD121323EC19D333DC2556 /* AgentTabView.swift */,
 				002C8D5C52466955E0A90606 /* BaseBranchSelector.swift */,
 				FF68BCA1222E7C06DA4AC595 /* BaseResolutionMapping.swift */,
@@ -6642,6 +6645,7 @@
 				2584552219DE6987E1E6AF36 /* AgentRunError.swift in Sources */,
 				0BA997A903C1DC2A41D64E22 /* AgentRunner.swift in Sources */,
 				2D428B399E48ED859E4D0797 /* AgentSidebarRollup.swift in Sources */,
+				D7DC1DB58494BFCCDB5732CA /* AgentTabPresentation.swift in Sources */,
 				D2F62FD2AC838FFDC305206D /* AgentTabView.swift in Sources */,
 				55C7881F382ACCEBCDB7D157 /* AgentsPane.swift in Sources */,
 				59EFDD354514B21BBA4206AD /* AiSplitButton.swift in Sources */,

--- a/Alas/Sources/Right/AgentTabPresentation.swift
+++ b/Alas/Sources/Right/AgentTabPresentation.swift
@@ -1,0 +1,353 @@
+import SwiftUI
+
+struct AgentSidebarEmptyState: View {
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(theme.color("accent"))
+                .frame(width: 38, height: 38)
+                .background(theme.color("accent").opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+            Text("No agent activity")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(theme.color("fg"))
+            Text("Agent sessions and terminals for this worktree will appear here.")
+                .font(.system(size: 10.5))
+                .foregroundStyle(theme.color("fg-muted"))
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 28)
+        .background(
+            LinearGradient(
+                colors: [
+                    theme.color("accent").opacity(0.08),
+                    theme.color("bg-1").opacity(0.55)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            ),
+            in: RoundedRectangle(cornerRadius: 12)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(theme.color("line").opacity(0.7), lineWidth: 0.75)
+        )
+        .accessibilityElement(children: .combine)
+    }
+}
+
+struct AgentSidebarSectionHeader: View {
+    let title: String
+    let count: Int
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(title.uppercased())
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.4)
+            Text("\(count)")
+                .font(.system(size: 9.5, weight: .semibold))
+                .monospacedDigit()
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(theme.color("seg-pill-bg"), in: Capsule())
+            Spacer(minLength: 0)
+        }
+        .foregroundStyle(theme.color("fg-muted"))
+        .padding(.horizontal, 2)
+        .padding(.top, 4)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+struct AgentSidebarRowView: View {
+    let row: AgentSidebarRow
+    let agent: AgentDefinition?
+    let actions: AgentSidebarActions
+    let canControl: Bool
+    let delivery: AgentSidebarFollowUpDelivery?
+    @Binding var draft: String
+    @State private var isEditing = false
+    @State private var isHovering = false
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Button { actions.onFocus(row.id) } label: {
+                HStack(alignment: .top, spacing: 10) {
+                    logo
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(row.title)
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(theme.color("fg"))
+                            .lineLimit(2)
+                        metadata
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    statusPill
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Focus \(row.title), \(accessibilityMetadata), \(row.state.label)")
+            .help("Focus \(row.title)")
+
+            if let plan = row.plan {
+                planProgress(plan)
+            }
+
+            if row.contextUsage != nil || canControl {
+                controls
+            }
+
+            if let sessionID = row.sessionID,
+               isEditing || !draft.isEmpty || delivery == .failed {
+                followUpComposer(sessionID: sessionID)
+            }
+        }
+        .padding(10)
+        .background(cardBackground, in: RoundedRectangle(cornerRadius: 11))
+        .overlay(
+            RoundedRectangle(cornerRadius: 11)
+                .strokeBorder(cardBorderColor, lineWidth: 0.75)
+        )
+        .shadow(color: .black.opacity(isHovering ? 0.18 : 0.10), radius: isHovering ? 5 : 3, y: 2)
+        .contentShape(RoundedRectangle(cornerRadius: 11))
+        .onHover { isHovering = $0 }
+        .onChange(of: delivery) {
+            if delivery == .sent {
+                isEditing = false
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private var logo: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(stateColor.opacity(0.13))
+            if let agent {
+                AgentLogoView(agent: agent, size: 20)
+                    .accessibilityHidden(true)
+            } else {
+                Image(systemName: row.agentID == "terminal" ? "terminal" : "sparkles")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(stateColor)
+                    .accessibilityHidden(true)
+            }
+        }
+        .frame(width: 32, height: 32)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(stateColor.opacity(0.24), lineWidth: 0.75)
+        )
+    }
+
+    private var metadata: some View {
+        HStack(spacing: 5) {
+            Text(agentName)
+                .fontWeight(.medium)
+            if let model = row.model {
+                Text("·")
+                Text(model)
+            }
+            if row.createdAt != .distantPast {
+                Text("·")
+                Text(row.createdAt, style: .relative)
+            }
+            if let host = row.host {
+                Text("·")
+                Image(systemName: "network")
+                    .accessibilityHidden(true)
+                Text(host)
+            }
+        }
+        .font(.system(size: 10))
+        .foregroundStyle(theme.color("fg-muted"))
+        .lineLimit(1)
+    }
+
+    private var statusPill: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(stateColor)
+                .frame(width: 6, height: 6)
+            Text(row.state.label)
+                .font(.system(size: 9.5, weight: .semibold))
+        }
+        .foregroundStyle(stateColor)
+        .padding(.horizontal, 7)
+        .frame(height: 22)
+        .background(stateColor.opacity(0.12), in: Capsule())
+        .overlay(Capsule().strokeBorder(stateColor.opacity(0.22), lineWidth: 0.5))
+        .fixedSize(horizontal: true, vertical: false)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Status: \(row.state.label)")
+    }
+
+    private func planProgress(_ plan: AgentSidebarPlanProgress) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(spacing: 5) {
+                Image(systemName: "checklist")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(stateColor)
+                Text("Tasks \(plan.completed)/\(plan.total)")
+                    .font(.system(size: 10, weight: .semibold))
+                Spacer(minLength: 0)
+                if let step = plan.currentStep {
+                    Text(step)
+                        .font(.system(size: 10))
+                        .foregroundStyle(theme.color("fg-muted"))
+                        .lineLimit(1)
+                }
+            }
+            ProgressView(value: Double(plan.completed), total: Double(plan.total))
+                .tint(stateColor)
+        }
+        .foregroundStyle(theme.color("fg"))
+        .padding(8)
+        .background(theme.color("bg-0").opacity(0.42), in: RoundedRectangle(cornerRadius: 7))
+    }
+
+    private var controls: some View {
+        HStack(spacing: 7) {
+            ACPContextUsageButton(usage: row.contextUsage, modelName: row.model)
+            Spacer(minLength: 0)
+            if let sessionID = row.sessionID, row.isLiveACP, canControl {
+                if row.state == .running || row.state == .awaitingInput || row.state == .permissionRequest {
+                    Button("Interrupt", systemImage: "stop.fill") {
+                        actions.onInterrupt(sessionID)
+                    }
+                    .tint(theme.color("del"))
+                }
+                Button("Follow up", systemImage: "arrowshape.turn.up.left.fill") {
+                    isEditing.toggle()
+                }
+                .tint(theme.color("accent"))
+                if let onDelegate = actions.onDelegate {
+                    Button("Delegate", systemImage: "person.badge.plus") {
+                        onDelegate(sessionID)
+                    }
+                    .tint(theme.color("accent"))
+                }
+            }
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+    }
+
+    private func followUpComposer(sessionID: ACPSession.ID) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            TextField("Follow-up message", text: $draft, axis: .vertical)
+                .lineLimit(2 ... 5)
+                .textFieldStyle(.plain)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 7)
+                .background(theme.color("bg-0").opacity(0.66), in: RoundedRectangle(cornerRadius: 7))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 7)
+                        .strokeBorder(theme.color("line"), lineWidth: 0.75)
+                )
+                .disabled(delivery == .sending)
+            HStack {
+                if delivery == .failed {
+                    Text("Could not send. Your message is kept here.")
+                        .font(.system(size: 10))
+                        .foregroundStyle(theme.color("del"))
+                }
+                Spacer(minLength: 0)
+                Button(delivery == .sending ? "Sending…" : "Send", systemImage: "arrow.up") {
+                    actions.onFollowUp(sessionID, draft)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(theme.color("accent"))
+                .disabled(
+                    !canControl
+                        || delivery == .sending
+                        || draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                )
+                .controlSize(.small)
+            }
+        }
+        .padding(8)
+        .background(theme.color("bg-1").opacity(0.62), in: RoundedRectangle(cornerRadius: 9))
+        .overlay(
+            RoundedRectangle(cornerRadius: 9)
+                .strokeBorder(theme.color("accent").opacity(0.22), lineWidth: 0.75)
+        )
+    }
+
+    private var cardBackground: some ShapeStyle {
+        LinearGradient(
+            colors: [
+                stateColor.opacity(isHovering ? 0.12 : 0.07),
+                theme.color("bg-1").opacity(isHovering ? 0.82 : 0.66)
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    private var cardBorderColor: Color {
+        isHovering ? stateColor.opacity(0.38) : theme.color("line").opacity(0.78)
+    }
+
+    private var agentName: String {
+        agent?.displayName ?? row.agentID
+    }
+
+    private var accessibilityMetadata: String {
+        var values = [agentName]
+        if let model = row.model {
+            values.append(model)
+        }
+        if row.createdAt != .distantPast {
+            values.append("created \(row.createdAt.formatted(.relative(presentation: .named)))")
+        }
+        if let host = row.host {
+            values.append("host \(host)")
+        }
+        return values.joined(separator: ", ")
+    }
+
+    private var stateColor: Color {
+        switch row.state {
+        case .running:
+            theme.color("add")
+        case .awaitingInput, .permissionRequest:
+            theme.color("warn")
+        case .idle:
+            theme.color("accent")
+        case .detached:
+            theme.color("fg-faint")
+        case .unknown:
+            row.isLiveACP ? theme.color("del") : theme.color("fg-faint")
+        }
+    }
+}
+
+extension AgentSidebarRow {
+    var sessionID: ACPSession.ID? {
+        guard case .acp(let sessionID) = id else { return nil }
+        return sessionID
+    }
+}
+
+extension AgentSidebarState {
+    var label: String {
+        switch self {
+        case .running: "Running"
+        case .awaitingInput: "Awaiting input"
+        case .permissionRequest: "Permission"
+        case .idle: "Idle"
+        case .detached: "History"
+        case .unknown: "Unknown"
+        }
+    }
+}

--- a/Alas/Sources/Right/AgentTabView.swift
+++ b/Alas/Sources/Right/AgentTabView.swift
@@ -37,6 +37,9 @@ struct AgentWorktreeTabView: View {
         let _ = sessionRevision
         AgentTabView(
             rollup: state.agentSidebarRollup(for: worktree),
+            agentLookup: { agentID in
+                state.agent(id: agentID == AgentKind.cursor.rawValue ? "cursor-agent" : agentID)
+            },
             actions: AgentSidebarActions(
                 onFocus: { rowID in
                     Task { await state.focusAgentSidebarRow(rowID, in: worktree) }
@@ -71,24 +74,23 @@ struct AgentWorktreeTabView: View {
 
 struct AgentTabView: View {
     let rollup: AgentSidebarRollup
+    let agentLookup: (String) -> AgentDefinition?
     let actions: AgentSidebarActions
     var controllableSessionIDs: Set<ACPSession.ID> = []
     @Binding var followUps: [ACPSession.ID: AgentSidebarFollowUpDraft]
-    @Environment(\.theme) private var theme
 
     var body: some View {
         ScrollView {
-            LazyVStack(alignment: .leading, spacing: 0) {
+            LazyVStack(alignment: .leading, spacing: 8) {
                 if rollup.rows.isEmpty {
-                    Text("No agent sessions or terminals in this worktree.")
-                        .font(.system(size: 12))
-                        .foregroundStyle(theme.color("fg-muted"))
-                        .padding(16)
+                    AgentSidebarEmptyState()
                 } else {
                     section(title: "Active", rows: rollup.active)
                     section(title: "History", rows: rollup.history)
                 }
             }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 12)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
@@ -96,18 +98,11 @@ struct AgentTabView: View {
     @ViewBuilder
     private func section(title: String, rows: [AgentSidebarRow]) -> some View {
         if !rows.isEmpty {
-            HStack {
-                Text(title)
-                Spacer()
-                Text("\(rows.count)").monospacedDigit()
-            }
-            .font(.system(size: 11, weight: .semibold))
-            .foregroundStyle(theme.color("fg-muted"))
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
+            AgentSidebarSectionHeader(title: title, count: rows.count)
             ForEach(rows) { row in
                 AgentSidebarRowView(
                     row: row,
+                    agent: agentLookup(row.agentID),
                     actions: actions,
                     canControl: row.sessionID.map { controllableSessionIDs.contains($0) } ?? false,
                     delivery: row.sessionID.flatMap { followUps[$0]?.delivery },
@@ -121,130 +116,6 @@ struct AgentTabView: View {
                     )
                 )
             }
-        }
-    }
-}
-
-private struct AgentSidebarRowView: View {
-    let row: AgentSidebarRow
-    let actions: AgentSidebarActions
-    let canControl: Bool
-    let delivery: AgentSidebarFollowUpDelivery?
-    @Binding var draft: String
-    @State private var isEditing = false
-    @Environment(\.theme) private var theme
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 7) {
-            Button { actions.onFocus(row.id) } label: {
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(alignment: .firstTextBaseline) {
-                        Text(row.title).font(.system(size: 12, weight: .medium)).lineLimit(2)
-                        Spacer(minLength: 4)
-                        Text(row.state.label)
-                            .font(.system(size: 10))
-                            .foregroundStyle(theme.color("fg-muted"))
-                    }
-                    HStack(spacing: 5) {
-                        Text(row.agentID)
-                        if let model = row.model { Text("· \(model)") }
-                        if row.createdAt != .distantPast {
-                            Text("·")
-                            Text(row.createdAt, style: .relative)
-                        }
-                    }
-                    .font(.system(size: 10))
-                    .foregroundStyle(theme.color("fg-muted"))
-                    .lineLimit(1)
-                    if let host = row.host {
-                        Label(host, systemImage: "network")
-                            .font(.system(size: 10))
-                            .foregroundStyle(theme.color("fg-muted"))
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .help("Focus \(row.title)")
-
-            if let plan = row.plan {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text("Tasks \(plan.completed)/\(plan.total)")
-                        .font(.system(size: 10, weight: .medium))
-                    if let step = plan.currentStep {
-                        Text(step).font(.system(size: 10)).lineLimit(2)
-                    }
-                    ProgressView(value: Double(plan.completed), total: Double(plan.total))
-                }
-                .foregroundStyle(theme.color("fg-muted"))
-            }
-            if row.contextUsage != nil || canControl {
-                HStack(spacing: 8) {
-                    ACPContextUsageButton(usage: row.contextUsage, modelName: row.model)
-                    Spacer(minLength: 0)
-                    if let sessionID = row.sessionID, row.isLiveACP, canControl {
-                        if row.state == .running || row.state == .awaitingInput || row.state == .permissionRequest {
-                            Button("Interrupt") { actions.onInterrupt(sessionID) }
-                        }
-                        Button("Follow up") { isEditing.toggle() }
-                        if let onDelegate = actions.onDelegate {
-                            Button("Delegate") { onDelegate(sessionID) }
-                        }
-                    }
-                }
-                .controlSize(.small)
-            }
-            if let sessionID = row.sessionID,
-               isEditing || !draft.isEmpty || delivery == .failed {
-                VStack(alignment: .leading, spacing: 5) {
-                    TextField("Follow-up message", text: $draft, axis: .vertical)
-                        .lineLimit(2...5)
-                        .textFieldStyle(.roundedBorder)
-                        .disabled(delivery == .sending)
-                    HStack {
-                        if delivery == .failed {
-                            Text("Could not send. Your message is kept here.")
-                                .font(.system(size: 10))
-                                .foregroundStyle(theme.color("fg-muted"))
-                        }
-                        Spacer(minLength: 0)
-                        Button(delivery == .sending ? "Sending…" : "Send") {
-                            actions.onFollowUp(sessionID, draft)
-                        }
-                        .disabled(!canControl || delivery == .sending || draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                        .controlSize(.small)
-                    }
-                }
-            }
-        }
-        .foregroundStyle(theme.color("fg"))
-        .padding(12)
-        .overlay(alignment: .bottom) { Divider() }
-        .onChange(of: delivery) {
-            if delivery == .sent {
-                isEditing = false
-            }
-        }
-    }
-}
-
-private extension AgentSidebarRow {
-    var sessionID: ACPSession.ID? {
-        guard case .acp(let sessionID) = id else { return nil }
-        return sessionID
-    }
-}
-
-private extension AgentSidebarState {
-    var label: String {
-        switch self {
-        case .running: "Running"
-        case .awaitingInput: "Awaiting input"
-        case .permissionRequest: "Permission requested"
-        case .idle: "Idle"
-        case .detached: "Detached"
-        case .unknown: "Unknown"
         }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### 🎨 Changed
+
+- Polish the Agent tab with provider logos, status colors, compact cards, and clearer controls.
+
 ## [0.16.1] - 2026-09-11
 
 ### ✨ Features


### PR DESCRIPTION
Polishes the worktree Agent tab with provider logos, state-specific color, compact cards, clearer session metadata, plan progress, and an inline follow-up composer.

Also installs Obra Superpowers brainstorming globally through the skills CLI, making it available to Pi alongside Codex and Claude.