### PR TITLE
feat(right-pane): icon rail redesign behind a preview flag

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -731,6 +731,7 @@
 		6B51524A0970D593F6AEEAB1 /* RemoteLastActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B2FEBEDD6FD3B2B37F4895 /* RemoteLastActivityTests.swift */; };
 		6B9E188A6C0A39C38D8723BF /* ReviewRequestDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1A152D4297DBB5B8DFF950 /* ReviewRequestDraftTests.swift */; };
 		6BA64E78F8AB2B8710665FC9 /* ReviewDraftModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA871B5464E4F9D3350851B /* ReviewDraftModels.swift */; };
+		6BE91D5A03CFB605DF4F51EA /* RightPaneRailModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7445ABFD7914FF0550AAC81F /* RightPaneRailModelTests.swift */; };
 		6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */; };
 		6C33DC3A21C3223832EA5D28 /* ACPSessionLeaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31E42DEC85081FEA8CA1BC3 /* ACPSessionLeaseTests.swift */; };
 		6C70755431CFBA41420A2F47 /* ACPSessionManagerRemoteRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069895A7C4E29B3275D8320E /* ACPSessionManagerRemoteRestoreTests.swift */; };
@@ -1201,6 +1202,7 @@
 		B647C09E6FFD4F2136E2E64F /* AlasCLIEnvInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA9CC6DA19BF2D0FD8FBDF3 /* AlasCLIEnvInjectionTests.swift */; };
 		B6580745C7EDF5AA65DB0A86 /* QueuedPromptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC961032C642C166F17EFD99 /* QueuedPromptTests.swift */; };
 		B66EE6A2445C0DDA607788C2 /* GitIgnoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */; };
+		B6707E09F111E2596D032A2A /* RightPaneRailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6A69B1DDB598D9748E594ED /* RightPaneRailModel.swift */; };
 		B6713CE9BFA38B7F1D089E5A /* CopilotInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */; };
 		B6B861A60445F450FB94A0CF /* ACPComposerFocusPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1494739C8FBECE52DAAAE3 /* ACPComposerFocusPolicy.swift */; };
 		B6C31E7AC3CE21AFEA371389 /* cool-slate.json in Resources */ = {isa = PBXBuildFile; fileRef = 8DEB85132B767DB3B253620C /* cool-slate.json */; };
@@ -2503,6 +2505,7 @@
 		73B4D726525024EBE47A0C7E /* AgentLifecycleEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLifecycleEventMapper.swift; sourceTree = "<group>"; };
 		741EFB94AD886324DBC73C72 /* AppKitDiffRowHostingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffRowHostingView.swift; sourceTree = "<group>"; };
 		743E347E3DE3EEAD3942CD78 /* StartupScriptResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolver.swift; sourceTree = "<group>"; };
+		7445ABFD7914FF0550AAC81F /* RightPaneRailModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneRailModelTests.swift; sourceTree = "<group>"; };
 		749E3289E4C70DA7E4DD80E6 /* MergeSingleResolvePromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeSingleResolvePromptEditorWindow.swift; sourceTree = "<group>"; };
 		74D394D40BC9060833DD640A /* LSPInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstaller.swift; sourceTree = "<group>"; };
 		7532F1267DB3F18530C9AD84 /* GGServiceActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGServiceActionsTests.swift; sourceTree = "<group>"; };
@@ -3015,6 +3018,7 @@
 		C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcherTests.swift; sourceTree = "<group>"; };
 		C60A6B7CB83D842FEE2D801C /* ThreePaneSizingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneSizingTests.swift; sourceTree = "<group>"; };
 		C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTabView.swift; sourceTree = "<group>"; };
+		C6A69B1DDB598D9748E594ED /* RightPaneRailModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneRailModel.swift; sourceTree = "<group>"; };
 		C6B874BF8AEC4B60FC536E04 /* ProjectIconImageStaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectIconImageStaging.swift; sourceTree = "<group>"; };
 		C6C27094E7804D975635EB11 /* WorktreeRowHeightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRowHeightTests.swift; sourceTree = "<group>"; };
 		C6CA79B71B4AA72697392702 /* NumstatParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParser.swift; sourceTree = "<group>"; };
@@ -3977,6 +3981,7 @@
 				94D15758C7213FF407FD957B /* RightPaneGGLandTests.swift */,
 				BA5820BB012E55F3A0C1272B /* RightPaneGGStackTests.swift */,
 				2C91EC7522F31BF41F062610 /* RightPaneOptimisticStageTests.swift */,
+				7445ABFD7914FF0550AAC81F /* RightPaneRailModelTests.swift */,
 				54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */,
 				6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */,
 				8233D58F8A76CFFA25EE8D22 /* RightPaneStateContentFingerprintTests.swift */,
@@ -4504,6 +4509,7 @@
 				4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */,
 				9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */,
 				F748F06725644571785BF658 /* PendingStashDrop.swift */,
+				C6A69B1DDB598D9748E594ED /* RightPaneRailModel.swift */,
 				91C1705E68E97111E85D83F3 /* RightPaneState.swift */,
 				795056B6AD803D2B555FC866 /* RightPaneStore.swift */,
 				4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */,
@@ -7284,6 +7290,7 @@
 				4DF50D8995FBF711085A40AF /* ReviewThreadMutations.swift in Sources */,
 				E89040915D30C5E67C67B4C8 /* RevisionFollowControl.swift in Sources */,
 				018E8980EAA0FA97A08A6EF6 /* RevisionSnapshotCache.swift in Sources */,
+				B6707E09F111E2596D032A2A /* RightPaneRailModel.swift in Sources */,
 				FBAB18AAEFB289EF765564C5 /* RightPaneSelectionState.swift in Sources */,
 				3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */,
 				6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */,
@@ -8090,6 +8097,7 @@
 				D4E6BD88D38563AF45E79C83 /* RightPaneGGLandTests.swift in Sources */,
 				4F6DAC87A8E1730770319BBB /* RightPaneGGStackTests.swift in Sources */,
 				D4C9B03A011D0692D6C97CB8 /* RightPaneOptimisticStageTests.swift in Sources */,
+				6BE91D5A03CFB605DF4F51EA /* RightPaneRailModelTests.swift in Sources */,
 				C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */,
 				38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */,
 				019EE52A9C64CF5D15AD9AF2 /* RightPaneStateContentFingerprintTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -330,6 +330,7 @@
 		2EFFCC845819E6EBC6D77801 /* DiffReviewComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF16ADC997E65FD6AEE5562A /* DiffReviewComments.swift */; };
 		2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */; };
 		2F1165AE6FD339D03943C182 /* ACPTranscriptRowContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62A0DA334B03D7D65A7D0B3 /* ACPTranscriptRowContentTests.swift */; };
+		2F492ED30DE9344F8116D387 /* RightRailSizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6877F0319EB6602B047BCC3F /* RightRailSizing.swift */; };
 		2FAA421AF3C23D27A864FDCA /* AgentBuiltins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */; };
 		2FAAA60EF431D109D842428F /* SelfUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBDEF50915BACBD0C3EE36AE /* SelfUpdaterTests.swift */; };
 		2FE10FC44BD9CDBD0C969374 /* MergeBulkResolvePromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */; };
@@ -1510,6 +1511,7 @@
 		E073EEE9E37052E17CB026A0 /* GGInboxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C511B229168DDEA87173A41 /* GGInboxStore.swift */; };
 		E099FB5101ED328389233B35 /* MermaidDiagramLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888112C4BC28BBC55C6804FA /* MermaidDiagramLayoutTests.swift */; };
 		E0AA2F46C6E53C547FEB6495 /* ClaudeCodeACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2FAABB50C8BE2321A1B1DD /* ClaudeCodeACPInstallerTests.swift */; };
+		E0AA8BE16FB4C2ADCB5DA436 /* RightRailSizingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B465A2A4B23154DA780FA44 /* RightRailSizingTests.swift */; };
 		E0AB8DE437378E43F55AAFDD /* WorkspaceTerminalSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65536124AD196057C61605DD /* WorkspaceTerminalSessionTests.swift */; };
 		E0CB3938E66BAE32A4424D96 /* ACPSessionForkPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A706214BC0BD3E0A16F6D4E /* ACPSessionForkPolicyTests.swift */; };
 		E0CC3918BF4D86FD20442922 /* ACPSessionForkPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBFDEDA4A9F2B99529C9442D /* ACPSessionForkPersistenceTests.swift */; };
@@ -2415,6 +2417,7 @@
 		67AF057E852E15EFF7FD04EE /* MCPHelloEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPHelloEvent.swift; sourceTree = "<group>"; };
 		67E03BF5DB4E6BFF8C2FA6A2 /* ACPPermissionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionRequest.swift; sourceTree = "<group>"; };
 		6821B71680094791995C4975 /* ShortcutsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsPane.swift; sourceTree = "<group>"; };
+		6877F0319EB6602B047BCC3F /* RightRailSizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightRailSizing.swift; sourceTree = "<group>"; };
 		68AC15742E7423AE2F3A203A /* ACPSessionInfoUpdateDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionInfoUpdateDecodeTests.swift; sourceTree = "<group>"; };
 		68B6937D50514C34A2C14BE1 /* TerminalServiceZmxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalServiceZmxTests.swift; sourceTree = "<group>"; };
 		69024633944E9FFF6DA76FAE /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
@@ -2758,6 +2761,7 @@
 		9B2CDF63D42D5322B04CDAB5 /* WorkspaceDefinitionDialogModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDefinitionDialogModel.swift; sourceTree = "<group>"; };
 		9B3DCDC9F76F91CE1071471C /* StagedDiffSelectionBridgingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedDiffSelectionBridgingTests.swift; sourceTree = "<group>"; };
 		9B44E54236211F972F3D1C24 /* RemoteFileOps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFileOps.swift; sourceTree = "<group>"; };
+		9B465A2A4B23154DA780FA44 /* RightRailSizingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightRailSizingTests.swift; sourceTree = "<group>"; };
 		9BB18B529D24C1BAE68B443B /* StartupRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupRecoveryTests.swift; sourceTree = "<group>"; };
 		9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneTransitionalView.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
@@ -4002,6 +4006,7 @@
 				1352DFCDFF4769EAF89B75CF /* RightPaneTabTests.swift */,
 				911C47748187EEA25C56E1C9 /* RightPaneToolbarModelTests.swift */,
 				B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */,
+				9B465A2A4B23154DA780FA44 /* RightRailSizingTests.swift */,
 				184A8668BB2C00AB8D1BB1C4 /* RunEndpointTests.swift */,
 				AB695F22D0C756A00CEFCA72 /* RunRecordStoreTests.swift */,
 				C0856147C5DC7F10944420ED /* RunScriptCompletionMonitorTests.swift */,
@@ -6109,6 +6114,7 @@
 			children = (
 				7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */,
 				7E467DCC037978A4942F8C8B /* PaneDragMath.swift */,
+				6877F0319EB6602B047BCC3F /* RightRailSizing.swift */,
 				5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */,
 				FEC68B05B719B9235865027F /* ThreePaneSizing.swift */,
 			);
@@ -7304,6 +7310,7 @@
 				22A16379A235AE393F5ACE25 /* RightPaneToolbarModel.swift in Sources */,
 				6117C4AD7519BCD82EA0CF56 /* RightPaneTransitionalView.swift in Sources */,
 				E4E04048352D9CBC77D954C5 /* RightPaneView.swift in Sources */,
+				2F492ED30DE9344F8116D387 /* RightRailSizing.swift in Sources */,
 				7B85B033B476943E77867BA3 /* RootView.swift in Sources */,
 				D0E7182835E93329C89FCD06 /* RunEndpoint.swift in Sources */,
 				02821E3FE8E67B2D162A4BC8 /* RunRecord.swift in Sources */,
@@ -8121,6 +8128,7 @@
 				D84D5F836F828349114F2D3C /* RightPaneTabTests.swift in Sources */,
 				9E890302990A7709343D11F6 /* RightPaneToolbarModelTests.swift in Sources */,
 				4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */,
+				E0AA8BE16FB4C2ADCB5DA436 /* RightRailSizingTests.swift in Sources */,
 				6EDBC8B0F9284ABF9796A4F0 /* RunEndpointTests.swift in Sources */,
 				324E539462E078CED452D311 /* RunRecordStoreTests.swift in Sources */,
 				0E17E7251EC6EAB4B50B10D6 /* RunScriptCompletionMonitorTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -531,6 +531,7 @@
 		497D21A67A062CE6282008CD /* PathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295319DB8544C170DDD6328D /* PathsTests.swift */; };
 		497FF183AAA6C00F88E8AEB2 /* ACPSpeechDictationEngineFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A01B605D486C5FE112088E /* ACPSpeechDictationEngineFormatTests.swift */; };
 		49C8C4C8B34444953FBA1809 /* DebounceTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */; };
+		4A90E5FF8B1BC12957D29966 /* RightPaneToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362981F0D01E8EAE39C1EAC5 /* RightPaneToolbar.swift */; };
 		4A99239BAD338EDCE7BE5F0E /* GGMutationModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1276253D1FB205BC9B5AEDF1 /* GGMutationModelsTests.swift */; };
 		4AFE4A55AF808EEFE3AA4DE2 /* ACPDelegatedSessionsPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0235A58C8825D42F1C406C /* ACPDelegatedSessionsPolicyTests.swift */; };
 		4B2031FB61782327D5279F98 /* FileTreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */; };
@@ -846,6 +847,7 @@
 		8011EDCDB9E13B454E58F45E /* ReviewDraftCommentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10E5AB5D726C40331681709 /* ReviewDraftCommentStore.swift */; };
 		8035C82C1C3F79801A0F2F39 /* ImageDiffPairKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38EAFDB135BDCF0DFF0121B1 /* ImageDiffPairKind.swift */; };
 		804D11E10C7478C00C0F5C40 /* DraftCommitTabStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB44F87B415733A4B2F2A990 /* DraftCommitTabStateTests.swift */; };
+		805F5E1366548BB90009676A /* RightPaneRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBAA6F5DEA20C61ADF36FA1E /* RightPaneRail.swift */; };
 		806A8D3076BDF74084FF05AB /* ACPVisibleRowsCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1C663053BAB6A85A664A52 /* ACPVisibleRowsCacheTests.swift */; };
 		806C55C225BA072937201651 /* WorkspaceWorkItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC31E49E6E453B417479C95 /* WorkspaceWorkItemTests.swift */; };
 		809972779548945B012F8B6C /* ACPConnectingPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFBD2A49431277EB68106AAA /* ACPConnectingPlaceholder.swift */; };
