### PR TITLE
fix(preview): resolve hosts with numeric address lookup

### DIFF
--- a/Alas/Sources/WebPreview/WebPreviewBrowser.swift
+++ b/Alas/Sources/WebPreview/WebPreviewBrowser.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Darwin
 import SwiftUI
 import WebKit
 
@@ -41,7 +42,7 @@ enum WebPreviewHostLookup {
         await withCheckedContinuation { continuation in
             let result = Resolution(continuation: continuation)
             let operation = BlockOperation {
-                let addresses = Host(name: host).addresses
+                let addresses = lookupAddresses(host)
                 Task { @MainActor in result.finish(addresses) }
             }
             queue.addOperation(operation)
@@ -51,6 +52,28 @@ enum WebPreviewHostLookup {
                 result.finish(nil)
             }
         }
+    }
+
+    private static func lookupAddresses(_ host: String) -> [String]? {
+        var hints = addrinfo()
+        hints.ai_family = AF_UNSPEC
+        hints.ai_socktype = SOCK_STREAM
+        var result: UnsafeMutablePointer<addrinfo>?
+        guard getaddrinfo(host, nil, &hints, &result) == 0, let result else { return nil }
+        defer { freeaddrinfo(result) }
+
+        var addresses = Set<String>()
+        var entry: UnsafeMutablePointer<addrinfo>? = result
+        while let current = entry {
+            let info = current.pointee
+            var buffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+            guard let address = info.ai_addr,
+                  getnameinfo(address, info.ai_addrlen, &buffer, socklen_t(buffer.count), nil, 0, NI_NUMERICHOST) == 0
+            else { return nil }
+            addresses.insert(String(cString: buffer))
+            entry = info.ai_next
+        }
+        return Array(addresses)
     }
 
     @MainActor

--- a/AlasTests/WebPreviewBrowserTests.swift
+++ b/AlasTests/WebPreviewBrowserTests.swift
@@ -53,6 +53,13 @@ struct WebPreviewBrowserTests {
         #expect(addresses.contains { RunEndpointPolicy.isLoopbackHost($0) })
     }
 
+    @Test(arguments: ["127.0.0.1", "::1"])
+    func nativeHostLookupRecognizesLoopbackAddresses(address: String) async throws {
+        let addresses = try #require(await WebPreviewHostLookup.resolve(address))
+        #expect(!addresses.isEmpty)
+        #expect(addresses.allSatisfy { RunEndpointPolicy.isLoopbackHost($0) })
+    }
+
     @Test func webKitInvokesNavigationGateForPageInitiatedRequests() async throws {
         let browser = WebPreviewBrowser(ownerKey: "navigation", remoteHost: nil)
         defer { browser.close() }


### PR DESCRIPTION
## Summary

Follow-up to #1193. Its final CI run completed after merge and failed because Foundation `Host` did not resolve `localhost` within the five-second deadline.

- Resolve addresses directly with `getaddrinfo` and extract only numeric addresses with `getnameinfo` and `NI_NUMERICHOST`.
- Preserve the existing five-second deadline, bounded worker queue, and fail-closed remote navigation policy.
- Keep the localhost regression and add numeric IPv4 and IPv6 loopback cases.

## Verification

- Local macOS build and focused tests passed: 125 tests, 127 executions, zero failures.
- Includes browser snapshots, navigation/DNS policy, feedback delivery, tab ownership/restoration, Run records, endpoint policy, and Workspace Checkout integration.
- Repository-wide SwiftFormat lint and whitespace checks passed.
- Full-suite limitations from #1193 remain; this change was verified with the focused suites above. CI will validate the rebased branch.

MCP and CLI automation remains separate in #1192.
