### PR TITLE
style(composer): unify the Send split button and stop it shrinking

### DIFF
--- a/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
@@ -86,6 +86,10 @@ struct ACPComposerActionButton: View {
                     .font(.system(size: 9, weight: .semibold))
                     .foregroundStyle(theme.color("bg-0"))
                     .padding(.horizontal, 7)
+                    // Height stays on the label so the whole painted segment is
+                    // clickable — a frame applied after `Menu` grows the layout
+                    // and background but leaves the hit target at label height.
+                    .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
             }
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
@@ -93,7 +97,6 @@ struct ACPComposerActionButton: View {
             // The fill belongs on the Menu, not on its label: `.borderlessButton`
             // wraps the label in its own chrome, so a label background stops short
             // of the control's edges and leaves a gap next to the primary half.
-            .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
             .background(
                 UnevenRoundedRectangle(
                     cornerRadii: .init(
@@ -202,11 +205,11 @@ struct ACPComposerActionButton: View {
                     .font(.system(size: 9, weight: .semibold))
                     .foregroundStyle(theme.color("fg"))
                     .padding(.horizontal, 7)
+                    .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
             }
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
             .fixedSize()
-            .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
             .background(
                 UnevenRoundedRectangle(
                     cornerRadii: .init(

--- a/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
@@ -32,7 +32,7 @@ struct ACPComposerActionButton: View {
     // MARK: - Send (split capsule, accent-colored)
 
     private var sendCapsule: some View {
-        HStack(spacing: 1) {
+        HStack(spacing: 0) {
             Button(action: onPrimary) {
                 HStack(spacing: 5) {
                     Image(systemName: "arrow.up")
@@ -52,6 +52,14 @@ struct ACPComposerActionButton: View {
                     )
                     .fill(theme.color("accent"))
                 )
+                .overlay(alignment: .trailing) {
+                    // `line` is a neutral hairline meant for neutral fills; on the
+                    // accent half it disappears. Tint the foreground color instead.
+                    segmentDivider(
+                        theme.color("bg-0")
+                            .opacity(ACPComposerActionButtonMetrics.dividerOnAccentOpacity)
+                    )
+                }
                 .overlay(alignment: .topTrailing) { badgeOverlay }
             }
             .buttonStyle(.plain)
@@ -78,20 +86,23 @@ struct ACPComposerActionButton: View {
                     .font(.system(size: 9, weight: .semibold))
                     .foregroundStyle(theme.color("bg-0"))
                     .padding(.horizontal, 7)
-                    .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
-                    .background(
-                        UnevenRoundedRectangle(
-                            cornerRadii: .init(
-                                bottomTrailing: ACPComposerActionButtonMetrics.cornerRadius,
-                                topTrailing: ACPComposerActionButtonMetrics.cornerRadius
-                            )
-                        )
-                        .fill(theme.color("accent"))
-                    )
             }
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
             .fixedSize()
+            // The fill belongs on the Menu, not on its label: `.borderlessButton`
+            // wraps the label in its own chrome, so a label background stops short
+            // of the control's edges and leaves a gap next to the primary half.
+            .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
+            .background(
+                UnevenRoundedRectangle(
+                    cornerRadii: .init(
+                        bottomTrailing: ACPComposerActionButtonMetrics.cornerRadius,
+                        topTrailing: ACPComposerActionButtonMetrics.cornerRadius
+                    )
+                )
+                .fill(theme.color("accent"))
+            )
             .help("Schedule send")
         }
         .popover(isPresented: $showsCustomSchedule) {
@@ -173,12 +184,8 @@ struct ACPComposerActionButton: View {
                     )
                     .fill(theme.color("bg-3"))
                 )
+                .overlay(alignment: .trailing) { segmentDivider(theme.color("line")) }
                 .overlay(alignment: .topTrailing) { badgeOverlay }
-                .overlay(alignment: .trailing) {
-                    Rectangle()
-                        .fill(theme.color("line"))
-                        .frame(width: 1, height: 16)
-                }
             }
             .buttonStyle(.plain)
             .help("Queue (⏎). Hold ⌥ to steer.")
@@ -195,28 +202,42 @@ struct ACPComposerActionButton: View {
                     .font(.system(size: 9, weight: .semibold))
                     .foregroundStyle(theme.color("fg"))
                     .padding(.horizontal, 7)
-                    .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
-                    .background(
-                        UnevenRoundedRectangle(
-                            cornerRadii: .init(
-                                topLeading: 0,
-                                bottomLeading: 0,
-                                bottomTrailing: ACPComposerActionButtonMetrics.cornerRadius,
-                                topTrailing: ACPComposerActionButtonMetrics.cornerRadius
-                            )
-                        )
-                        .fill(theme.color("bg-3"))
-                    )
             }
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
             .fixedSize()
+            .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
+            .background(
+                UnevenRoundedRectangle(
+                    cornerRadii: .init(
+                        topLeading: 0,
+                        bottomLeading: 0,
+                        bottomTrailing: ACPComposerActionButtonMetrics.cornerRadius,
+                        topTrailing: ACPComposerActionButtonMetrics.cornerRadius
+                    )
+                )
+                .fill(theme.color("bg-3"))
+            )
             .help("More actions")
         }
         .overlay(
             RoundedRectangle(cornerRadius: ACPComposerActionButtonMetrics.cornerRadius)
                 .strokeBorder(theme.color("line"), lineWidth: 1)
         )
+    }
+
+    // MARK: - Segment divider (hairline between the primary half and the chevron)
+
+    /// Inset hairline drawn on the trailing edge of the primary half. Both
+    /// halves share one background, so this divider is the only thing marking
+    /// the split.
+    private func segmentDivider(_ color: Color) -> some View {
+        Rectangle()
+            .fill(color)
+            .frame(
+                width: ACPComposerActionButtonMetrics.dividerWidth,
+                height: ACPComposerActionButtonMetrics.dividerHeight
+            )
     }
 
     @ViewBuilder
@@ -265,6 +286,9 @@ enum ACPComposerActionButtonMetrics {
     static let badgeMinWidth: CGFloat = 16
     static let badgeMinHeight: CGFloat = 14
     static let badgeOffset = CGSize(width: 6, height: -6)
+    static let dividerWidth: CGFloat = 1
+    static let dividerHeight: CGFloat = 16
+    static let dividerOnAccentOpacity: Double = 0.35
 
     static var badgeTopOutset: CGFloat {
         max(0, -badgeOffset.height)

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -372,6 +372,13 @@ struct ACPComposer: View {
                     onSchedule: { actions.submitWithIntent?(.schedule($0)) },
                     queueBadgeCount: session.visibleQueueCount
                 )
+                // Send/Queue/Stop is the row's primary action, so it must never
+                // be the thing that ellipsizes when the composer is narrow.
+                // `fixedSize` stops it compressing below its ideal width;
+                // `layoutPriority` makes the stack hand it space before the
+                // chips, which truncate instead.
+                .fixedSize(horizontal: true, vertical: false)
+                .layoutPriority(1)
             }
             .padding(.horizontal, 2)
         }

--- a/AlasTests/ACP/UI/ACPComposerActionButtonMetricsTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerActionButtonMetricsTests.swift
@@ -11,6 +11,14 @@ struct ACPComposerActionButtonMetricsTests {
                 >= ACPComposerActionButtonMetrics.capsuleHeight)
     }
 
+    @Test("segment divider is an inset hairline inside the capsule")
+    func segmentDividerIsInsetHairline() {
+        #expect(ACPComposerActionButtonMetrics.dividerWidth == 1)
+        #expect(ACPComposerActionButtonMetrics.dividerHeight < ACPComposerActionButtonMetrics.capsuleHeight)
+        #expect(ACPComposerActionButtonMetrics.dividerOnAccentOpacity > 0)
+        #expect(ACPComposerActionButtonMetrics.dividerOnAccentOpacity < 1)
+    }
+
     @Test("badge remains compact relative to the composer action capsule")
     func badgeStaysCompactRelativeToActionCapsule() {
         #expect(ACPComposerActionButtonMetrics.badgeMinHeight < ACPComposerActionButtonMetrics.capsuleHeight)


### PR DESCRIPTION
## What

Finishes the segmented-button work started in 6e41b61, which only reached `queueSplitCapsule` — the Send button, the one that actually mattered, was untouched.

Target look is Slack's segmented send control: one continuous fill across both halves, split by a thin vertical divider before the chevron.

### Changes

- **`sendCapsule`**: `spacing: 1` → `0`, plus the inset hairline divider on the trailing edge of the primary half. It can't reuse `theme.color("line")` the way Queue does — that's a neutral hairline meant for neutral fills and it disappears against `accent` — so Send tints its own foreground (`bg-0`) instead.
- **Chevron fill moved from the Menu's label to the Menu itself.** With `.menuStyle(.borderlessButton)` the label is wrapped in the control's own chrome, so a background on the label stops short of the edges and leaves a visible gap next to the primary half. This is why the chevron rendered detached on the dark composer background rather than on the accent fill.
- **Shared `segmentDivider` helper + divider metrics** in `ACPComposerActionButtonMetrics`. The two capsules diverged in the first place because the divider was an inline literal in only one of them.
- **Action button no longer shrinks.** `fixedSize(horizontal:)` + `layoutPriority(1)` in the composer toolbar: Send/Queue/Stop is the row's primary action and shouldn't be what ellipsizes when the composer is narrow. The parameter chips truncate instead.

## Testing

- `xcodebuild build` — clean.
- `ACPComposerActionButtonMetricsTests` — 3/3 pass, including a new assertion that the divider stays a sub-capsule-height hairline at partial opacity.

The visual result has not been verified on-device yet; these are layout changes whose failure mode is precisely "reads fine, renders wrong", so the rendering deserves an eyeball.

Note: `AlasTests/RemoteWebAssetTests.swift:565` fails on this branch independently of these changes (force-unwrap of a missing `/changes-view.js?v=6` range returns nil and crashes the test host). No remote/web files are touched here.