@@ -2092,6 +2094,7 @@
 		35A13D9B95A126987AD92885 /* ACPSessionManagerDisposalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerDisposalTests.swift; sourceTree = "<group>"; };
 		35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationHelper.swift; sourceTree = "<group>"; };
 		35D6BBD77A210BB378E217FC /* GitRefNameInputFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRefNameInputFilterTests.swift; sourceTree = "<group>"; };
+		362981F0D01E8EAE39C1EAC5 /* RightPaneToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneToolbar.swift; sourceTree = "<group>"; };
 		364213292935A05F3B52F51F /* Paths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paths.swift; sourceTree = "<group>"; };
 		364507D55CD5D73CD44819E7 /* InstallerHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallerHostTests.swift; sourceTree = "<group>"; };
 		3659703F6EB9AD2454C2898B /* ACPChatTypographyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChatTypographyTests.swift; sourceTree = "<group>"; };
@@ -2954,6 +2957,7 @@
 		BA9D3F3FFE39D7E29827D83D /* TabsManagerReviewSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerReviewSessionTests.swift; sourceTree = "<group>"; };
 		BAE3E5634CC9BA68765EA539 /* ANSIStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIStream.swift; sourceTree = "<group>"; };
 		BB6A90FAE1D410744D02A454 /* CommitPromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptEditorWindow.swift; sourceTree = "<group>"; };
+		BBAA6F5DEA20C61ADF36FA1E /* RightPaneRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneRail.swift; sourceTree = "<group>"; };
 		BBBEFD27FD7013D458435779 /* ACPSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSession.swift; sourceTree = "<group>"; };
 		BC147F9FE645065318A7B175 /* ACPRemoteAdapterManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRemoteAdapterManagement.swift; sourceTree = "<group>"; };
 		BC2967A37F842D09F43063F3 /* AppKitDiffScrollerReconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitDiffScrollerReconciler.swift; sourceTree = "<group>"; };
@@ -4519,10 +4523,12 @@
 				4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */,
 				9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */,
 				F748F06725644571785BF658 /* PendingStashDrop.swift */,
+				BBAA6F5DEA20C61ADF36FA1E /* RightPaneRail.swift */,
 				C6A69B1DDB598D9748E594ED /* RightPaneRailModel.swift */,
 				91C1705E68E97111E85D83F3 /* RightPaneState.swift */,
 				795056B6AD803D2B555FC866 /* RightPaneStore.swift */,
 				4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */,
+				362981F0D01E8EAE39C1EAC5 /* RightPaneToolbar.swift */,
 				0E96E19D611E94F2AB1E3A50 /* RightPaneToolbarModel.swift */,
 				9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */,
 				FE66950F2226F1182DCDD39A /* RightPaneView.swift */,
@@ -7302,11 +7308,13 @@
 				4DF50D8995FBF711085A40AF /* ReviewThreadMutations.swift in Sources */,
 				E89040915D30C5E67C67B4C8 /* RevisionFollowControl.swift in Sources */,
 				018E8980EAA0FA97A08A6EF6 /* RevisionSnapshotCache.swift in Sources */,
+				805F5E1366548BB90009676A /* RightPaneRail.swift in Sources */,
 				B6707E09F111E2596D032A2A /* RightPaneRailModel.swift in Sources */,
 				FBAB18AAEFB289EF765564C5 /* RightPaneSelectionState.swift in Sources */,
 				3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */,
 				6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */,
 				BFB452EE7A29CF81F7A4BD8A /* RightPaneTabBar.swift in Sources */,
+				4A90E5FF8B1BC12957D29966 /* RightPaneToolbar.swift in Sources */,
 				22A16379A235AE393F5ACE25 /* RightPaneToolbarModel.swift in Sources */,
 				6117C4AD7519BCD82EA0CF56 /* RightPaneTransitionalView.swift in Sources */,
 				E4E04048352D9CBC77D954C5 /* RightPaneView.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
 		28D41D400C04EF69F8A31A26 /* WorkspacesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71562064227F929B0906048A /* WorkspacesManager.swift */; };
 		28D8C1BBA0B577679782AA68 /* ACPMarkdownInlineTextViewMeasurementCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D73156DBE6DB95469D4D80 /* ACPMarkdownInlineTextViewMeasurementCacheTests.swift */; };
+		28DEE43D0373ACDCC5756AE5 /* RightPaneRailReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465766A878C5A449626578EB /* RightPaneRailReducerTests.swift */; };
 		28F0C140D930388611F34BCE /* AgentSidebarRollupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC853E34EAA7644C6893FBEF /* AgentSidebarRollupTests.swift */; };
 		28F42E0137436A3B5F72CB85 /* ACPImageEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */; };
 		2908D330D59E98775E26C688 /* MarkdownPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */; };
@@ -2208,6 +2209,7 @@
 		45EABFDF5380D8D48B15312C /* ACPHarnessBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPHarnessBridge.swift; sourceTree = "<group>"; };
 		4610C65B69BD08EF8DF12311 /* DragOutSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragOutSession.swift; sourceTree = "<group>"; };
 		46554893BA6205CD856B99B5 /* AppStateKeepSessionsAliveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateKeepSessionsAliveTests.swift; sourceTree = "<group>"; };
+		465766A878C5A449626578EB /* RightPaneRailReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneRailReducerTests.swift; sourceTree = "<group>"; };
 		467E833E3CE05D82DB88C5C5 /* ReviewReadinessModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReadinessModel.swift; sourceTree = "<group>"; };
 		46D97A89C40731455D9EC2DA /* ACPTranscriptVisibleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptVisibleRow.swift; sourceTree = "<group>"; };
 		46F45BB91770EDBD3B17A28D /* WebPreviewBrowserAutomation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPreviewBrowserAutomation.swift; sourceTree = "<group>"; };
@@ -3994,6 +3996,7 @@
 				BA5820BB012E55F3A0C1272B /* RightPaneGGStackTests.swift */,
 				2C91EC7522F31BF41F062610 /* RightPaneOptimisticStageTests.swift */,
 				7445ABFD7914FF0550AAC81F /* RightPaneRailModelTests.swift */,
+				465766A878C5A449626578EB /* RightPaneRailReducerTests.swift */,
 				54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */,
 				6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */,
 				8233D58F8A76CFFA25EE8D22 /* RightPaneStateContentFingerprintTests.swift */,
@@ -8120,6 +8123,7 @@
 				4F6DAC87A8E1730770319BBB /* RightPaneGGStackTests.swift in Sources */,
 				D4C9B03A011D0692D6C97CB8 /* RightPaneOptimisticStageTests.swift in Sources */,
 				6BE91D5A03CFB605DF4F51EA /* RightPaneRailModelTests.swift in Sources */,
+				28DEE43D0373ACDCC5756AE5 /* RightPaneRailReducerTests.swift in Sources */,
 				C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */,
 				38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */,
 				019EE52A9C64CF5D15AD9AF2 /* RightPaneStateContentFingerprintTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1278,6 +1278,7 @@
 		BEFFE99F341935C249CA4943 /* TerminalCLIInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */; };
 		BF0A3B3A162F31E86DB13404 /* session-update-current-model.json in Resources */ = {isa = PBXBuildFile; fileRef = 02347E4D2EA79A5CB8DF82DC /* session-update-current-model.json */; };
 		BF776A9CE2409594D67DE4BF /* AlasSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C8F14A2CEAE4B8404213C73 /* AlasSegmentedControl.swift */; };
+		BF86C9B65917B33B4E353CFC /* RightPaneTabShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC246F932856AEBAD7BAEE67 /* RightPaneTabShortcutTests.swift */; };
 		BF887495CBAAA98792FBF74D /* DiffReviewRenderEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A723CF5BB46FABA23D8C9543 /* DiffReviewRenderEligibilityTests.swift */; };
 		BF9C16C33DF0BBAF2946AFC3 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88379ACE40F42BE4A3257659 /* ThemeTests.swift */; };
 		BF9F7D24CA25F467B5A86810 /* RunTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB198FBD900842FAC632F6E /* RunTabView.swift */; };
@@ -3315,6 +3316,7 @@
 		EBF4DE84207D33D518DD7D3E /* ACPSessionByteAccounting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionByteAccounting.swift; sourceTree = "<group>"; };
 		EBFDEDA4A9F2B99529C9442D /* ACPSessionForkPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionForkPersistenceTests.swift; sourceTree = "<group>"; };
 		EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerConfigMasonPrefill.swift; sourceTree = "<group>"; };
+		EC246F932856AEBAD7BAEE67 /* RightPaneTabShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneTabShortcutTests.swift; sourceTree = "<group>"; };
 		EC35CACDC7D469C7D0382F31 /* ACPUserInputFormState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPUserInputFormState.swift; sourceTree = "<group>"; };
 		EC461E04DD9DDF78F8825942 /* ViewDragOut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewDragOut.swift; sourceTree = "<group>"; };
 		EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProjectDialog.swift; sourceTree = "<group>"; };
@@ -4010,6 +4012,7 @@
 				0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */,
 				8451C5BCEE50F118F07CDD83 /* RightPaneStoreBaseBranchTests.swift */,
 				F76808E76F12DB79DFDC119C /* RightPaneTabBarLayoutTests.swift */,
+				EC246F932856AEBAD7BAEE67 /* RightPaneTabShortcutTests.swift */,
 				1352DFCDFF4769EAF89B75CF /* RightPaneTabTests.swift */,
 				911C47748187EEA25C56E1C9 /* RightPaneToolbarModelTests.swift */,
 				B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */,
@@ -8137,6 +8140,7 @@
 				57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */,
 				4186372EBF16A9C7CB38F558 /* RightPaneStoreBaseBranchTests.swift in Sources */,
 				24916B243B32BA9DB9444BD6 /* RightPaneTabBarLayoutTests.swift in Sources */,
+				BF86C9B65917B33B4E353CFC /* RightPaneTabShortcutTests.swift in Sources */,
 				D84D5F836F828349114F2D3C /* RightPaneTabTests.swift in Sources */,
 				9E890302990A7709343D11F6 /* RightPaneToolbarModelTests.swift in Sources */,
 				4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		21F53035247CA88EA8DBB1AC /* MarkdownCodeBlockStylerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039CD39D75F64498A6C8320A /* MarkdownCodeBlockStylerTests.swift */; };
 		21FBAF70DBD55FF57DAB796D /* ReviewRequestDiffLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCAB297DB983CBDD70CDDB24 /* ReviewRequestDiffLoaderTests.swift */; };
 		2281077800674169E69C6C3B /* HoverWindowControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9032BA9542C617A09EF848 /* HoverWindowControllerTests.swift */; };
+		22A16379A235AE393F5ACE25 /* RightPaneToolbarModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E96E19D611E94F2AB1E3A50 /* RightPaneToolbarModel.swift */; };
 		22FDE2FB05952993DA2D0EB7 /* WorkingTreeSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */; };
 		23013D3D2538AC2D1BD3403D /* ChangesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */; };
 		230BD521ACDBA5BB7AA9167D /* ChangesPreparationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54BBE356A720AF00F2A7C56 /* ChangesPreparationModel.swift */; };
@@ -1064,6 +1065,7 @@
 		9E302329243407946D47DC91 /* BranchPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */; };
 		9E349701BA73BBCCCBB135B3 /* DraftCommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */; };
 		9E4B32E154B18BD2285F0D34 /* CommitDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF18448EDA0DCC8B171F11D /* CommitDiffView.swift */; };
+		9E890302990A7709343D11F6 /* RightPaneToolbarModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911C47748187EEA25C56E1C9 /* RightPaneToolbarModelTests.swift */; };
 		9ECB0CE387C7078D238B3A15 /* ACPElicitationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C49F11F34AA97B21936FC1 /* ACPElicitationCoordinator.swift */; };
 		9ED684E261871342BA6DFAC9 /* MergeWordDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72970A1D2817539DB5243058 /* MergeWordDiffTests.swift */; };
 		9FD539228216762192A02C69 /* DialogChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEDACEB27E6AF219054496E /* DialogChrome.swift */; };
@@ -1827,6 +1829,7 @@
 		0E2A10683D1B7D0258F28E5F /* IssueResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueResolverTests.swift; sourceTree = "<group>"; };
 		0E6600436B01C75D85C01FFA /* Clipboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clipboard.swift; sourceTree = "<group>"; };
 		0E8A1143A53C09FD0B4D5CF6 /* ACPComposerPairedDelimiterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerPairedDelimiterTests.swift; sourceTree = "<group>"; };
+		0E96E19D611E94F2AB1E3A50 /* RightPaneToolbarModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneToolbarModel.swift; sourceTree = "<group>"; };
 		0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCHTests.swift; sourceTree = "<group>"; };
 		0EE8745F3A4C6F0645D1D44A /* RemoteHelperInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHelperInstaller.swift; sourceTree = "<group>"; };
 		0EE97D2D6875CD6A1DBF4DE9 /* GitService+ReviewRequestDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+ReviewRequestDraft.swift"; sourceTree = "<group>"; };
@@ -2685,6 +2688,7 @@
 		910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTreeBuilder.swift; sourceTree = "<group>"; };
 		9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMonoNerdFont-Regular.ttf"; sourceTree = "<group>"; };
 		9110E1C886ADC873C72C06E5 /* WorkspaceCheckoutRemoteInvocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCheckoutRemoteInvocationTests.swift; sourceTree = "<group>"; };
+		911C47748187EEA25C56E1C9 /* RightPaneToolbarModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneToolbarModelTests.swift; sourceTree = "<group>"; };
 		9160AF4DDD35E2A02262D868 /* GGService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GGService.swift; sourceTree = "<group>"; };
 		91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictToolbar.swift; sourceTree = "<group>"; };
 		91C1705E68E97111E85D83F3 /* RightPaneState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneState.swift; sourceTree = "<group>"; };
@@ -3996,6 +4000,7 @@
 				8451C5BCEE50F118F07CDD83 /* RightPaneStoreBaseBranchTests.swift */,
 				F76808E76F12DB79DFDC119C /* RightPaneTabBarLayoutTests.swift */,
 				1352DFCDFF4769EAF89B75CF /* RightPaneTabTests.swift */,
+				911C47748187EEA25C56E1C9 /* RightPaneToolbarModelTests.swift */,
 				B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */,
 				184A8668BB2C00AB8D1BB1C4 /* RunEndpointTests.swift */,
 				AB695F22D0C756A00CEFCA72 /* RunRecordStoreTests.swift */,
@@ -4513,6 +4518,7 @@
 				91C1705E68E97111E85D83F3 /* RightPaneState.swift */,
 				795056B6AD803D2B555FC866 /* RightPaneStore.swift */,
 				4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */,
+				0E96E19D611E94F2AB1E3A50 /* RightPaneToolbarModel.swift */,
 				9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */,
 				FE66950F2226F1182DCDD39A /* RightPaneView.swift */,
 				50E00B5DC5B34A5FCF2935BF /* RunTabPresentation.swift */,
@@ -7295,6 +7301,7 @@
 				3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */,
 				6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */,
 				BFB452EE7A29CF81F7A4BD8A /* RightPaneTabBar.swift in Sources */,
+				22A16379A235AE393F5ACE25 /* RightPaneToolbarModel.swift in Sources */,
 				6117C4AD7519BCD82EA0CF56 /* RightPaneTransitionalView.swift in Sources */,
 				E4E04048352D9CBC77D954C5 /* RightPaneView.swift in Sources */,
 				7B85B033B476943E77867BA3 /* RootView.swift in Sources */,
@@ -8112,6 +8119,7 @@
 				4186372EBF16A9C7CB38F558 /* RightPaneStoreBaseBranchTests.swift in Sources */,
 				24916B243B32BA9DB9444BD6 /* RightPaneTabBarLayoutTests.swift in Sources */,
 				D84D5F836F828349114F2D3C /* RightPaneTabTests.swift in Sources */,
