### PR TITLE
feat(sidebar): default reopened right pane to changes

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -7075,7 +7075,7 @@ final class AppState {
         )
     }
 
-    func revealInFiles(worktreeId: String, path: String) {
+    func revealInFiles(worktreeId: String, path: String, opensPane: Bool) {
         guard let worktree = worktree(withId: worktreeId) else { return }
         config.rightPaneVisible = true
         _ = saveConfig()
@@ -7084,7 +7084,7 @@ final class AppState {
             baseBranch: config.worktrees.baseBranch,
             comparisonMode: config.changes.comparisonMode
         )
-        rps.reveal(path: path)
+        rps.reveal(path: path, opensPane: opensPane)
     }
 
     /// Open a markdown relative-link target as a new editor tab in the same worktree.

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -445,7 +445,13 @@ struct CenterPaneView: View {
                                             revealCharacter: s.revealCharacter,
                                             revealRevision: s.revealRevision,
                                             appState: state,
-                                            onRevealInFiles: { path in state.revealInFiles(worktreeId: worktree.id, path: path) },
+                                            onRevealInFiles: { path in
+                                                state.revealInFiles(
+                                                    worktreeId: worktree.id,
+                                                    path: path,
+                                                    opensPane: !effectiveRightPaneVisible
+                                                )
+                                            },
                                             onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) })
                         } else {
                             EditorTabView(worktree: worktree,
@@ -461,7 +467,13 @@ struct CenterPaneView: View {
                                           externalAbsolutePath: s.externalAbsolutePath,
                                           externalEditable: s.isExternalEditable,
                                           originatingRelativePath: s.originatingRelativePath,
-                                          onRevealInFiles: { path in state.revealInFiles(worktreeId: worktree.id, path: path) },
+                                          onRevealInFiles: { path in
+                                              state.revealInFiles(
+                                                  worktreeId: worktree.id,
+                                                  path: path,
+                                                  opensPane: !effectiveRightPaneVisible
+                                              )
+                                          },
                                           onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) })
                         }
                     case .diff(let s):
