### PR TITLE
fix(git): Treat cancelled git refreshes as cancellation

### DIFF
--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -118,8 +118,7 @@ extension Process {
         // SIGTERM the child if the awaiting Task is cancelled. The
         // terminationHandler will fire from the kernel-delivered exit and
         // resolve the ExitGate, so `exit.wait()` returns normally and we
-        // fall through to read accumulated output / report a non-zero exit
-        // code — same recovery path as the watchdog uses on timeout.
+        // can drain accumulated output before rethrowing cancellation.
         await withTaskCancellationHandler {
             await exit.wait()
         } onCancel: {
@@ -145,6 +144,7 @@ extension Process {
         if timedOut {
             throw ProcessError.timedOut(executable: executable, args: args, seconds: timeout)
         }
+        try Task.checkCancellation()
 
         return ProcessResult(
             exitCode: process.terminationStatus,

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
@@ -109,6 +109,13 @@ final class ReviewLoopState {
         }
     }
 
+    func cancelLocalRefresh(_ attempt: ReviewLoopRefreshAttempt) {
+        guard isCurrentRefresh(attempt.generation) else { return }
+
+        refreshGeneration += 1
+        isRefreshing = false
+    }
+
     func finishLocalRefresh(
         _ attempt: ReviewLoopRefreshAttempt,
         preservingRemoteWith local: ReviewLoopLocalState

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1016,6 +1016,9 @@ final class RightPaneState: GGSplitCommitServicing {
                 changesGeneration += 1
             }
             return true
+        } catch is CancellationError {
+            reviewLoop.cancelLocalRefresh(reviewLoopInspection)
+            return false
         } catch {
             reviewLoop.failLocalRefresh(reviewLoopInspection, error: error)
             guard snapshotGeneration == snapshotInvalidationGeneration else {

--- a/AlasTests/Integrations/ReviewLoopStateTests.swift
+++ b/AlasTests/Integrations/ReviewLoopStateTests.swift
@@ -933,6 +933,21 @@ struct ReviewLoopStateTests {
         #expect(state.lastError?.contains("git status failed") == true)
     }
 
+    @Test func localInspectionCancellationClearsRefreshingWithoutError() async throws {
+        let state = ReviewLoopState(
+            worktreePath: URL(fileURLWithPath: "/tmp/alas-review-loop"),
+            baseBranch: "main",
+            providerRegistry: CodeHostProviderRegistry(providers: [:])
+        )
+
+        let attempt = state.beginLocalInspection()
+        state.cancelLocalRefresh(attempt)
+
+        #expect(state.isRefreshing == false)
+        #expect(state.snapshot == nil)
+        #expect(state.lastError == nil)
+    }
+
     @Test func localRefreshFailureClearsInFlightRefreshingFlag() async throws {
         let remote = Self.makeRemote()
         let local = Self.makeLocal(branchName: "feature/slow", needsPush: false)

--- a/AlasTests/ProcessGitTests.swift
+++ b/AlasTests/ProcessGitTests.swift
@@ -174,11 +174,15 @@ struct ProcessGitTests {
         try await Task.sleep(nanoseconds: 100_000_000)   // let it spawn
         task.cancel()
         let start = Date()
-        let result = try await task.value
-        let elapsed = Date().timeIntervalSince(start)
-        #expect(elapsed < 3.0, "expected cancellation to terminate quickly, took \(elapsed)s")
-        // SIGTERM => exit code 15 by convention, or non-zero signal status
-        #expect(result.exitCode != 0)
+        do {
+            _ = try await task.value
+            Issue.record("expected cancellation")
+        } catch is CancellationError {
+            let elapsed = Date().timeIntervalSince(start)
+            #expect(elapsed < 3.0, "expected cancellation to terminate quickly, took \(elapsed)s")
+        } catch {
+            Issue.record("wrong error: \(error)")
+        }
     }
 
     @Test func gitConvenienceCallStillWorks() async throws {


### PR DESCRIPTION
## Summary

Cancelled right-pane refreshes were bubbling up as opaque `Alas.ProcessError error 2` banners after their git child process was SIGTERM'd. This PR makes cancellation stay cancellation: the shared process runner re-checks task cancellation after the child exits, and the right pane ignores cancelled refreshes instead of treating them as user-visible failures.

## Changes

- Re-throw `CancellationError` after a cancelled git process has terminated and drained output.
- Ignore cancelled right-pane refreshes so rapid worktree switching does not show a stale error banner.
- Update the process cancellation regression test to require `CancellationError`.

## Verification

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet -only-testing:AlasTests/ProcessGitTests test`

Full local `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` ran 2,193 tests and exited 65 with 12 issues in unrelated suites. The focused process cancellation suite passed before and after rebasing onto current `main`.