### PR TITLE
fix(ci): avoid blocked socket and host lookups in preview tests

### DIFF
--- a/Alas/Sources/WebPreview/WebPreviewBrowser.swift
+++ b/Alas/Sources/WebPreview/WebPreviewBrowser.swift
@@ -39,10 +39,15 @@ enum WebPreviewHostLookup {
 
     @MainActor
     static func resolve(_ host: String) async -> [String]? {
-        await withCheckedContinuation { continuation in
+        let normalizedHost = host.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+        if RunEndpointPolicy.isLoopbackHost(normalizedHost) || isNumericAddress(normalizedHost) {
+            return [normalizedHost]
+        }
+
+        return await withCheckedContinuation { continuation in
             let result = Resolution(continuation: continuation)
             let operation = BlockOperation {
-                let addresses = lookupAddresses(host)
+                let addresses = lookupAddresses(normalizedHost)
                 Task { @MainActor in result.finish(addresses) }
             }
             queue.addOperation(operation)
@@ -52,6 +57,13 @@ enum WebPreviewHostLookup {
                 result.finish(nil)
             }
         }
+    }
+
+    private static func isNumericAddress(_ host: String) -> Bool {
+        var ipv4 = in_addr()
+        if inet_pton(AF_INET, host, &ipv4) == 1 { return true }
+        var ipv6 = in6_addr()
+        return inet_pton(AF_INET6, host, &ipv6) == 1
     }
 
     private static func lookupAddresses(_ host: String) -> [String]? {

--- a/AlasTests/AgentHookSocketServerCLITests.swift
+++ b/AlasTests/AgentHookSocketServerCLITests.swift
@@ -50,6 +50,19 @@ struct AgentHookSocketServerCLITests {
         guard fd >= 0 else { throw POSIXError(.EIO) }
         defer { close(fd) }
 
+        var timeout = timeval(tv_sec: 5, tv_usec: 0)
+        for option in [SO_RCVTIMEO, SO_SNDTIMEO] {
+            let result = withUnsafePointer(to: &timeout) { pointer in
+                Darwin.setsockopt(
+                    fd,
+                    SOL_SOCKET,
+                    option,
+                    pointer,
+                    socklen_t(MemoryLayout<timeval>.size))
+            }
+            guard result == 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+        }
+
         var addr = sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)
         let pathBytes = path.utf8CString

--- a/AlasTests/AgentHookSocketServerCLITests.swift
+++ b/AlasTests/AgentHookSocketServerCLITests.swift
@@ -1,4 +1,5 @@
 import Darwin
+import Dispatch
 import Foundation
 import Testing
 @testable import Alas
@@ -34,18 +35,17 @@ struct AgentHookSocketServerCLITests {
         return (dir, { try? FileManager.default.removeItem(atPath: dir) })
     }
 
-    private func sendToSocket(path: String, payload: String) throws -> String {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/bash")
-        process.arguments = ["-c", "printf '%s' '\(payload)' | /usr/bin/nc -U -w5 '\(path)'"]
-        let outPipe = Pipe()
-        process.standardOutput = outPipe
-        try process.run()
-        process.waitUntilExit()
-        return String(data: outPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    private static func sendToSocket(path: String, payload: String) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(with: Result {
+                    try sendToSocketDirect(path: path, payload: payload)
+                })
+            }
+        }
     }
 
-    private func sendToSocketDirect(path: String, payload: String) throws -> String {
+    private static func sendToSocketDirect(path: String, payload: String) throws -> String {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else { throw POSIXError(.EIO) }
         defer { close(fd) }
@@ -73,7 +73,7 @@ struct AgentHookSocketServerCLITests {
         return try readAll(fd: fd)
     }
 
-    private func writeAll(fd: Int32, data: Data) throws {
+    private static func writeAll(fd: Int32, data: Data) throws {
         try data.withUnsafeBytes { buffer in
             guard let base = buffer.baseAddress else { return }
             var written = 0
@@ -89,7 +89,7 @@ struct AgentHookSocketServerCLITests {
         }
     }
 
-    private func readAll(fd: Int32) throws -> String {
+    private static func readAll(fd: Int32) throws -> String {
         var data = Data()
         var buffer = [UInt8](repeating: 0, count: 64 * 1024)
         while true {
@@ -128,7 +128,7 @@ struct AgentHookSocketServerCLITests {
         }
 
         let json = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["/tmp/a.txt"]}"#
-        let response = try sendToSocket(path: path, payload: json)
+        let response = try await Self.sendToSocket(path: path, payload: json)
         let object = try responseObject(response)
 
         #expect(object["ok"] as? Bool == true)
@@ -137,7 +137,7 @@ struct AgentHookSocketServerCLITests {
         #expect(request?.paths == ["/tmp/a.txt"])
     }
 
-    @Test func cliRequestReturnsHandlerError() throws {
+    @Test func cliRequestReturnsHandlerError() async throws {
         let (dir, cleanup) = tmpSocketDir()
         defer { cleanup() }
         let path = "\(dir)/test.sock"
@@ -147,14 +147,14 @@ struct AgentHookSocketServerCLITests {
         server.onCLIRequest = { _ in .error("Path does not exist.") }
 
         let json = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["/tmp/missing.txt"]}"#
-        let response = try sendToSocket(path: path, payload: json)
+        let response = try await Self.sendToSocket(path: path, payload: json)
         let object = try responseObject(response)
 
         #expect(object["ok"] as? Bool == false)
         #expect(object["error"] as? String == "Path does not exist.")
     }
 
-    @Test func cliRequestWithoutHandlerReturnsUnavailableError() throws {
+    @Test func cliRequestWithoutHandlerReturnsUnavailableError() async throws {
         let (dir, cleanup) = tmpSocketDir()
         defer { cleanup() }
         let path = "\(dir)/test.sock"
@@ -162,7 +162,7 @@ struct AgentHookSocketServerCLITests {
         defer { server.shutdown() }
 
         let json = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["/tmp/a.txt"]}"#
-        let response = try sendToSocket(path: path, payload: json)
+        let response = try await Self.sendToSocket(path: path, payload: json)
         let object = try responseObject(response)
 
         #expect(object["ok"] as? Bool == false)
@@ -181,7 +181,7 @@ struct AgentHookSocketServerCLITests {
         server.onCLIRequest = { _ in .ok }
 
         let json = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["/tmp/a.txt"]}"#
-        _ = try sendToSocket(path: path, payload: json)
+        _ = try await Self.sendToSocket(path: path, payload: json)
         let event = await holder.wait(timeoutMs: 300)
 
         #expect(event == nil)
@@ -199,7 +199,7 @@ struct AgentHookSocketServerCLITests {
         server.onCLIRequest = { _ in .ok }
 
         let json = #"{"v":1,"kind":"cli","event":"busy","agent":"claude","session_id":"s1","paths":["/tmp/a"]}"#
-        let response = try sendToSocket(path: path, payload: json)
+        let response = try await Self.sendToSocket(path: path, payload: json)
         let object = try responseObject(response)
         let event = await holder.wait(timeoutMs: 300)
 
@@ -234,18 +234,19 @@ struct AgentHookSocketServerCLITests {
         let longRequest = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["/tmp/a.txt"]}"#
         let cancelRequest = #"{"v":1,"kind":"cli","command":"preview_cancel","session_id":"s1","params":{"preview_id":"p1"}}"#
 
-        let longTask = Task { try sendToSocketDirect(path: path, payload: longRequest) }
+        let longTask = Task { try await Self.sendToSocket(path: path, payload: longRequest) }
         await gate.waitUntilEntered()
 
         let response: String
         do {
             response = try await withThrowingTaskGroup(of: String.self) { group in
-                group.addTask { try sendToSocketDirect(path: path, payload: cancelRequest) }
+                group.addTask { try await Self.sendToSocket(path: path, payload: cancelRequest) }
                 group.addTask {
                     try await Task.sleep(nanoseconds: 1_000_000_000)
                     throw POSIXError(.ETIMEDOUT)
                 }
-                let first = try await #require(group.next())
+                let next = try await group.next()
+                let first = try #require(next)
                 group.cancelAll()
                 return first
             }
@@ -274,7 +275,7 @@ struct AgentHookSocketServerCLITests {
         server.onCLIRequest = { _ in .text([payload]) }
 
         let json = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["/tmp/a.txt"]}"#
-        let response = try sendToSocketDirect(path: path, payload: json)
+        let response = try await Self.sendToSocket(path: path, payload: json)
         let object = try responseObject(response)
 
         #expect(object["ok"] as? Bool == true)
@@ -303,7 +304,7 @@ struct AgentHookSocketServerCLITests {
         let json = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["/tmp/a.txt"]}"#
         let clientTask = Task {
             do {
-                _ = try sendToSocketDirect(path: path, payload: json)
+                _ = try await Self.sendToSocket(path: path, payload: json)
             } catch {
             }
             await completion.finish()

--- a/AlasTests/WebPreviewBrowserTests.swift
+++ b/AlasTests/WebPreviewBrowserTests.swift
@@ -60,6 +60,11 @@ struct WebPreviewBrowserTests {
         #expect(addresses.allSatisfy { RunEndpointPolicy.isLoopbackHost($0) })
     }
 
+    @Test(arguments: ["192.0.2.1", "2001:db8::1"])
+    func nativeHostLookupReturnsNumericAddressesWithoutDNS(address: String) async throws {
+        #expect(await WebPreviewHostLookup.resolve(address) == [address])
+    }
+
     @Test func webKitInvokesNavigationGateForPageInitiatedRequests() async throws {
         let browser = WebPreviewBrowser(ownerKey: "navigation", remoteHost: nil)
         defer { browser.close() }


### PR DESCRIPTION
## Summary
- run Unix-domain socket client I/O on a dedicated Dispatch queue
- preserve five-second socket read and write timeouts
- resolve loopback and numeric hosts without invoking DNS
- avoid mutating a task group inside a Testing macro expansion

## Root causes
The CLI socket tests performed blocking process/socket I/O from Swift concurrency tasks. On the constrained CI cooperative executor, those clients occupied workers needed by AgentHookSocketServer, causing empty responses and an eight-minute timeout.

Once that suite completed, CI exposed a second sandbox-specific failure: getaddrinfo timed out even for localhost and numeric IP literals. Those inputs are now classified locally; DNS remains in use for hostnames that require resolution.

## Verification
- `swiftformat --lint` on all changed files
- AgentHookSocketServerCLITests with normal executor
- AgentHookSocketServerCLITests with `LIBDISPATCH_COOPERATIVE_POOL_STRICT=1`
- WebPreviewBrowserTests plus AgentHookSocketServerCLITests with `LIBDISPATCH_COOPERATIVE_POOL_STRICT=1`