+				9E890302990A7709343D11F6 /* RightPaneToolbarModelTests.swift in Sources */,
 				4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */,
 				6EDBC8B0F9284ABF9796A4F0 /* RunEndpointTests.swift in Sources */,
 				324E539462E078CED452D311 /* RunRecordStoreTests.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -266,6 +266,30 @@ struct AlasApp: App {
                 NotificationCenter.default.post(name: .alasToggleRightPane, object: nil)
             }
             .keyboardShortcut(state.shortcut(for: .toggleRightPane))
+            Button("Right Sidebar: Changes") {
+                NotificationCenter.default.post(name: .alasSelectRightPaneTab,
+                                                object: RightPaneTab.changes.rawValue)
+            }
+            .keyboardShortcut(state.shortcut(for: .rightPaneChangesTab))
+            .disabled(!state.config.rightPaneRailEnabled)
+            Button("Right Sidebar: Files") {
+                NotificationCenter.default.post(name: .alasSelectRightPaneTab,
+                                                object: RightPaneTab.files.rawValue)
+            }
+            .keyboardShortcut(state.shortcut(for: .rightPaneFilesTab))
+            .disabled(!state.config.rightPaneRailEnabled)
+            Button("Right Sidebar: Agent") {
+                NotificationCenter.default.post(name: .alasSelectRightPaneTab,
+                                                object: RightPaneTab.agent.rawValue)
+            }
+            .keyboardShortcut(state.shortcut(for: .rightPaneAgentTab))
+            .disabled(!state.config.rightPaneRailEnabled || !state.config.agentTabEnabled)
+            Button("Right Sidebar: Run") {
+                NotificationCenter.default.post(name: .alasSelectRightPaneTab,
+                                                object: RightPaneTab.run.rawValue)
+            }
+            .keyboardShortcut(state.shortcut(for: .rightPaneRunTab))
+            .disabled(!state.config.rightPaneRailEnabled || !state.config.runTabEnabled)
             Button("New Terminal Tab") {
                 NotificationCenter.default.post(name: .alasNewTerminalTab, object: nil)
             }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1036,43 +1036,16 @@ final class AppState {
         _ = saveConfig()
     }
 
-    /// Keyboard equivalent of tapping `tab` on the right pane's icon rail:
-    /// opens the pane on that tab, switches to it when the pane is already
-    /// showing, and collapses the pane when that tab is the one showing.
-    ///
-    /// Routed through the same `resolve` + `apply` pair the rail's own click
-    /// handler uses, so the keyboard and the mouse cannot drift apart.
-    ///
-    /// Rail-preview only. With the flag off a hidden pane has no mounted
-    /// `RightPaneState` to target, and mounting one fires
-    /// `prepareForVisiblePane`, which resets the active tab to Changes — so
-    /// the shortcut would silently land on the wrong tab.
-    func activateRightPaneTab(_ tab: RightPaneTab) {
-        guard config.rightPaneRailEnabled else { return }
-        guard RightPaneTab.available(
-            agentTabEnabled: config.agentTabEnabled,
-            runTabEnabled: config.runTabEnabled
-        ).contains(tab) else { return }
-        guard let worktreeId = selectedWorktreeId,
-              let rps = rightPaneStore.activeState(worktreeId: worktreeId)
-        else { return }
-
-        let outcome = RightPaneRailModel.apply(
-            RightPaneRailAction.resolve(
-                tapped: tab,
-                active: rps.activeTab,
-                collapsed: !config.rightPaneVisible
-            ),
-            currentTab: rps.activeTab,
-            currentVisible: config.rightPaneVisible
-        )
-        if rps.activeTab != outcome.tab {
-            rps.activeTab = outcome.tab
-        }
-        if config.rightPaneVisible != outcome.visible {
-            config.rightPaneVisible = outcome.visible
-            _ = saveConfig()
-        }
+    /// Whether a rail tab shortcut should act at all. The rail-hosting views
+    /// own the rest of the decision: only they know the *effective* collapsed
+    /// state, which differs from `rightPaneVisible` whenever a narrow window
+    /// made `ThreePaneSizing` auto-collapse the pane.
+    func acceptsRightPaneTabShortcut(_ tab: RightPaneTab) -> Bool {
+        config.rightPaneRailEnabled
+            && RightPaneTab.available(
+                agentTabEnabled: config.agentTabEnabled,
+                runTabEnabled: config.runTabEnabled
+            ).contains(tab)
     }
 
     func toggleSidebarVisibility() {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1036,6 +1036,45 @@ final class AppState {
         _ = saveConfig()
     }
 
+    /// Keyboard equivalent of tapping `tab` on the right pane's icon rail:
+    /// opens the pane on that tab, switches to it when the pane is already
+    /// showing, and collapses the pane when that tab is the one showing.
+    ///
+    /// Routed through the same `resolve` + `apply` pair the rail's own click
+    /// handler uses, so the keyboard and the mouse cannot drift apart.
+    ///
+    /// Rail-preview only. With the flag off a hidden pane has no mounted
+    /// `RightPaneState` to target, and mounting one fires
+    /// `prepareForVisiblePane`, which resets the active tab to Changes — so
+    /// the shortcut would silently land on the wrong tab.
+    func activateRightPaneTab(_ tab: RightPaneTab) {
+        guard config.rightPaneRailEnabled else { return }
+        guard RightPaneTab.available(
+            agentTabEnabled: config.agentTabEnabled,
+            runTabEnabled: config.runTabEnabled
+        ).contains(tab) else { return }
+        guard let worktreeId = selectedWorktreeId,
+              let rps = rightPaneStore.activeState(worktreeId: worktreeId)
+        else { return }
+
+        let outcome = RightPaneRailModel.apply(
+            RightPaneRailAction.resolve(
+                tapped: tab,
+                active: rps.activeTab,
+                collapsed: !config.rightPaneVisible
+            ),
+            currentTab: rps.activeTab,
+            currentVisible: config.rightPaneVisible
+        )
+        if rps.activeTab != outcome.tab {
+            rps.activeTab = outcome.tab
+        }
+        if config.rightPaneVisible != outcome.visible {
+            config.rightPaneVisible = outcome.visible
+            _ = saveConfig()
+        }
+    }
+
     func toggleSidebarVisibility() {
         config.sidebarVisible.toggle()
         _ = saveConfig()

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -908,9 +908,16 @@ private struct RootBaseHandlers: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: .alasToggleSidebar)) { _ in
                 state.toggleSidebarVisibility()
             }
-        let a = aSidebar
+        let aRightPane = aSidebar
             .onReceive(NotificationCenter.default.publisher(for: .alasToggleRightPane)) { _ in
                 state.toggleRightPaneVisibility()
+            }
+        let a = aRightPane
+            .onReceive(NotificationCenter.default.publisher(for: .alasSelectRightPaneTab)) { notification in
+                guard let raw = notification.object as? String,
+                      let tab = RightPaneTab(rawValue: raw)
+                else { return }
+                state.activateRightPaneTab(tab)
             }
         let b = a
             .onReceive(NotificationCenter.default.publisher(for: .alasCreateProject)) { _ in
@@ -1135,6 +1142,8 @@ private struct RootPaneHandlers: ViewModifier {
 extension Notification.Name {
     static let alasToggleSidebar     = Notification.Name("AlasToggleSidebar")
     static let alasToggleRightPane   = Notification.Name("AlasToggleRightPane")
+    /// Object carries the target `RightPaneTab.rawValue`.
+    static let alasSelectRightPaneTab = Notification.Name("AlasSelectRightPaneTab")
     static let alasCreateProject     = Notification.Name("AlasCreateProject")
     static let alasNewWorktree       = Notification.Name("AlasNewWorktree")
     static let alasFocusMainWorktree = Notification.Name("AlasFocusMainWorktree")

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -237,6 +237,7 @@ struct RootView: View {
             RightPaneView(
                 state: state,
                 worktree: wt,
+                collapsed: collapsed,
                 onSelectChangedFile: { file in
                     openOrFocusDiff(
                         worktree: wt,

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -913,12 +913,6 @@ private struct RootBaseHandlers: ViewModifier {
                 state.toggleRightPaneVisibility()
             }
         let a = aRightPane
-            .onReceive(NotificationCenter.default.publisher(for: .alasSelectRightPaneTab)) { notification in
-                guard let raw = notification.object as? String,
-                      let tab = RightPaneTab(rawValue: raw)
-                else { return }
-                state.activateRightPaneTab(tab)
-            }
         let b = a
             .onReceive(NotificationCenter.default.publisher(for: .alasCreateProject)) { _ in
                 showNewProject = true

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -182,12 +182,17 @@ struct RootView: View {
                 rightVisible: state.config.rightPaneVisible
                     && rightPaneSelection.showsRightPane
                     && !state.suppressesRestoredRightPaneAfterAbandonedStartup,
+                rightCollapsedWidth: state.config.rightPaneRailEnabled
+                    && rightPaneSelection.showsRightPane
+                    && !state.suppressesRestoredRightPaneAfterAbandonedStartup
+                    ? Double(RightPaneRail.width)
+                    : nil,
                 onWidthsChanged: { state.saveConfig() },
                 sidebar: { sidebarContent },
                 center: { effectiveRightPaneVisible in
                     centerContent(effectiveRightPaneVisible: effectiveRightPaneVisible)
                 },
-                right: { rightContent(selection: rightPaneSelection) }
+                right: { collapsed in rightContent(selection: rightPaneSelection, collapsed: collapsed) }
             )
         }
     }
@@ -224,7 +229,7 @@ struct RootView: View {
     }
 
     @ViewBuilder
-    private func rightContent(selection: RightPaneSelectionState) -> some View {
+    private func rightContent(selection: RightPaneSelectionState, collapsed: Bool) -> some View {
         switch selection {
         case .empty:
             EmptyView()
@@ -254,11 +259,11 @@ struct RootView: View {
                 }
             )
         case .creating(let wt):
-            RightPaneTransitionalView(state: state, worktree: wt, kind: .creating)
+            RightPaneTransitionalView(state: state, worktree: wt, kind: .creating, collapsed: collapsed)
         case .deleting(let wt):
-            RightPaneTransitionalView(state: state, worktree: wt, kind: .deleting)
+            RightPaneTransitionalView(state: state, worktree: wt, kind: .deleting, collapsed: collapsed)
         case .createFailed(let wt):
-            RightPaneTransitionalView(state: state, worktree: wt, kind: .createFailed)
+            RightPaneTransitionalView(state: state, worktree: wt, kind: .createFailed, collapsed: collapsed)
         }
     }
 

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -355,7 +355,7 @@ struct CenterPaneView: View {
                     state.config.rightPaneVisible = true
                     state.saveConfig()
                 },
-                rightSidebarHidden: !state.config.rightPaneVisible,
+                rightSidebarHidden: !state.config.rightPaneVisible && !state.config.rightPaneRailEnabled,
                 onRevealSidebar: {
                     state.config.sidebarVisible = true
                     state.saveConfig()

--- a/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
+++ b/Alas/Sources/Center/Diff/Scroller/AppKitDiffScroller.swift
@@ -7,16 +7,25 @@ struct AppKitDiffScroller: NSViewRepresentable {
     let scrollRequest: AppKitDiffScrollRequest?
     let onActiveOwnerChange: (String?) -> Void
     let onScrollRequestCompletion: (Int) -> Void
+    /// Drops the vertical scroller control. Scrolling itself is unaffected —
+    /// wheel and trackpad still work — this only removes the chrome, for hosts
+    /// narrow enough that a permanent scroller reads as clutter. Opt-in so the
+    /// center pane's diff keeps its scroller.
+    var hidesScroller: Bool = false
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     func makeNSView(context: Context) -> AppKitDiffScrollView {
         let scrollView = AppKitDiffScrollView(frame: .zero)
+        scrollView.hasVerticalScroller = !hidesScroller
         context.coordinator.attach(scrollView: scrollView, onActiveOwnerChange: onActiveOwnerChange)
         return scrollView
     }
 
     func updateNSView(_ scrollView: AppKitDiffScrollView, context: Context) {
+        // Re-applied on update so toggling the host's preference takes effect
+        // without rebuilding the scroll view.
+        scrollView.hasVerticalScroller = !hidesScroller
         context.coordinator.update(
             plan: plan,
             scrollRequest: scrollRequest,

--- a/Alas/Sources/Layout/RightRailSizing.swift
+++ b/Alas/Sources/Layout/RightRailSizing.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Wraps `ThreePaneSizing` for the icon rail presentation, where a 36pt rail
+/// stays on screen after the pane body collapses.
+///
+/// When the body is expanded the rail is drawn inside the right pane's own
+/// width, so nothing needs reserving. When the body is hidden — whether the
+/// user collapsed it or the window was too narrow for `ThreePaneSizing` to
+/// keep it — the rail becomes a separate strip, and the remaining panes have
+/// to negotiate the width that is left. `ThreePaneSizing` is not modified;
+/// it is simply asked a second time with a smaller budget.
+enum RightRailSizing {
+    struct Result: Equatable {
+        var sizing: ThreePaneSizing.Result
+        /// Width of the standalone rail strip. Zero when no strip is drawn,
+        /// either because the flag is off or because the body is expanded.
+        var railWidth: Double
+    }
+
+    static func calculate(
+        availableWidth: Double,
+        preferredSidebarWidth: Double,
+        preferredRightWidth: Double,
+        sidebarPreferredVisible: Bool,
+        rightPreferredVisible: Bool,
+        railWidth: Double?,
+        configuration: ThreePaneSizing.Configuration
+    ) -> Result {
+        let sizing = ThreePaneSizing.calculate(
+            availableWidth: availableWidth,
+            preferredSidebarWidth: preferredSidebarWidth,
+            preferredRightWidth: preferredRightWidth,
+            sidebarPreferredVisible: sidebarPreferredVisible,
+            rightPreferredVisible: rightPreferredVisible,
+            configuration: configuration
+        )
+
+        guard let railWidth, railWidth > 0, !sizing.rightVisible else {
+            return Result(sizing: sizing, railWidth: 0)
+        }
+
+        let reduced = ThreePaneSizing.calculate(
+            availableWidth: max(0, availableWidth - railWidth),
+            preferredSidebarWidth: preferredSidebarWidth,
+            preferredRightWidth: preferredRightWidth,
+            sidebarPreferredVisible: sidebarPreferredVisible,
+            rightPreferredVisible: false,
+            configuration: configuration
+        )
+        return Result(sizing: reduced, railWidth: railWidth)
+    }
+}

--- a/Alas/Sources/Layout/ThreePaneLayout.swift
+++ b/Alas/Sources/Layout/ThreePaneLayout.swift
@@ -5,10 +5,13 @@ struct ThreePaneLayout<Sidebar: View, Center: View, Right: View>: View {
     @Binding var rightWidth: Double
     let sidebarVisible: Bool
     let rightVisible: Bool
+    /// Width of the rail strip drawn in place of a hidden right pane. `nil`
+    /// hides the right pane entirely, which is the long-standing behavior.
+    var rightCollapsedWidth: Double? = nil
     let onWidthsChanged: () -> Void
     @ViewBuilder let sidebar: () -> Sidebar
     @ViewBuilder let center: (_ rightVisible: Bool) -> Center
-    @ViewBuilder let right: () -> Right
+    @ViewBuilder let right: (_ collapsed: Bool) -> Right
 
     // Gutter drags mutate only this transient state, so the drag invalidates
     // just this view. The bindings write into app-wide observable config —
@@ -29,12 +32,13 @@ struct ThreePaneLayout<Sidebar: View, Center: View, Right: View>: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let sizing = ThreePaneSizing.calculate(
+            let railSizing = RightRailSizing.calculate(
                 availableWidth: Double(proxy.size.width),
                 preferredSidebarWidth: transientSidebarWidth ?? sidebarWidth,
                 preferredRightWidth: transientRightWidth ?? rightWidth,
                 sidebarPreferredVisible: sidebarVisible,
                 rightPreferredVisible: rightVisible,
+                railWidth: rightCollapsedWidth,
                 configuration: ThreePaneSizing.Configuration(
                     sidebarMin: sidebarMin,
                     sidebarMax: sidebarMax,
@@ -44,6 +48,7 @@ struct ThreePaneLayout<Sidebar: View, Center: View, Right: View>: View {
                     dividerWidth: dividerWidth
                 )
             )
+            let sizing = railSizing.sizing
 
             // Pixel-align the side panes; the center absorbs the ≤1px
             // rounding remainder so the row still fills the window exactly.
@@ -54,7 +59,7 @@ struct ThreePaneLayout<Sidebar: View, Center: View, Right: View>: View {
                 + (sizing.rightVisible ? dividerWidth : 0)
             let alignedCenterWidth = max(
                 0,
-                Double(proxy.size.width) - dividerTotal
+                Double(proxy.size.width) - dividerTotal - railSizing.railWidth
                     - (sizing.sidebarVisible ? alignedSidebarWidth : 0)
                     - (sizing.rightVisible ? alignedRightWidth : 0)
             )
@@ -116,8 +121,12 @@ struct ThreePaneLayout<Sidebar: View, Center: View, Right: View>: View {
                             rightDragStartWidth = nil
                         }
                     )
-                    right()
+                    right(false)
                         .frame(width: CGFloat(alignedRightWidth))
+                        .frame(maxHeight: .infinity)
+                } else if railSizing.railWidth > 0 {
+                    right(true)
+                        .frame(width: CGFloat(railSizing.railWidth))
                         .frame(maxHeight: .infinity)
                 }
             }

--- a/Alas/Sources/Layout/ThreePaneLayout.swift
+++ b/Alas/Sources/Layout/ThreePaneLayout.swift
@@ -97,36 +97,43 @@ struct ThreePaneLayout<Sidebar: View, Center: View, Right: View>: View {
                 center(sizing.rightVisible)
                     .frame(width: CGFloat(alignedCenterWidth))
                     .frame(maxHeight: .infinity)
-                if sizing.rightVisible {
-                    DragHandle(
-                        axis: .horizontal,
-                        onDragChanged: { translation in
-                            let start = rightDragStartWidth ?? sizing.rightWidth
-                            rightDragStartWidth = start
-                            // Dragging this gutter right shrinks the right
-                            // pane, hence the negated translation.
-                            transientRightWidth = PaneDragMath.resolvedWidth(
-                                startWidth: start,
-                                translation: -Double(translation),
-                                min: rightMin,
-                                max: rightMax
-                            )
-                        },
-                        onDragEnded: {
-                            if let width = transientRightWidth {
-                                rightWidth = width
-                                onWidthsChanged()
+                // `right(...)` is called from exactly one place, inside a
+                // single `if`, so collapsing or expanding the pane never moves
+                // it between two `_ConditionalContent` branches. Swapping
+                // branches would give the subtree a new identity, tearing down
+                // `RightPaneView`'s state and re-firing `.onAppear` /
+                // `.onDisappear` on every rail click. Only the drag handle's
+                // presence and the frame width vary; an `Optional`-wrapped
+                // sibling appearing or disappearing leaves the stable sibling's
+                // identity untouched.
+                if sizing.rightVisible || railSizing.railWidth > 0 {
+                    if sizing.rightVisible {
+                        DragHandle(
+                            axis: .horizontal,
+                            onDragChanged: { translation in
+                                let start = rightDragStartWidth ?? sizing.rightWidth
+                                rightDragStartWidth = start
+                                // Dragging this gutter right shrinks the right
+                                // pane, hence the negated translation.
+                                transientRightWidth = PaneDragMath.resolvedWidth(
+                                    startWidth: start,
+                                    translation: -Double(translation),
+                                    min: rightMin,
+                                    max: rightMax
+                                )
+                            },
+                            onDragEnded: {
+                                if let width = transientRightWidth {
+                                    rightWidth = width
+                                    onWidthsChanged()
+                                }
+                                transientRightWidth = nil
+                                rightDragStartWidth = nil
                             }
-                            transientRightWidth = nil
-                            rightDragStartWidth = nil
-                        }
-                    )
-                    right(false)
-                        .frame(width: CGFloat(alignedRightWidth))
-                        .frame(maxHeight: .infinity)
-                } else if railSizing.railWidth > 0 {
-                    right(true)
-                        .frame(width: CGFloat(railSizing.railWidth))
+                        )
+                    }
+                    right(!sizing.rightVisible)
+                        .frame(width: CGFloat(sizing.rightVisible ? alignedRightWidth : railSizing.railWidth))
                         .frame(maxHeight: .infinity)
                 }
             }

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -50,6 +50,9 @@ struct AppConfig: Codable, Equatable {
     /// Preview gate for the worktree Agent tab. This remains off until the
     /// per-worktree rollup has completed preview testing.
     var agentTabEnabled: Bool = false
+    /// Preview gate for the right pane icon rail. This remains off until the
+    /// rail presentation has completed preview testing.
+    var rightPaneRailEnabled: Bool = false
     var recentProjectIds: [String] = []
     var recentWorktreeIdsByProject: [String: [String]] = [:]
     var recentWorktreeRefs: [RepoSelectorRecents.RecentWorktreeRef] = []
@@ -513,6 +516,7 @@ struct AppConfig: Codable, Equatable {
         workspacesEnabled: false,
         runTabEnabled: false,
         agentTabEnabled: false,
+        rightPaneRailEnabled: false,
         recentProjectIds: [],
         recentWorktreeIdsByProject: [:],
         recentWorktreeRefs: [],
@@ -607,6 +611,7 @@ extension AppConfig {
              workspacesEnabled,
              runTabEnabled,
              agentTabEnabled,
+             rightPaneRailEnabled,
              recentProjectIds, recentWorktreeIdsByProject, recentWorktreeRefs,
              collapsedProjectIds,
              sidebarChromeOverrides,
@@ -848,6 +853,7 @@ extension AppConfig {
         // The Agent tab preview is opt-in. Configs written before it existed
         // continue to load without exposing the sidebar rollup.
         agentTabEnabled = (try? c.decode(Bool.self, forKey: .agentTabEnabled)) ?? false
+        rightPaneRailEnabled = (try? c.decode(Bool.self, forKey: .rightPaneRailEnabled)) ?? false
         recentProjectIds = (try? c.decode([String].self, forKey: .recentProjectIds)) ?? []
         recentWorktreeIdsByProject =
             (try? c.decode([String: [String]].self, forKey: .recentWorktreeIdsByProject)) ?? [:]

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -871,7 +871,7 @@ extension AppConfig {
         migrateLegacyAgentLauncherShortcutOverrides()
         removeShortcutOverridesCollidingWithReservedBindings()
         // Last: it must see the final override set.
-        unbindNewAgentLauncherDefaultsClaimedByOverrides()
+        unbindNewActionDefaultsClaimedByOverrides()
     }
 }
 
@@ -912,16 +912,23 @@ private extension AppConfig {
         }
     }
 
-    /// The split actions introduce defaults (⌘⌥⇧C, and ⌘⌥⇧T for the terminal
-    /// half) that an older config may already have assigned to something else
-    /// — legal at the time, since `conflict(for:excluding:)` only guards
-    /// interactive assignment in Settings, never decode. Without an override
-    /// of their own the new actions would silently claim the same chord and
-    /// both menu items would register it. Leave the user's binding alone and
-    /// start the new action explicitly unbound; Settings can restore its
-    /// default once the chord is free.
-    mutating func unbindNewAgentLauncherDefaultsClaimedByOverrides() {
-        for action in [ShortcutAction.launchAgentInTerminal, .launchAgentInChat] {
+    /// Actions added after the first release ship defaults an older config may
+    /// already have assigned to something else — legal at the time, since
+    /// `conflict(for:excluding:)` only guards interactive assignment in
+    /// Settings, never decode. Without an override of their own the new
+    /// actions would silently claim the same chord and both menu items would
+    /// register it. Leave the user's binding alone and start the new action
+    /// explicitly unbound; Settings can restore its default once the chord is
+    /// free.
+    ///
+    /// Covers the agent-launcher split (⌘⌥⇧C, ⌘⌥⇧T) and the right pane's rail
+    /// tabs (⌘⌃1–4).
+    mutating func unbindNewActionDefaultsClaimedByOverrides() {
+        let newActions: [ShortcutAction] = [
+            .launchAgentInTerminal, .launchAgentInChat,
+            .rightPaneChangesTab, .rightPaneFilesTab, .rightPaneAgentTab, .rightPaneRunTab,
+        ]
+        for action in newActions {
             guard !shortcutOverrides.keys.contains(action.rawValue) else { continue }
             let isClaimed = shortcutOverrides.contains { key, override in
                 key != action.rawValue && override == action.defaultBinding

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -101,7 +101,10 @@ struct ChangesTabView: View {
                 onActiveOwnerChange: { _ in },
                 onScrollRequestCompletion: { generation in
                     if rps.attentionScrollRequest?.generation == generation { rps.attentionScrollRequest = nil }
-                }
+                },
+                // The rail presentation drops the scroller: against a 36pt rail
+                // and a narrow pane, a permanent scroller reads as clutter.
+                hidesScroller: appState.config.rightPaneRailEnabled
             )
             if isGGDrawerActive, rps.attentionRevealedTarget != nil {
                 Button("Back to stack") { rps.endAttentionReveal() }

--- a/Alas/Sources/Right/RightPaneRail.swift
+++ b/Alas/Sources/Right/RightPaneRail.swift
@@ -96,7 +96,9 @@ private struct RightPaneRailButton: View {
         .onHover { hovering = $0 }
         .help(collapsed ? "Open \(label)" : label)
         .accessibilityLabel(accessibilityLabel)
-        .accessibilityAddTraits(state == .active ? .isSelected : [])
+        // `.activeCollapsed` is still the selected tab — it is the one the
+        // pane reopens on — so it carries the trait too.
+        .accessibilityAddTraits(state == .active || state == .activeCollapsed ? .isSelected : [])
     }
 
     private var foreground: Color {
@@ -116,7 +118,10 @@ private struct RightPaneRailButton: View {
             RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line"), lineWidth: 0.5)
         case .inactive:
             if hovering {
-                RoundedRectangle(cornerRadius: 6).fill(Color.white.opacity(0.06))
+                // A theme token rather than a white wash: the rail sits on
+                // `bg-1`, and `bg-3` reads as a subtle step away from it in
+                // both the dark and the light theme.
+                RoundedRectangle(cornerRadius: 6).fill(theme.color("bg-3"))
             } else {
                 Color.clear
             }
@@ -161,6 +166,9 @@ private struct RightPaneRailButton: View {
     }
 
     private var accessibilityLabel: String {
+        // The live dot draws no text, so VoiceOver would otherwise hear
+        // nothing at all where a sighted user sees activity.
+        if badge == .liveDot { return "\(label), running" }
         guard let text = badge.displayText else { return label }
         return "\(label), \(text)"
     }

--- a/Alas/Sources/Right/RightPaneRail.swift
+++ b/Alas/Sources/Right/RightPaneRail.swift
@@ -47,7 +47,9 @@ struct RightPaneRail: View {
         .padding(.horizontal, 3)
         .frame(width: Self.width)
         .frame(maxHeight: .infinity)
-        .background(theme.color("bg-1"))
+        // No opaque fill of its own: the rail sits over the same
+        // `SidebarMaterialBackground` as the rest of the expanded pane, and
+        // an opaque background here would occlude it just for this column.
         .overlay(Divider().opacity(0.5), alignment: .leading)
     }
 
@@ -129,12 +131,14 @@ private struct RightPaneRailButton: View {
     }
 
     /// The collapsed active tab keeps a leading edge marker so the rail still
-    /// records which tab the pane will reopen on.
+    /// records which tab the pane will reopen on. Accent-colored like the
+    /// expanded selection fill, so it still reads as "selected", not just
+    /// "last used."
     @ViewBuilder
     private var collapsedMarker: some View {
         if state == .activeCollapsed {
             RoundedRectangle(cornerRadius: 1)
-                .fill(theme.color("fg-faint"))
+                .fill(theme.color("accent"))
                 .frame(width: 2, height: 12)
                 .offset(x: -3)
         }

--- a/Alas/Sources/Right/RightPaneRail.swift
+++ b/Alas/Sources/Right/RightPaneRail.swift
@@ -1,0 +1,167 @@
+import SwiftUI
+
+/// The right pane's vertical tab rail. Sits on the outer edge of the pane and
+/// stays visible when the body collapses, so a collapsed pane can still be
+/// reopened — and still shows live badges — without a separate reveal button.
+struct RightPaneRail: View {
+    static let width: CGFloat = 36
+
+    let activeTab: RightPaneTab
+    let collapsed: Bool
+    let changesCount: Int
+    var activeAgentCount: Int = 0
+    var activeRunCount: Int = 0
+    var showAgentTab: Bool = false
+    var showRunTab: Bool = false
+    let onAction: (RightPaneRailAction) -> Void
+
+    @Environment(\.theme) private var theme
+
+    private var tabs: [RightPaneTab] {
+        RightPaneTab.available(agentTabEnabled: showAgentTab, runTabEnabled: showRunTab)
+    }
+
+    var body: some View {
+        VStack(spacing: 3) {
+            ForEach(tabs, id: \.rawValue) { tab in
+                RightPaneRailButton(
+                    tab: tab,
+                    label: Self.label(for: tab),
+                    icon: Self.icon(for: tab),
+                    state: RightPaneRailModel.tabState(for: tab, active: activeTab, collapsed: collapsed),
+                    badge: RightPaneRailModel.badge(
+                        for: tab,
+                        changesCount: changesCount,
+                        activeAgentCount: activeAgentCount,
+                        activeRunCount: activeRunCount
+                    ),
+                    collapsed: collapsed,
+                    onTap: {
+                        onAction(RightPaneRailAction.resolve(tapped: tab, active: activeTab, collapsed: collapsed))
+                    }
+                )
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 5)
+        .padding(.horizontal, 3)
+        .frame(width: Self.width)
+        .frame(maxHeight: .infinity)
+        .background(theme.color("bg-1"))
+        .overlay(Divider().opacity(0.5), alignment: .leading)
+    }
+
+    static func label(for tab: RightPaneTab) -> String {
+        switch tab {
+        case .changes: return "Changes"
+        case .files:   return "Files"
+        case .agent:   return "Agent"
+        case .run:     return "Run"
+        }
+    }
+
+    static func icon(for tab: RightPaneTab) -> String {
+        switch tab {
+        case .changes: return "diff"
+        case .files:   return "folder"
+        case .agent:   return "person.crop.circle"
+        case .run:     return "play"
+        }
+    }
+}
+
+private struct RightPaneRailButton: View {
+    let tab: RightPaneTab
+    let label: String
+    let icon: String
+    let state: RightPaneRailTabState
+    let badge: RightPaneRailBadge
+    let collapsed: Bool
+    let onTap: () -> Void
+
+    @Environment(\.theme) private var theme
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: onTap) {
+            Icon(name: icon, size: 14, color: foreground)
+                .frame(width: 26, height: 26)
+                .background(background)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .overlay(alignment: .leading) { collapsedMarker }
+                .overlay(alignment: .topTrailing) { badgeView }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .help(collapsed ? "Open \(label)" : label)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityAddTraits(state == .active ? .isSelected : [])
+    }
+
+    private var foreground: Color {
+        switch state {
+        case .active:          return theme.color("accent")
+        case .activeCollapsed: return theme.color("fg-dim")
+        case .inactive:        return hovering ? theme.color("fg-muted") : theme.color("fg-faint")
+        }
+    }
+
+    @ViewBuilder
+    private var background: some View {
+        switch state {
+        case .active:
+            RoundedRectangle(cornerRadius: 6).fill(theme.color("accent-soft"))
+        case .activeCollapsed:
+            RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line"), lineWidth: 0.5)
+        case .inactive:
+            if hovering {
+                RoundedRectangle(cornerRadius: 6).fill(Color.white.opacity(0.06))
+            } else {
+                Color.clear
+            }
+        }
+    }
+
+    /// The collapsed active tab keeps a leading edge marker so the rail still
+    /// records which tab the pane will reopen on.
+    @ViewBuilder
+    private var collapsedMarker: some View {
+        if state == .activeCollapsed {
+            RoundedRectangle(cornerRadius: 1)
+                .fill(theme.color("fg-faint"))
+                .frame(width: 2, height: 12)
+                .offset(x: -3)
+        }
+    }
+
+    @ViewBuilder
+    private var badgeView: some View {
+        switch badge {
+        case .none:
+            EmptyView()
+        case .liveDot:
+            Circle()
+                .fill(theme.color("add"))
+                .frame(width: 7, height: 7)
+                .overlay(Circle().strokeBorder(theme.color("bg-1"), lineWidth: 1.5))
+                .offset(x: 2, y: -2)
+        case .count:
+            if let text = badge.displayText {
+                Text(text)
+                    .font(.system(size: 8.5, weight: .bold))
+                    .foregroundColor(theme.color("fg-muted"))
+                    .padding(.horizontal, 3)
+                    .frame(minWidth: 12, minHeight: 12)
+                    .background(Capsule().fill(theme.color("bg-4")))
+                    .overlay(Capsule().strokeBorder(theme.color("bg-1"), lineWidth: 1.5))
+                    .offset(x: 4, y: -3)
+            }
+        }
+    }
+
+    private var accessibilityLabel: String {
+        guard let text = badge.displayText else { return label }
+        return "\(label), \(text)"
+    }
+}

--- a/Alas/Sources/Right/RightPaneRailModel.swift
+++ b/Alas/Sources/Right/RightPaneRailModel.swift
@@ -28,6 +28,13 @@ enum RightPaneRailBadge: Equatable {
     }
 }
 
+/// The right pane state a resolved rail action leads to: which tab is active
+/// and whether the pane body is expanded.
+struct RightPaneRailOutcome: Equatable {
+    var tab: RightPaneTab
+    var visible: Bool
+}
+
 /// How a rail tab button paints. The collapsed active tab is its own state:
 /// it drops its accent fill and becomes a muted "last used" marker.
 enum RightPaneRailTabState: Equatable {
@@ -58,5 +65,26 @@ enum RightPaneRailModel {
     ) -> RightPaneRailTabState {
         guard tab == active else { return .inactive }
         return collapsed ? .activeCollapsed : .active
+    }
+
+    /// Applies a resolved rail action to the pane's state. Kept pure and
+    /// separate from the view so the transition that decides which tab a
+    /// collapsed pane reopens on is covered by tests rather than only by
+    /// clicking the rail.
+    static func apply(
+        _ action: RightPaneRailAction,
+        currentTab: RightPaneTab,
+        currentVisible: Bool
+    ) -> RightPaneRailOutcome {
+        switch action {
+        case .collapse:
+            return RightPaneRailOutcome(tab: currentTab, visible: false)
+        case .expand(let tab):
+            return RightPaneRailOutcome(tab: tab, visible: true)
+        case .select(let tab):
+            // Selecting never changes whether the body is showing; it is only
+            // reachable while the pane is already expanded.
+            return RightPaneRailOutcome(tab: tab, visible: currentVisible)
+        }
     }
 }

--- a/Alas/Sources/Right/RightPaneRailModel.swift
+++ b/Alas/Sources/Right/RightPaneRailModel.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// What a click on a rail tab button means, given what is currently active
+/// and whether the pane body is collapsed.
+enum RightPaneRailAction: Equatable {
+    case collapse
+    case expand(RightPaneTab)
+    case select(RightPaneTab)
+
+    static func resolve(tapped: RightPaneTab, active: RightPaneTab, collapsed: Bool) -> Self {
+        if collapsed { return .expand(tapped) }
+        return tapped == active ? .collapse : .select(tapped)
+    }
+}
+
+/// The overlay a rail tab carries. `liveDot` signals activity without a
+/// number; the Run tab uses it because the count is almost always one.
+enum RightPaneRailBadge: Equatable {
+    case none
+    case count(Int)
+    case liveDot
+
+    /// Text drawn inside the badge pill, or `nil` when the badge draws no
+    /// text. Capped so a large count cannot widen the 36pt rail.
+    var displayText: String? {
+        guard case .count(let value) = self else { return nil }
+        return value > 99 ? "99+" : String(value)
+    }
+}
+
+/// How a rail tab button paints. The collapsed active tab is its own state:
+/// it drops its accent fill and becomes a muted "last used" marker.
+enum RightPaneRailTabState: Equatable {
+    case active
+    case activeCollapsed
+    case inactive
+}
+
+enum RightPaneRailModel {
+    static func badge(
+        for tab: RightPaneTab,
+        changesCount: Int,
+        activeAgentCount: Int,
+        activeRunCount: Int
+    ) -> RightPaneRailBadge {
+        switch tab {
+        case .changes: return changesCount > 0 ? .count(changesCount) : .none
+        case .files:   return .none
+        case .agent:   return activeAgentCount > 0 ? .count(activeAgentCount) : .none
+        case .run:     return activeRunCount > 0 ? .liveDot : .none
+        }
+    }
+
+    static func tabState(
+        for tab: RightPaneTab,
+        active: RightPaneTab,
+        collapsed: Bool
+    ) -> RightPaneRailTabState {
+        guard tab == active else { return .inactive }
+        return collapsed ? .activeCollapsed : .active
+    }
+}

--- a/Alas/Sources/Right/RightPaneToolbar.swift
+++ b/Alas/Sources/Right/RightPaneToolbar.swift
@@ -31,6 +31,7 @@ struct RightPaneToolbar: View {
         .frame(height: 24)
         .background(theme.color("bg-2"))
         .overlay(Divider().opacity(0.5), alignment: .bottom)
+        .windowDragHandle()
     }
 
     /// Only the Changes tab names a branch, so only it gets the branch icon;

--- a/Alas/Sources/Right/RightPaneToolbar.swift
+++ b/Alas/Sources/Right/RightPaneToolbar.swift
@@ -28,7 +28,7 @@ struct RightPaneToolbar: View {
         }
         .padding(.leading, 10)
         .padding(.trailing, 4)
-        .frame(height: 24)
+        .frame(height: 34)
         .background(theme.color("bg-2"))
         .overlay(Divider().opacity(0.5), alignment: .bottom)
         .windowDragHandle()

--- a/Alas/Sources/Right/RightPaneToolbar.swift
+++ b/Alas/Sources/Right/RightPaneToolbar.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+/// The right pane's context row. The selected rail tab already names the
+/// panel, so this row carries per-tab context instead of a title.
+struct RightPaneToolbar: View {
+    let tab: RightPaneTab
+    var branch: String = ""
+    var totalAdd: Int = 0
+    var totalDel: Int = 0
+    var activeAgentCount: Int = 0
+    var waitingAgentCount: Int = 0
+    var runningScriptNames: [String] = []
+    var showIgnored: Bool = false
+    var onToggleShowIgnored: () -> Void = {}
+    var onSearch: () -> Void = {}
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(RightPaneToolbarModel.leading(
+                for: tab,
+                branch: branch,
+                activeAgentCount: activeAgentCount,
+                waitingAgentCount: waitingAgentCount,
+                runningScriptNames: runningScriptNames
+            ))
+            .font(.system(size: 10.5, design: .monospaced))
+            .foregroundColor(theme.color("fg-muted"))
+            .lineLimit(1)
+            .truncationMode(.middle)
+
+            Spacer(minLength: 6)
+            trailing
+            if RightPaneToolbarModel.showsOverflowMenu(for: tab) {
+                overflowMenu
+            }
+        }
+        .padding(.leading, 10)
+        .padding(.trailing, 4)
+        .frame(height: 24)
+        .background(theme.color("bg-2"))
+        .overlay(Divider().opacity(0.5), alignment: .bottom)
+    }
+
+    @ViewBuilder
+    private var trailing: some View {
+        switch RightPaneToolbarModel.trailing(for: tab, totalAdd: totalAdd, totalDel: totalDel) {
+        case .none:
+            EmptyView()
+        case .diffTotals(let add, let del):
+            HStack(spacing: 6) {
+                Text("+\(add)").foregroundColor(theme.color("add"))
+                Text("−\(del)").foregroundColor(theme.color("del"))
+            }
+            .font(.system(size: 10.5, design: .monospaced))
+        case .search:
+            ToolbarBtn(icon: "search", tooltip: "Search files", action: onSearch)
+        }
+    }
+
+    private var overflowMenu: some View {
+        Menu {
+            Toggle("Show ignored or excluded files", isOn: Binding(
+                get: { showIgnored },
+                set: { _ in onToggleShowIgnored() }
+            ))
+        } label: {
+            Icon(name: "menu", size: 12, color: theme.color("fg-faint"))
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .frame(width: 20)
+        .help("More options")
+    }
+}

--- a/Alas/Sources/Right/RightPaneToolbar.swift
+++ b/Alas/Sources/Right/RightPaneToolbar.swift
@@ -18,17 +18,7 @@ struct RightPaneToolbar: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            Text(RightPaneToolbarModel.leading(
-                for: tab,
-                branch: branch,
-                activeAgentCount: activeAgentCount,
-                waitingAgentCount: waitingAgentCount,
-                runningScriptNames: runningScriptNames
-            ))
-            .font(.system(size: 10.5, design: .monospaced))
-            .foregroundColor(theme.color("fg-muted"))
-            .lineLimit(1)
-            .truncationMode(.middle)
+            leading
 
             Spacer(minLength: 6)
             trailing
@@ -41,6 +31,27 @@ struct RightPaneToolbar: View {
         .frame(height: 24)
         .background(theme.color("bg-2"))
         .overlay(Divider().opacity(0.5), alignment: .bottom)
+    }
+
+    /// Only the Changes tab names a branch, so only it gets the branch icon;
+    /// the other tabs' leading text is a summary, not a ref.
+    private var leading: some View {
+        HStack(spacing: 4) {
+            if tab == .changes {
+                Icon(name: "branch", size: 10, color: theme.color("fg-muted"))
+            }
+            Text(RightPaneToolbarModel.leading(
+                for: tab,
+                branch: branch,
+                activeAgentCount: activeAgentCount,
+                waitingAgentCount: waitingAgentCount,
+                runningScriptNames: runningScriptNames
+            ))
+            .font(.system(size: 10.5, design: .monospaced))
+            .foregroundColor(theme.color("fg-muted"))
+            .lineLimit(1)
+            .truncationMode(.middle)
+        }
     }
 
     @ViewBuilder

--- a/Alas/Sources/Right/RightPaneToolbarModel.swift
+++ b/Alas/Sources/Right/RightPaneToolbarModel.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// The trailing accessory of the right pane toolbar, which differs per tab.
+enum RightPaneToolbarTrailing: Equatable {
+    case none
+    case diffTotals(add: Int, del: Int)
+    case search
+}
+
+/// Derives the right pane toolbar's text and accessories from the active tab.
+/// The toolbar replaces the panel title: the selected rail tab already names
+/// the panel, so this row carries context instead.
+enum RightPaneToolbarModel {
+    static func leading(
+        for tab: RightPaneTab,
+        branch: String,
+        activeAgentCount: Int,
+        waitingAgentCount: Int,
+        runningScriptNames: [String]
+    ) -> String {
+        switch tab {
+        case .changes:
+            return branch.isEmpty ? "Detached HEAD" : branch
+        case .files:
+            return "Working tree"
+        case .agent:
+            guard activeAgentCount > 0 else { return "No agents" }
+            guard waitingAgentCount > 0 else { return "\(activeAgentCount) active" }
+            return "\(activeAgentCount) active · \(waitingAgentCount) waiting"
+        case .run:
+            switch runningScriptNames.count {
+            case 0:  return "Nothing running"
+            case 1:  return runningScriptNames[0]
+            default: return "\(runningScriptNames.count) running"
+            }
+        }
+    }
+
+    static func trailing(for tab: RightPaneTab, totalAdd: Int, totalDel: Int) -> RightPaneToolbarTrailing {
+        switch tab {
+        case .changes:
+            return (totalAdd == 0 && totalDel == 0) ? .none : .diffTotals(add: totalAdd, del: totalDel)
+        case .files:
+            return .search
+        case .agent, .run:
+            return .none
+        }
+    }
+
+    /// Only Files has anything to put in the overflow menu, and an empty menu
+    /// is worse than no button.
+    static func showsOverflowMenu(for tab: RightPaneTab) -> Bool {
+        tab == .files
+    }
+}

--- a/Alas/Sources/Right/RightPaneTransitionalView.swift
+++ b/Alas/Sources/Right/RightPaneTransitionalView.swift
@@ -9,6 +9,15 @@ import SwiftUI
 /// `.disabled(true)` — all controls (including the hide-pane button) are
 /// inert. Recovery actions for the failure states live on the sidebar row
 /// context menu and the center pane.
+///
+/// The icon rail is the one exception: under the preview flag it is the
+/// pane's only reveal affordance (the center pane suppresses its own
+/// reveal button whenever the flag is on), so a rail tap must still be able
+/// to expand a collapsed pane here — otherwise a pane collapsed before a
+/// worktree entered a transitional state could never be reopened to show
+/// its status. Tab identity has no real effect on `content` beyond which
+/// skeleton variant `.creating` shows, so this reuses the same
+/// `RightPaneRailModel.apply` transition `RightPaneView` uses.
 struct RightPaneTransitionalView: View {
     enum Kind {
         case creating
@@ -43,9 +52,19 @@ struct RightPaneTransitionalView: View {
                             activeAgentCount: state.agentSidebarRollup(for: worktree).active.count,
                             showAgentTab: state.config.agentTabEnabled,
                             showRunTab: state.config.runTabEnabled,
-                            onAction: { _ in }
+                            onAction: { action in
+                                let outcome = RightPaneRailModel.apply(
+                                    action,
+                                    currentTab: activeTab,
+                                    currentVisible: state.config.rightPaneVisible
+                                )
+                                activeTab = outcome.tab
+                                if state.config.rightPaneVisible != outcome.visible {
+                                    state.config.rightPaneVisible = outcome.visible
+                                    state.saveConfig()
+                                }
+                            }
                         )
-                        .disabled(true)
                     }
                 } else {
                     VStack(spacing: 0) {

--- a/Alas/Sources/Right/RightPaneTransitionalView.swift
+++ b/Alas/Sources/Right/RightPaneTransitionalView.swift
@@ -30,22 +30,42 @@ struct RightPaneTransitionalView: View {
                 choice: state.config.sidebarMaterial,
                 backgroundOpacity: override.backgroundOpacity
             )
-            VStack(spacing: 0) {
-                RightPaneTabBar(
-                    activeTab: $activeTab,
-                    changesCount: 0,
-                    totalAdd: 0,
-                    totalDel: 0,
-                    onHidePane: {},
-                    showIgnored: state.config.files.showIgnored,
-                    onToggleShowIgnored: {},
-                    showAgentTab: state.config.agentTabEnabled,
-                    showRunTab: state.config.runTabEnabled,
-                    activeAgentCount: state.agentSidebarRollup(for: worktree).active.count
-                )
-                .disabled(true)
+            Group {
+                if state.config.rightPaneRailEnabled {
+                    HStack(spacing: 0) {
+                        if !collapsed {
+                            content
+                        }
+                        RightPaneRail(
+                            activeTab: activeTab,
+                            collapsed: collapsed,
+                            changesCount: 0,
+                            activeAgentCount: state.agentSidebarRollup(for: worktree).active.count,
+                            showAgentTab: state.config.agentTabEnabled,
+                            showRunTab: state.config.runTabEnabled,
+                            onAction: { _ in }
+                        )
+                        .disabled(true)
+                    }
+                } else {
+                    VStack(spacing: 0) {
+                        RightPaneTabBar(
+                            activeTab: $activeTab,
+                            changesCount: 0,
+                            totalAdd: 0,
+                            totalDel: 0,
+                            onHidePane: {},
+                            showIgnored: state.config.files.showIgnored,
+                            onToggleShowIgnored: {},
+                            showAgentTab: state.config.agentTabEnabled,
+                            showRunTab: state.config.runTabEnabled,
+                            activeAgentCount: state.agentSidebarRollup(for: worktree).active.count
+                        )
+                        .disabled(true)
 
-                content
+                        content
+                    }
+                }
             }
             .sidebarChromeTheme(textContrast: override.textContrast)
         }

--- a/Alas/Sources/Right/RightPaneTransitionalView.swift
+++ b/Alas/Sources/Right/RightPaneTransitionalView.swift
@@ -43,7 +43,12 @@ struct RightPaneTransitionalView: View {
                 if state.config.rightPaneRailEnabled {
                     HStack(spacing: 0) {
                         if !collapsed {
+                            // Unlike the active pane, a transitional pane has
+                            // no separate toolbar row — `content` is the only
+                            // header-equivalent region, so it carries the
+                            // drag handle the removed tab bar used to.
                             content
+                                .windowDragHandle()
                         }
                         RightPaneRail(
                             activeTab: activeTab,

--- a/Alas/Sources/Right/RightPaneTransitionalView.swift
+++ b/Alas/Sources/Right/RightPaneTransitionalView.swift
@@ -19,6 +19,7 @@ struct RightPaneTransitionalView: View {
     @Bindable var state: AppState
     let worktree: Worktree
     let kind: Kind
+    var collapsed: Bool = false
 
     @State private var activeTab: RightPaneTab = .changes
 

--- a/Alas/Sources/Right/RightPaneTransitionalView.swift
+++ b/Alas/Sources/Right/RightPaneTransitionalView.swift
@@ -57,18 +57,7 @@ struct RightPaneTransitionalView: View {
                             activeAgentCount: state.agentSidebarRollup(for: worktree).active.count,
                             showAgentTab: state.config.agentTabEnabled,
                             showRunTab: state.config.runTabEnabled,
-                            onAction: { action in
-                                let outcome = RightPaneRailModel.apply(
-                                    action,
-                                    currentTab: activeTab,
-                                    currentVisible: state.config.rightPaneVisible
-                                )
-                                activeTab = outcome.tab
-                                if state.config.rightPaneVisible != outcome.visible {
-                                    state.config.rightPaneVisible = outcome.visible
-                                    state.saveConfig()
-                                }
-                            }
+                            onAction: { handle($0) }
                         )
                     }
                 } else {
@@ -92,7 +81,35 @@ struct RightPaneTransitionalView: View {
                 }
             }
             .sidebarChromeTheme(textContrast: override.textContrast)
+            .onReceive(NotificationCenter.default.publisher(for: .alasSelectRightPaneTab)) { notification in
+                handleTabShortcut(notification)
+            }
         }
+    }
+
+    /// Shared by the rail's own taps and by the tab shortcuts, so both move
+    /// this pane the same way. There is no `RightPaneState` for a transitional
+    /// worktree — `activeTab` is local — but the pane can still be opened and
+    /// closed, and `.creating` varies its skeleton by tab.
+    private func handle(_ action: RightPaneRailAction) {
+        let outcome = RightPaneRailModel.apply(
+            action,
+            currentTab: activeTab,
+            currentVisible: state.config.rightPaneVisible
+        )
+        activeTab = outcome.tab
+        if state.config.rightPaneVisible != outcome.visible {
+            state.config.rightPaneVisible = outcome.visible
+            state.saveConfig()
+        }
+    }
+
+    private func handleTabShortcut(_ notification: Notification) {
+        guard let raw = notification.object as? String,
+              let tab = RightPaneTab(rawValue: raw),
+              state.acceptsRightPaneTabShortcut(tab)
+        else { return }
+        handle(RightPaneRailAction.resolve(tapped: tab, active: activeTab, collapsed: collapsed))
     }
 
     @ViewBuilder

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -279,7 +279,7 @@ struct RightPaneView: View {
                                 state.config.files.showIgnored.toggle()
                                 state.saveConfig()
                             },
-                            onSearch: { state.search.open() }
+                            onSearch: { state.openSearchOverlay() }
                         )
                         tabContent(rps: rps)
                     }

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -9,6 +9,7 @@ struct RightPaneView: View {
     let onSelectCommit: (CommitInfo) -> Void
     let onEditCommit: (CommitInfo, String) -> Void
     let onReviewCommit: (CommitInfo) -> Void
+    var collapsed: Bool = false
     @Environment(\.theme) var theme
     @State private var rps: RightPaneState?
     @State private var agentManager: ACPSessionManager?
@@ -17,6 +18,7 @@ struct RightPaneView: View {
     init(
         state: AppState,
         worktree: Worktree,
+        collapsed: Bool = false,
         onSelectChangedFile: @escaping (ChangedFile) -> Void,
         onSelectTreeFile: @escaping (FileTreeNode) -> Void,
         onSelectCommit: @escaping (CommitInfo) -> Void,
@@ -25,6 +27,7 @@ struct RightPaneView: View {
     ) {
         self.state = state
         self.worktree = worktree
+        self.collapsed = collapsed
         self.onSelectChangedFile = onSelectChangedFile
         self.onSelectTreeFile = onSelectTreeFile
         self.onSelectCommit = onSelectCommit
@@ -51,93 +54,7 @@ struct RightPaneView: View {
                 backgroundOpacity: override.backgroundOpacity
             )
             if let rps = rps, rps.worktree.id == worktree.id {
-                VStack(spacing: 0) {
-                    RightPaneTabBar(
-                        activeTab: Binding(
-                            get: { rps.activeTab },
-                            set: { rps.activeTab = $0 }
-                        ),
-                        changesCount: rps.displayChanges.count,
-                        totalAdd: rps.displayChanges.reduce(0) { $0 + $1.add },
-                        totalDel: rps.displayChanges.reduce(0) { $0 + $1.del },
-                        onHidePane: {
-                            state.config.rightPaneVisible = false
-                            state.saveConfig()
-                        },
-                        showIgnored: state.config.files.showIgnored,
-                        onToggleShowIgnored: {
-                            state.config.files.showIgnored.toggle()
-                            state.saveConfig()
-                        },
-                        showAgentTab: state.config.agentTabEnabled,
-                        showRunTab: state.config.runTabEnabled,
-                        activeRunCount: state.runRecords
-                            .records(worktreeID: worktree.id)
-                            .count { $0.status.isActive },
-                        activeAgentCount: state.agentSidebarRollup(for: worktree).active.count
-                    )
-
-                    if rps.hasLoadedSnapshot || (rps.activeTab == .agent && state.config.agentTabEnabled) {
-                        switch rps.activeTab {
-                        case .changes:
-                            ChangesTabView(
-                                rps: rps,
-                                appState: state,
-                                onSelect: onSelectChangedFile,
-                                onSelectCommit: onSelectCommit,
-                                onEditCommit: onEditCommit,
-                                onReviewCommit: onReviewCommit
-                            )
-                        case .files:
-                            FilesTabView(
-                                nodes: rps.fileTree,
-                                fileTreeGeneration: rps.fileTreeGeneration,
-                                worktreePath: worktree.path,
-                                openPaths: Binding(
-                                    get: { rps.openPaths },
-                                    set: { rps.openPaths = $0 }
-                                ),
-                                onSelectFile: onSelectTreeFile,
-                                onFileHistory: { node in
-                                    state.openFileHistory(relativePath: node.path, worktreeId: worktree.id)
-                                },
-                                onCreateFile: { path in
-                                    state.newFile(in: worktree.id, directoryPath: path) {
-                                        Task { await rps.refresh() }
-                                    }
-                                },
-                                onCreateFolder: { path in
-                                    state.newFolder(in: worktree.id, directoryPath: path) {
-                                        Task { await rps.refresh() }
-                                    }
-                                },
-                                shouldAutoLoadChildren: { path, childrenState in
-                                    rps.shouldAutoLoadFileTreeChildren(path: path, childrenState: childrenState)
-                                },
-                                onLoadChildren: { rps.loadFileTreeChildren(path: $0) },
-                                showIgnored: state.config.files.showIgnored,
-                                revealPath: rps.revealPath,
-                                revealTick: rps.revealTick,
-                                onClearReveal: { rps.clearReveal() },
-                                worktreeRoot: rps.worktree.path
-                            )
-                        case .agent:
-                            Group {
-                                if let agentManager, agentManager.worktreeId == worktree.id {
-                                    AgentWorktreeTabView(state: state, worktree: worktree, manager: agentManager)
-                                        .id(worktree.id)
-                                } else {
-                                    ProgressView("Loading sessions…")
-                                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                }
-                            }
-                        case .run:
-                            RunTabView(state: state, worktree: worktree)
-                        }
-                    } else {
-                        RightPaneLoadingSkeletonView(activeTab: rps.activeTab)
-                    }
-                }
+                presentation(rps: rps)
                 .sidebarChromeTheme(textContrast: override.textContrast)
                 .task(id: worktree.id) {
                     agentManager = state.acpManager(for: worktree)
@@ -277,6 +194,165 @@ struct RightPaneView: View {
         .onDisappear {
             state.rightPaneStore.deactivate()
         }
+    }
+
+    @ViewBuilder
+    private func tabContent(rps: RightPaneState) -> some View {
+        if rps.hasLoadedSnapshot || (rps.activeTab == .agent && state.config.agentTabEnabled) {
+            switch rps.activeTab {
+            case .changes:
+                ChangesTabView(
+                    rps: rps,
+                    appState: state,
+                    onSelect: onSelectChangedFile,
+                    onSelectCommit: onSelectCommit,
+                    onEditCommit: onEditCommit,
+                    onReviewCommit: onReviewCommit
+                )
+            case .files:
+                FilesTabView(
+                    nodes: rps.fileTree,
+                    fileTreeGeneration: rps.fileTreeGeneration,
+                    worktreePath: worktree.path,
+                    openPaths: Binding(
+                        get: { rps.openPaths },
+                        set: { rps.openPaths = $0 }
+                    ),
+                    onSelectFile: onSelectTreeFile,
+                    onFileHistory: { node in
+                        state.openFileHistory(relativePath: node.path, worktreeId: worktree.id)
+                    },
+                    onCreateFile: { path in
+                        state.newFile(in: worktree.id, directoryPath: path) {
+                            Task { await rps.refresh() }
+                        }
+                    },
+                    onCreateFolder: { path in
+                        state.newFolder(in: worktree.id, directoryPath: path) {
+                            Task { await rps.refresh() }
+                        }
+                    },
+                    shouldAutoLoadChildren: { path, childrenState in
+                        rps.shouldAutoLoadFileTreeChildren(path: path, childrenState: childrenState)
+                    },
+                    onLoadChildren: { rps.loadFileTreeChildren(path: $0) },
+                    showIgnored: state.config.files.showIgnored,
+                    revealPath: rps.revealPath,
+                    revealTick: rps.revealTick,
+                    onClearReveal: { rps.clearReveal() },
+                    worktreeRoot: rps.worktree.path
+                )
+            case .agent:
+                Group {
+                    if let agentManager, agentManager.worktreeId == worktree.id {
+                        AgentWorktreeTabView(state: state, worktree: worktree, manager: agentManager)
+                            .id(worktree.id)
+                    } else {
+                        ProgressView("Loading sessions…")
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
+                }
+            case .run:
+                RunTabView(state: state, worktree: worktree)
+            }
+        } else {
+            RightPaneLoadingSkeletonView(activeTab: rps.activeTab)
+        }
+    }
+
+    @ViewBuilder
+    private func presentation(rps: RightPaneState) -> some View {
+        if state.config.rightPaneRailEnabled {
+            HStack(spacing: 0) {
+                if !collapsed {
+                    VStack(spacing: 0) {
+                        RightPaneToolbar(
+                            tab: rps.activeTab,
+                            branch: rps.currentBranch,
+                            totalAdd: rps.displayChanges.reduce(0) { $0 + $1.add },
+                            totalDel: rps.displayChanges.reduce(0) { $0 + $1.del },
+                            activeAgentCount: agentRollup.active.count,
+                            waitingAgentCount: waitingAgentCount,
+                            runningScriptNames: runningScriptNames,
+                            showIgnored: state.config.files.showIgnored,
+                            onToggleShowIgnored: {
+                                state.config.files.showIgnored.toggle()
+                                state.saveConfig()
+                            },
+                            onSearch: { state.search.open() }
+                        )
+                        tabContent(rps: rps)
+                    }
+                }
+                RightPaneRail(
+                    activeTab: rps.activeTab,
+                    collapsed: collapsed,
+                    changesCount: rps.displayChanges.count,
+                    activeAgentCount: agentRollup.active.count,
+                    activeRunCount: runningScriptNames.count,
+                    showAgentTab: state.config.agentTabEnabled,
+                    showRunTab: state.config.runTabEnabled,
+                    onAction: { action in handle(action, rps: rps) }
+                )
+            }
+        } else {
+            VStack(spacing: 0) {
+                RightPaneTabBar(
+                    activeTab: Binding(
+                        get: { rps.activeTab },
+                        set: { rps.activeTab = $0 }
+                    ),
+                    changesCount: rps.displayChanges.count,
+                    totalAdd: rps.displayChanges.reduce(0) { $0 + $1.add },
+                    totalDel: rps.displayChanges.reduce(0) { $0 + $1.del },
+                    onHidePane: {
+                        state.config.rightPaneVisible = false
+                        state.saveConfig()
+                    },
+                    showIgnored: state.config.files.showIgnored,
+                    onToggleShowIgnored: {
+                        state.config.files.showIgnored.toggle()
+                        state.saveConfig()
+                    },
+                    showAgentTab: state.config.agentTabEnabled,
+                    showRunTab: state.config.runTabEnabled,
+                    activeRunCount: state.runRecords
+                        .records(worktreeID: worktree.id)
+                        .count { $0.status.isActive },
+                    activeAgentCount: state.agentSidebarRollup(for: worktree).active.count
+                )
+                tabContent(rps: rps)
+            }
+        }
+    }
+
+    private func handle(_ action: RightPaneRailAction, rps: RightPaneState) {
+        switch action {
+        case .collapse:
+            state.config.rightPaneVisible = false
+            state.saveConfig()
+        case .expand(let tab):
+            rps.activeTab = tab
+            state.config.rightPaneVisible = true
+            state.saveConfig()
+        case .select(let tab):
+            rps.activeTab = tab
+        }
+    }
+
+    private var agentRollup: AgentSidebarRollup {
+        state.agentSidebarRollup(for: worktree)
+    }
+
+    private var waitingAgentCount: Int {
+        agentRollup.active.count { $0.state == .awaitingInput || $0.state == .permissionRequest }
+    }
+
+    private var runningScriptNames: [String] {
+        state.runRecords
+            .records(worktreeID: worktree.id)
+            .filter { $0.status.isActive }
+            .map(\.scriptName)
     }
 }
 

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -327,16 +327,17 @@ struct RightPaneView: View {
     }
 
     private func handle(_ action: RightPaneRailAction, rps: RightPaneState) {
-        switch action {
-        case .collapse:
-            state.config.rightPaneVisible = false
+        let outcome = RightPaneRailModel.apply(
+            action,
+            currentTab: rps.activeTab,
+            currentVisible: state.config.rightPaneVisible
+        )
+        if rps.activeTab != outcome.tab {
+            rps.activeTab = outcome.tab
+        }
+        if state.config.rightPaneVisible != outcome.visible {
+            state.config.rightPaneVisible = outcome.visible
             state.saveConfig()
-        case .expand(let tab):
-            rps.activeTab = tab
-            state.config.rightPaneVisible = true
-            state.saveConfig()
-        case .select(let tab):
-            rps.activeTab = tab
         }
     }
 

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -281,7 +281,12 @@ struct RightPaneView: View {
                             },
                             onSearch: { state.openSearchOverlay() }
                         )
+                        // Hides the indicators of every SwiftUI ScrollView in
+                        // the tab bodies (Files, Agent, Run). The Changes tab
+                        // scrolls through AppKit, which this cannot reach — it
+                        // opts out via `AppKitDiffScroller.hidesScroller`.
                         tabContent(rps: rps)
+                            .scrollIndicators(.hidden)
                     }
                 }
                 RightPaneRail(

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -56,6 +56,9 @@ struct RightPaneView: View {
             if let rps = rps, rps.worktree.id == worktree.id {
                 presentation(rps: rps)
                 .sidebarChromeTheme(textContrast: override.textContrast)
+                .onReceive(NotificationCenter.default.publisher(for: .alasSelectRightPaneTab)) { notification in
+                    handleTabShortcut(notification, rps: rps)
+                }
                 .task(id: worktree.id) {
                     agentManager = state.acpManager(for: worktree)
                 }
@@ -329,6 +332,22 @@ struct RightPaneView: View {
                 tabContent(rps: rps)
             }
         }
+    }
+
+    /// Keyboard equivalent of tapping a rail tab. Handled here rather than in
+    /// `AppState` because `collapsed` is the layout's *effective* state: when a
+    /// narrow window makes `ThreePaneSizing` auto-collapse the pane it is true
+    /// while `config.rightPaneVisible` is still true, and resolving from the
+    /// preference alone would collapse a pane the user sees as already closed.
+    private func handleTabShortcut(_ notification: Notification, rps: RightPaneState) {
+        guard let raw = notification.object as? String,
+              let tab = RightPaneTab(rawValue: raw),
+              state.acceptsRightPaneTabShortcut(tab)
+        else { return }
+        handle(
+            RightPaneRailAction.resolve(tapped: tab, active: rps.activeTab, collapsed: collapsed),
+            rps: rps
+        )
     }
 
     private func handle(_ action: RightPaneRailAction, rps: RightPaneState) {

--- a/Alas/Sources/Settings/AdvancedPane.swift
+++ b/Alas/Sources/Settings/AdvancedPane.swift
@@ -53,6 +53,18 @@ struct AdvancedPane: View {
                             }
                         ))
                     }
+                    SettingsRow(
+                        name: "Right pane icon rail",
+                        desc: "Replaces the right pane tab bar with a vertical icon rail (preview)."
+                    ) {
+                        AlasToggle(on: Binding(
+                            get: { state.config.rightPaneRailEnabled },
+                            set: { enabled in
+                                state.config.rightPaneRailEnabled = enabled
+                                state.saveConfig()
+                            }
+                        ))
+                    }
                     if let recovery = state.workspaceRecoveryError {
                         VStack(alignment: .leading, spacing: 8) {
                             Text("Workspace recovery required: \(recovery.message)")

--- a/Alas/Sources/Shortcuts/ShortcutAction.swift
+++ b/Alas/Sources/Shortcuts/ShortcutAction.swift
@@ -15,6 +15,7 @@ enum ShortcutGroup: String, CaseIterable, Sendable {
 enum ShortcutAction: String, CaseIterable, Codable, Sendable {
     // Global
     case searchFiles, switchRepository, findAndReplace, replaceInEditor, toggleSidebar, toggleRightPane,
+         rightPaneChangesTab, rightPaneFilesTab, rightPaneAgentTab, rightPaneRunTab,
          createProject, newWorktree, focusMainWorktree, newTerminalTab,
          launchAgent, launchAgentInTerminal, launchAgentInChat,
          openReviewPalette, runScript, selectPreviousTab, selectNextTab,
@@ -29,6 +30,7 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
     var group: ShortcutGroup {
         switch self {
         case .searchFiles, .switchRepository, .findAndReplace, .replaceInEditor, .toggleSidebar, .toggleRightPane,
+             .rightPaneChangesTab, .rightPaneFilesTab, .rightPaneAgentTab, .rightPaneRunTab,
              .createProject, .newWorktree, .focusMainWorktree, .newTerminalTab,
              .launchAgent, .launchAgentInTerminal, .launchAgentInChat,
              .openReviewPalette, .runScript, .selectPreviousTab, .selectNextTab,
@@ -53,6 +55,10 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         case .replaceInEditor:          return "Find and Replace"
         case .toggleSidebar:            return "Toggle Sidebar"
         case .toggleRightPane:          return "Toggle Right Sidebar"
+        case .rightPaneChangesTab:      return "Right Sidebar: Changes"
+        case .rightPaneFilesTab:        return "Right Sidebar: Files"
+        case .rightPaneAgentTab:        return "Right Sidebar: Agent"
+        case .rightPaneRunTab:          return "Right Sidebar: Run"
         case .createProject:            return "Create Project"
         case .newWorktree:              return "New Worktree"
         case .focusMainWorktree:        return "Focus Main Worktree"
@@ -92,6 +98,8 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         case .launchAgentInChat:      return "Open the agent launcher locked to Chat"
         case .openReviewPalette:   return "Open the review target palette"
         case .runScript:           return "Open the run script palette"
+        case .rightPaneChangesTab, .rightPaneFilesTab, .rightPaneAgentTab, .rightPaneRunTab:
+            return "Opens the right sidebar on this tab; collapses it when the tab is already showing"
         case .commitInComposer:   return "In the draft commit tab"
         default:                  return nil
         }
@@ -119,6 +127,13 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         case .replaceInEditor:          return .init(key: "f",          modifiers: [.command, .option])
         case .toggleSidebar:            return .init(key: "b",          modifiers: [.command])
         case .toggleRightPane:          return .init(key: "b",          modifiers: [.command, .option])
+        // Cmd+digit is the center tab switcher and Cmd+Option+digit selects a
+        // Space, so the right pane's tabs take the one free digit family.
+        // Cmd+Shift+digit is out: 3/4/5 are macOS screen capture.
+        case .rightPaneChangesTab:      return .init(key: "1",          modifiers: [.command, .control])
+        case .rightPaneFilesTab:        return .init(key: "2",          modifiers: [.command, .control])
+        case .rightPaneAgentTab:        return .init(key: "3",          modifiers: [.command, .control])
+        case .rightPaneRunTab:          return .init(key: "4",          modifiers: [.command, .control])
         case .createProject:            return .init(key: "n",          modifiers: [.command, .shift])
         case .newWorktree:              return .init(key: "n",          modifiers: [.command, .option])
         // Cmd+Shift+M is Toggle Markdown Preview; Cmd+Option+M is macOS Minimize All.

--- a/AlasTests/AppConfigTests.swift
+++ b/AlasTests/AppConfigTests.swift
@@ -32,6 +32,7 @@ struct AppConfigTests {
         #expect(cfg.workspacesEnabled == false)
         #expect(cfg.agentTabEnabled == false)
         #expect(cfg.runTabEnabled == false)
+        #expect(cfg.rightPaneRailEnabled == false)
     }
 
     @Test func decodeOldConfigDefaultsWorkspacesDisabled() throws {
@@ -65,6 +66,17 @@ struct AppConfigTests {
         let decoded = try JSONDecoder().decode(AppConfig.self, from: oldConfig)
 
         #expect(decoded.agentTabEnabled == false)
+    }
+
+    @Test func decodeOldConfigDefaultsRightPaneRailDisabled() throws {
+        let data = try JSONEncoder().encode(AppConfig.defaults)
+        var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        object.removeValue(forKey: "rightPaneRailEnabled")
+
+        let oldConfig = try JSONSerialization.data(withJSONObject: object)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: oldConfig)
+
+        #expect(decoded.rightPaneRailEnabled == false)
     }
 
     @Test func decodeOldHarnessConfigDefaultsAwaitingPingOn() throws {

--- a/AlasTests/RightPaneRailModelTests.swift
+++ b/AlasTests/RightPaneRailModelTests.swift
@@ -1,0 +1,54 @@
+import Testing
+@testable import Alas
+
+struct RightPaneRailModelTests {
+    @Test func tappingTheActiveTabWhileExpandedCollapsesThePane() {
+        #expect(RightPaneRailAction.resolve(tapped: .changes, active: .changes, collapsed: false) == .collapse)
+        #expect(RightPaneRailAction.resolve(tapped: .run, active: .run, collapsed: false) == .collapse)
+    }
+
+    @Test func tappingAnInactiveTabWhileExpandedSwitchesTabs() {
+        #expect(RightPaneRailAction.resolve(tapped: .files, active: .changes, collapsed: false) == .select(.files))
+        #expect(RightPaneRailAction.resolve(tapped: .agent, active: .run, collapsed: false) == .select(.agent))
+    }
+
+    @Test func tappingAnyTabWhileCollapsedExpandsOnThatTab() {
+        #expect(RightPaneRailAction.resolve(tapped: .changes, active: .changes, collapsed: true) == .expand(.changes))
+        #expect(RightPaneRailAction.resolve(tapped: .files, active: .changes, collapsed: true) == .expand(.files))
+    }
+
+    @Test func changesBadgeCountsChangesAndHidesAtZero() {
+        #expect(RightPaneRailModel.badge(for: .changes, changesCount: 12, activeAgentCount: 0, activeRunCount: 0) == .count(12))
+        #expect(RightPaneRailModel.badge(for: .changes, changesCount: 0, activeAgentCount: 0, activeRunCount: 0) == .none)
+    }
+
+    @Test func filesNeverBadges() {
+        #expect(RightPaneRailModel.badge(for: .files, changesCount: 12, activeAgentCount: 4, activeRunCount: 2) == .none)
+    }
+
+    @Test func agentBadgeCountsActiveRowsAndHidesAtZero() {
+        #expect(RightPaneRailModel.badge(for: .agent, changesCount: 0, activeAgentCount: 2, activeRunCount: 0) == .count(2))
+        #expect(RightPaneRailModel.badge(for: .agent, changesCount: 0, activeAgentCount: 0, activeRunCount: 0) == .none)
+    }
+
+    @Test func runBadgeIsALiveDotRatherThanACount() {
+        #expect(RightPaneRailModel.badge(for: .run, changesCount: 0, activeAgentCount: 0, activeRunCount: 1) == .liveDot)
+        #expect(RightPaneRailModel.badge(for: .run, changesCount: 0, activeAgentCount: 0, activeRunCount: 3) == .liveDot)
+        #expect(RightPaneRailModel.badge(for: .run, changesCount: 0, activeAgentCount: 0, activeRunCount: 0) == .none)
+    }
+
+    @Test func badgeTextCapsAtNinetyNine() {
+        #expect(RightPaneRailBadge.count(7).displayText == "7")
+        #expect(RightPaneRailBadge.count(99).displayText == "99")
+        #expect(RightPaneRailBadge.count(100).displayText == "99+")
+        #expect(RightPaneRailBadge.liveDot.displayText == nil)
+        #expect(RightPaneRailBadge.none.displayText == nil)
+    }
+
+    @Test func collapsedActiveTabRendersAsItsOwnState() {
+        #expect(RightPaneRailModel.tabState(for: .changes, active: .changes, collapsed: false) == .active)
+        #expect(RightPaneRailModel.tabState(for: .changes, active: .changes, collapsed: true) == .activeCollapsed)
+        #expect(RightPaneRailModel.tabState(for: .files, active: .changes, collapsed: true) == .inactive)
+        #expect(RightPaneRailModel.tabState(for: .files, active: .changes, collapsed: false) == .inactive)
+    }
+}

--- a/AlasTests/RightPaneRailReducerTests.swift
+++ b/AlasTests/RightPaneRailReducerTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import Alas
+
+/// Covers `RightPaneRailModel.apply` — the transition from a resolved rail
+/// action to the pane's `(activeTab, rightPaneVisible)` pair. This is the step
+/// a remount used to silently undo, so it is worth pinning down directly.
+struct RightPaneRailReducerTests {
+    @Test func collapseHidesTheBodyAndKeepsTheActiveTab() {
+        let outcome = RightPaneRailModel.apply(.collapse, currentTab: .files, currentVisible: true)
+        #expect(outcome.tab == .files)
+        #expect(outcome.visible == false)
+    }
+
+    @Test func expandShowsTheBodyOnTheTappedTab() {
+        let outcome = RightPaneRailModel.apply(.expand(.run), currentTab: .changes, currentVisible: false)
+        #expect(outcome.tab == .run)
+        #expect(outcome.visible == true)
+    }
+
+    @Test func expandOnTheAlreadyActiveTabJustShowsTheBody() {
+        let outcome = RightPaneRailModel.apply(.expand(.agent), currentTab: .agent, currentVisible: false)
+        #expect(outcome.tab == .agent)
+        #expect(outcome.visible == true)
+    }
+
+    @Test func selectSwitchesTabsWithoutTouchingVisibility() {
+        let outcome = RightPaneRailModel.apply(.select(.agent), currentTab: .changes, currentVisible: true)
+        #expect(outcome.tab == .agent)
+        #expect(outcome.visible == true)
+    }
+
+    /// The reopened-tab regression in one assertion: resolving a tap on a
+    /// non-active tab while collapsed, then applying it, must land on the
+    /// tapped tab — not fall back to Changes.
+    @Test func tappingACollapsedRailTabReopensOnThatTab() {
+        for tapped in [RightPaneTab.changes, .files, .agent, .run] {
+            let action = RightPaneRailAction.resolve(tapped: tapped, active: .changes, collapsed: true)
+            let outcome = RightPaneRailModel.apply(action, currentTab: .changes, currentVisible: false)
+            #expect(outcome.tab == tapped)
+            #expect(outcome.visible == true)
+        }
+    }
+}

--- a/AlasTests/RightPaneTabShortcutTests.swift
+++ b/AlasTests/RightPaneTabShortcutTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 @testable import Alas
 
 /// The keyboard path into the rail (`AppState.activateRightPaneTab`) routes
@@ -85,5 +86,50 @@ struct RightPaneTabShortcutTests {
         let toggle = ShortcutAction.toggleRightPane.defaultBinding
         #expect(toggle.key == "b")
         #expect(toggle.modifiers == [.command, .option])
+    }
+
+    /// A narrow window makes `ThreePaneSizing` auto-collapse the pane while
+    /// `rightPaneVisible` stays true. Resolving from that preference instead
+    /// of the effective collapsed state would close a pane the user already
+    /// sees as closed; resolving from the effective state reopens it instead.
+    @Test func autoCollapsedPaneResolvesFromTheEffectiveState() {
+        let fromEffectiveState = outcome(tapped: .changes, active: .changes, visible: false)
+        #expect(fromEffectiveState.tab == .changes)
+        #expect(fromEffectiveState.visible == true)
+
+        let fromPreferenceAlone = outcome(tapped: .changes, active: .changes, visible: true)
+        #expect(fromPreferenceAlone.visible == false)
+    }
+
+    /// An older config may already have bound ⌘⌃1–4 to something else — legal
+    /// before these actions existed. The new action must start unbound rather
+    /// than silently claiming a chord the user already assigned.
+    @Test func anExistingOverrideOnARailChordKeepsItsBinding() throws {
+        var config = AppConfig.defaults
+        config.shortcutOverrides[ShortcutAction.searchFiles.rawValue] =
+            ShortcutAction.rightPaneChangesTab.defaultBinding
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.shortcutOverrides[ShortcutAction.searchFiles.rawValue]
+            == ShortcutAction.rightPaneChangesTab.defaultBinding)
+        // Present as an explicit nil: claimed, so deliberately unbound.
+        let railOverride = try #require(
+            decoded.shortcutOverrides[ShortcutAction.rightPaneChangesTab.rawValue]
+        )
+        #expect(railOverride == nil)
+    }
+
+    /// A rail chord nobody else claimed must keep its default — the migration
+    /// only unbinds on a real collision.
+    @Test func anUnclaimedRailChordKeepsItsDefault() throws {
+        let data = try JSONEncoder().encode(AppConfig.defaults)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        for action in [ShortcutAction.rightPaneChangesTab, .rightPaneFilesTab,
+                       .rightPaneAgentTab, .rightPaneRunTab] {
+            #expect(decoded.shortcutOverrides[action.rawValue] == nil)
+        }
     }
 }

--- a/AlasTests/RightPaneTabShortcutTests.swift
+++ b/AlasTests/RightPaneTabShortcutTests.swift
@@ -1,0 +1,89 @@
+import Testing
+@testable import Alas
+
+/// The keyboard path into the rail (`AppState.activateRightPaneTab`) routes
+/// through the same `resolve` + `apply` pair the rail's click handler uses.
+/// These pin that composition end to end, so a change to either half that
+/// broke the keyboard's "open on this tab / collapse when already showing"
+/// contract fails here rather than only under a live keypress.
+struct RightPaneTabShortcutTests {
+    private func outcome(
+        tapped: RightPaneTab,
+        active: RightPaneTab,
+        visible: Bool
+    ) -> RightPaneRailOutcome {
+        RightPaneRailModel.apply(
+            RightPaneRailAction.resolve(tapped: tapped, active: active, collapsed: !visible),
+            currentTab: active,
+            currentVisible: visible
+        )
+    }
+
+    @Test func shortcutForAHiddenPaneOpensItOnThatTab() {
+        let result = outcome(tapped: .run, active: .changes, visible: false)
+        #expect(result.tab == .run)
+        #expect(result.visible == true)
+    }
+
+    @Test func shortcutForTheShowingTabCollapsesThePane() {
+        let result = outcome(tapped: .files, active: .files, visible: true)
+        #expect(result.tab == .files)
+        #expect(result.visible == false)
+    }
+
+    @Test func shortcutForAnotherTabSwitchesWithoutClosing() {
+        let result = outcome(tapped: .agent, active: .changes, visible: true)
+        #expect(result.tab == .agent)
+        #expect(result.visible == true)
+    }
+
+    /// Re-pressing the same shortcut twice should land back where it started:
+    /// collapse, then reopen on the very tab it collapsed from.
+    @Test func pressingTheSameShortcutTwiceRoundTrips() {
+        let collapsed = outcome(tapped: .changes, active: .changes, visible: true)
+        #expect(collapsed.visible == false)
+
+        let reopened = outcome(tapped: .changes, active: collapsed.tab, visible: collapsed.visible)
+        #expect(reopened.tab == .changes)
+        #expect(reopened.visible == true)
+    }
+
+    /// Every shortcut maps to a fixed tab identity, not a rail position, so
+    /// the same key means the same tab whether or not the Agent/Run previews
+    /// are adding entries to the rail.
+    @Test func eachTabHasItsOwnDistinctDefaultBinding() {
+        let bindings: [ShortcutBinding] = [
+            ShortcutAction.rightPaneChangesTab.defaultBinding,
+            ShortcutAction.rightPaneFilesTab.defaultBinding,
+            ShortcutAction.rightPaneAgentTab.defaultBinding,
+            ShortcutAction.rightPaneRunTab.defaultBinding,
+        ]
+        #expect(Set(bindings).count == 4)
+        for binding in bindings {
+            #expect(binding.modifiers == [.command, .control])
+        }
+        #expect(bindings.map(\.key) == ["1", "2", "3", "4"])
+    }
+
+    /// Cmd+digit is the center tab switcher and Cmd+Option+digit selects a
+    /// Space; neither family may be reused here.
+    @Test func tabBindingsAvoidTheReservedAndSpacesDigitFamilies() {
+        let tabBindings = [
+            ShortcutAction.rightPaneChangesTab.defaultBinding,
+            ShortcutAction.rightPaneFilesTab.defaultBinding,
+            ShortcutAction.rightPaneAgentTab.defaultBinding,
+            ShortcutAction.rightPaneRunTab.defaultBinding,
+        ]
+        for binding in tabBindings {
+            #expect(!ShortcutAction.reservedBindings.contains(binding))
+            #expect(binding.modifiers != [.command, .option])
+        }
+    }
+
+    /// The rail toggle keeps its own binding — the tab shortcuts are additive.
+    @Test func toggleRightPaneKeepsItsBinding() {
+        let toggle = ShortcutAction.toggleRightPane.defaultBinding
+        #expect(toggle.key == "b")
+        #expect(toggle.modifiers == [.command, .option])
+    }
+}

--- a/AlasTests/RightPaneToolbarModelTests.swift
+++ b/AlasTests/RightPaneToolbarModelTests.swift
@@ -1,0 +1,66 @@
+import Testing
+@testable import Alas
+
+struct RightPaneToolbarModelTests {
+    private func leading(
+        _ tab: RightPaneTab,
+        branch: String = "main",
+        activeAgentCount: Int = 0,
+        waitingAgentCount: Int = 0,
+        runningScriptNames: [String] = []
+    ) -> String {
+        RightPaneToolbarModel.leading(
+            for: tab,
+            branch: branch,
+            activeAgentCount: activeAgentCount,
+            waitingAgentCount: waitingAgentCount,
+            runningScriptNames: runningScriptNames
+        )
+    }
+
+    @Test func changesShowsTheCurrentBranch() {
+        #expect(leading(.changes, branch: "nacho/sidebar-new-design") == "nacho/sidebar-new-design")
+    }
+
+    @Test func changesFallsBackWhenTheBranchIsUnknown() {
+        #expect(leading(.changes, branch: "") == "Detached HEAD")
+    }
+
+    @Test func filesLabelsTheWorkingTree() {
+        #expect(leading(.files) == "Working tree")
+    }
+
+    @Test func agentSummarisesActiveAndWaitingCounts() {
+        #expect(leading(.agent, activeAgentCount: 2, waitingAgentCount: 1) == "2 active · 1 waiting")
+        #expect(leading(.agent, activeAgentCount: 2, waitingAgentCount: 0) == "2 active")
+        #expect(leading(.agent, activeAgentCount: 1, waitingAgentCount: 0) == "1 active")
+        #expect(leading(.agent, activeAgentCount: 0, waitingAgentCount: 0) == "No agents")
+    }
+
+    @Test func runNamesASingleCommandAndCountsSeveral() {
+        #expect(leading(.run, runningScriptNames: ["pnpm test"]) == "pnpm test")
+        #expect(leading(.run, runningScriptNames: ["pnpm test", "pnpm dev"]) == "2 running")
+        #expect(leading(.run, runningScriptNames: []) == "Nothing running")
+    }
+
+    @Test func onlyChangesShowsDiffTotals() {
+        #expect(RightPaneToolbarModel.trailing(for: .changes, totalAdd: 412, totalDel: 88) == .diffTotals(add: 412, del: 88))
+        #expect(RightPaneToolbarModel.trailing(for: .agent, totalAdd: 412, totalDel: 88) == .none)
+        #expect(RightPaneToolbarModel.trailing(for: .run, totalAdd: 412, totalDel: 88) == .none)
+    }
+
+    @Test func changesHidesTotalsWhenThereIsNoDiff() {
+        #expect(RightPaneToolbarModel.trailing(for: .changes, totalAdd: 0, totalDel: 0) == .none)
+    }
+
+    @Test func filesOffersSearch() {
+        #expect(RightPaneToolbarModel.trailing(for: .files, totalAdd: 0, totalDel: 0) == .search)
+    }
+
+    @Test func onlyFilesShowsTheOverflowMenu() {
+        #expect(RightPaneToolbarModel.showsOverflowMenu(for: .files))
+        #expect(!RightPaneToolbarModel.showsOverflowMenu(for: .changes))
+        #expect(!RightPaneToolbarModel.showsOverflowMenu(for: .agent))
+        #expect(!RightPaneToolbarModel.showsOverflowMenu(for: .run))
+    }
+}

--- a/AlasTests/RightRailSizingTests.swift
+++ b/AlasTests/RightRailSizingTests.swift
@@ -1,0 +1,78 @@
+import Testing
+@testable import Alas
+
+struct RightRailSizingTests {
+    private let config = ThreePaneSizing.Configuration(
+        sidebarMin: 200,
+        sidebarMax: 420,
+        rightMin: 240,
+        rightMax: 560,
+        centerMin: 400,
+        dividerWidth: 6
+    )
+
+    private func isApproximatelyEqual(_ actual: Double, _ expected: Double, tolerance: Double = 0.001) -> Bool {
+        abs(actual - expected) < tolerance
+    }
+
+    private func calculate(
+        availableWidth: Double,
+        rightPreferredVisible: Bool,
+        railWidth: Double?
+    ) -> RightRailSizing.Result {
+        RightRailSizing.calculate(
+            availableWidth: availableWidth,
+            preferredSidebarWidth: 244,
+            preferredRightWidth: 320,
+            sidebarPreferredVisible: true,
+            rightPreferredVisible: rightPreferredVisible,
+            railWidth: railWidth,
+            configuration: config
+        )
+    }
+
+    @Test func flagOffNeverReservesRailWidth() {
+        let hidden = calculate(availableWidth: 1_200, rightPreferredVisible: false, railWidth: nil)
+        #expect(hidden.railWidth == 0)
+        #expect(hidden.sizing.rightVisible == false)
+
+        let shown = calculate(availableWidth: 1_200, rightPreferredVisible: true, railWidth: nil)
+        #expect(shown.railWidth == 0)
+        #expect(shown.sizing.rightVisible == true)
+    }
+
+    @Test func expandedPaneKeepsTheRailInsideItsOwnWidth() {
+        let result = calculate(availableWidth: 1_200, rightPreferredVisible: true, railWidth: 36)
+
+        #expect(result.railWidth == 0)
+        #expect(result.sizing.rightVisible == true)
+        #expect(isApproximatelyEqual(result.sizing.rightWidth, 320))
+        #expect(isApproximatelyEqual(result.sizing.centerWidth, 624))
+    }
+
+    @Test func collapsedPaneReservesTheRailAndGivesTheRestToCenter() {
+        let result = calculate(availableWidth: 1_200, rightPreferredVisible: false, railWidth: 36)
+
+        #expect(result.railWidth == 36)
+        #expect(result.sizing.rightVisible == false)
+        #expect(isApproximatelyEqual(result.sizing.sidebarWidth, 244))
+        // 1200 − 36 rail − 6 divider − 244 sidebar
+        #expect(isApproximatelyEqual(result.sizing.centerWidth, 914))
+    }
+
+    @Test func narrowWindowAutoCollapseStillReservesTheRail() {
+        // Too narrow for sidebar + center + right at their minimums, so
+        // ThreePaneSizing drops the right pane on its own.
+        let result = calculate(availableWidth: 800, rightPreferredVisible: true, railWidth: 36)
+
+        #expect(result.sizing.rightVisible == false)
+        #expect(result.railWidth == 36)
+        #expect(isApproximatelyEqual(result.sizing.sidebarWidth + result.sizing.centerWidth, 758))
+    }
+
+    @Test func aZeroOrNegativeRailWidthIsTreatedAsNoRail() {
+        let result = calculate(availableWidth: 1_200, rightPreferredVisible: false, railWidth: 0)
+        #expect(result.railWidth == 0)
+        #expect(isApproximatelyEqual(result.sizing.centerWidth, 950))
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a vertical 36pt icon rail as an alternative presentation for the right pane's tabs (Changes/Files/Agent/Run), replacing the horizontal segmented tab bar and folding the hide-pane button into a collapse-to-rail interaction.
- Entirely gated behind a new Debug settings flag (`rightPaneRailEnabled`, off by default) — every touched code path renders exactly as it did before this branch when the flag is off.
- Design spec: `Right Pane Tabs Spike v3 - 4a only.html`, from the Claude Design project referenced in the linked ticket/conversation.

### What changed

- `AppConfig.rightPaneRailEnabled` + Debug → Experimental toggle
- `RightPaneRailModel` / `RightPaneRailAction` / `RightPaneRailBadge` — pure tap-semantics and badge rules
- `RightPaneToolbarModel` — pure per-tab toolbar content
- `RightRailSizing` — wraps `ThreePaneSizing` (unmodified) to reserve rail width without touching its arithmetic
- `RightPaneRail` / `RightPaneToolbar` — the new SwiftUI views
- `ThreePaneLayout`, `RootView`, `CenterPaneView`, `RightPaneTransitionalView` — layout wiring for a persistent collapsed-rail strip
- `RightPaneView` — presentation branch between the rail and the legacy tab bar

### Reviewer notes

- The most behaviorally sensitive part of this branch: collapsing/expanding the rail must not remount `RightPaneView` (a remount would let an unrelated `.onAppear` hook reset the active tab to Changes). `ThreePaneLayout` renders the right subtree from a single call site for exactly this reason — see the comment at the relevant `if` block.
- `RightPaneRailModel.apply(_:currentTab:currentVisible:)` is the pure state-transition function backing the rail's click handling; `RightPaneRailReducerTests` pins the "tapping a collapsed rail tab reopens on that tab" behavior directly.
- Flag-off behavior is intentionally byte-for-byte identical to `main` — several code paths look duplicated between the flag-on/flag-off branches because of this constraint, not by oversight.
- **Not yet done**: a hands-on walkthrough of the flag in the running app (toggle it on, click through tabs, collapse/expand, resize the window, toggle back off). Everything here is covered by unit tests on the pure logic and a full app build, but nobody has clicked through it live yet — flagging this explicitly rather than silently skipping it.