### PR TITLE
fix(workspace): title hover boundary

### DIFF
--- a/Alas/Sources/Sidebar/WorkspaceSidebarTree.swift
+++ b/Alas/Sources/Sidebar/WorkspaceSidebarTree.swift
@@ -191,6 +191,7 @@ struct WorkspaceSidebarTree<ProjectRow: View>: View {
             }
         }
         .padding(.horizontal, 6)
+        .contentShape(Rectangle())
         .onHover { hoveringWorkspaceID = $0 ? workspace.id : nil }
         .contextMenu {
             Button("New checkout...", systemImage: "plus") { creatingCheckout = workspace }


### PR DESCRIPTION
Keeps the workspace title row's hover region stable while the checkout count swaps to the plus button.\n\nVerification:\n- xcodegen\n- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -quiet build\n- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -quiet test -only-testing:AlasTests/WorkspacePresentationTests\n\nThe full test suite was also run. It has existing failures outside this change, including ACP session restore, remote web assets, and workspace lifecycle/store tests.