### PR TITLE
feat(sidebar): show delegated sessions as a tree in the agent tab

### DIFF
--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationPersistence.swift
@@ -41,6 +41,10 @@ actor ACPOrchestrationPersistence {
         try openedStore().parent(childSessionId: childSessionId)
     }
 
+    func delegationParents() throws -> [String: String] {
+        try openedStore().delegationParents()
+    }
+
     func updatePhase(
         childSessionId: String,
         phase: ACPDelegationPhase,

--- a/Alas/Sources/ACP/Orchestration/ACPOrchestrationStore.swift
+++ b/Alas/Sources/ACP/Orchestration/ACPOrchestrationStore.swift
@@ -158,6 +158,19 @@ final class ACPOrchestrationStore {
         """).compactMap { $0["target_session_id"] as? String }
     }
 
+    /// Child-to-parent links for every delegation ever recorded. The sidebar
+    /// needs the whole map up front, and the two id columns are far cheaper to
+    /// read than decoding full records.
+    func delegationParents() throws -> [String: String] {
+        try db.query("SELECT child_session_id, parent_session_id FROM delegations")
+            .reduce(into: [String: String]()) { links, row in
+                guard let child = row["child_session_id"] as? String,
+                      let parent = row["parent_session_id"] as? String
+                else { return }
+                links[child] = parent
+            }
+    }
+
     func incompleteDelegations() throws -> [ACPDelegationRecord] {
         try db.query(
             "SELECT * FROM delegations WHERE phase IN (?, ?)",

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1127,6 +1127,7 @@ final class AppState {
         sweepOrphanZmxSessions(worktreeIds: allWorktreeIds)
         reconcileAttention(observations: currentAttentionObservations)
         Task { [weak self] in
+            await self?.loadDelegatedSessionParents()
             await self?.reconcileInterruptedDelegations()
         }
         Task { @MainActor [weak self] in
@@ -8969,8 +8970,19 @@ final class AppState {
     @ObservationIgnored
     private let acpOrchestrationPersistence = ACPOrchestrationPersistence()
 
-    @ObservationIgnored
-    private var delegatedSessionParents: [String: String] = [:]
+    /// Observed, not `@ObservationIgnored`: the agent sidebar reads this to
+    /// draw delegated children under their parent, so a newly recorded link
+    /// has to invalidate the view.
+    private(set) var delegatedSessionParents: [String: String] = [:]
+
+    /// Backfills the links completed in earlier runs. Without this the map only
+    /// ever holds delegations this launch created or recovered, and restored
+    /// history loses its hierarchy.
+    private func loadDelegatedSessionParents() async {
+        guard let links = try? await acpOrchestrationPersistence.delegationParents() else { return }
+        // Live entries win: they may describe a delegation still being written.
+        delegatedSessionParents = links.merging(delegatedSessionParents) { _, live in live }
+    }
 
     /// Force-flush every per-session debounced composer-draft write across
     /// all live managers. Called from app-will-terminate so an in-flight
@@ -9055,7 +9067,8 @@ final class AppState {
             },
             terminalTabs: terminalTabs,
             harnessActivity: harness.activityBySession,
-            remoteHost: projectAndWorktree(withWorktreeId: worktree.id)?.project.host
+            remoteHost: projectAndWorktree(withWorktreeId: worktree.id)?.project.host,
+            delegatedParents: delegatedSessionParents
         ))
     }
 

--- a/Alas/Sources/Right/AgentSidebarRollup.swift
+++ b/Alas/Sources/Right/AgentSidebarRollup.swift
@@ -15,6 +15,24 @@ struct AgentSidebarPlanProgress: Equatable {
     let currentStep: String?
 }
 
+/// A delegated family is at most two levels deep: `ACPSessionOrchestrationPolicy`
+/// refuses `authorizeCreate` for a session that already has a parent, so a child
+/// can never delegate further and the sidebar never indents more than once.
+enum AgentSidebarDelegation: Equatable {
+    /// Carries how many of this session's children are present in the rollup,
+    /// which may be fewer than it ever spawned once archived rows drop out.
+    case parent(childCount: Int)
+    /// `isNested` is false when the parent is missing from this worktree's
+    /// rollup or sits in the other section, in which case the child renders at
+    /// top level with a caption instead of under a connector.
+    case child(parentID: ACPSession.ID, parentTitle: String?, isNested: Bool)
+
+    var isNestedChild: Bool {
+        guard case .child(_, _, let isNested) = self else { return false }
+        return isNested
+    }
+}
+
 struct AgentSidebarRow: Identifiable, Equatable {
     enum ID: Hashable {
         case acp(ACPSession.ID)
@@ -31,6 +49,7 @@ struct AgentSidebarRow: Identifiable, Equatable {
     let host: String?
     let createdAt: Date
     let isLiveACP: Bool
+    var delegation: AgentSidebarDelegation?
 
     static func acp(
         id: ACPSession.ID,
@@ -42,7 +61,8 @@ struct AgentSidebarRow: Identifiable, Equatable {
         plan: AgentSidebarPlanProgress? = nil,
         host: String? = nil,
         createdAt: Date,
-        isLive: Bool
+        isLive: Bool,
+        delegation: AgentSidebarDelegation? = nil
     ) -> Self {
         Self(
             id: .acp(id),
@@ -54,7 +74,8 @@ struct AgentSidebarRow: Identifiable, Equatable {
             plan: plan,
             host: host,
             createdAt: createdAt,
-            isLiveACP: isLive
+            isLiveACP: isLive,
+            delegation: delegation
         )
     }
 
@@ -76,7 +97,8 @@ struct AgentSidebarRow: Identifiable, Equatable {
             plan: nil,
             host: host,
             createdAt: .distantPast,
-            isLiveACP: false
+            isLiveACP: false,
+            delegation: nil
         )
     }
 }
@@ -104,6 +126,9 @@ struct AgentSidebarRollupBuilder {
         let terminalTabs: [TerminalTabState]
         let harnessActivity: [String: HarnessService.HarnessActivityState]
         let remoteHost: String?
+        /// Child session id to parent session id, spanning every delegation the
+        /// app knows about. Ids outside this rollup are ignored.
+        var delegatedParents: [String: String] = [:]
     }
 
     static func build(_ input: Input) -> AgentSidebarRollup {
@@ -118,7 +143,82 @@ struct AgentSidebarRollupBuilder {
             terminalRows(for: $0, activity: input.harnessActivity, remoteHost: input.remoteHost)
         }
 
-        return AgentSidebarRollup(rows: liveRows + persistedRows + terminalRowsList)
+        let acpRows = nestDelegations(in: liveRows + persistedRows, parents: input.delegatedParents)
+        return AgentSidebarRollup(rows: acpRows + terminalRowsList)
+    }
+
+    /// Annotates ACP rows with their delegation relationship and moves nested
+    /// children directly behind their parent, leaving every other row in place.
+    private static func nestDelegations(
+        in rows: [AgentSidebarRow],
+        parents: [String: String]
+    ) -> [AgentSidebarRow] {
+        guard !parents.isEmpty else { return rows }
+
+        var isActive: [ACPSession.ID: Bool] = [:]
+        var titles: [ACPSession.ID: String] = [:]
+        for row in rows {
+            guard let id = row.sessionID else { continue }
+            isActive[id] = row.state != .detached
+            titles[id] = row.title
+        }
+        // Only links whose parent is also on screen can be drawn as a tree.
+        let presentParents = rows.reduce(into: [ACPSession.ID: ACPSession.ID]()) { links, row in
+            guard let id = row.sessionID,
+                  let parentID = parents[id],
+                  parentID != id,
+                  isActive[parentID] != nil
+            else { return }
+            links[id] = parentID
+        }
+
+        var annotations: [ACPSession.ID: AgentSidebarDelegation] = [:]
+        var nestedChildren: [ACPSession.ID: [ACPSession.ID]] = [:]
+        var childCounts: [ACPSession.ID: Int] = [:]
+
+        for row in rows {
+            guard let id = row.sessionID, let parentID = parents[id] else { continue }
+            guard presentParents[id] != nil else {
+                annotations[id] = .child(parentID: parentID, parentTitle: nil, isNested: false)
+                continue
+            }
+            childCounts[parentID, default: 0] += 1
+            // A parent that is itself a child would imply a third level, which
+            // the orchestration policy forbids; refusing to nest there also
+            // keeps a corrupt parent cycle from dropping rows below.
+            let nested = presentParents[parentID] == nil && isActive[parentID] == isActive[id]
+            annotations[id] = .child(parentID: parentID, parentTitle: titles[parentID], isNested: nested)
+            if nested { nestedChildren[parentID, default: []].append(id) }
+        }
+        for (parentID, count) in childCounts where annotations[parentID] == nil {
+            annotations[parentID] = .parent(childCount: count)
+        }
+
+        let rowsByID = rows.reduce(into: [ACPSession.ID: AgentSidebarRow]()) { result, row in
+            if let id = row.sessionID { result[id] = row }
+        }
+        func annotated(_ row: AgentSidebarRow) -> AgentSidebarRow {
+            var copy = row
+            copy.delegation = row.sessionID.flatMap { annotations[$0] }
+            return copy
+        }
+
+        var ordered: [AgentSidebarRow] = []
+        ordered.reserveCapacity(rows.count)
+        for row in rows {
+            guard let id = row.sessionID else {
+                ordered.append(row)
+                continue
+            }
+            // Nested children are emitted by their parent's iteration instead.
+            if annotations[id]?.isNestedChild == true { continue }
+            ordered.append(annotated(row))
+            for childID in nestedChildren[id] ?? [] {
+                guard let childRow = rowsByID[childID] else { continue }
+                ordered.append(annotated(childRow))
+            }
+        }
+        return ordered
     }
 
     private static func liveRow(for session: ACPSession, remoteHost: String?) -> AgentSidebarRow {

--- a/Alas/Sources/Right/AgentTabPresentation.swift
+++ b/Alas/Sources/Right/AgentTabPresentation.swift
@@ -65,6 +65,40 @@ struct AgentSidebarSectionHeader: View {
     }
 }
 
+/// The elbow drawn in the gutter of a nested child card. It deliberately
+/// overshoots the card by the stack spacing at both ends so the rail reads as
+/// one continuous line across the gaps between sibling cards.
+struct AgentSidebarDelegationConnector: View {
+    static let gutter: CGFloat = 18
+    private static let stackSpacing: CGFloat = 8
+    private static let elbowY: CGFloat = 20
+    private static let railX: CGFloat = 7
+
+    let continuesBelow: Bool
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        GeometryReader { proxy in
+            Path { path in
+                path.move(to: CGPoint(x: Self.railX, y: -Self.stackSpacing))
+                path.addLine(to: CGPoint(
+                    x: Self.railX,
+                    y: continuesBelow ? proxy.size.height + Self.stackSpacing : Self.elbowY
+                ))
+                path.move(to: CGPoint(x: Self.railX, y: Self.elbowY))
+                path.addLine(to: CGPoint(x: Self.gutter - 3, y: Self.elbowY))
+            }
+            .stroke(
+                theme.color("line"),
+                style: StrokeStyle(lineWidth: 1, lineCap: .round, lineJoin: .round)
+            )
+        }
+        .frame(width: Self.gutter)
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+}
+
 struct AgentSidebarRowView: View {
     let row: AgentSidebarRow
     let agent: AgentDefinition?
@@ -87,6 +121,7 @@ struct AgentSidebarRowView: View {
                             .foregroundStyle(theme.color("fg"))
                             .lineLimit(2)
                         metadata
+                        delegationNote
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     statusPill
@@ -171,6 +206,46 @@ struct AgentSidebarRowView: View {
         .font(.system(size: 10))
         .foregroundStyle(theme.color("fg-muted"))
         .lineLimit(1)
+    }
+
+    /// A nested child needs no caption — its connector already says who owns
+    /// it — so only parents and orphaned children annotate themselves.
+    @ViewBuilder
+    private var delegationNote: some View {
+        switch row.delegation {
+        case .parent(let childCount):
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.triangle.branch")
+                    .font(.system(size: 8, weight: .semibold))
+                    .accessibilityHidden(true)
+                Text(childCount == 1 ? "1 delegated" : "\(childCount) delegated")
+                    .font(.system(size: 9.5, weight: .semibold))
+                    .monospacedDigit()
+            }
+            .foregroundStyle(theme.color("fg-muted"))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(theme.color("seg-pill-bg"), in: Capsule())
+            .padding(.top, 1)
+        case .child(_, let parentTitle, false):
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.turn.down.right")
+                    .font(.system(size: 8, weight: .semibold))
+                    .accessibilityHidden(true)
+                Text(delegatedByLabel(parentTitle))
+                    .font(.system(size: 9.5))
+                    .lineLimit(1)
+            }
+            .foregroundStyle(theme.color("fg-faint"))
+            .padding(.top, 1)
+        case .child, .none:
+            EmptyView()
+        }
+    }
+
+    private func delegatedByLabel(_ parentTitle: String?) -> String {
+        guard let parentTitle else { return "Delegated by another session" }
+        return "Delegated by \(parentTitle)"
     }
 
     private var statusPill: some View {
@@ -312,6 +387,14 @@ struct AgentSidebarRowView: View {
         }
         if let host = row.host {
             values.append("host \(host)")
+        }
+        switch row.delegation {
+        case .parent(let childCount):
+            values.append(childCount == 1 ? "1 delegated session" : "\(childCount) delegated sessions")
+        case .child(_, let parentTitle, _):
+            values.append(delegatedByLabel(parentTitle))
+        case .none:
+            break
         }
         return values.joined(separator: ", ")
     }

--- a/Alas/Sources/Right/AgentTabView.swift
+++ b/Alas/Sources/Right/AgentTabView.swift
@@ -99,7 +99,8 @@ struct AgentTabView: View {
     private func section(title: String, rows: [AgentSidebarRow]) -> some View {
         if !rows.isEmpty {
             AgentSidebarSectionHeader(title: title, count: rows.count)
-            ForEach(rows) { row in
+            ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                let isNested = row.delegation?.isNestedChild == true
                 AgentSidebarRowView(
                     row: row,
                     agent: agentLookup(row.agentID),
@@ -115,7 +116,23 @@ struct AgentTabView: View {
                         }
                     )
                 )
+                .padding(.leading, isNested ? AgentSidebarDelegationConnector.gutter : 0)
+                .background(alignment: .topLeading) {
+                    if isNested {
+                        AgentSidebarDelegationConnector(
+                            continuesBelow: hasSiblingBelow(rows, after: index)
+                        )
+                    }
+                }
             }
         }
+    }
+
+    /// The builder emits a parent's nested children consecutively, so the rail
+    /// only has to continue when the very next row is nested too.
+    private func hasSiblingBelow(_ rows: [AgentSidebarRow], after index: Int) -> Bool {
+        let next = index + 1
+        guard next < rows.count else { return false }
+        return rows[next].delegation?.isNestedChild == true
     }
 }

--- a/AlasTests/ACP/Orchestration/ACPOrchestrationStoreTests.swift
+++ b/AlasTests/ACP/Orchestration/ACPOrchestrationStoreTests.swift
@@ -107,6 +107,33 @@ struct ACPOrchestrationStoreTests {
         #expect(record.updatedAt == 130)
     }
 
+    @Test("reports every child-to-parent link regardless of phase")
+    func returnsAllDelegationParents() throws {
+        let store = try ACPOrchestrationStore(path: temporaryPath())
+        try store.insert(newRecord(childSessionId: "child-a", parentSessionId: "parent-1"))
+        try store.insert(newRecord(childSessionId: "child-b", parentSessionId: "parent-1"))
+        try store.insert(newRecord(childSessionId: "child-c", parentSessionId: "parent-2"))
+        try store.updatePhase(
+            childSessionId: "child-c",
+            phase: .closed,
+            failureMessage: nil,
+            updatedAt: 140
+        )
+
+        #expect(try store.delegationParents() == [
+            "child-a": "parent-1",
+            "child-b": "parent-1",
+            "child-c": "parent-2",
+        ])
+    }
+
+    @Test("returns no delegation parents for an empty store")
+    func returnsNoDelegationParentsWhenEmpty() throws {
+        let store = try ACPOrchestrationStore(path: temporaryPath())
+
+        #expect(try store.delegationParents().isEmpty)
+    }
+
     @Test("rejects a duplicate child session id")
     func rejectsDuplicateChild() throws {
         let store = try ACPOrchestrationStore(path: temporaryPath())

--- a/AlasTests/AgentSidebarRollupTests.swift
+++ b/AlasTests/AgentSidebarRollupTests.swift
@@ -114,6 +114,98 @@ struct AgentSidebarRollupTests {
         #expect(rollup.rows.map(\.agentID) == ["codex", "claude"])
     }
 
+    @Test @MainActor
+    func delegatedChildrenNestUnderTheirParentWithinTheSameSection() {
+        let parent = makeLiveSession(id: "parent", worktreeID: "worktree-a")
+        let first = makeLiveSession(id: "child-1", worktreeID: "worktree-a")
+        let second = makeLiveSession(id: "child-2", worktreeID: "worktree-a")
+
+        let rollup = AgentSidebarRollupBuilder.build(.init(
+            worktreeID: "worktree-a", persistedACP: [], liveACP: [first, parent, second],
+            terminalTabs: [], harnessActivity: [:], remoteHost: nil,
+            delegatedParents: ["child-1": "parent", "child-2": "parent"]
+        ))
+
+        #expect(rollup.rows.map(\.id) == [.acp("parent"), .acp("child-1"), .acp("child-2")])
+        #expect(rollup.rows[0].delegation == .parent(childCount: 2))
+        #expect(rollup.rows[1].delegation == .child(parentID: "parent", parentTitle: "Session parent", isNested: true))
+        #expect(rollup.rows[2].delegation == .child(parentID: "parent", parentTitle: "Session parent", isNested: true))
+    }
+
+    @Test @MainActor
+    func childKeepsTopLevelPlacementWhenItsParentSitsInTheOtherSection() {
+        let child = makeLiveSession(id: "child-1", worktreeID: "worktree-a")
+
+        let rollup = AgentSidebarRollupBuilder.build(.init(
+            worktreeID: "worktree-a", persistedACP: [makeRow(id: "parent")], liveACP: [child],
+            terminalTabs: [], harnessActivity: [:], remoteHost: nil,
+            delegatedParents: ["child-1": "parent"]
+        ))
+
+        #expect(rollup.active.map(\.id) == [.acp("child-1")])
+        #expect(rollup.history.map(\.id) == [.acp("parent")])
+        #expect(rollup.active[0].delegation == .child(parentID: "parent", parentTitle: "Session parent", isNested: false))
+        #expect(rollup.history[0].delegation == .parent(childCount: 1))
+    }
+
+    @Test @MainActor
+    func childWhoseParentIsNotInThisWorktreeFallsBackToAnUntitledCaption() {
+        let child = makeLiveSession(id: "child-1", worktreeID: "worktree-a")
+
+        let rollup = AgentSidebarRollupBuilder.build(.init(
+            worktreeID: "worktree-a", persistedACP: [], liveACP: [child],
+            terminalTabs: [], harnessActivity: [:], remoteHost: nil,
+            delegatedParents: ["child-1": "parent-elsewhere"]
+        ))
+
+        #expect(rollup.rows.map(\.id) == [.acp("child-1")])
+        #expect(rollup.rows[0].delegation == .child(parentID: "parent-elsewhere", parentTitle: nil, isNested: false))
+    }
+
+    @Test @MainActor
+    func liveChildReplacingItsPersistedRowNestsExactlyOnce() {
+        let parent = makeLiveSession(id: "parent", worktreeID: "worktree-a")
+        let child = makeLiveSession(id: "child-1", worktreeID: "worktree-a")
+
+        let rollup = AgentSidebarRollupBuilder.build(.init(
+            worktreeID: "worktree-a",
+            persistedACP: [makeRow(id: "parent"), makeRow(id: "child-1")],
+            liveACP: [parent, child],
+            terminalTabs: [], harnessActivity: [:], remoteHost: nil,
+            delegatedParents: ["child-1": "parent"]
+        ))
+
+        #expect(rollup.rows.map(\.id) == [.acp("parent"), .acp("child-1")])
+        #expect(rollup.rows[0].delegation == .parent(childCount: 1))
+    }
+
+    @Test @MainActor
+    func mutuallyReferentialDelegationsStayFlatAndKeepEveryRow() {
+        let first = makeLiveSession(id: "a", worktreeID: "worktree-a")
+        let second = makeLiveSession(id: "b", worktreeID: "worktree-a")
+
+        let rollup = AgentSidebarRollupBuilder.build(.init(
+            worktreeID: "worktree-a", persistedACP: [], liveACP: [first, second],
+            terminalTabs: [], harnessActivity: [:], remoteHost: nil,
+            delegatedParents: ["a": "b", "b": "a"]
+        ))
+
+        #expect(rollup.rows.map(\.id) == [.acp("a"), .acp("b")])
+        #expect(rollup.rows.allSatisfy { $0.delegation?.isNestedChild == false })
+    }
+
+    @Test @MainActor
+    func terminalRowsAreNeverAnnotatedWithDelegation() {
+        let rollup = AgentSidebarRollupBuilder.build(.init(
+            worktreeID: "worktree-a", persistedACP: [], liveACP: [],
+            terminalTabs: [makeTerminal(id: "terminal-a", sessionID: "shell-a")],
+            harnessActivity: [:], remoteHost: nil,
+            delegatedParents: ["shell-a": "parent"]
+        ))
+
+        #expect(rollup.rows.map(\.delegation) == [nil])
+    }
+
     @MainActor
     private func makeLiveSession(id: String, worktreeID: String) -> ACPSession {
         ACPSession(id: id, agentId: "codex", worktreeId: worktreeID, title: "Session \(id)")


### PR DESCRIPTION
## Summary
- Delegated child sessions (via `alas session new`) rendered as flat, indistinguishable cards in the agent sidebar, which looked like session duplication when several delegations landed close together with fast-changing auto-generated titles.
- Nests a delegated child directly under its parent when both land in the same sidebar section, with a connector rail; a parent card shows a "N delegated" count pill.
- When a family straddles Active/History (parent idle, child still running, or vice versa), the child stays at top level with a "Delegated by <parent>" caption instead of being hidden or misplaced.
- Warms `delegatedSessionParents` from the orchestration store at app startup, so hierarchy survives a restart instead of only covering delegations recorded in the current session.

### Reviewer notes
- `AgentSidebarRollupBuilder.nestDelegations` assumes delegation is at most two levels deep — `ACPSessionOrchestrationPolicy.authorizeCreate` already refuses to let a session with a parent create a child, so this is enforced elsewhere, not re-validated here. A defensive check still guards against a corrupt parent cycle by falling back to a flat caption rather than dropping rows.
- New `ACPOrchestrationStore.delegationParents()` / `ACPOrchestrationPersistence.delegationParents()` return every child→parent link regardless of phase, used only for this startup warm-up.
- Terminal rows are explicitly excluded from delegation annotation (delegation only applies to ACP sessions).

### Testing
- `AgentSidebarRollupTests`: nesting within a section, cross-section fallback caption, orphaned-parent fallback, live row replacing a persisted row nests exactly once, mutual-reference cycle stays flat, terminal rows never annotated.
- `ACPOrchestrationStoreTests`: `delegationParents()` returns links across all phases and is empty for a fresh store.