### PR TITLE
fix(composer): fix chevron color, height and hit target on the send/queue split buttons

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -584,6 +584,7 @@
 		52A5CDD852333A0C4BDC6995 /* ACPPermissionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E03BF5DB4E6BFF8C2FA6A2 /* ACPPermissionRequest.swift */; };
 		52AB869F9071103FD1649552 /* RemoteHostStatusStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416C797DBD3F9F4901817769 /* RemoteHostStatusStore.swift */; };
 		52D1F226CE8DB1967977D3F3 /* ACPQuestionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9D4FBF08CBAB59C08BBF1D /* ACPQuestionRequest.swift */; };
+		52E1F744D076C631138EE8C1 /* ACPComposerActionButtonChevronTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7BF3B9C7985A07F3E79E76 /* ACPComposerActionButtonChevronTests.swift */; };
 		52E3CDEB14242DB611348EEA /* WorktreeSortMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97DEBCFA106423E38276E9C2 /* WorktreeSortMenu.swift */; };
 		534E1DFA40F7F467F82D900E /* AppKitDiffReviewPresentationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4EE1C8C8564C2920CC8DAF /* AppKitDiffReviewPresentationState.swift */; };
 		53616344796772ACC89097E3 /* WorkspaceSpacePersistenceBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC5721A309B06845548B46B /* WorkspaceSpacePersistenceBridge.swift */; };
@@ -3421,6 +3422,7 @@
 		FF68BCA1222E7C06DA4AC595 /* BaseResolutionMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResolutionMapping.swift; sourceTree = "<group>"; };
 		FF71AF50DF50AA4158A96177 /* DiffContextExpansion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffContextExpansion.swift; sourceTree = "<group>"; };
 		FF741B889D6DC8B1F4EB350F /* ProcessGitDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessGitDataTests.swift; sourceTree = "<group>"; };
+		FF7BF3B9C7985A07F3E79E76 /* ACPComposerActionButtonChevronTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerActionButtonChevronTests.swift; sourceTree = "<group>"; };
 		FFAFB40F5FACBC726C7E4172 /* ACPAdapterInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterInstaller.swift; sourceTree = "<group>"; };
 		FFB1CCDE2E4D85A46E6CFB1A /* GitServiceReviewRequestDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceReviewRequestDraftTests.swift; sourceTree = "<group>"; };
 		FFE911B77AC087704180BDB5 /* ImageDiffModeApplicabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffModeApplicabilityTests.swift; sourceTree = "<group>"; };
@@ -4602,6 +4604,7 @@
 				90762AFB51B237B783D4190C /* ACPChatLayoutTests.swift */,
 				3659703F6EB9AD2454C2898B /* ACPChatTypographyTests.swift */,
 				81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */,
+				FF7BF3B9C7985A07F3E79E76 /* ACPComposerActionButtonChevronTests.swift */,
 				2B7ADCB7C4178FE036A31214 /* ACPComposerActionButtonMetricsTests.swift */,
 				DE2ABBFA4FB2E5FC2D38C5D3 /* ACPComposerCodeBlockStylingTests.swift */,
 				42F1A28F4C52A2FC6B0B4186 /* ACPComposerCodeFenceKeyTests.swift */,
@@ -7440,6 +7443,7 @@
 				E2B39318C3417839BAE511A7 /* ACPChatTypographyTests.swift in Sources */,
 				5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */,
 				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,