@@ -573,12 +585,24 @@ struct CenterPaneView: View {
                     case .imagePreview(let s):
                         ImagePreviewTabView(worktreePath: worktree.path,
                                              relativePath: s.relativePath,
-                                             onRevealInFiles: { path in state.revealInFiles(worktreeId: worktree.id, path: path) },
+                                             onRevealInFiles: { path in
+                                                 state.revealInFiles(
+                                                     worktreeId: worktree.id,
+                                                     path: path,
+                                                     opensPane: !effectiveRightPaneVisible
+                                                 )
+                                             },
                                              onStartupRecoveryReady: { completeStartupRecoveryIfActive(s.id) })
                     case .binaryPreview(let s):
                         BinaryPreviewTabView(worktreePath: worktree.path,
                                              relativePath: s.relativePath,
-                                             onRevealInFiles: { path in state.revealInFiles(worktreeId: worktree.id, path: path) })
+                                             onRevealInFiles: { path in
+                                                 state.revealInFiles(
+                                                     worktreeId: worktree.id,
+                                                     path: path,
+                                                     opensPane: !effectiveRightPaneVisible
+                                                 )
+                                             })
                     case .mergeConflict(let s):
                         MergeConflictTabView(
                             state: state,

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -106,6 +106,7 @@ final class RightPaneState: GGSplitCommitServicing {
     var openPaths: Set<String> = []   // expanded directories in the tree
     var revealPath: String? = nil
     private(set) var revealTick: Int = 0
+    private var pendingRevealForPaneMount = false
     private(set) var loadedFileTreeChildPaths: Set<String> = [""]
     private(set) var loadingFileTreeChildPaths: Set<String> = []
     private(set) var failedFileTreeChildPaths: Set<String> = []
@@ -2707,8 +2708,9 @@ final class RightPaneState: GGSplitCommitServicing {
         }
     }
 
-    func reveal(path: String) {
+    func reveal(path: String, opensPane: Bool = false) {
         activeTab = .files
+        pendingRevealForPaneMount = pendingRevealForPaneMount || opensPane
         let pathComponents = path.split(separator: "/").map(String.init)
         for i in 0..<(pathComponents.count - 1) {
             let ancestor = pathComponents[0...i].joined(separator: "/")
@@ -2719,6 +2721,15 @@ final class RightPaneState: GGSplitCommitServicing {
         }
         revealPath = path
         revealTick += 1
+    }
+
+    func consumePendingRevealForPaneMount() -> Bool {
+        defer { pendingRevealForPaneMount = false }
+        return pendingRevealForPaneMount
+    }
+
+    func completeInitialTabSelection() {
+        didInitDefaultTab = true
     }
 
     func clearReveal() {

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -385,6 +385,24 @@ final class RightPaneStore {
         activeId = nil
     }
 
+    /// Selects the initial tab when the right pane is mounted. Center-pane
+    /// tabs can activate this store while the sidebar is hidden, so visibility
+    /// is tracked by the view lifecycle rather than `activeId`.
+    func prepareForVisiblePane(worktreeId: String) {
+        guard let state = states[worktreeId] else { return }
+        state.completeInitialTabSelection()
+        guard !state.consumePendingRevealForPaneMount() else { return }
+        state.activeTab = .changes
+    }
+
+    /// Clears a reveal intent when its worktree replaces an already-visible
+    /// pane. Unlike mounting a pane, switching worktrees must not reset tabs.
+    func consumePendingRevealForVisiblePane(worktreeId: String) {
+        guard let state = states[worktreeId] else { return }
+        state.completeInitialTabSelection()
+        _ = state.consumePendingRevealForPaneMount()
+    }
+
     /// The cached `RightPaneState` for `worktreeId`, if one exists.
     /// Does NOT create a new state — returns nil if the worktree isn't active.
     /// Used by `DraftCommitTabView` to observe staged-set changes.

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -212,6 +212,12 @@ struct RightPaneView: View {
             rps = activated
             await activated.refresh(forceReviewLoopRemote: true)
         }
+        .onAppear {
+            state.rightPaneStore.prepareForVisiblePane(worktreeId: worktree.id)
+        }
+        .onChange(of: worktree.id) { _, worktreeId in
+            state.rightPaneStore.consumePendingRevealForVisiblePane(worktreeId: worktreeId)
+        }
         // When the right pane is hidden or unmounted (no worktree selected),
         // stop the active state's filesystem watcher and 5-min sync timer
         // so they don't keep running with no UI consumer. Re-mounting

--- a/AlasTests/RightPaneStoreBaseBranchTests.swift
+++ b/AlasTests/RightPaneStoreBaseBranchTests.swift
@@ -74,6 +74,96 @@ struct RightPaneStoreBaseBranchTests {
         #expect(store.activeState(worktreeId: worktree.id, baseBranch: "release") == nil)
     }
 
+    @Test func reactivatingRightPaneDefaultsToChangesTab() async throws {
+        let repo = try await makeRepoOnMain()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let worktree = makeWorktree(at: repo, branch: "feature/default-tab")
+        let store = RightPaneStore(git: GitService())
+
+        let state = store.state(for: worktree, baseBranch: "main", comparisonMode: .manual)
+        state.activeTab = .files
+
+        store.deactivate()
+        let backgroundState = store.state(for: worktree, baseBranch: "main", comparisonMode: .manual)
+
+        #expect(backgroundState.activeTab == .files)
+
+        store.prepareForVisiblePane(worktreeId: worktree.id)
+
+        #expect(backgroundState.activeTab == .changes)
+    }
+
+    @Test func switchingWorktreesPreservesSelectedTab() async throws {
+        let firstRepo = try await makeRepoOnMain()
+        defer { try? FileManager.default.removeItem(at: firstRepo) }
+        let secondRepo = try await makeRepoOnMain()
+        defer { try? FileManager.default.removeItem(at: secondRepo) }
+        let first = makeWorktree(at: firstRepo, branch: "feature/first")
+        let second = makeWorktree(at: secondRepo, branch: "feature/second")
+        let store = RightPaneStore(git: GitService())
+
+        let firstState = store.state(for: first, baseBranch: "main", comparisonMode: .manual)
+        firstState.activeTab = .files
+
+        _ = store.state(for: second, baseBranch: "main", comparisonMode: .manual)
+        let reactivated = store.state(for: first, baseBranch: "main", comparisonMode: .manual)
+
+        #expect(reactivated.activeTab == .files)
+    }
+
+    @Test func pendingFileRevealKeepsFilesTabWhenPaneAppears() async throws {
+        let repo = try await makeRepoOnMain()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let worktree = makeWorktree(at: repo, branch: "feature/reveal")
+        let store = RightPaneStore(git: GitService())
+        let state = store.state(for: worktree, baseBranch: "main", comparisonMode: .manual)
+
+        state.reveal(path: "a.txt", opensPane: true)
+        store.prepareForVisiblePane(worktreeId: worktree.id)
+
+        #expect(state.activeTab == .files)
+    }
+
+    @Test func existingFileRevealDoesNotPreventDefaultTabWhenPaneReopens() async throws {
+        let repo = try await makeRepoOnMain()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let worktree = makeWorktree(at: repo, branch: "feature/reveal-default")
+        let store = RightPaneStore(git: GitService())
+        let state = store.state(for: worktree, baseBranch: "main", comparisonMode: .manual)
+
+        state.reveal(path: "a.txt")
+        store.prepareForVisiblePane(worktreeId: worktree.id)
+
+        #expect(state.activeTab == .changes)
+    }
+
+    @Test func visibleWorktreeSwitchConsumesPendingFileReveal() async throws {
+        let repo = try await makeRepoOnMain()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let worktree = makeWorktree(at: repo, branch: "feature/reveal-switch")
+        let store = RightPaneStore(git: GitService())
+        let state = store.state(for: worktree, baseBranch: "main", comparisonMode: .manual)
+
+        state.reveal(path: "a.txt", opensPane: true)
+        store.consumePendingRevealForVisiblePane(worktreeId: worktree.id)
+        store.prepareForVisiblePane(worktreeId: worktree.id)
+
+        #expect(state.activeTab == .changes)
+    }
+
+    @Test func visiblePaneDefaultSurvivesInitialRefresh() async throws {
+        let repo = try await makeRepoOnMain()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let worktree = makeWorktree(at: repo, branch: "feature/refresh-default")
+        let store = RightPaneStore(git: GitService())
+        let state = store.state(for: worktree, baseBranch: "main", comparisonMode: .manual)
+
+        store.prepareForVisiblePane(worktreeId: worktree.id)
+        await state.refresh(forceReviewLoopRemote: true)
+
+        #expect(state.activeTab == .changes)
+    }
+
     @Test func asyncProbeConfirmsSlashNamedOriginRef() async throws {
         let repo = try await makeRepoOnMain(branch: "release/1.0")
         defer { try? FileManager.default.removeItem(at: repo) }


### PR DESCRIPTION
## Summary
- open cached right-pane state on Changes when the sidebar is reactivated
- cover the cached Files-to-Changes transition with a regression test

## Testing
- `git diff --check`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RightPaneStoreBaseBranchTests test` *(blocked locally before compilation because the cached Ghostty XCFramework is rejected by Xcode; rebuilding requires the unavailable Metal toolchain)*