### PR TITLE
feat(attention): dismiss items from inbox and present it as a popover

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -103,7 +103,6 @@ final class AppState {
     @ObservationIgnored var attentionNavigationDepth = 0
     var attentionNavigationErrors: [UUID: String] = [:]
     @ObservationIgnored var attentionNavigationEnvironment: AttentionNavigationEnvironment?
-    @ObservationIgnored var attentionReturnDestination: AttentionReturnDestination?
     @ObservationIgnored var attentionSuppressedStartupSignals: [AttentionSourceKey: String] = [:]
     @ObservationIgnored var attentionInitializedSnapshotSources: Set<String> = []
     @ObservationIgnored var attentionPendingReviewReveal: AttentionPendingReviewReveal?

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -278,18 +278,7 @@ struct RootView: View {
 
     @ViewBuilder
     private func centerContent(effectiveRightPaneVisible: Bool) -> some View {
-        if state.isAttentionInboxOpen {
-            AttentionInboxView(
-                aggregation: state.attentionAggregation,
-                loadError: state.attentionStore.loadError?.localizedDescription,
-                writeError: state.attentionStore.writeError?.localizedDescription,
-                navigationErrors: state.attentionNavigationErrors,
-                onClose: { state.closeAttentionInbox() },
-                onOpen: { item in _ = await state.openAttentionItem(item) }
-            )
-        } else {
-            worktreeCenterContent(effectiveRightPaneVisible: effectiveRightPaneVisible)
-        }
+        worktreeCenterContent(effectiveRightPaneVisible: effectiveRightPaneVisible)
     }
 
     @ViewBuilder

--- a/Alas/Sources/Attention/AppState+Attention.swift
+++ b/Alas/Sources/Attention/AppState+Attention.swift
@@ -199,8 +199,10 @@ extension AppState {
     }
 
     func dismissAllAttentionItems() {
-        for item in attentionAggregation.items {
-            attentionStore.acknowledge(eventID: item.eventID, at: Date())
+        let items = attentionAggregation.items
+        guard !items.isEmpty else { return }
+        attentionStore.acknowledge(eventIDs: items.map(\.eventID), at: Date())
+        for item in items {
             attentionNavigationErrors[item.eventID] = nil
         }
     }

--- a/Alas/Sources/Attention/AppState+Attention.swift
+++ b/Alas/Sources/Attention/AppState+Attention.swift
@@ -1,14 +1,5 @@
 import Foundation
 
-struct AttentionReturnDestination {
-    let spaceID: String
-    let worktreeID: String?
-    let activeTabID: TabID?
-    let workspaceNavigationState: WorkspaceNavigationState
-    let sharedSessionOwner: SessionOwnerID?
-    let sharedActiveTabID: TabID?
-}
-
 enum AttentionNavigationResult: Equatable {
     case opened
     case opening
@@ -167,7 +158,6 @@ extension AppState {
         guard opened else { return unavailable(failure) }
         attentionNavigationErrors[item.eventID] = nil
         isAttentionInboxOpen = false
-        attentionReturnDestination = nil
         if attentionPendingReviewReveal?.eventIDs == [item.eventID] { return .opening }
         attentionStore.acknowledge(eventID: item.eventID, at: Date())
         return .opened
@@ -200,6 +190,18 @@ extension AppState {
             } else {
                 attentionNavigationErrors[eventID] = "The review comment could not be revealed."
             }
+        }
+    }
+
+    func dismissAttentionItem(_ item: AttentionItem) {
+        attentionStore.acknowledge(eventID: item.eventID, at: Date())
+        attentionNavigationErrors[item.eventID] = nil
+    }
+
+    func dismissAllAttentionItems() {
+        for item in attentionAggregation.items {
+            attentionStore.acknowledge(eventID: item.eventID, at: Date())
+            attentionNavigationErrors[item.eventID] = nil
         }
     }
 
@@ -457,42 +459,12 @@ extension AppState {
     func openAttentionInbox() {
         guard !isAttentionInboxOpen else { return }
         if let selectedWorktreeId { rightPaneStore.activeState(worktreeId: selectedWorktreeId)?.endAttentionReveal() }
-        attentionReturnDestination = AttentionReturnDestination(
-            spaceID: spacesManager.activeSpaceId,
-            worktreeID: selectedWorktreeId,
-            activeTabID: selectedWorktreeId.flatMap { tabs.activeTabId(forWorktree: $0) },
-            workspaceNavigationState: workspaceNavigationState,
-            sharedSessionOwner: selectedWorkspaceCheckout.map { .workspaceCheckout($0.id, $0.executionLocation) },
-            sharedActiveTabID: selectedWorkspaceCheckout.map { .workspaceCheckout($0.id, $0.executionLocation) }.flatMap { tabs.activeTabId(for: $0) }
-        )
         isAttentionInboxOpen = true
     }
 
     func closeAttentionInbox() {
         guard isAttentionInboxOpen else { return }
         isAttentionInboxOpen = false
-        guard let destination = attentionReturnDestination else { return }
-        attentionReturnDestination = nil
-        guard canRestoreAttentionReturnDestination(destination) else { return }
-        _ = switchToSpace(id: destination.spaceID)
-        workspaceNavigationState = destination.workspaceNavigationState
-        selectedWorktreeId = destination.worktreeID
-        if let worktreeID = destination.worktreeID {
-            if let tabID = destination.activeTabID,
-               tabs.tabs(forWorktree: worktreeID).contains(where: { $0.id == tabID }) {
-                tabs.activate(worktreeId: worktreeID, tabId: tabID)
-            } else if destination.activeTabID == nil {
-                tabs.clearActiveTab(worktreeId: worktreeID)
-            }
-        }
-        if let owner = destination.sharedSessionOwner {
-            if let tabID = destination.sharedActiveTabID,
-               tabs.tabs(for: owner).contains(where: { $0.id == tabID }) {
-                tabs.activate(owner: owner, tabId: tabID)
-            } else if destination.sharedActiveTabID == nil {
-                tabs.clearActiveTab(owner: owner)
-            }
-        }
     }
 
     /// Snapshot reconciliation cannot invent events when previous acknowledgments are unknown.
@@ -894,48 +866,11 @@ extension AppState {
         return nil
     }
 
-    private func canRestoreAttentionReturnDestination(_ destination: AttentionReturnDestination) -> Bool {
-        guard spacesManager.space(id: destination.spaceID) != nil else { return false }
-        if let worktreeID = destination.worktreeID {
-            guard isRestorableAttentionWorktree(id: worktreeID) else { return false }
-            if let tabID = destination.activeTabID,
-               !tabs.tabs(forWorktree: worktreeID).contains(where: { $0.id == tabID }) {
-                return false
-            }
-        }
-        if let checkoutID = destination.workspaceNavigationState.selectedCheckoutID {
-            guard let checkout = workspacesManager.checkout(id: checkoutID),
-                  checkout.archivedAt == nil else { return false }
-            if let memberID = destination.workspaceNavigationState.focusedCheckoutMemberID {
-                let memberWorktreeIDs = attentionWorkspaceMemberWorktreeIDs(checkout)
-                guard let worktreeID = memberWorktreeIDs[memberID],
-                      isRestorableAttentionWorktree(id: worktreeID),
-                      destination.worktreeID == nil || destination.worktreeID == worktreeID else { return false }
-            }
-            if case .workspaceCheckout(let ownerCheckoutID, let location)? = destination.sharedSessionOwner,
-               ownerCheckoutID != checkoutID || checkout.executionLocation.normalized != location.normalized {
-                return false
-            }
-        }
-        if let owner = destination.sharedSessionOwner,
-           let tabID = destination.sharedActiveTabID,
-           !tabs.tabs(for: owner).contains(where: { $0.id == tabID }) {
-            return false
-        }
-        return true
-    }
-
     private func attentionWorkspaceMemberWorktreeIDs(_ checkout: WorkspaceCheckout) -> [UUID: String] {
         WorkspaceMemberWorktreeResolver.resolvedWorktreeIDs(
             checkout: checkout,
             worktrees: projects.flatMap { projectsManager.worktrees(projectId: $0.id) }
         )
-    }
-
-    private func isRestorableAttentionWorktree(id: String) -> Bool {
-        guard let worktree = attentionWorktrees.first(where: { $0.worktree.id == id })?.worktree,
-              let project = projects.first(where: { $0.id == worktree.projectId }) else { return false }
-        return !projectsManager.isWorktreeHidden(projectId: project.id, path: worktree.path)
     }
 
     private func isSuppressedAttentionFingerprintShrink(

--- a/Alas/Sources/Attention/AttentionInboxView.swift
+++ b/Alas/Sources/Attention/AttentionInboxView.swift
@@ -34,6 +34,10 @@ struct AttentionInboxRowPresentation: Identifiable {
         if item.jumpTarget == .none { return "This event has no destination." }
         return nil
     }
+    var dismissAccessibilityLabel: String? {
+        guard item.acknowledgedAt == nil else { return nil }
+        return "Dismiss, \(title), \(attribution)"
+    }
 
     static func timestamp(_ date: Date, now: Date, calendar: Calendar = .current) -> String {
         date.formatted(Date.FormatStyle(
@@ -70,7 +74,7 @@ struct AttentionInboxView: View {
     let loadError: String?
     let writeError: String?
     let navigationErrors: [UUID: String]
-    let onClose: () -> Void
+    let onDismiss: (AttentionItem) -> Void
     let onOpen: (AttentionItem) async -> Void
     @Environment(\.theme) private var theme
 
@@ -82,65 +86,64 @@ struct AttentionInboxView: View {
             VStack(spacing: 0) {
                 HStack(spacing: 9) {
                     Image(systemName: "exclamationmark.triangle")
+                        .font(.system(size: 12))
                         .foregroundStyle(theme.color("warn"))
                         .accessibilityHidden(true)
                     Text("Needs attention")
-                        .font(.system(size: 14, weight: .semibold))
+                        .font(.system(size: 13, weight: .semibold))
                     Text("\(aggregation.unresolvedCount)")
                         .font(.system(size: 11, weight: .medium))
                         .monospacedDigit()
                         .foregroundStyle(theme.color("fg-muted"))
                         .accessibilityLabel("\(aggregation.unresolvedCount) unresolved items")
                     Spacer()
-                    Button(action: onClose) {
-                        Image(systemName: "xmark")
-                            .frame(width: 24, height: 24)
-                            .contentShape(Rectangle())
+                    if !presentation.activeRows.isEmpty {
+                        Button("Dismiss all") {
+                            for item in presentation.activeRows { onDismiss(item.item) }
+                        }
+                        .controlSize(.small)
+                        .accessibilityLabel("Dismiss all \(aggregation.unresolvedCount) unresolved items")
                     }
-                    .buttonStyle(.plain)
-                    .help("Close attention inbox")
-                    .accessibilityLabel("Close attention inbox")
-                    .keyboardShortcut(.cancelAction)
                 }
                 .foregroundStyle(theme.color("fg"))
-                .padding(.horizontal, 20)
-                .padding(.vertical, 12)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
                 Divider()
                 ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 12) {
+                    LazyVStack(alignment: .leading, spacing: 10) {
                         ForEach(presentation.errors) { error in
                             AttentionInboxErrorRow(title: error.title, message: error.message)
                         }
                         if let emptyTitle = presentation.emptyTitle {
                             VStack(alignment: .leading, spacing: 6) {
-                                Text(emptyTitle).font(.system(size: 14, weight: .medium))
+                                Text(emptyTitle).font(.system(size: 13, weight: .medium))
                                 Text("New requests will appear here. Earlier events stay below.")
                                     .font(.system(size: 12))
                                     .foregroundStyle(theme.color("fg-muted"))
                             }
-                            .padding(.vertical, 20)
+                            .padding(.vertical, 16)
                         }
                         ForEach(presentation.activeRows) { row in
                             AttentionInboxRow(presentation: row, isHistory: false,
-                                              navigationError: navigationErrors[row.id], onOpen: onOpen)
+                                              navigationError: navigationErrors[row.id], onDismiss: onDismiss, onOpen: onOpen)
                         }
                         if !presentation.historyRows.isEmpty {
                             Text("Earlier")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.system(size: 11, weight: .semibold))
                                 .foregroundStyle(theme.color("fg-muted"))
-                                .padding(.top, 16)
+                                .padding(.top, 10)
                                 .accessibilityAddTraits(.isHeader)
                             ForEach(presentation.historyRows) { row in
                                 AttentionInboxRow(presentation: row, isHistory: true,
-                                                  navigationError: navigationErrors[row.id], onOpen: onOpen)
+                                                  navigationError: navigationErrors[row.id], onDismiss: onDismiss, onOpen: onOpen)
                             }
                         }
                     }
-                    .frame(maxWidth: 780, alignment: .leading)
-                    .padding(20)
-                    .frame(maxWidth: .infinity)
+                    .padding(14)
                 }
             }
+            .frame(width: 400)
+            .frame(maxHeight: 520)
             .background(theme.color("bg-1"))
             .foregroundStyle(theme.color("fg"))
         }
@@ -151,6 +154,7 @@ struct AttentionInboxRow: View {
     let presentation: AttentionInboxRowPresentation
     let isHistory: Bool
     let navigationError: String?
+    let onDismiss: (AttentionItem) -> Void
     let onOpen: (AttentionItem) async -> Void
     @Environment(\.theme) private var theme
     @State private var opening = false
@@ -195,6 +199,11 @@ struct AttentionInboxRow: View {
                         .accessibilityLabel(presentation.acknowledgmentHelp ?? acknowledgment)
                 }
                 Spacer(minLength: 0)
+                if !isHistory {
+                    Button("Dismiss") { onDismiss(presentation.item) }
+                        .controlSize(.small)
+                        .accessibilityLabel(presentation.dismissAccessibilityLabel ?? "Dismiss")
+                }
                 if !isHistory || presentation.item.jumpTarget != .none {
                     Button(presentation.actionTitle) {
                         opening = true

--- a/Alas/Sources/Attention/AttentionStore.swift
+++ b/Alas/Sources/Attention/AttentionStore.swift
@@ -93,12 +93,20 @@ final class AttentionStore {
     }
 
     func acknowledge(eventID: UUID, at date: Date) {
-        guard document.events.contains(where: { $0.id == eventID }) else { return }
-        guard document.acknowledgments[eventID] == nil else {
+        acknowledge(eventIDs: [eventID], at: date)
+    }
+
+    func acknowledge(eventIDs: [UUID], at date: Date) {
+        var changed = false
+        let knownIDs = Set(document.events.map(\.id))
+        for eventID in eventIDs where knownIDs.contains(eventID) && document.acknowledgments[eventID] == nil {
+            document.acknowledgments[eventID] = AttentionAcknowledgment(eventID: eventID, acknowledgedAt: date)
+            changed = true
+        }
+        guard changed else {
             retryPersistingUnwrittenDocumentIfNeeded()
             return
         }
-        document.acknowledgments[eventID] = AttentionAcknowledgment(eventID: eventID, acknowledgedAt: date)
         retain(at: date)
         persist()
     }

--- a/Alas/Sources/Sidebar/SidebarHeaderView.swift
+++ b/Alas/Sources/Sidebar/SidebarHeaderView.swift
@@ -11,6 +11,8 @@ struct SidebarHeaderView: View {
     var attentionCount: Int = 0
     @Binding var attentionInboxOpen: Bool
     var attentionAggregation: AttentionAggregation = AttentionAggregation(items: [], history: [], unresolvedCount: 0, unresolvedCountByProject: [:])
+    var attentionLoadError: String? = nil
+    var attentionWriteError: String? = nil
     var attentionNavigationErrors: [UUID: String] = [:]
     var onDismissAttentionItem: (AttentionItem) -> Void = { _ in }
     var onOpenAttentionItem: (AttentionItem) async -> Void = { _ in }
@@ -24,6 +26,8 @@ struct SidebarHeaderView: View {
          attentionCount: Int = 0,
          attentionInboxOpen: Binding<Bool> = .constant(false),
          attentionAggregation: AttentionAggregation = AttentionAggregation(items: [], history: [], unresolvedCount: 0, unresolvedCountByProject: [:]),
+         attentionLoadError: String? = nil,
+         attentionWriteError: String? = nil,
          attentionNavigationErrors: [UUID: String] = [:],
          onDismissAttentionItem: @escaping (AttentionItem) -> Void = { _ in },
          onOpenAttentionItem: @escaping (AttentionItem) async -> Void = { _ in }) {
@@ -37,6 +41,8 @@ struct SidebarHeaderView: View {
         self.attentionCount = attentionCount
         self._attentionInboxOpen = attentionInboxOpen
         self.attentionAggregation = attentionAggregation
+        self.attentionLoadError = attentionLoadError
+        self.attentionWriteError = attentionWriteError
         self.attentionNavigationErrors = attentionNavigationErrors
         self.onDismissAttentionItem = onDismissAttentionItem
         self.onOpenAttentionItem = onOpenAttentionItem
@@ -68,8 +74,8 @@ struct SidebarHeaderView: View {
         AttentionToolbarButton(count: attentionCount, isOpen: $attentionInboxOpen) {
             AttentionInboxView(
                 aggregation: attentionAggregation,
-                loadError: nil,
-                writeError: nil,
+                loadError: attentionLoadError,
+                writeError: attentionWriteError,
                 navigationErrors: attentionNavigationErrors,
                 onDismiss: onDismissAttentionItem,
                 onOpen: onOpenAttentionItem

--- a/Alas/Sources/Sidebar/SidebarHeaderView.swift
+++ b/Alas/Sources/Sidebar/SidebarHeaderView.swift
@@ -9,8 +9,38 @@ struct SidebarHeaderView: View {
     let onHideSidebar: () -> Void
     var onNewWorkspace: (() -> Void)? = nil
     var attentionCount: Int = 0
-    var attentionInboxOpen: Bool = false
-    var onOpenAttentionInbox: () -> Void = {}
+    @Binding var attentionInboxOpen: Bool
+    var attentionAggregation: AttentionAggregation = AttentionAggregation(items: [], history: [], unresolvedCount: 0, unresolvedCountByProject: [:])
+    var attentionNavigationErrors: [UUID: String] = [:]
+    var onDismissAttentionItem: (AttentionItem) -> Void = { _ in }
+    var onOpenAttentionItem: (AttentionItem) async -> Void = { _ in }
+    init(worktreeSortMode: AppConfig.WorktreeSortMode,
+         onSetWorktreeSortMode: @escaping (AppConfig.WorktreeSortMode) -> Void,
+         onSettings: @escaping () -> Void,
+         onAddProject: @escaping () -> Void,
+         onSearch: @escaping () -> Void,
+         onHideSidebar: @escaping () -> Void,
+         onNewWorkspace: (() -> Void)? = nil,
+         attentionCount: Int = 0,
+         attentionInboxOpen: Binding<Bool> = .constant(false),
+         attentionAggregation: AttentionAggregation = AttentionAggregation(items: [], history: [], unresolvedCount: 0, unresolvedCountByProject: [:]),
+         attentionNavigationErrors: [UUID: String] = [:],
+         onDismissAttentionItem: @escaping (AttentionItem) -> Void = { _ in },
+         onOpenAttentionItem: @escaping (AttentionItem) async -> Void = { _ in }) {
+        self.worktreeSortMode = worktreeSortMode
+        self.onSetWorktreeSortMode = onSetWorktreeSortMode
+        self.onSettings = onSettings
+        self.onAddProject = onAddProject
+        self.onSearch = onSearch
+        self.onHideSidebar = onHideSidebar
+        self.onNewWorkspace = onNewWorkspace
+        self.attentionCount = attentionCount
+        self._attentionInboxOpen = attentionInboxOpen
+        self.attentionAggregation = attentionAggregation
+        self.attentionNavigationErrors = attentionNavigationErrors
+        self.onDismissAttentionItem = onDismissAttentionItem
+        self.onOpenAttentionItem = onOpenAttentionItem
+    }
     @Environment(\.theme) private var theme
     @State private var hovering = false
     @State private var addMenuHovered = false
@@ -34,6 +64,19 @@ struct SidebarHeaderView: View {
         .windowDragHandle()
     }
 
+    private var attentionToolbarButton: some View {
+        AttentionToolbarButton(count: attentionCount, isOpen: $attentionInboxOpen) {
+            AttentionInboxView(
+                aggregation: attentionAggregation,
+                loadError: nil,
+                writeError: nil,
+                navigationErrors: attentionNavigationErrors,
+                onDismiss: onDismissAttentionItem,
+                onOpen: onOpenAttentionItem
+            )
+        }
+    }
+
     private var expandedHeader: some View {
         HStack(alignment: .center, spacing: 12) {
             TrafficLights()
@@ -45,7 +88,7 @@ struct SidebarHeaderView: View {
                     headerHovered: hovering
                 )
                 ToolbarBtn(icon: "search", tooltip: "Search", action: onSearch)
-                AttentionToolbarButton(count: attentionCount, isOpen: attentionInboxOpen, action: onOpenAttentionInbox)
+                attentionToolbarButton
                 if let onNewWorkspace {
                     Menu {
                         Button("Add repository...", systemImage: "folder.badge.plus", action: onAddProject)
@@ -78,7 +121,7 @@ struct SidebarHeaderView: View {
             Spacer(minLength: 0)
             HStack(spacing: 2) {
                 ToolbarBtn(icon: "search", tooltip: "Search", action: onSearch)
-                AttentionToolbarButton(count: attentionCount, isOpen: attentionInboxOpen, action: onOpenAttentionInbox)
+                attentionToolbarButton
                 Menu {
                     Menu("Sort worktrees") {
                         ForEach(WorktreeSortPresentation.modes, id: \.self) { mode in
@@ -115,15 +158,17 @@ struct SidebarHeaderView: View {
     }
 }
 
-private struct AttentionToolbarButton: View {
+private struct AttentionToolbarButton<Content: View>: View {
     let count: Int
-    let isOpen: Bool
-    let action: () -> Void
+    @Binding var isOpen: Bool
+    @ViewBuilder let content: () -> Content
     @Environment(\.theme) private var theme
     @State private var hovering = false
 
     var body: some View {
-        Button(action: action) {
+        Button {
+            isOpen.toggle()
+        } label: {
             Image(systemName: "exclamationmark.triangle")
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(theme.color(count > 0 ? "warn" : (hovering ? "fg" : "fg-muted")))
@@ -151,6 +196,9 @@ private struct AttentionToolbarButton: View {
         .help(SidebarHeaderView.attentionAccessibilityLabel(count: count))
         .accessibilityLabel(SidebarHeaderView.attentionAccessibilityLabel(count: count))
         .accessibilityAddTraits(isOpen ? .isSelected : [])
+        .popover(isPresented: $isOpen, arrowEdge: .bottom) {
+            content()
+        }
     }
 }
 

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -36,8 +36,11 @@ struct SidebarView: View {
                     onHideSidebar: onHideSidebar,
                     onNewWorkspace: state.config.workspacesEnabled ? { showingNewWorkspace = true } : nil,
                     attentionCount: attentionAggregation.unresolvedCount,
-                    attentionInboxOpen: state.isAttentionInboxOpen,
-                    onOpenAttentionInbox: { state.openAttentionInbox() }
+                    attentionInboxOpen: $state.isAttentionInboxOpen,
+                    attentionAggregation: attentionAggregation,
+                    attentionNavigationErrors: state.attentionNavigationErrors,
+                    onDismissAttentionItem: { state.dismissAttentionItem($0) },
+                    onOpenAttentionItem: { item in _ = await state.openAttentionItem(item) }
                 )
                 ScrollView(.vertical, showsIndicators: true) {
                     VStack(alignment: .leading, spacing: 8) {

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -38,6 +38,8 @@ struct SidebarView: View {
                     attentionCount: attentionAggregation.unresolvedCount,
                     attentionInboxOpen: $state.isAttentionInboxOpen,
                     attentionAggregation: attentionAggregation,
+                    attentionLoadError: state.attentionStore.loadError?.localizedDescription,
+                    attentionWriteError: state.attentionStore.writeError?.localizedDescription,
                     attentionNavigationErrors: state.attentionNavigationErrors,
                     onDismissAttentionItem: { state.dismissAttentionItem($0) },
                     onOpenAttentionItem: { item in _ = await state.openAttentionItem(item) }

--- a/AlasTests/Attention/AppStateAttentionTests.swift
+++ b/AlasTests/Attention/AppStateAttentionTests.swift
@@ -190,6 +190,40 @@ struct AppStateAttentionTests {
         #expect(state.harness.activityBySession[session.id] == nil)
     }
 
+    @Test func dismissAttentionItemAcknowledgesAndClearsNavigationError() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let state = fixture.makeStateWithWorktree()
+        _ = state.tabs.appendTerminal(worktreeId: "worktree", title: "Agent", sessionId: "session")
+        state.harness.setExternalActivity(sessionId: "session", agent: .claude, state: .awaitingInput)
+        let item = try #require(state.attentionAggregation.items.first)
+        state.attentionNavigationErrors[item.eventID] = "The session is no longer available."
+
+        state.dismissAttentionItem(item)
+
+        #expect(state.attentionStore.acknowledgments[item.eventID] != nil)
+        #expect(state.attentionNavigationErrors[item.eventID] == nil)
+        #expect(state.attentionAggregation.unresolvedCount == 0)
+        #expect(state.attentionAggregation.history.contains { $0.eventID == item.eventID })
+    }
+
+    @Test func dismissAllAttentionItemsAcknowledgesEveryActiveItem() throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let state = fixture.makeStateWithWorktree()
+        _ = state.tabs.appendTerminal(worktreeId: "worktree", title: "Agent", sessionId: "session")
+        _ = state.tabs.appendTerminal(worktreeId: "worktree", title: "Agent 2", sessionId: "other")
+        state.harness.setExternalActivity(sessionId: "session", agent: .claude, state: .awaitingInput)
+        state.harness.setExternalActivity(sessionId: "other", agent: .codex, state: .permissionRequest)
+        let before = state.attentionAggregation.items
+        #expect(before.count == 2)
+
+        state.dismissAllAttentionItems()
+
+        #expect(before.allSatisfy { state.attentionStore.acknowledgments[$0.eventID] != nil })
+        #expect(state.attentionAggregation.unresolvedCount == 0)
+    }
+
     @Test func acpResponseInteractionAcknowledgesSessionAttention() throws {
         let fixture = try Fixture()
         defer { fixture.cleanup() }
@@ -630,37 +664,6 @@ struct AppStateAttentionTests {
         #expect(state.attentionStore.document.aliases[legacyOwner]?.lineageID == "lineage")
     }
 
-    @Test func inboxRestoresOriginalTabAfterRepeatedOpen() throws {
-        let fixture = try Fixture()
-        defer { fixture.cleanup() }
-        let state = fixture.makeState()
-        let first = state.tabs.appendTerminal(worktreeId: "worktree", title: "First", sessionId: "first")
-        state.selectedWorktreeId = "worktree"
-        state.openAttentionInbox()
-        _ = state.tabs.appendTerminal(worktreeId: "worktree", title: "Second", sessionId: "second")
-        state.openAttentionInbox()
-        state.closeAttentionInbox()
-
-        #expect(!state.isAttentionInboxOpen)
-        #expect(state.selectedWorktreeId == "worktree")
-        #expect(state.tabs.activeTabId(forWorktree: "worktree") == first.id)
-    }
-
-    @Test func closingInboxKeepsFallbackWhenSavedWorktreeDisappears() throws {
-        let fixture = try Fixture()
-        defer { fixture.cleanup() }
-        let state = fixture.makeStateWithWorktree()
-        state.selectedWorktreeId = "worktree"
-
-        state.openAttentionInbox()
-        state.projectsManager = ProjectsManager(persistedProjects: [])
-        state.selectedWorktreeId = nil
-        state.closeAttentionInbox()
-
-        #expect(!state.isAttentionInboxOpen)
-        #expect(state.selectedWorktreeId == nil)
-    }
-
     @Test func stoppedRightPaneStatesDoNotContributeLiveAttentionSignals() throws {
         let fixture = try Fixture()
         defer { fixture.cleanup() }
@@ -885,59 +888,19 @@ struct AppStateAttentionTests {
         #expect(state.attentionStore.acknowledgments[item.eventID] != nil)
     }
 
-    @Test func closingInboxRestoresWorkspaceCheckoutNavigation() async throws {
+    @Test func openingAndClosingInboxTogglesStateAndCancelsPendingReviewReveal() throws {
         let fixture = try Fixture()
         defer { fixture.cleanup() }
-        let workspaceURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".json")
-        defer { try? FileManager.default.removeItem(at: workspaceURL) }
-        let workspaceStore = WorkspaceStore(url: workspaceURL)
-        let workspacesManager = WorkspacesManager(bridge: WorkspaceSpacePersistenceBridge(workspaceStore: workspaceStore))
-        let workspaceID = UUID()
-        let project = ProjectConfig(id: "project", name: "Project", path: "/repo", color: "blue", addedAt: fixture.now)
-        let worktree = Worktree(id: "worktree", projectId: project.id, name: "main", branch: "main",
-                                path: URL(fileURLWithPath: "/repo"), status: .clean, lastActivity: fixture.now)
-        let memberID = UUID()
-        let checkout = WorkspaceCheckout(
-            workspaceID: workspaceID,
-            fallbackWorkspaceName: "Shared",
-            executionLocation: .local,
-            branch: "topic",
-            rootPath: "/repo",
-            members: [
-                WorkspaceCheckoutMember(
-                    workspaceMemberID: memberID,
-                    projectID: project.id,
-                    fallbackProjectName: project.name,
-                    fallbackRepositoryRoot: project.path,
-                    worktreePath: worktree.path.path,
-                    availability: .available
-                )
-            ]
-        )
-        try await workspaceStore.checkpoint(WorkspaceStateFile(checkouts: [checkout]))
-        _ = await workspacesManager.setEnabled(true, spacesFile: SpacesFile(activeSpaceId: "main", spaces: []))
-        let state = AppState(
-            store: MemoryStore(),
-            workspacesManager: workspacesManager,
-            workspaceStore: workspaceStore,
-            attentionStore: AttentionStore(url: fixture.url)
-        )
-        state.projectsManager = ProjectsManager(persistedProjects: [project])
-        state.projectsManager.insertOptimisticWorktree(worktree)
-        state.selectWorkspaceCheckout(id: checkout.id)
-        let owner = SessionOwnerID.workspaceCheckout(checkout.id, checkout.executionLocation)
-        let sharedTab = state.tabs.appendACP(owner: owner, sessionId: "shared-acp", title: "Shared agent")
-        state.tabs.activate(owner: owner, tabId: sharedTab.id)
+        let state = fixture.makeStateWithWorktree()
 
         state.openAttentionInbox()
-        state.selectWorktree(id: Optional<String>.none)
+        #expect(state.isAttentionInboxOpen)
+        state.openAttentionInbox()
+        #expect(state.isAttentionInboxOpen)
         state.closeAttentionInbox()
-
-        #expect(state.selectedWorkspaceCheckout?.id == checkout.id)
-        #expect(state.workspaceNavigationState.focusedCheckoutMemberID == memberID)
-        #expect(state.workspaceNavigationState.repositoryFocusWorktreeID == worktree.id)
-        #expect(state.selectedWorktreeId == worktree.id)
-        #expect(state.tabs.activeTabId(for: owner) == sharedTab.id)
+        #expect(!state.isAttentionInboxOpen)
+        state.closeAttentionInbox()
+        #expect(!state.isAttentionInboxOpen)
     }
 
     @Test func offlineHostEventOpensWorktreeAndClearsWhileStillOffline() async throws {

--- a/AlasTests/Attention/AttentionInboxViewTests.swift
+++ b/AlasTests/Attention/AttentionInboxViewTests.swift
@@ -48,6 +48,16 @@ struct AttentionInboxViewTests {
         #expect(presentation.activeRows.isEmpty)
     }
 
+    @Test func activeRowsExposeDismissActionButHistoryRowsDoNot() {
+        let active = makeItem()
+        let acknowledged = makeItem(acknowledgedAt: Date(timeIntervalSince1970: 200))
+        let presentation = AttentionInboxPresentation(
+            aggregation: aggregation(items: [active], history: [acknowledged]), loadError: nil
+        )
+        #expect(presentation.activeRows[0].dismissAccessibilityLabel == "Dismiss, \(active.title), Alas · feature/inbox · build-host")
+        #expect(presentation.historyRows[0].dismissAccessibilityLabel == nil)
+    }
+
     @Test func compactTimestampIncludesDateOnlyForOlderEvents() {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!
@@ -85,7 +95,7 @@ struct AttentionInboxViewTests {
     private func historyRowHeight(ownerAvailable: Bool) throws -> CGFloat {
         let item = makeItem(acknowledgedAt: Date(timeIntervalSince1970: 200), ownerAvailable: ownerAvailable)
         let view = AttentionInboxRow(presentation: .init(item: item, now: Date()), isHistory: true,
-                                    navigationError: nil, onOpen: { _ in })
+                                    navigationError: nil, onDismiss: { _ in }, onOpen: { _ in })
             .environment(\.theme, try ThemeStore().current)
         let controller = NSHostingController(rootView: view)
         return controller.sizeThatFits(in: NSSize(width: 700, height: CGFloat.greatestFiniteMagnitude)).height
@@ -95,7 +105,7 @@ struct AttentionInboxViewTests {
         let view = SidebarHeaderView(worktreeSortMode: .lastUpdateDesc, onSetWorktreeSortMode: { _ in },
                                      onSettings: {}, onAddProject: {}, onSearch: {}, onHideSidebar: {},
                                      onNewWorkspace: workspacesEnabled ? {} : nil,
-                                     attentionCount: count, attentionInboxOpen: false, onOpenAttentionInbox: {})
+                                     attentionCount: count, attentionInboxOpen: .constant(false))
             .environment(\.theme, try ThemeStore().current)
         let controller = NSHostingController(rootView: view)
         return controller.sizeThatFits(in: NSSize(width: width, height: CGFloat.greatestFiniteMagnitude))


### PR DESCRIPTION
## Summary

- Adds per-item dismissal to the needs-attention inbox: each active row gets a `Dismiss` button and the header gets a `Dismiss all` action when items exist. Dismissing acknowledges the underlying event, so the item moves to the *Earlier* section until its condition changes (same semantics as navigating to an item).
- Replaces the full center-pane inbox with a popover anchored to the sidebar toolbar button (~400pt wide, capped height, scrollable). The center pane no longer swaps content while the inbox is open.
- Removes the return-destination machinery (`AttentionReturnDestination`, save/restore on open/close, validation helpers) that only existed to restore center-pane state after closing the full-pane inbox.

## Reviewer notes

- `isAttentionInboxOpen` is kept with its `didSet` side effects (navigation generation bump, pending review reveal clear) — popover dismissal now routes through the SwiftUI binding.
- The three tests covering return-destination restore behavior were deleted along with the feature; a new test covers the simplified open/close toggle.
- Existing failures in `AppStateAttentionTests` (checkout-owned session flows, fingerprint encoding) are pre-existing on `main` and unrelated to this change.