### PR TITLE
fix(merge): hide conflict minimap when the center pane is too narrow

### DIFF
--- a/Alas/Sources/Center/Merge/MergeView3Way.swift
+++ b/Alas/Sources/Center/Merge/MergeView3Way.swift
@@ -19,7 +19,17 @@ struct MergeView3Way: View {
     let onJumpToConflict: (Int) -> Void
 
     @State private var coordinator = MergeScrollCoordinator()
+    /// Available width of the merge view. Drives minimap visibility: below
+    /// `minWidthForMinimap` the three panes are too narrow to be usable with
+    /// a 13pt strip reserved on the right.
+    @State private var availableWidth: CGFloat = 0
     @Environment(\.theme) var theme
+
+    static let minWidthForMinimap: CGFloat = 730
+
+    private var showsMinimap: Bool {
+        availableWidth >= Self.minWidthForMinimap
+    }
 
     private var layout: MergeRegionVisualLayout.Layout {
         MergeRegionVisualLayout.compute(regions: model.regions, showBase: showBase)
@@ -116,16 +126,23 @@ struct MergeView3Way: View {
                 codeFontSize: codeFontSize,
                 coordinator: coordinator
             )
-            MergeConflictMinimap(
-                conflictCount: model.conflictCount,
-                resolvedCount: max(model.initialConflictCount - model.conflictCount, 0),
-                currentConflictIndex: model.currentConflictIndex,
-                onJump: onJumpToConflict
-            )
-            .frame(width: 13)
+            if showsMinimap {
+                MergeConflictMinimap(
+                    conflictCount: model.conflictCount,
+                    resolvedCount: max(model.initialConflictCount - model.conflictCount, 0),
+                    currentConflictIndex: model.currentConflictIndex,
+                    onJump: onJumpToConflict
+                )
+                .frame(width: 13)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .clipped()
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { width in
+            availableWidth = width
+        }
         .onChange(of: model.currentConflictIndex, initial: true) { _, _ in
             scrollToCurrentConflict()
         }
@@ -177,17 +194,20 @@ private struct MergeThreeWayLayout: Layout {
         subviews: Subviews,
         cache: inout ()
     ) {
-        guard subviews.count == 6 else { return }
-        let fixedWidth = actionGutterWidth * 2 + minimapWidth
+        guard subviews.count == 6 || subviews.count == 5 else { return }
+        let minimapVisible = subviews.count == 6
+        let fixedWidth = actionGutterWidth * 2 + (minimapVisible ? minimapWidth : 0)
         let paneWidth = max((bounds.width - fixedWidth) / 3, 0)
-        let widths = [
+        var widths = [
             paneWidth,
             actionGutterWidth,
             paneWidth,
             actionGutterWidth,
             paneWidth,
-            minimapWidth,
         ]
+        if minimapVisible {
+            widths.append(minimapWidth)
+        }
 
         var x = bounds.minX
         for (index, width) in widths.enumerated() {

--- a/AlasTests/MergeView3WayLayoutTests.swift
+++ b/AlasTests/MergeView3WayLayoutTests.swift
@@ -6,6 +6,49 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct MergeView3WayLayoutTests {
+    @Test func minimapIsHiddenWhenCenterPaneIsTooNarrow() throws {
+        let model = Self.makeModel()
+        try assertMinimapVisibility(width: 700, visible: false, model: model)
+        try assertMinimapVisibility(width: 1_200, visible: true, model: model)
+    }
+
+    private static func makeModel() -> MergeConflictTabModel {
+        let model = MergeConflictTabModel(
+            worktreePath: URL(fileURLWithPath: "/tmp/alas-layout-test"),
+            relativePath: "long.swift",
+            gitService: GitService()
+        )
+        model.resultText = longConflictText(lineCount: 1_200)
+        model.reparse()
+        return model
+    }
+
+    @discardableResult
+    private func assertMinimapVisibility(width: CGFloat, visible: Bool, model: MergeConflictTabModel) throws -> NSHostingController<AnyView> {
+        let view = MergeView3Way(
+            model: model,
+            fileExtension: "swift",
+            codeFontFamily: "SF Mono",
+            codeFontSize: 13,
+            showBase: false,
+            onJumpToConflict: { _ in }
+        )
+        .environment(\.theme, try ThemeStore().current)
+        let controller = NSHostingController(rootView: AnyView(view))
+        controller.view.frame = NSRect(x: 0, y: 0, width: width, height: 600)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let divider = controller.view.descendantViews { view in
+            abs(view.frame.width - 6) < 0.5 && abs(view.frame.height - 14) < 0.5
+        }
+        if visible {
+            #expect(!divider.isEmpty)
+        } else {
+            #expect(divider.isEmpty)
+        }
+        return controller
+    }
+
     @Test func longConflictedFilesDoNotExpandMergeViewHeight() throws {
         let model = MergeConflictTabModel(
             worktreePath: URL(fileURLWithPath: "/tmp/alas-layout-test"),
@@ -68,12 +111,14 @@ struct MergeView3WayLayoutTests {
 
 private extension NSView {
     func descendantScrollViews() -> [NSScrollView] {
-        var result: [NSScrollView] = []
-        if let scrollView = self as? NSScrollView {
-            result.append(scrollView)
-        }
+        descendantViews { $0 is NSScrollView }.compactMap { $0 as? NSScrollView }
+    }
+
+    func descendantViews(where predicate: (NSView) -> Bool) -> [NSView] {
+        var result: [NSView] = []
+        if predicate(self) { result.append(self) }
         for subview in subviews {
-            result.append(contentsOf: subview.descendantScrollViews())
+            result.append(contentsOf: subview.descendantViews(where: predicate))
         }
         return result
     }


### PR DESCRIPTION
## Summary

- Hides the merge-conflict minimap when the merge view is narrower than 730pt. Below that threshold the three panes are too narrow to be usable while a 13pt strip stays reserved on the right edge.
- `MergeThreeWayLayout` now distributes the full width across the three panes when the minimap is absent, so narrow windows get maximum pane width.

## Reviewer notes

- Visibility is driven by an `onGeometryChange` width probe in `MergeView3Way`; the threshold is `MergeView3Way.minWidthForMinimap` (3 × 220pt minimum pane + 56pt gutters + 13pt minimap).
- Layout test asserts minimap ticks exist at 1200pt and are absent at 700pt.