+				52E1F744D076C631138EE8C1 /* ACPComposerActionButtonChevronTests.swift in Sources */,
 				33A0FC862C45CDFF47053A04 /* ACPComposerActionButtonMetricsTests.swift in Sources */,
 				C31DBE249E28F1C82421537C /* ACPComposerCodeBlockStylingTests.swift in Sources */,
 				12FD90326DDF6E8BDF2A67B4 /* ACPComposerCodeFenceKeyTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
@@ -34,38 +34,18 @@ struct ACPComposerActionButton: View {
     private var sendCapsule: some View {
         HStack(spacing: 0) {
             Button(action: onPrimary) {
-                HStack(spacing: 5) {
-                    Image(systemName: "arrow.up")
-                        .font(.system(size: 12, weight: .bold))
-                    Text("Send")
-                        .font(.system(size: 11.5, weight: .semibold))
-                }
-                .foregroundStyle(theme.color("bg-0"))
-                .padding(.horizontal, 11)
-                .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
-                .background(
-                    UnevenRoundedRectangle(
-                        cornerRadii: .init(
-                            topLeading: ACPComposerActionButtonMetrics.cornerRadius,
-                            bottomLeading: ACPComposerActionButtonMetrics.cornerRadius
-                        )
-                    )
-                    .fill(theme.color("accent"))
-                )
-                .overlay(alignment: .trailing) {
+                primaryHalf(
+                    title: "Send",
                     // `line` is a neutral hairline meant for neutral fills; on the
                     // accent half it disappears. Tint the foreground color instead.
-                    segmentDivider(
-                        theme.color("bg-0")
-                            .opacity(ACPComposerActionButtonMetrics.dividerOnAccentOpacity)
-                    )
-                }
-                .overlay(alignment: .topTrailing) { badgeOverlay }
+                    divider: theme.color("bg-0")
+                        .opacity(ACPComposerActionButtonMetrics.dividerOnAccentOpacity)
+                )
             }
             .buttonStyle(.plain)
             .help("Send (⏎)")
 
-            Menu {
+            chevronHalf(help: "Schedule send") {
                 let now = Date()
                 ForEach(ACPSchedulePreset.allCases) { preset in
                     if preset.date(after: now) != nil {
@@ -81,33 +61,12 @@ struct ACPComposerActionButton: View {
                         ?? ACPSchedulePreset.tomorrowMorning.date(after: now)!
                     showsCustomSchedule = true
                 }
-            } label: {
-                Image(systemName: "chevron.down")
-                    .font(.system(size: 9, weight: .semibold))
-                    .foregroundStyle(theme.color("bg-0"))
-                    .padding(.horizontal, 7)
-                    // Height stays on the label so the whole painted segment is
-                    // clickable — a frame applied after `Menu` grows the layout
-                    // and background but leaves the hit target at label height.
-                    .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
             }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .fixedSize()
-            // The fill belongs on the Menu, not on its label: `.borderlessButton`
-            // wraps the label in its own chrome, so a label background stops short
-            // of the control's edges and leaves a gap next to the primary half.
-            .background(
-                UnevenRoundedRectangle(
-                    cornerRadii: .init(
-                        bottomTrailing: ACPComposerActionButtonMetrics.cornerRadius,
-                        topTrailing: ACPComposerActionButtonMetrics.cornerRadius
-                    )
-                )
-                .fill(theme.color("accent"))
-            )
-            .help("Schedule send")
         }
+        .capsuleSurface(
+            foreground: theme.color("bg-0"),
+            fill: theme.color("accent")
+        )
         .popover(isPresented: $showsCustomSchedule) {
             VStack(alignment: .leading, spacing: 12) {
                 Text("Schedule message")
@@ -167,66 +126,79 @@ struct ACPComposerActionButton: View {
     private func queueSplitCapsule(menu: [ComposerMenuItem]) -> some View {
         HStack(spacing: 0) {
             Button(action: onPrimary) {
-                HStack(spacing: 5) {
-                    Image(systemName: "arrow.up")
-                        .font(.system(size: 12, weight: .bold))
-                    Text("Queue")
-                        .font(.system(size: 11.5, weight: .semibold))
-                }
-                .foregroundStyle(theme.color("fg"))
-                .padding(.horizontal, 11)
-                .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
-                .background(
-                    UnevenRoundedRectangle(
-                        cornerRadii: .init(
-                            topLeading: ACPComposerActionButtonMetrics.cornerRadius,
-                            bottomLeading: ACPComposerActionButtonMetrics.cornerRadius,
-                            bottomTrailing: 0,
-                            topTrailing: 0
-                        )
-                    )
-                    .fill(theme.color("bg-3"))
-                )
-                .overlay(alignment: .trailing) { segmentDivider(theme.color("line")) }
-                .overlay(alignment: .topTrailing) { badgeOverlay }
+                primaryHalf(title: "Queue", divider: theme.color("line"))
             }
             .buttonStyle(.plain)
             .help("Queue (⏎). Hold ⌥ to steer.")
 
-            Menu {
+            chevronHalf(help: "More actions") {
                 ForEach(menu, id: \.self) { item in
                     menuButton(for: item)
                     if item == .steer, menu.contains(.stop) {
                         Divider()
                     }
                 }
-            } label: {
-                Image(systemName: "chevron.down")
-                    .font(.system(size: 9, weight: .semibold))
-                    .foregroundStyle(theme.color("fg"))
-                    .padding(.horizontal, 7)
-                    .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
             }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .fixedSize()
-            .background(
-                UnevenRoundedRectangle(
-                    cornerRadii: .init(
-                        topLeading: 0,
-                        bottomLeading: 0,
-                        bottomTrailing: ACPComposerActionButtonMetrics.cornerRadius,
-                        topTrailing: ACPComposerActionButtonMetrics.cornerRadius
-                    )
-                )
-                .fill(theme.color("bg-3"))
-            )
-            .help("More actions")
         }
+        .capsuleSurface(
+            foreground: theme.color("fg"),
+            fill: theme.color("bg-3")
+        )
         .overlay(
             RoundedRectangle(cornerRadius: ACPComposerActionButtonMetrics.cornerRadius)
                 .strokeBorder(theme.color("line"), lineWidth: 1)
         )
+    }
+
+    // MARK: - Split-capsule halves
+
+    /// Primary half: icon + title, the hairline marking the split, and the
+    /// queue badge. It paints no fill of its own — the capsule draws one
+    /// background behind both halves (see `capsuleSurface`), so the two can't
+    /// disagree about height, radius or color.
+    private func primaryHalf(title: String, divider: Color) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: "arrow.up")
+                .font(.system(size: 12, weight: .bold))
+            Text(title)
+                .font(.system(size: 11.5, weight: .semibold))
+        }
+        .padding(.horizontal, 11)
+        .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
+        .contentShape(Rectangle())
+        .overlay(alignment: .trailing) { segmentDivider(divider) }
+        .overlay(alignment: .topTrailing) { badgeOverlay }
+    }
+
+    /// Chevron half: the menu affordance at the trailing end of the capsule.
+    ///
+    /// `.button` + `.plain`, deliberately not `.borderlessButton`. The
+    /// borderless style hands the label to an `NSPopUpButton`, which draws the
+    /// glyph in its own label color and sizes itself to the label's intrinsic
+    /// ~14pt no matter what frame the label carries. That gave us three bugs at
+    /// once: a chevron tinted differently from the title, a segment background
+    /// shorter than the primary half, and 6pt of dead space at the top and
+    /// bottom of the segment where clicks missed the menu. `.button` keeps the
+    /// label in SwiftUI, where the frame and the inherited foreground style
+    /// both apply.
+    private func chevronHalf<Content: View>(
+        help: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        Menu {
+            content()
+        } label: {
+            Image(systemName: "chevron.down")
+                .font(.system(size: 9, weight: .semibold))
+                .padding(.horizontal, ACPComposerActionButtonMetrics.chevronHorizontalPadding)
+                .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help(help)
     }
 
     // MARK: - Segment divider (hairline between the primary half and the chevron)
@@ -283,9 +255,25 @@ struct ACPComposerActionButton: View {
     }
 }
 
+private extension View {
+    /// Paints a split capsule as one surface: a single fill behind both halves
+    /// and a single foreground style inherited by both. Neither half carries a
+    /// background or a color of its own, so they cannot drift out of alignment
+    /// or out of tint.
+    func capsuleSurface(foreground: Color, fill: Color) -> some View {
+        foregroundStyle(foreground)
+            .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
+            .background(
+                fill,
+                in: RoundedRectangle(cornerRadius: ACPComposerActionButtonMetrics.cornerRadius)
+            )
+    }
+}
+
 enum ACPComposerActionButtonMetrics {
     static let capsuleHeight: CGFloat = 26
     static let cornerRadius: CGFloat = 7
+    static let chevronHorizontalPadding: CGFloat = 7
     static let badgeMinWidth: CGFloat = 16
     static let badgeMinHeight: CGFloat = 14
     static let badgeOffset = CGSize(width: 6, height: -6)

--- a/AlasTests/ACP/UI/ACPComposerActionButtonChevronTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerActionButtonChevronTests.swift
@@ -1,0 +1,55 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+/// Guards the construction of the split button's chevron half.
+///
+/// `.menuStyle(.borderlessButton)` renders the label inside an `NSPopUpButton`,
+/// which ignores the label's frame (it sizes itself to the glyph, ~14pt) and
+/// paints the glyph in its own label color. In a 26pt capsule that produced a
+/// chevron tinted differently from the title, a segment background shorter than
+/// the primary half, and dead click zones at the top and bottom of the segment.
+/// No AppKit popup in the tree means the label stayed in SwiftUI, where the
+/// frame and the inherited foreground style both apply.
+@MainActor
+@Suite("ACPComposerActionButton chevron half")
+struct ACPComposerActionButtonChevronTests {
+    @Test("send capsule renders its menu without an AppKit popup control")
+    func sendCapsuleHasNoPopUpButton() {
+        #expect(popUpButtons(in: .send).isEmpty)
+    }
+
+    @Test("queue capsule renders its menu without an AppKit popup control")
+    func queueCapsuleHasNoPopUpButton() {
+        #expect(popUpButtons(in: .queue(menu: [.steer, .stop])).isEmpty)
+    }
+
+    @Test("chevron padding keeps the segment narrower than the primary half")
+    func chevronPaddingIsCompact() {
+        #expect(ACPComposerActionButtonMetrics.chevronHorizontalPadding > 0)
+        #expect(ACPComposerActionButtonMetrics.chevronHorizontalPadding * 2
+                < ACPComposerActionButtonMetrics.capsuleHeight)
+    }
+
+    // MARK: - Helpers
+
+    private func popUpButtons(in action: ComposerAction) -> [NSView] {
+        let host = NSHostingView(
+            rootView: ACPComposerActionButton(
+                action: action,
+                onPrimary: {},
+                onMenu: { _ in },
+                onSchedule: { _ in },
+                queueBadgeCount: 0
+            )
+        )
+        host.frame = NSRect(x: 0, y: 0, width: 200, height: 60)
+        host.layoutSubtreeIfNeeded()
+        return descendants(of: host).filter { $0 is NSPopUpButton }
+    }
+
+    private func descendants(of view: NSView) -> [NSView] {
+        view.subviews + view.subviews.flatMap { descendants(of: $0) }
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes the composer's Send/Queue split buttons: the chevron half was tinted differently from the title, its painted background was shorter than the primary half, and roughly 6pt at the top and bottom of the chevron segment did not respond to clicks.
- Root cause: `.menuStyle(.borderlessButton)` hands the chevron label to an `NSPopUpButton`, which ignores the label's `.foregroundStyle` and its `.frame(height:)` — it paints the glyph in its own label color and sizes itself to the label's intrinsic ~14pt regardless of the surrounding 26pt capsule.
- Switches both capsules to `.menuStyle(.button)` + `.buttonStyle(.plain)`, which keeps the label in SwiftUI so the frame and inherited foreground both apply.
- Both halves now paint through one shared `capsuleSurface` (one fill, one foreground) instead of two independently-shaped backgrounds, so Send and Queue can't drift out of sync again — this is what let the regression slip in undetected on Queue (its neutral fill hid the color mismatch).

### Reviewer notes

- `ACPComposerActionButtonChevronTests` asserts neither capsule renders an `NSPopUpButton` in its view tree. Verified it fails on the pre-fix construction and passes on the fixed one.
- Menu content/positioning is unaffected — captured the opened `NSMenu` window under both the old and new trigger and it's byte-identical in size.