### PR TITLE
feat(minimap): add editor and transcript minimaps

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		106120CBE8107E0AC4EA353A /* ProcessKiller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3A345F0B643467352DB5F3 /* ProcessKiller.swift */; };
 		1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8B52175A7F6144B4C52010 /* EditorTabView.swift */; };
 		107D5EC59DC4F2E708D74865 /* session-update-context-compaction-partial.json in Resources */ = {isa = PBXBuildFile; fileRef = 1C8926C5ABBB7B8157ACFEF3 /* session-update-context-compaction-partial.json */; };
+		10A9B73828294B8041DA5FA7 /* MinimapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D94619222BA8E41FB8C6776 /* MinimapTests.swift */; };
 		10C27B7147AF2D41AD109E9A /* session-update-session-info-goal.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D751485790AD46EBC15A979 /* session-update-session-info-goal.json */; };
 		10D0D26BCE0EF4D8677CEA79 /* GGServiceInboxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF688C3B9D43B4F5FF48F7D3 /* GGServiceInboxTests.swift */; };
 		10F83C7DA89B3BF168E47310 /* DiffSelectableTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34ED0F4DB5FB6620993ECFC /* DiffSelectableTextTests.swift */; };
@@ -625,6 +626,7 @@
 		58B2E8C756F6D3CB08FB3B10 /* ReviewSessionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7E37886988A6F285BEA163 /* ReviewSessionModels.swift */; };
 		58ED3DFB6576F9B3C473D16C /* ACPNewChatEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7294C0B27241ADEB9A95347A /* ACPNewChatEmptyStateView.swift */; };
 		5936DF2636F0B74BEAB33A57 /* DraftAmendPrefillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB02326DBD7A82431A33C50F /* DraftAmendPrefillTests.swift */; };
+		595006B141A5C6357DB9772C /* CodeEditorMinimap.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5335592CD850B86A8562093 /* CodeEditorMinimap.swift */; };
 		59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */; };
 		597B1697EFF3B1CE03D538A3 /* AttentionInboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75CBEC5902D78CEB4F03E481 /* AttentionInboxView.swift */; };
 		599302478830809946BF6D66 /* BinaryFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 308A1ADAE5DCA81A50FFDF82 /* BinaryFileTypeTests.swift */; };
@@ -882,6 +884,7 @@
 		8510C6B68C2CF6664574C161 /* ACPSystemNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */; };
 		8514D39E901232E7C7343C26 /* FakeJSONRPCTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E340D23D2484C570F8E4B7F /* FakeJSONRPCTransport.swift */; };
 		852B01E3449841603FEEDC61 /* ReleaseInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D788808DF3BE405143F91F7 /* ReleaseInfoTests.swift */; };
+		8599D9118656CCA27C393C55 /* MinimapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E7D627F1E84F5E2CCBD020 /* MinimapView.swift */; };
 		859AD39BA8D5A9FCC905648D /* ImageDiffViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120D10644A278775A9AE1990 /* ImageDiffViewTests.swift */; };
 		85B8A8B929BD4ED4DC21FEDD /* ACPDelayedHoverVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3D3BB0A631D42AD22DBE0F /* ACPDelayedHoverVisibility.swift */; };
 		85C7E65296AB9500FF52060A /* session-update-plan.json in Resources */ = {isa = PBXBuildFile; fileRef = 7094534860369BA79FC5A877 /* session-update-plan.json */; };
@@ -1536,6 +1539,7 @@
 		E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */; };
 		E3C34254BA474878AEC6683D /* PendingReviewTray.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDFF1C68250433F4B9891F1A /* PendingReviewTray.swift */; };
 		E3D59DB020583EF3E0EB7171 /* ProviderReviewPublishConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF69D638124D1B4D1C04BD31 /* ProviderReviewPublishConfirmationView.swift */; };
+		E416F033FE5772B85A07CAF2 /* ACPTranscriptMinimap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09673A323A79C650D9C66D49 /* ACPTranscriptMinimap.swift */; };
 		E433BB79E6D79DAF4532172A /* Kbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CA8FEE64D73BDEBAF74878 /* Kbd.swift */; };
 		E44EBD2F2F9A398207E55C6D /* ACPTerminal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0594E7E039B5FC403783C6E8 /* ACPTerminal.swift */; };
 		E468E95C778E0C9BE6F1EDED /* LegacyHookSweep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE0FF00CB2F81000FB09A72 /* LegacyHookSweep.swift */; };
@@ -1798,6 +1802,7 @@
 		0914F0E19514D1DF89C74B41 /* MergeConflictResolvedEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictResolvedEmptyView.swift; sourceTree = "<group>"; };
 		09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvResolverTests.swift; sourceTree = "<group>"; };
 		0934F7BB22E33263B63925B7 /* ImageDiffPair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPair.swift; sourceTree = "<group>"; };
+		09673A323A79C650D9C66D49 /* ACPTranscriptMinimap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMinimap.swift; sourceTree = "<group>"; };
 		098AA369AE6B2740439CD504 /* AttachIssueDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachIssueDialog.swift; sourceTree = "<group>"; };
 		09C9EEDB5A71C5FAE2D0E42B /* ReviewChangesRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewChangesRail.swift; sourceTree = "<group>"; };
 		09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistry.swift; sourceTree = "<group>"; };
@@ -2298,6 +2303,7 @@
 		54897710493742A6DFD6ABF3 /* ACPToolCallContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolCallContentTests.swift; sourceTree = "<group>"; };
 		5499A8C3A9E9EB6D00D86D90 /* ACPSessionFork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionFork.swift; sourceTree = "<group>"; };
 		55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindController.swift; sourceTree = "<group>"; };
+		55E7D627F1E84F5E2CCBD020 /* MinimapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimapView.swift; sourceTree = "<group>"; };
 		561094BA96058468F12002A1 /* ConflictsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictsSection.swift; sourceTree = "<group>"; };
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
 		56780EE994E2CA14A3ABBA7B /* MergeActionGutter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeActionGutter.swift; sourceTree = "<group>"; };
@@ -2552,6 +2558,7 @@
 		7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandle.swift; sourceTree = "<group>"; };
 		7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointingHandCursor.swift; sourceTree = "<group>"; };
 		7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionSnippetCacheTests.swift; sourceTree = "<group>"; };
+		7D94619222BA8E41FB8C6776 /* MinimapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinimapTests.swift; sourceTree = "<group>"; };
 		7DCF803DF778CF9C06AC1579 /* ACPTranscriptWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptWindowTests.swift; sourceTree = "<group>"; };
 		7DD6C7F7A898CE1A030F28C3 /* MergeWordDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeWordDiff.swift; sourceTree = "<group>"; };
 		7DE5F609BDA1D7CE2DF4A491 /* ACPScrollDirectionClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPScrollDirectionClassifier.swift; sourceTree = "<group>"; };
@@ -3127,6 +3134,7 @@
 		D4FAB28A45A3606C316044F3 /* ACPGoalPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPGoalPill.swift; sourceTree = "<group>"; };
 		D510DACCD80A328B2DFABDC0 /* CompletionFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionFeature.swift; sourceTree = "<group>"; };
 		D52FB6333DDC1A21B0959C1B /* ReviewReadinessModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewReadinessModelTests.swift; sourceTree = "<group>"; };
+		D5335592CD850B86A8562093 /* CodeEditorMinimap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorMinimap.swift; sourceTree = "<group>"; };
 		D539F34969F540B8294BDC35 /* WebPreviewAutomationBrowserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPreviewAutomationBrowserTests.swift; sourceTree = "<group>"; };
 		D54BBE356A720AF00F2A7C56 /* ChangesPreparationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPreparationModel.swift; sourceTree = "<group>"; };
 		D568D53950A3CA2CD1F4EECB /* ImageDiffPairResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairResolver.swift; sourceTree = "<group>"; };
@@ -3909,6 +3917,7 @@
 				883981BBADF9816718091CE1 /* MergeScrollCoordinatorTests.swift */,
 				CE3FA58107EA372581313A5F /* MergeView3WayLayoutTests.swift */,
 				72970A1D2817539DB5243058 /* MergeWordDiffTests.swift */,
+				7D94619222BA8E41FB8C6776 /* MinimapTests.swift */,
 				E288FF8FA00AC18E1CDD3CA2 /* NewWorktreeDialogTests.swift */,
 				C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */,
 				4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */,
@@ -4435,6 +4444,7 @@
 				0BBB2C6C4347C245481650DA /* RunScripts */,
 				986CC94FDFD6411BCED67A48 /* Search */,
 				59E804284C70FCAD77A09774 /* Settings */,
+				88307C6773052068C643F707 /* Shared */,
 				DA23E862C6C2D386B4C76E10 /* Shortcuts */,
 				697AACFEA2DCEBE4CEB2CD4E /* Sidebar */,
 				F4E7F552A9A004DB7193809A /* SQLiteKit */,
@@ -5057,6 +5067,7 @@
 			isa = PBXGroup;
 			children = (
 				B6935E92CDED46890ABEABB6 /* ACPTranscriptLogicalScrollModel.swift */,
+				09673A323A79C650D9C66D49 /* ACPTranscriptMinimap.swift */,
 				A4626606D2916B0CFE65F16B /* ACPTranscriptRowHostingPool.swift */,
 				7BA6DF8E37E9B38C627B030A /* ACPTranscriptRowHostingView.swift */,
 				ABC94CFEB59F22E028DA462F /* ACPTranscriptRowSpec.swift */,
@@ -5190,6 +5201,14 @@
 				7963D4DD10B67EB683510FF6 /* SpaceConfig.swift */,
 			);
 			path = Persistence;
+			sourceTree = "<group>";
+		};
+		88307C6773052068C643F707 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				55E7D627F1E84F5E2CCBD020 /* MinimapView.swift */,
+			);
+			path = Shared;
 			sourceTree = "<group>";
 		};
 		895189284B82DBD794D9F2F0 /* Fixtures */ = {
@@ -5603,6 +5622,7 @@
 				30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */,
 				A903C69ED6A3B550CCDF477A /* CodeEditorLayoutManager.swift */,
 				76B767602C3F8E5909A44B7C /* CodeEditorLineNumberRulerView.swift */,
+				D5335592CD850B86A8562093 /* CodeEditorMinimap.swift */,
 				FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */,
 				FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */,
 				64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */,
@@ -6708,6 +6728,7 @@
 				8F5EA17127E27B25AA60D88B /* ACPTranscriptLogicalScrollModel.swift in Sources */,
 				C12FCCB35EBD486D20EC65D2 /* ACPTranscriptMarkdown.swift in Sources */,
 				3C9CA493D2D1B5BB77CC96AE /* ACPTranscriptMessageRows.swift in Sources */,
+				E416F033FE5772B85A07CAF2 /* ACPTranscriptMinimap.swift in Sources */,
 				C5FB3A21BB1DF1BDCF813375 /* ACPTranscriptQueuePolicy.swift in Sources */,
 				414DEC9066B4CEB304F77639 /* ACPTranscriptRowContent.swift in Sources */,
 				95E01DC5A933FCC077399762 /* ACPTranscriptRowHostingPool.swift in Sources */,
@@ -6834,6 +6855,7 @@
 				41F6712EA71CC9AF6AB7ED94 /* CodeEditorCoordinator.swift in Sources */,
 				752E634D54ED2AA2C50D36B4 /* CodeEditorLayoutManager.swift in Sources */,
 				7324AD398C5F4168C067F4B0 /* CodeEditorLineNumberRulerView.swift in Sources */,
+				595006B141A5C6357DB9772C /* CodeEditorMinimap.swift in Sources */,
 				A9D0D8D94E1D46F35D17DDBA /* CodeEditorView.swift in Sources */,
 				DA0C1B28A1161C52F83C05DF /* CodeHostIssueProvider.swift in Sources */,
 				91725E17B5C8C079D1A5C116 /* CodeHostIssueResolver.swift in Sources */,
@@ -7143,6 +7165,7 @@
 				F8DFFC12D5F7F2E1F8F19A02 /* MermaidRenderCache.swift in Sources */,
 				8DC2ADB1F7CC8D4B9667BD94 /* MermaidRenderService.swift in Sources */,
 				0BCDD4F3A4AE0B3944460D87 /* MermaidTextAttachment.swift in Sources */,
+				8599D9118656CCA27C393C55 /* MinimapView.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
 				92BDCA81E566BF56CFE87AFB /* NewRunScriptDialog.swift in Sources */,
@@ -7965,6 +7988,7 @@
 				FCF61C2ECFE2CC61226F78D5 /* MermaidRenderCacheTests.swift in Sources */,
 				5ABD7DF29A68C38C8AA9EF37 /* MermaidRenderServiceTests.swift in Sources */,
 				4F6177806CEB8E50F0D70F7B /* MermaidViewerStateTests.swift in Sources */,
+				10A9B73828294B8041DA5FA7 /* MinimapTests.swift in Sources */,
 				1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */,
 				1240D4046831ECB9ED93AD03 /* NewWorktreeIssueStateTests.swift in Sources */,
 				3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -34,6 +34,7 @@ struct ACPMessageList: View {
     let onFork: (ACPForkMessageBoundary, String) -> Void
     let onOpenForkSource: (String) -> Void
     let agentDisplayName: (String) -> String
+    var showMinimap: Bool = false
     @Environment(\.theme) private var theme
 
     /// Height of an invisible spacer at the tail of the transcript stack. The
@@ -74,7 +75,8 @@ struct ACPMessageList: View {
                 onQueueClearAll: onQueueClearAll,
                 onRetryContextRecovery: onRetryContextRecovery,
                 onOpenForkSource: onOpenForkSource,
-                agentDisplayName: agentDisplayName
+                agentDisplayName: agentDisplayName,
+                showMinimap: showMinimap
             )
             if Self.shouldShowGoToNewestAffordance(
                 followsTranscriptTail: session.followsTranscriptTail
@@ -84,6 +86,7 @@ struct ACPMessageList: View {
                     transcript.resetWindowToTail()
                     onRememberScrollAnchor(nil, nil, true)
                 }
+                .padding(.trailing, showMinimap ? MinimapView.width : 0)
             }
         }
         .background(

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -274,7 +274,11 @@ private struct ACPSessionView: View {
             let chatContentMaxWidth = ACPChatLayout.contentMaxWidth(
                 forChatColumnWidth: chatProxy.size.width
             )
-            chatSurface(contentMaxWidth: chatContentMaxWidth)
+            let showMinimap = ACPTranscriptScrollerView.shouldShowMinimap(
+                preferred: state.config.harness.acpShowMinimap,
+                availableWidth: chatProxy.size.width
+            )
+            chatSurface(contentMaxWidth: chatContentMaxWidth, showMinimap: showMinimap)
                 .frame(width: chatProxy.size.width, height: chatProxy.size.height)
                 .animation(emptyStateAnimation, value: isNewEmptySession)
                 .animation(emptyStateAnimation, value: isFirstRunConnecting)
@@ -305,10 +309,10 @@ private struct ACPSessionView: View {
         return true
     }
 
-    private func chatSurface(contentMaxWidth: CGFloat) -> some View {
+    private func chatSurface(contentMaxWidth: CGFloat, showMinimap: Bool) -> some View {
         ZStack(alignment: .bottom) {
             if showsPreSessionUserInput {
-                messageList(contentMaxWidth: contentMaxWidth)
+                messageList(contentMaxWidth: contentMaxWidth, showMinimap: showMinimap)
                     .transition(.opacity)
             } else if let phase = firstRunConnectingPhase {
                 introStateAndComposer(contentMaxWidth: contentMaxWidth) {
@@ -335,7 +339,7 @@ private struct ACPSessionView: View {
                         agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId
                     )
                 } else {
-                    messageList(contentMaxWidth: contentMaxWidth)
+                    messageList(contentMaxWidth: contentMaxWidth, showMinimap: showMinimap)
                         .transition(.opacity)
                 }
 
@@ -344,6 +348,7 @@ private struct ACPSessionView: View {
                     contentMaxWidth: contentMaxWidth,
                     typography: chatTypography
                 )
+                .padding(.trailing, showMinimap && !isConnecting ? MinimapView.width : 0)
 
                 if let undo = session.steerUndo, !undo.snapshot.isEmpty {
                     VStack {
@@ -363,7 +368,7 @@ private struct ACPSessionView: View {
         }
     }
 
-    private func messageList(contentMaxWidth: CGFloat) -> ACPMessageList {
+    private func messageList(contentMaxWidth: CGFloat, showMinimap: Bool) -> ACPMessageList {
         ACPMessageList(
             session: session,
             transcript: session.transcript,
@@ -495,7 +500,8 @@ private struct ACPSessionView: View {
             },
             agentDisplayName: { agentID in
                 state.agent(id: agentID)?.displayName ?? agentID
-            }
+            },
+            showMinimap: showMinimap
         )
     }
 

--- a/Alas/Sources/ACP/UI/ACPToolbar.swift
+++ b/Alas/Sources/ACP/UI/ACPToolbar.swift
@@ -36,6 +36,19 @@ struct ACPToolbar: View {
             }
             ACPPlanPill(transcript: session.transcript)
                 .layoutPriority(1)
+            Spacer(minLength: 0)
+            Button {
+                state.config.harness.acpShowMinimap.toggle()
+                state.saveConfig()
+            } label: {
+                Image(systemName: "rectangle.trailingthird.inset.filled")
+                    .foregroundStyle(state.config.harness.acpShowMinimap ? theme.color("accent") : theme.color("fg-muted"))
+                    .frame(width: 24, height: 24)
+            }
+            .buttonStyle(.plain)
+            .help(state.config.harness.acpShowMinimap ? "Hide minimap" : "Show minimap")
+            .accessibilityLabel("Transcript minimap")
+            .accessibilityValue(state.config.harness.acpShowMinimap ? "On" : "Off")
         }
         .padding(.horizontal, 12)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptMinimap.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptMinimap.swift
@@ -51,20 +51,35 @@ final class ACPTranscriptMinimap {
         let promptColor = NSColor(theme.color("accent")).withAlphaComponent(0.26)
         let cardColor = NSColor(theme.color("bg-2"))
         let textColor = NSColor(theme.color("fg-faint")).withAlphaComponent(0.6)
-        for (index, message) in transcript.messages.enumerated() where !indices.contains(index) {
-            let y = CGFloat(transcript.messageIndexOffset + index) * slot
+        for start in stride(from: 0, to: transcript.messages.count, by: sampleStride) {
+            let end = min(transcript.messages.count, start + sampleStride)
+            let messages = transcript.messages[start..<end]
+            guard let message = messages.first(where: {
+                if case .user = $0 { return true }
+                return false
+            }) ?? messages.first(where: {
+                if case .toolCall = $0 { return true }
+                if case .fileEdit = $0 { return true }
+                return false
+            }) ?? messages.first(where: {
+                if case .plan = $0 { return false }
+                return true
+            }) else { continue }
+            let y = CGFloat(transcript.messageIndexOffset + start) * slot
+            let height = CGFloat(end - start) * slot
             let rect: CGRect
             let color: NSColor
             switch message {
             case .user:
-                rect = CGRect(x: 24, y: y, width: 64, height: 18)
-                color = promptColor
+                rect = CGRect(x: 24, y: y, width: 64, height: max(2, height))
+                color = promptColor.withAlphaComponent(promptColor.alphaComponent * 0.45)
             case .toolCall, .fileEdit:
-                rect = CGRect(x: 0, y: y, width: 88, height: 8)
+                rect = CGRect(x: 0, y: y, width: 88, height: max(2, min(8, height)))
                 color = cardColor
-            case .plan: continue
+            case .plan:
+                continue
             default:
-                rect = CGRect(x: 0, y: y, width: 60, height: 2)
+                rect = CGRect(x: 0, y: y, width: 60, height: max(1, min(2, height)))
                 color = textColor
             }
             result.marks.append(.init(rect: rect, color: color))

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptMinimap.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptMinimap.swift
@@ -1,0 +1,174 @@
+import AppKit
+
+@MainActor
+final class ACPTranscriptMinimap {
+    private struct Entry {
+        let message: ACPMessage
+        let revision: UInt64
+        let drawing: MinimapDrawing
+    }
+    private var entries: [ACPMessage.StableIdentityKey: Entry] = [:]
+    private var theme: Theme?
+    private var generation: UInt64?
+    private var tick: UInt32?
+    private var offset: Int?
+    private var transcriptID: ObjectIdentifier?
+    private var cachedDrawing = MinimapDrawing()
+
+    func needsUpdate(transcript: ACPTranscript, theme: Theme) -> Bool {
+        self.theme != theme || generation != transcript.messagesGeneration
+            || tick != transcript.streamingTick || offset != transcript.messageIndexOffset
+            || transcriptID != ObjectIdentifier(transcript)
+    }
+
+    func drawing(transcript: ACPTranscript, theme: Theme) -> MinimapDrawing {
+        guard needsUpdate(transcript: transcript, theme: theme) else { return cachedDrawing }
+        if self.theme != theme || transcriptID != ObjectIdentifier(transcript) { entries.removeAll() }
+        transcriptID = ObjectIdentifier(transcript)
+        self.theme = theme
+        generation = transcript.messagesGeneration
+        tick = transcript.streamingTick
+        offset = transcript.messageIndexOffset
+        let count = transcript.logicalMessageCount
+        let slot: CGFloat = max(24, 360 / CGFloat(max(1, count)))
+        var result = MinimapDrawing(height: CGFloat(max(1, count)) * slot)
+        if transcript.messageIndexOffset > 0 {
+            result.marks.append(.init(
+                rect: CGRect(x: 0, y: 0, width: 88, height: CGFloat(transcript.messageIndexOffset) * slot),
+                color: NSColor(theme.color("fg-faint")).withAlphaComponent(0.12)
+            ))
+        }
+        // Bound preview generation independently of history length. Each sample
+        // keeps its global position; a hidden render window never changes the map.
+        var sampleStride = 1
+        while count / sampleStride > 382 { sampleStride *= 2 }
+        let firstGlobal = ((transcript.messageIndexOffset + sampleStride - 1) / sampleStride) * sampleStride
+        var indices = Set(stride(from: firstGlobal - transcript.messageIndexOffset, to: transcript.messages.count, by: sampleStride))
+        if !transcript.messages.isEmpty {
+            indices.insert(0)
+            indices.insert(transcript.messages.count - 1)
+        }
+        let promptColor = NSColor(theme.color("accent")).withAlphaComponent(0.26)
+        let cardColor = NSColor(theme.color("bg-2"))
+        let textColor = NSColor(theme.color("fg-faint")).withAlphaComponent(0.6)
+        for (index, message) in transcript.messages.enumerated() where !indices.contains(index) {
+            let y = CGFloat(transcript.messageIndexOffset + index) * slot
+            let rect: CGRect
+            let color: NSColor
+            switch message {
+            case .user:
+                rect = CGRect(x: 24, y: y, width: 64, height: 18)
+                color = promptColor
+            case .toolCall, .fileEdit:
+                rect = CGRect(x: 0, y: y, width: 88, height: 8)
+                color = cardColor
+            case .plan: continue
+            default:
+                rect = CGRect(x: 0, y: y, width: 60, height: 2)
+                color = textColor
+            }
+            result.marks.append(.init(rect: rect, color: color))
+        }
+        var retained: [ACPMessage.StableIdentityKey: Entry] = [:]
+        for index in indices.sorted() {
+            let message = transcript.messages[index]
+            let revision: UInt64
+            switch message {
+            case .agent(_, _, let text), .thought(_, _, let text): revision = text.revision
+            default: revision = 0
+            }
+            let key = message.stableIdentityKey
+            let entry: Entry
+            if let cached = entries[key], cached.message == message, cached.revision == revision {
+                entry = cached
+            } else {
+                entry = Entry(message: message, revision: revision, drawing: Self.preview(message, theme: theme))
+            }
+            retained[key] = entry
+            let y = CGFloat(transcript.messageIndexOffset + index) * slot
+            let scale = min(1, (slot - 4) / max(1, entry.drawing.height))
+            result.marks.append(contentsOf: entry.drawing.marks.map {
+                .init(rect: CGRect(x: $0.rect.minX, y: y + $0.rect.minY * scale,
+                                   width: $0.rect.width, height: $0.rect.height * scale), color: $0.color)
+            })
+        }
+        entries = retained
+        cachedDrawing = result
+        return result
+    }
+
+    static func preview(_ message: ACPMessage, theme: Theme) -> MinimapDrawing {
+        let fg = NSColor(theme.color("fg"))
+        let muted = NSColor(theme.color("fg-faint"))
+        let accent = NSColor(theme.color("accent"))
+        var drawing: MinimapDrawing
+        switch message {
+        case .user(_, _, let text, let attachments, _):
+            drawing = markdown(text, theme: theme, columns: 60)
+            var bubble = MinimapDrawing(height: drawing.height + 6)
+            bubble.marks.append(.init(rect: CGRect(x: 24, y: 0, width: 64, height: bubble.height),
+                                      color: accent.withAlphaComponent(0.26)))
+            bubble.append(drawing, x: 26, y: 3)
+            for index in attachments.prefix(4).indices {
+                bubble.marks.append(.init(rect: CGRect(x: 26 + index * 10, y: 0, width: 8, height: 4), color: accent))
+            }
+            return bubble
+        case .agent(_, _, let text):
+            return markdown(text.value, theme: theme, columns: 84)
+        case .thought(_, _, let text):
+            drawing = MinimapDrawing.text(NSAttributedString(string: String(text.value.prefix(1024)), attributes: [.foregroundColor: muted]), columns: 80, wraps: true)
+            drawing.marks.insert(.init(rect: CGRect(x: 0, y: 0, width: 1, height: drawing.height), color: NSColor(theme.color("bg-4"))), at: 0)
+        case .toolCall(let tool):
+            drawing = MinimapDrawing.text(NSAttributedString(string: String(tool.title.prefix(80)), attributes: [.foregroundColor: fg]), columns: 76)
+            var card = MinimapDrawing(height: 8)
+            card.marks.append(.init(rect: CGRect(x: 0, y: 0, width: 88, height: 8), color: NSColor(theme.color("bg-2"))))
+            let status = tool.status == "failed" ? "del" : tool.status == "completed" ? "add" : "accent"
+            card.marks.append(.init(rect: CGRect(x: 2, y: 2, width: 3, height: 3), color: NSColor(theme.color(status))))
+            card.append(drawing, x: 8, y: 2)
+            return card
+        case .fileEdit(_, let edit):
+            drawing = MinimapDrawing.text(NSAttributedString(string: String(edit.path.prefix(80)), attributes: [.foregroundColor: accent]))
+            drawing.marks.append(.init(rect: CGRect(x: 0, y: 4, width: CGFloat(min(40, edit.added)), height: 2), color: NSColor(theme.color("add"))))
+            drawing.marks.append(.init(rect: CGRect(x: 44, y: 4, width: CGFloat(min(40, edit.removed)), height: 2), color: NSColor(theme.color("del"))))
+            drawing.height = 8
+        case .systemNotice(_, let text):
+            drawing = MinimapDrawing.text(NSAttributedString(string: String(text.prefix(160)), attributes: [.foregroundColor: muted]), wraps: true)
+        case .plan:
+            drawing = MinimapDrawing(height: 3)
+        }
+        return drawing
+    }
+
+    private static func markdown(_ text: String, theme: Theme, columns: Int) -> MinimapDrawing {
+        var result = MinimapDrawing()
+        for block in ACPMarkdownText.parse(String(text.prefix(4096))) {
+            let attributed: NSAttributedString
+            var background: NSColor?
+            switch block {
+            case .code(let language, let body), .streamingCode(let language, let body):
+                attributed = ACPCodeBlockHighlighter.attributedString(code: String(body.prefix(2048)), language: language, theme: theme)
+                background = NSColor(theme.color("bg-2"))
+            case .heading(let level, let text):
+                attributed = ACPMarkdownInlineRenderer.makeAttributedString(source: text, theme: theme, typography: .default, role: .heading(level: level))
+            case .paragraph(let text):
+                attributed = ACPMarkdownInlineRenderer.makeAttributedString(source: text, theme: theme, typography: .default, role: .body)
+            case .quote(let text):
+                attributed = ACPMarkdownInlineRenderer.makeAttributedString(source: text, theme: theme, typography: .default, role: .quote)
+            case .taskList(let items):
+                attributed = NSAttributedString(string: items.map { $0.text }.joined(separator: "\n"), attributes: [.foregroundColor: NSColor(theme.color("fg"))])
+            case .table(let header, let rows):
+                attributed = NSAttributedString(string: ([header] + rows).map { $0.joined(separator: "  ") }.joined(separator: "\n"), attributes: [.foregroundColor: NSColor(theme.color("fg"))])
+            case .mermaid(let source):
+                attributed = NSAttributedString(string: String(source.prefix(1024)), attributes: [.foregroundColor: NSColor(theme.color("accent"))])
+            }
+            let drawing = MinimapDrawing.text(attributed, columns: columns, wraps: background == nil)
+            let y = result.height
+            if let background {
+                result.marks.append(.init(rect: CGRect(x: 0, y: y, width: CGFloat(columns), height: drawing.height), color: background))
+            }
+            result.append(drawing, y: y)
+            result.height += 3
+        }
+        return result
+    }
+}

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -36,6 +36,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
     let onRetryContextRecovery: () -> Void
     let onOpenForkSource: (String) -> Void
     let agentDisplayName: (String) -> String
+    var showMinimap: Bool = false
 
     /// Ambient theme at the point this representable sits in the SwiftUI
     /// tree. Individual rows are hosted in their own, otherwise-disconnected
@@ -96,6 +97,8 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         /// Stable id to align at the viewport top after its bounded window
         /// has been reconciled into the AppKit tiling map.
         private var pendingLogicalTargetId: String?
+        private var pendingMinimapRowFraction: CGFloat = 0
+        private var minimapGestureRange: (count: Int, proportion: CGFloat)?
         private var isPendingLogicalResolutionScheduled = false
         private let scrollSettleTimer: DebounceTimer
         /// Memoizes the window-sliced row list + its id → message-index
@@ -107,6 +110,8 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         /// its message index is O(window) work in exactly the state where
         /// scrolling must stay smooth.
         private let visibleRowsCache = ACPVisibleRowsCache()
+        private var minimapRenderer: ACPTranscriptMinimap?
+        private var pendingMinimapUpdate: DispatchWorkItem?
 
         static let composerSpacerHeight: CGFloat = 220
 
@@ -139,6 +144,16 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             }
             scroller.onLogicalScrollCommit = { [weak self] value in
                 self?.commitLogicalScroll(value: value)
+            }
+            scroller.minimap.onNavigate = { [weak self] value in
+                self?.commitMinimapScroll(value: value)
+            }
+            scroller.minimap.onNavigationStart = { [weak self] in
+                guard let self, let host = self.host, let scroller = self.scroller else { return }
+                self.minimapGestureRange = (host.transcript.logicalMessageCount, scroller.minimap.proportion)
+            }
+            scroller.minimap.onNavigationEnd = { [weak self] in
+                self?.minimapGestureRange = nil
             }
             update(host: host)
         }
@@ -245,6 +260,8 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             // "already applied" memo would leave the transcript permanently
             // empty once a real width does arrive.
             guard let reconciler, let scroller else { return }
+            scroller.minimapPreferred = host.showMinimap
+            updateMinimap()
             let contentWidth = scroller.contentView.bounds.width
             let specs = Self.rowSpecs(
                 host: host,
@@ -275,6 +292,33 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         }
 
         // MARK: row specs
+
+        private func updateMinimap() {
+            guard let host, let scroller else { return }
+            guard host.showMinimap, scroller.showsMinimap else {
+                minimapGestureRange = nil
+                pendingMinimapUpdate?.cancel()
+                pendingMinimapUpdate = nil
+                minimapRenderer = nil
+                scroller.minimap.update(drawing: MinimapDrawing())
+                return
+            }
+            scroller.minimap.backgroundColor = NSColor(host.theme.color("bg-1"))
+            scroller.minimap.indicatorColor = NSColor(host.theme.color("fg-muted"))
+            if let minimapRenderer, !minimapRenderer.needsUpdate(transcript: host.transcript, theme: host.theme) { return }
+            guard pendingMinimapUpdate == nil else { return }
+            let work = DispatchWorkItem { [weak self] in
+                guard let self else { return }
+                self.pendingMinimapUpdate = nil
+                guard let host = self.host, host.showMinimap, let scroller = self.scroller, scroller.showsMinimap else { return }
+                if self.minimapRenderer == nil { self.minimapRenderer = ACPTranscriptMinimap() }
+                if let drawing = self.minimapRenderer?.drawing(transcript: host.transcript, theme: host.theme) {
+                    scroller.minimap.update(drawing: drawing)
+                }
+            }
+            pendingMinimapUpdate = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: work)
+        }
 
         /// Wraps a row's content with the layout and environment values that
         /// would otherwise reach it "for free" as a child of a single shared
@@ -847,6 +891,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         }
 
         private func commitLogicalScroll(value: Double) {
+            pendingMinimapRowFraction = 0
             guard let host, let scroller, host.transcript.logicalMessageCount > 0 else { return }
             if value >= 1 - Double.ulpOfOne {
                 pendingLogicalTargetGlobalIndex = nil
@@ -880,6 +925,25 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             }
         }
 
+        private func commitMinimapScroll(value: Double) {
+            guard let host, let scroller, host.transcript.logicalMessageCount > 0 else { return }
+            if value >= 1 {
+                commitLogicalScroll(value: 1)
+                return
+            }
+            pauseTailFollow()
+            reconciler?.setFollowsTail(false)
+            host.transcript.freezeVisibleTail()
+            let count = host.transcript.logicalMessageCount
+            // Keep the drag's mapping stable while rows of different heights enter the viewport.
+            let range = minimapGestureRange ?? (count: count, proportion: scroller.minimap.proportion)
+            let position = min(CGFloat(count) - 0.000_001,
+                               max(0, CGFloat(value) * (1 - range.proportion) * CGFloat(range.count)))
+            pendingLogicalTargetGlobalIndex = Int(position)
+            pendingMinimapRowFraction = position - floor(position)
+            if resolvePendingLogicalTargetIfPossible() { update(host: host) }
+        }
+
         /// Returns true when the pending global target is materialized and a
         /// bounded local window has been selected for the next reconcile.
         @discardableResult
@@ -892,8 +956,26 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             }
             let clampedTarget = min(max(0, target), count - 1)
             pendingLogicalTargetGlobalIndex = clampedTarget
-            guard let localIndex = host.transcript.localIndex(forGlobalIndex: clampedTarget) else {
+            guard var localIndex = host.transcript.localIndex(forGlobalIndex: clampedTarget) else {
                 return false
+            }
+            if case .plan = host.transcript.messages[localIndex] {
+                let original = localIndex
+                while localIndex < host.transcript.messages.count {
+                    if case .plan = host.transcript.messages[localIndex] { localIndex += 1 } else { break }
+                }
+                if localIndex == host.transcript.messages.count {
+                    localIndex = original - 1
+                    while localIndex >= 0 {
+                        if case .plan = host.transcript.messages[localIndex] { localIndex -= 1 } else { break }
+                    }
+                }
+                pendingMinimapRowFraction = 0
+                guard localIndex >= 0 else {
+                    pendingLogicalTargetGlobalIndex = nil
+                    pendingLogicalTargetId = nil
+                    return false
+                }
             }
             pendingLogicalTargetGlobalIndex = nil
             pendingLogicalTargetId = host.transcript.stableId(
@@ -930,7 +1012,9 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                   let row = tiling.row(withId: id),
                   let scroller
             else { return }
-            scroller.setScrollY(row.minY)
+            let fraction = pendingMinimapRowFraction
+            pendingMinimapRowFraction = 0
+            scroller.setScrollY(row.minY + row.height * fraction)
             pendingLogicalTargetId = nil
             rememberCurrentAnchor()
         }
@@ -947,6 +1031,19 @@ struct ACPTranscriptScroller: NSViewRepresentable {
                 topGlobalIndex: topGlobalIndex,
                 isAtTail: host.session.followsTranscriptTail
             ))
+            syncMinimapViewport()
+        }
+
+        private func syncMinimapViewport() {
+            guard let host, host.showMinimap, let scroller, scroller.showsMinimap,
+                  host.transcript.logicalMessageCount > 0,
+                  pendingLogicalTargetGlobalIndex == nil else { return }
+            let count = CGFloat(host.transcript.logicalMessageCount)
+            let top = globalMessagePosition(at: scroller.scrollY) ?? 0
+            let bottom = globalMessagePosition(at: scroller.scrollY + scroller.viewportHeight) ?? count
+            let proportion = min(1, max(0.000_001, (bottom - top) / count))
+            scroller.minimap.proportion = proportion
+            scroller.minimap.value = host.session.followsTranscriptTail ? 1 : Double(min(1, top / max(0.000_001, count * (1 - proportion))))
         }
 
         private func currentTopGlobalMessageIndex() -> Int? {
@@ -971,6 +1068,26 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             )
             guard let localIndex = lookup.transcriptIndex(for: anchorId) else { return nil }
             return host.transcript.globalIndex(forLocalIndex: localIndex)
+        }
+
+        private func globalMessagePosition(at y: CGFloat) -> CGFloat? {
+            guard let host,
+                  let id = tiling.nearestNonSyntheticRowId(to: y, syntheticIdPrefix: ACPTranscriptScrollerReconciler.syntheticIdPrefix),
+                  let row = tiling.row(withId: id) else { return nil }
+            let lookup = visibleRowsCache.lookup(
+                generation: host.transcript.messagesGeneration,
+                head: host.transcript.visibleHead,
+                tail: host.transcript.visibleTailBound,
+                build: {
+                    ACPTranscriptVisibleRow.rows(messages: host.transcript.messages,
+                                                 visibleHead: host.transcript.visibleHead,
+                                                 visibleTail: host.transcript.visibleTailBound,
+                                                 stableId: { host.transcript.stableId(for: $0) })
+                }
+            )
+            guard let localIndex = lookup.transcriptIndex(for: id),
+                  let globalIndex = host.transcript.globalIndex(forLocalIndex: localIndex) else { return nil }
+            return CGFloat(globalIndex) + min(1, max(0, (y - row.minY) / max(1, row.height)))
         }
 
         private func pauseTailFollow() {

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
@@ -41,7 +41,13 @@ final class ACPTranscriptLogicalScroller: NSScroller {
 /// older rows graft in with zero visible movement and live trackpad
 /// momentum keeps working against the same scroll view.
 @MainActor
-final class ACPTranscriptScrollerView: NSScrollView {
+final class ACPTranscriptScrollerView: MinimapScrollView {
+    nonisolated static let minimapMinimumWidth: CGFloat = 720
+
+    nonisolated static func shouldShowMinimap(preferred: Bool, availableWidth: CGFloat) -> Bool {
+        preferred && availableWidth >= minimapMinimumWidth
+    }
+
     let flippedDocumentView = ACPTranscriptDocumentView()
     var onScroll: ((_ previousY: CGFloat?, _ newY: CGFloat, _ viewportHeight: CGFloat, _ contentHeight: CGFloat, _ isProgrammatic: Bool) -> Void)?
     var onLogicalScrollCommit: ((Double) -> Void)?
@@ -61,6 +67,9 @@ final class ACPTranscriptScrollerView: NSScrollView {
     /// the sole subscriber.
     var onContentWidthChange: (() -> Void)?
     private var lastReportedContentWidth: CGFloat?
+    var minimapPreferred = false {
+        didSet { updateMinimapVisibility() }
+    }
 
     /// Fired from `layout()` whenever `contentView.bounds.height` differs
     /// from the last height reported, PROVIDED the width did NOT also
@@ -220,6 +229,7 @@ final class ACPTranscriptScrollerView: NSScrollView {
     }
 
     override func layout() {
+        updateMinimapVisibility()
         super.layout()
         // `super.layout()` runs AppKit's own scroll-view tiling first, so
         // `contentView.bounds` already reflects any scroller-visibility
@@ -242,6 +252,13 @@ final class ACPTranscriptScrollerView: NSScrollView {
             onViewportHeightChange?()
         }
         applyLogicalScrollerMetrics()
+    }
+
+    private func updateMinimapVisibility() {
+        showsMinimap = Self.shouldShowMinimap(
+            preferred: minimapPreferred,
+            availableWidth: bounds.width
+        )
     }
 
     override func reflectScrolledClipView(_ cView: NSClipView) {

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -110,7 +110,23 @@ struct EditorTabView: View {
                         ))
                     }
                 },
-                trailing: AnyView(statusBadge)
+                trailing: AnyView(HStack(spacing: 8) {
+                    statusBadge
+                    if !isBinary {
+                        Button {
+                            appState.config.code.showMinimap.toggle()
+                            appState.saveConfig()
+                        } label: {
+                            Image(systemName: "rectangle.trailingthird.inset.filled")
+                                .foregroundStyle(appState.config.code.showMinimap ? theme.color("accent") : theme.color("fg-muted"))
+                                .frame(width: 24, height: 24)
+                        }
+                        .buttonStyle(.plain)
+                        .help(appState.config.code.showMinimap ? "Hide minimap" : "Show minimap")
+                        .accessibilityLabel("Editor minimap")
+                        .accessibilityValue(appState.config.code.showMinimap ? "On" : "Off")
+                    }
+                })
             )
             if isBinary {
                 binaryPlaceholder
@@ -157,6 +173,7 @@ struct EditorTabView: View {
                     fontFamily: appState.config.code.fontFamily,
                     fontSize: appState.config.code.fontSize,
                     showLineNumbers: appState.config.code.showLineNumbers,
+                    showMinimap: appState.config.code.showMinimap,
                     textRendering: CodeEditorTextRenderingConfiguration(code: appState.config.code),
                     onTextViewAttached: { attachFindController(to: $0) },
                     onTextViewDetached: { detachFindController(from: $0) },

--- a/Alas/Sources/Code/Editor/CodeEditorMinimap.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorMinimap.swift
@@ -79,5 +79,4 @@ final class CodeEditorScrollView: MinimapScrollView {
         observers.removeAll()
         observedStorage = nil
     }
-
 }

--- a/Alas/Sources/Code/Editor/CodeEditorMinimap.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorMinimap.swift
@@ -1,0 +1,83 @@
+import AppKit
+import Combine
+
+@MainActor
+final class CodeEditorScrollView: MinimapScrollView {
+    private weak var observedStorage: NSTextStorage?
+    private var observers: [AnyCancellable] = []
+    private var pendingDrawing: DispatchWorkItem?
+    private var minimapTheme: Theme?
+
+    func configureMinimap(shown: Bool, theme: Theme) {
+        let wasShown = showsMinimap
+        showsMinimap = shown
+        guard shown, let textView = documentView as? NSTextView else {
+            stopObserving()
+            minimap.update(drawing: MinimapDrawing())
+            return
+        }
+        minimap.backgroundColor = NSColor(theme.color("bg-1"))
+        minimap.indicatorColor = NSColor(theme.color("fg-muted"))
+        if !minimap.preservesLineScale { minimap.preservesLineScale = true }
+        minimap.onNavigate = { [weak self] value in
+            guard let self, let documentView = self.documentView else { return }
+            let maximum = max(0, documentView.frame.height - self.contentView.bounds.height)
+            self.contentView.scroll(to: NSPoint(x: self.contentView.bounds.minX, y: CGFloat(value) * maximum))
+            self.reflectScrolledClipView(self.contentView)
+            self.updateMinimapViewport()
+        }
+        if observedStorage !== textView.textStorage || !wasShown {
+            stopObserving()
+            observedStorage = textView.textStorage
+            let center = NotificationCenter.default
+            if let storage = textView.textStorage {
+                observers.append(center.publisher(for: NSTextStorage.didProcessEditingNotification, object: storage).sink { [weak self] _ in
+                    MainActor.assumeIsolated { self?.scheduleDrawing() }
+                })
+            }
+            contentView.postsBoundsChangedNotifications = true
+            textView.postsFrameChangedNotifications = true
+            for (name, object) in [(NSView.boundsDidChangeNotification, contentView as NSView),
+                                   (NSView.frameDidChangeNotification, textView as NSView)] {
+                observers.append(center.publisher(for: name, object: object).sink { [weak self] _ in
+                    MainActor.assumeIsolated { self?.updateMinimapViewport() }
+                })
+            }
+            scheduleDrawing()
+        }
+        if minimapTheme != theme {
+            minimapTheme = theme
+            scheduleDrawing()
+        }
+        updateMinimapViewport()
+    }
+
+    private func scheduleDrawing() {
+        guard showsMinimap, pendingDrawing == nil else { return }
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.pendingDrawing = nil
+            guard self.showsMinimap, let storage = self.observedStorage else { return }
+            self.minimap.update(drawing: MinimapDrawing.editorText(storage))
+            self.updateMinimapViewport()
+        }
+        pendingDrawing = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08, execute: work)
+    }
+
+    private func updateMinimapViewport() {
+        guard showsMinimap, let documentView else { return }
+        let height = max(1, documentView.frame.height)
+        let viewport = contentView.bounds.height
+        minimap.proportion = min(1, viewport / height)
+        minimap.value = Double(max(0, contentView.bounds.minY) / max(1, height - viewport))
+    }
+
+    private func stopObserving() {
+        pendingDrawing?.cancel()
+        pendingDrawing = nil
+        observers.removeAll()
+        observedStorage = nil
+    }
+
+}

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -127,6 +127,7 @@ struct CodeEditorView: NSViewRepresentable {
     let fontFamily: String
     let fontSize: Int
     let showLineNumbers: Bool
+    var showMinimap: Bool = false
     let textRendering: CodeEditorTextRenderingConfiguration
     var onTextViewAttached: (CodeTextView) -> Void = { _ in }
     var onTextViewDetached: (CodeTextView?) -> Void = { _ in }
@@ -138,7 +139,7 @@ struct CodeEditorView: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> NSScrollView {
-        let scroll = NSScrollView()
+        let scroll = CodeEditorScrollView()
         scroll.hasVerticalScroller = true
         scroll.hasHorizontalScroller = true
         scroll.borderType = .noBorder
@@ -229,6 +230,7 @@ struct CodeEditorView: NSViewRepresentable {
             originatingRelativePath: originatingRelativePath,
             externalEditable: externalEditable
         )
+        scroll.configureMinimap(shown: showMinimap, theme: theme)
         return scroll
     }
 
@@ -258,6 +260,7 @@ struct CodeEditorView: NSViewRepresentable {
                 rendersTextDecorations: !context.coordinator.currentBufferReadOnly
             )
         }
+        (nsView as? CodeEditorScrollView)?.configureMinimap(shown: showMinimap, theme: theme)
     }
 
     static func dismantleNSView(_ nsView: NSScrollView, coordinator: CodeEditorCoordinator) {

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -191,6 +191,7 @@ struct MarkdownTabView: View {
             fontFamily: appState.config.code.fontFamily,
             fontSize: appState.config.code.fontSize,
             showLineNumbers: appState.config.code.showLineNumbers,
+            showMinimap: appState.config.code.showMinimap,
             textRendering: CodeEditorTextRenderingConfiguration(code: appState.config.code),
             onInitialHighlightReady: {
                 if resolvedMode == .editor {

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -257,6 +257,7 @@ struct AppConfig: Codable, Equatable {
         /// (the agent runs tools without asking). Seeds the per-session value
         /// only; the composer bolt still wins afterward. Default: false.
         var acpAutoRunByDefault: Bool
+        var acpShowMinimap: Bool
         /// When true (default), every local ACP session gets the built-in
         /// "alas" MCP server exposing CLI actions (open, worktrees, review).
         var exposeAlasMCP: Bool
@@ -270,7 +271,7 @@ struct AppConfig: Codable, Equatable {
         enum CodingKeys: String, CodingKey {
             case notifyOnFinish, notifyOnAwaiting,
                  dismissedHookInstallNudges, dismissedACPSetupNudges,
-                 confirmCloseChatTabs, acpSendOnEnter, acpAutoRunByDefault,
+                 confirmCloseChatTabs, acpSendOnEnter, acpAutoRunByDefault, acpShowMinimap,
                  exposeAlasMCP, alasMCPTransport, acpDictationLocale
         }
 
@@ -280,6 +281,7 @@ struct AppConfig: Codable, Equatable {
              confirmCloseChatTabs: Bool = false,
              acpSendOnEnter: Bool = true,
              acpAutoRunByDefault: Bool = false,
+             acpShowMinimap: Bool = false,
              exposeAlasMCP: Bool = true,
              alasMCPTransport: AlasMCPTransport = .stdio,
              acpDictationLocale: String = "")
@@ -291,6 +293,7 @@ struct AppConfig: Codable, Equatable {
             self.confirmCloseChatTabs = confirmCloseChatTabs
             self.acpSendOnEnter = acpSendOnEnter
             self.acpAutoRunByDefault = acpAutoRunByDefault
+            self.acpShowMinimap = acpShowMinimap
             self.exposeAlasMCP = exposeAlasMCP
             self.alasMCPTransport = alasMCPTransport
             self.acpDictationLocale = acpDictationLocale
@@ -305,6 +308,7 @@ struct AppConfig: Codable, Equatable {
             confirmCloseChatTabs = (try? c.decode(Bool.self, forKey: .confirmCloseChatTabs)) ?? false
             acpSendOnEnter = (try? c.decode(Bool.self, forKey: .acpSendOnEnter)) ?? true
             acpAutoRunByDefault = (try? c.decode(Bool.self, forKey: .acpAutoRunByDefault)) ?? false
+            acpShowMinimap = (try? c.decode(Bool.self, forKey: .acpShowMinimap)) ?? false
             exposeAlasMCP = (try? c.decode(Bool.self, forKey: .exposeAlasMCP)) ?? true
             alasMCPTransport = (try? c.decode(AlasMCPTransport.self, forKey: .alasMCPTransport)) ?? .stdio
             acpDictationLocale = (try? c.decode(String.self, forKey: .acpDictationLocale)) ?? ""
@@ -319,6 +323,7 @@ struct AppConfig: Codable, Equatable {
         var languageServers: [LanguageServerConfig]
         var dismissedInstallNudges: [String]
         var userDefinedRecipes: [String: [InstallRecipe]]
+        var showMinimap: Bool = false
         var showInvisibleCharacters: Bool = false
         var showSpaces: Bool = true
         var showTabs: Bool = true
@@ -327,7 +332,7 @@ struct AppConfig: Codable, Equatable {
         var warningCharacters: [WarningCharacter] = WarningCharacter.defaults
 
         enum CodingKeys: String, CodingKey {
-            case fontFamily, fontSize, formatOnSave, showLineNumbers,
+            case fontFamily, fontSize, formatOnSave, showLineNumbers, showMinimap,
                  languageServers, dismissedInstallNudges, userDefinedRecipes,
                  showInvisibleCharacters, showSpaces, showTabs, showLineEndings,
                  showWarningCharacters, warningCharacters
@@ -717,6 +722,7 @@ extension AppConfig {
                 languageServers: servers,
                 dismissedInstallNudges: dismissed,
                 userDefinedRecipes: userRecipes,
+                showMinimap: (try? codeContainer.decode(Bool.self, forKey: .showMinimap)) ?? false,
                 showInvisibleCharacters: showInvisibleCharacters,
                 showSpaces: showSpaces,
                 showTabs: showTabs,

--- a/Alas/Sources/Settings/ChatPane.swift
+++ b/Alas/Sources/Settings/ChatPane.swift
@@ -57,6 +57,9 @@ struct ChatPane: View {
                     .padding(.bottom, 12)
 
                 SettingsGroup(title: GroupTitles.appearance) {
+                    SettingsRow(name: "Show minimap") {
+                        AlasToggle(on: state.bind(\.harness.acpShowMinimap))
+                    }
                     SettingsRow(name: RowLabels.fontFamily) {
                         FontFamilyPicker(
                             family: state.bind(\.agents.chatFontFamily),

--- a/Alas/Sources/Settings/CodePane.swift
+++ b/Alas/Sources/Settings/CodePane.swift
@@ -38,6 +38,9 @@ struct CodePane: View {
                                 desc: "Display a non-selectable gutter in editor panes.") {
                         AlasToggle(on: state.bind(\.code.showLineNumbers))
                     }
+                    SettingsRow(name: "Show minimap") {
+                        AlasToggle(on: state.bind(\.code.showMinimap))
+                    }
                     SettingsRow(name: "Format on save",
                                 desc: "Request document formatting from the language server before writing to disk.") {
                         AlasToggle(on: state.bind(\.code.formatOnSave))

--- a/Alas/Sources/Shared/MinimapView.swift
+++ b/Alas/Sources/Shared/MinimapView.swift
@@ -1,0 +1,306 @@
+import AppKit
+import CoreText
+
+struct MinimapGeometry {
+    let height: CGFloat
+    let proportion: CGFloat
+    let value: Double
+    var width: CGFloat = MinimapView.width
+
+    var thumb: CGRect {
+        let h = max(0, height)
+        let extent = min(h, max(16, h * min(1, max(0, proportion))))
+        return CGRect(x: 0, y: CGFloat(min(1, max(0, value))) * (h - extent), width: width, height: extent)
+    }
+
+}
+
+struct MinimapDrawing {
+    struct Mark {
+        var rect: CGRect
+        let color: NSColor
+    }
+
+    var marks: [Mark] = []
+    var height: CGFloat = 0
+    var columns: CGFloat = 88
+
+    static func editorText(_ text: NSAttributedString, columns: Int = 88) -> Self {
+        let source = text.string as NSString
+        var lines: [NSRange] = []
+        var position = 0
+        while position < source.length {
+            var end = 0
+            var contentsEnd = 0
+            source.getLineStart(nil, end: &end, contentsEnd: &contentsEnd, for: NSRange(location: position, length: 0))
+            lines.append(NSRange(location: position, length: contentsEnd - position))
+            position = end
+        }
+        if source.length == 0 || text.string.last?.isNewline == true {
+            lines.append(NSRange(location: source.length, length: 0))
+        }
+        var result = Self(height: CGFloat(lines.count * 3), columns: CGFloat(columns))
+        // Keep drawing memory bounded for generated files. CoreText lays out only
+        // sampled line prefixes, using the editor's fonts, tab stops and colors.
+        let stride = max(1, Int(ceil(Double(lines.count) / 4096)))
+        for index in lines.indices where index % stride == 0 || index == lines.count - 1 {
+            let range = lines[index]
+            guard range.length > 0 else { continue }
+            let prefix = source.rangeOfComposedCharacterSequences(for: NSRange(location: range.location, length: min(range.length, 512)))
+            let attributed = text.attributedSubstring(from: prefix)
+            let font = attributed.attribute(.font, at: 0, effectiveRange: nil) as? NSFont ?? .monospacedSystemFont(ofSize: 13, weight: .regular)
+            let cell = max(1, ("M" as NSString).size(withAttributes: [.font: font]).width)
+            let line = CTLineCreateWithAttributedString(attributed)
+            var offset = 0
+            for character in attributed.string {
+                let length = String(character).utf16.count
+                defer { offset += length }
+                let x = CTLineGetOffsetForStringIndex(line, offset, nil) / cell
+                guard x < CGFloat(columns) else { break }
+                guard !character.isWhitespace else { continue }
+                let end = CTLineGetOffsetForStringIndex(line, offset + length, nil) / cell
+                let color = attributed.attribute(.foregroundColor, at: offset, effectiveRange: nil) as? NSColor ?? .labelColor
+                result.marks.append(Mark(rect: CGRect(x: x, y: CGFloat(index * 3), width: max(0.5, min(CGFloat(columns) - x, abs(end - x) * 0.85)), height: 2), color: color))
+            }
+        }
+        return result
+    }
+
+    /// Character-sized blocks retain syntax runs and the negative space between tokens.
+    static func text(_ text: NSAttributedString, columns: Int = 88, tabWidth: Int = 4, wraps: Bool = false) -> Self {
+        var result = Self(columns: CGFloat(max(1, columns)))
+        var row = 0
+        var column = 0
+        var offset = 0
+        var colorRange = NSRange(location: 0, length: 0)
+        var color = NSColor.labelColor
+        for character in text.string {
+            let string = String(character)
+            let length = string.utf16.count
+            defer { offset += length }
+            if character.isNewline {
+                row += 1
+                column = 0
+                continue
+            }
+            if character == "\t" {
+                column += max(1, tabWidth) - column % max(1, tabWidth)
+                continue
+            }
+            if wraps, column >= columns {
+                row += 1
+                column = 0
+            }
+            if !character.isWhitespace, column < columns {
+                if !NSLocationInRange(offset, colorRange) {
+                    color = text.attribute(.foregroundColor, at: offset, effectiveRange: &colorRange) as? NSColor ?? .labelColor
+                }
+                result.marks.append(Mark(
+                    rect: CGRect(x: CGFloat(column), y: CGFloat(row * 3), width: 0.85, height: 2),
+                    color: color
+                ))
+            }
+            column += 1
+        }
+        result.height = CGFloat((row + 1) * 3)
+        return result
+    }
+
+    mutating func append(_ other: Self, x: CGFloat = 0, y: CGFloat) {
+        marks.append(contentsOf: other.marks.map {
+            Mark(rect: $0.rect.offsetBy(dx: x, dy: y), color: $0.color)
+        })
+        height = max(height, y + other.height)
+    }
+}
+
+@MainActor
+final class MinimapView: NSView {
+    nonisolated static let width: CGFloat = 96
+    var onNavigate: ((Double) -> Void)?
+    var onNavigationStart: (() -> Void)?
+    var onNavigationEnd: (() -> Void)?
+    var value: Double = 0 { didSet { needsDisplay = true } }
+    var proportion: CGFloat = 1 { didSet { needsDisplay = true } }
+    var backgroundColor = NSColor.textBackgroundColor { didSet { needsDisplay = true } }
+    var indicatorColor = NSColor.secondaryLabelColor { didSet { needsDisplay = true } }
+    var preservesLineScale = false { didSet { raster = nil; needsDisplay = true } }
+    private var drawing = MinimapDrawing()
+    private var raster: CGImage?
+    private var rasterSize = CGSize.zero
+    private var rasterOffset: CGFloat = -1
+    private var dragStartY: CGFloat = 0
+    private var dragStartValue: Double = 0
+    private var dragTravel: CGFloat = 1
+    private var lastDragY: CGFloat = 0
+
+    override var isFlipped: Bool { true }
+    override var acceptsFirstResponder: Bool { true }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        clipsToBounds = true
+        setAccessibilityElement(true)
+        setAccessibilityRole(.slider)
+        setAccessibilityLabel("Minimap")
+        toolTip = "Minimap"
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("not supported") }
+
+    func update(drawing: MinimapDrawing) {
+        self.drawing = drawing
+        raster = nil
+        needsDisplay = true
+    }
+
+    private var geometry: MinimapGeometry {
+        let height = min(bounds.height, max(16, drawing.height * verticalScale))
+        return MinimapGeometry(height: height, proportion: drawing.height * verticalScale * proportion / max(1, height), value: value, width: bounds.width)
+    }
+
+    private var verticalScale: CGFloat {
+        if preservesLineScale, drawing.height <= 4096 * 3 { return 1 }
+        return min(1, bounds.height / max(1, drawing.height))
+    }
+
+    private var drawingOffset: CGFloat {
+        CGFloat(min(1, max(0, value))) * max(0, drawing.height * verticalScale - bounds.height)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        backgroundColor.setFill()
+        bounds.fill()
+        guard bounds.width > 0, bounds.height > 0 else { return }
+        let scale = window?.backingScaleFactor ?? 2
+        let size = CGSize(width: bounds.width * scale, height: bounds.height * scale)
+        let offset = drawingOffset
+        if raster == nil || rasterSize != size || rasterOffset != offset {
+            rasterSize = size
+            rasterOffset = offset
+            if let context = CGContext(data: nil, width: Int(ceil(size.width)), height: Int(ceil(size.height)),
+                                       bitsPerComponent: 8, bytesPerRow: 0, space: CGColorSpaceCreateDeviceRGB(),
+                                       bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) {
+                context.translateBy(x: 0, y: size.height)
+                context.scaleBy(x: scale, y: -scale)
+                let sx = max(0, bounds.width - 8) / max(1, drawing.columns)
+                let sy = verticalScale
+                let marks: ArraySlice<MinimapDrawing.Mark>
+                if preservesLineScale, sy == 1 {
+                    var low = 0
+                    var high = drawing.marks.count
+                    while low < high {
+                        let mid = (low + high) / 2
+                        if drawing.marks[mid].rect.maxY < offset { low = mid + 1 } else { high = mid }
+                    }
+                    marks = drawing.marks[low...].prefix { $0.rect.minY <= offset + bounds.height }
+                } else {
+                    marks = drawing.marks[...]
+                }
+                for mark in marks {
+                    context.setFillColor(mark.color.cgColor)
+                    context.fill(CGRect(x: 4 + mark.rect.minX * sx, y: mark.rect.minY * sy - offset,
+                                        width: mark.rect.width * sx, height: max(0.5 / scale, mark.rect.height * sy)))
+                }
+                raster = context.makeImage()
+            }
+        }
+        if let raster {
+            NSImage(cgImage: raster, size: bounds.size).draw(in: bounds, from: .zero, operation: .sourceOver, fraction: 1, respectFlipped: true, hints: [.interpolation: NSImageInterpolation.none.rawValue])
+        }
+        indicatorColor.withAlphaComponent(indicatorColor.alphaComponent * 0.1).setFill()
+        geometry.thumb.fill()
+        indicatorColor.withAlphaComponent(indicatorColor.alphaComponent * 0.5).setStroke()
+        NSBezierPath(rect: geometry.thumb.insetBy(dx: 0.5, dy: 0.5)).stroke()
+        indicatorColor.withAlphaComponent(indicatorColor.alphaComponent * 0.2).setFill()
+        CGRect(x: 0, y: 0, width: 0.5, height: bounds.height).fill()
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        onNavigationStart?()
+        let y = convert(event.locationInWindow, from: nil).y
+        let thumb = geometry.thumb
+        dragStartValue = value
+        dragTravel = max(1, geometry.height - thumb.height)
+        if !(thumb.minY...thumb.maxY ~= y) {
+            let travel = drawing.height * verticalScale - thumb.height
+            let target = travel > 0 ? Double((drawingOffset + y - thumb.height / 2) / travel) : 0
+            dragStartValue = min(1, max(0, target))
+            navigate(to: target)
+        }
+        dragStartY = y
+        lastDragY = y
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        let y = convert(event.locationInWindow, from: nil).y
+        guard y != lastDragY else { return }
+        lastDragY = y
+        let delta = y - dragStartY
+        navigate(to: dragStartValue + Double(delta / dragTravel))
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        mouseDragged(with: event)
+        onNavigationEnd?()
+    }
+
+    override func keyDown(with event: NSEvent) {
+        switch event.keyCode {
+        case 126: navigate(to: value - max(0.01, Double(proportion) / 2))
+        case 125: navigate(to: value + max(0.01, Double(proportion) / 2))
+        case 115: navigate(to: 0)
+        case 119: navigate(to: 1)
+        default: super.keyDown(with: event)
+        }
+    }
+
+    override func accessibilityValue() -> Any? { NSNumber(value: value) }
+    override func accessibilityPerformIncrement() -> Bool {
+        navigate(to: value + max(0.01, Double(proportion) / 2))
+        return true
+    }
+    override func accessibilityPerformDecrement() -> Bool {
+        navigate(to: value - max(0.01, Double(proportion) / 2))
+        return true
+    }
+
+    private func navigate(to value: Double) {
+        self.value = min(1, max(0, value))
+        onNavigate?(self.value)
+    }
+}
+
+@MainActor
+class MinimapScrollView: NSScrollView {
+    let minimap = MinimapView(frame: .zero)
+    var showsMinimap = false {
+        didSet {
+            guard showsMinimap != oldValue else { return }
+            if showsMinimap { addSubview(minimap) } else { minimap.removeFromSuperview() }
+            tile()
+            needsLayout = true
+        }
+    }
+
+    override func tile() {
+        super.tile()
+        guard showsMinimap else { return }
+        let width = min(MinimapView.width, max(0, bounds.width / 3))
+        var clip = contentView.frame
+        clip.size.width = max(0, clip.width - width)
+        contentView.frame = clip
+        if let verticalScroller {
+            var frame = verticalScroller.frame
+            frame.origin.x -= width
+            verticalScroller.frame = frame
+        }
+        if let horizontalScroller {
+            var frame = horizontalScroller.frame
+            frame.size.width = max(0, frame.width - width)
+            horizontalScroller.frame = frame
+        }
+        minimap.frame = CGRect(x: bounds.maxX - width, y: 0, width: width, height: bounds.height)
+    }
+}

--- a/Alas/Sources/Shared/MinimapView.swift
+++ b/Alas/Sources/Shared/MinimapView.swift
@@ -12,7 +12,6 @@ struct MinimapGeometry {
         let extent = min(h, max(16, h * min(1, max(0, proportion))))
         return CGRect(x: 0, y: CGFloat(min(1, max(0, value))) * (h - extent), width: width, height: extent)
     }
-
 }
 
 struct MinimapDrawing {
@@ -124,7 +123,8 @@ final class MinimapView: NSView {
     var proportion: CGFloat = 1 { didSet { needsDisplay = true } }
     var backgroundColor = NSColor.textBackgroundColor { didSet { needsDisplay = true } }
     var indicatorColor = NSColor.secondaryLabelColor { didSet { needsDisplay = true } }
-    var preservesLineScale = false { didSet { raster = nil; needsDisplay = true } }
+    var preservesLineScale = false { didSet { raster = nil
+    needsDisplay = true } }
     private var drawing = MinimapDrawing()
     private var raster: CGImage?
     private var rasterSize = CGSize.zero

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -725,6 +725,100 @@ struct ACPTranscriptScrollerViewportHeightReconciliationTests {
 @MainActor
 @Suite("ACPTranscriptScroller logical navigation")
 struct ACPTranscriptScrollerLogicalNavigationTests {
+    @Test("Minimap drag mapping stays stable across differently sized messages")
+    func minimapDragMapping() {
+        let session = ACPSession(id: "mixed-minimap", agentId: "claude", worktreeId: "w", title: "t")
+        let short = ACPMessage.systemNotice(id: UUID(), text: "Short message")
+        let tall = ACPMessage.agent(id: UUID(), StreamingText(String(repeating: "A long response.\n\n", count: 100)))
+        session.replaceTranscriptMessages([short, tall, .systemNotice(id: UUID(), text: "End")])
+        session.followsTranscriptTail = true
+        var host = makeHost(session: session)
+        host.showMinimap = true
+        let scroller = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 800, height: 400))
+        let coordinator = ACPTranscriptScroller.Coordinator()
+        coordinator.attach(scroller: scroller, host: host)
+        scroller.layoutSubtreeIfNeeded()
+        scroller.minimap.onNavigate?(0)
+        let initialProportion = scroller.minimap.proportion
+        let destination = Double(0.5 / (1 - initialProportion))
+        #expect(destination < 1)
+        scroller.minimap.onNavigationStart?()
+        scroller.minimap.onNavigate?(destination)
+        let position = scroller.scrollY
+        #expect(coordinator.topVisibleMessageIdForTesting == tall.stableId)
+        #expect(abs(scroller.minimap.proportion - initialProportion) > 0.01)
+        scroller.minimap.onNavigate?(destination)
+        #expect(abs(scroller.scrollY - position) < 1)
+        scroller.minimap.onNavigationEnd?()
+    }
+
+    @Test("Minimap targets skip plan entries that have no transcript row")
+    func minimapSkipsHiddenPlans() {
+        let session = ACPSession(id: "plan-minimap", agentId: "claude", worktreeId: "w", title: "t")
+        let first = ACPMessage.agent(id: UUID(), StreamingText(String(repeating: "First response.\n\n", count: 80)))
+        let last = ACPMessage.agent(id: UUID(), StreamingText(String(repeating: "Last response.\n\n", count: 80)))
+        session.replaceTranscriptMessages([first, .plan(id: UUID(), []), last])
+        session.followsTranscriptTail = true
+        var host = makeHost(session: session)
+        host.showMinimap = true
+        let scroller = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 800, height: 400))
+        let coordinator = ACPTranscriptScroller.Coordinator()
+        coordinator.attach(scroller: scroller, host: host)
+        scroller.layoutSubtreeIfNeeded()
+        scroller.minimap.onNavigate?(0)
+        #expect(coordinator.topVisibleMessageIdForTesting == first.stableId)
+        scroller.minimap.onNavigate?(0.5)
+        #expect(coordinator.topVisibleMessageIdForTesting == last.stableId)
+        #expect(!session.followsTranscriptTail)
+    }
+
+    @Test("Minimap navigation leaves tail-follow paused while new messages arrive")
+    func minimapNavigationDuringStreaming() throws {
+        let session = ACPSession(id: "minimap", agentId: "claude", worktreeId: "w", title: "t")
+        let allMessages = messages(200)
+        session.replaceTranscriptMessages(allMessages)
+        session.transcript.resetWindowToTail()
+        session.followsTranscriptTail = true
+        var host = makeHost(session: session)
+        host.showMinimap = true
+        let scroller = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 800, height: 400))
+        let coordinator = ACPTranscriptScroller.Coordinator()
+        coordinator.attach(scroller: scroller, host: host)
+        scroller.layoutSubtreeIfNeeded()
+        scroller.minimap.onNavigate?(0.5)
+        #expect(!session.followsTranscriptTail)
+        let anchor = coordinator.topVisibleMessageIdForTesting
+        #expect(anchor != nil && anchor != allMessages.last?.stableId)
+        let position = scroller.scrollY
+        session.transcript.messages.append(.systemNotice(id: UUID(), text: "new message"))
+        coordinator.update(host: host)
+        #expect(!session.followsTranscriptTail)
+        #expect(abs(scroller.scrollY - position) < 1)
+        #expect(coordinator.topVisibleMessageIdForTesting == anchor)
+        scroller.minimap.onNavigate?(1)
+        #expect(session.followsTranscriptTail)
+        #expect(scroller.distanceFromBottom < 1)
+    }
+
+    @Test("Minimap can navigate inside a single response taller than the viewport")
+    func minimapNavigatesWithinResponse() {
+        let session = ACPSession(id: "long-minimap", agentId: "claude", worktreeId: "w", title: "t")
+        session.replaceTranscriptMessages([.agent(id: UUID(), StreamingText(String(repeating: "A paragraph of a long response.\n\n", count: 100)))])
+        session.followsTranscriptTail = true
+        var host = makeHost(session: session)
+        host.showMinimap = true
+        let scroller = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 800, height: 400))
+        let coordinator = ACPTranscriptScroller.Coordinator()
+        coordinator.attach(scroller: scroller, host: host)
+        scroller.layoutSubtreeIfNeeded()
+        #expect(scroller.contentHeight > scroller.viewportHeight * 3)
+        #expect(scroller.minimap.proportion < 1)
+        scroller.minimap.onNavigate?(0.5)
+        #expect(!session.followsTranscriptTail)
+        #expect(scroller.scrollY > scroller.viewportHeight)
+        #expect(scroller.distanceFromBottom > scroller.viewportHeight)
+    }
+
     private func messages(_ count: Int) -> [ACPMessage] {
         (0..<count).map { index in
             .systemNotice(id: UUID(), text: "message \(index)")

--- a/AlasTests/MinimapTests.swift
+++ b/AlasTests/MinimapTests.swift
@@ -1,0 +1,239 @@
+import AppKit
+import Testing
+
+@testable import Alas
+
+@MainActor
+private final class MinimapColorReferenceView: NSView {
+    override var isFlipped: Bool { true }
+
+    override func draw(_ dirtyRect: NSRect) {
+        NSColor.black.setFill()
+        bounds.fill()
+        NSColor.red.setFill()
+        CGRect(x: 14, y: 10, width: 10, height: 10).fill()
+        NSColor.blue.setFill()
+        CGRect(x: 14, y: 70, width: 10, height: 10).fill()
+    }
+}
+
+@Suite("Minimap")
+struct MinimapTests {
+    @Test("Drag release does not navigate twice when the viewport changes")
+    @MainActor func dragRelease() throws {
+        let view = MinimapView(frame: CGRect(x: 0, y: 0, width: 96, height: 600))
+        view.proportion = 0.2
+        view.update(drawing: MinimapDrawing(height: 600))
+        let window = NSWindow(contentRect: view.frame, styleMask: .borderless, backing: .buffered, defer: false)
+        window.contentView = view
+        var destinations: [Double] = []
+        view.onNavigate = { value in
+            destinations.append(value)
+            view.proportion = 0.01
+            view.value = value * 0.8 / 0.99
+        }
+        func event(_ type: NSEvent.EventType, y: CGFloat) throws -> NSEvent {
+            try #require(NSEvent.mouseEvent(with: type, location: view.convert(CGPoint(x: 40, y: y), to: nil), modifierFlags: [], timestamp: 0, windowNumber: window.windowNumber, context: nil, eventNumber: 0, clickCount: 1, pressure: 1))
+        }
+        view.mouseDown(with: try event(.leftMouseDown, y: 60))
+        view.mouseDragged(with: try event(.leftMouseDragged, y: 300))
+        let destination = view.value
+        view.mouseUp(with: try event(.leftMouseUp, y: 300))
+        #expect(destinations.count == 1)
+        #expect(view.value == destination)
+    }
+
+    @Test("A detailed minimap click stays put on release and dragging reaches both ends")
+    @MainActor func pointerNavigation() throws {
+        let view = MinimapView(frame: CGRect(x: 0, y: 0, width: 96, height: 600))
+        view.preservesLineScale = true
+        view.proportion = 0.1
+        view.update(drawing: MinimapDrawing(height: 1500))
+        let window = NSWindow(contentRect: view.frame, styleMask: .borderless, backing: .buffered, defer: false)
+        window.contentView = view
+        func event(_ type: NSEvent.EventType, y: CGFloat) throws -> NSEvent {
+            try #require(NSEvent.mouseEvent(with: type, location: view.convert(CGPoint(x: 40, y: y), to: nil), modifierFlags: [], timestamp: 0, windowNumber: window.windowNumber, context: nil, eventNumber: 0, clickCount: 1, pressure: 1))
+        }
+        view.mouseDown(with: try event(.leftMouseDown, y: 300))
+        let clicked = view.value
+        #expect(clicked > 0 && clicked < 0.3)
+        view.mouseUp(with: try event(.leftMouseUp, y: 300))
+        #expect(view.value == clicked)
+        view.mouseDragged(with: try event(.leftMouseDragged, y: 1200))
+        #expect(view.value == 1)
+        view.mouseDragged(with: try event(.leftMouseDragged, y: -1200))
+        #expect(view.value == 0)
+    }
+
+    @Test("Editor preview uses actual tab stops and syntax attributes")
+    func editorTabs() throws {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.tabStops = [NSTextTab(textAlignment: .left, location: 60)]
+        let text = NSAttributedString(string: "\tlet x\r\n  return x", attributes: [
+            .font: NSFont.monospacedSystemFont(ofSize: 10, weight: .regular),
+            .paragraphStyle: paragraph,
+            .foregroundColor: NSColor.systemPink,
+        ])
+        let drawing = MinimapDrawing.editorText(text)
+        #expect(drawing.height == 6)
+        #expect(try #require(drawing.marks.first).rect.minX > 8)
+        #expect(drawing.marks.allSatisfy { $0.color == NSColor.systemPink })
+        #expect(drawing.marks.contains { abs($0.rect.minX - 2) < 0.01 && $0.rect.minY == 3 })
+    }
+
+    @Test("The cached bitmap preserves top-to-bottom orientation and distinct colors")
+    @MainActor func pixels() throws {
+        let view = MinimapView(frame: CGRect(x: 0, y: 0, width: 96, height: 100))
+        view.backgroundColor = .black
+        view.indicatorColor = .clear
+        view.update(drawing: MinimapDrawing(marks: [
+            .init(rect: CGRect(x: 10, y: 10, width: 10, height: 10), color: .red),
+            .init(rect: CGRect(x: 10, y: 70, width: 10, height: 10), color: .blue),
+        ], height: 100))
+        let window = NSWindow(contentRect: view.frame, styleMask: .borderless, backing: .buffered, defer: false)
+        window.contentView = view
+        let bitmap = try #require(view.bitmapImageRepForCachingDisplay(in: view.bounds))
+        view.cacheDisplay(in: view.bounds, to: bitmap)
+        let scale = CGFloat(bitmap.pixelsWide) / view.bounds.width
+        let top = try #require(bitmap.colorAt(x: Int(19 * scale), y: Int(15 * scale))?.usingColorSpace(.sRGB))
+        let bottom = try #require(bitmap.colorAt(x: Int(19 * scale), y: Int(75 * scale))?.usingColorSpace(.sRGB))
+        let reference = MinimapColorReferenceView(frame: view.frame)
+        window.contentView = reference
+        let referenceBitmap = try #require(reference.bitmapImageRepForCachingDisplay(in: reference.bounds))
+        reference.cacheDisplay(in: reference.bounds, to: referenceBitmap)
+        let referenceScale = CGFloat(referenceBitmap.pixelsWide) / reference.bounds.width
+        let referenceTop = try #require(referenceBitmap.colorAt(x: Int(19 * referenceScale), y: Int(15 * referenceScale))?.usingColorSpace(.sRGB))
+        let referenceBottom = try #require(referenceBitmap.colorAt(x: Int(19 * referenceScale), y: Int(75 * referenceScale))?.usingColorSpace(.sRGB))
+        for (actual, expected) in [(top, referenceTop), (bottom, referenceBottom)] {
+            #expect(abs(actual.redComponent - expected.redComponent) < 0.02, "\(actual) versus native \(expected)")
+            #expect(abs(actual.greenComponent - expected.greenComponent) < 0.02)
+            #expect(abs(actual.blueComponent - expected.blueComponent) < 0.02)
+        }
+        #expect(top.redComponent > top.blueComponent + 0.5)
+        #expect(bottom.blueComponent > bottom.redComponent + 0.5)
+    }
+
+    @Test("Legacy settings leave both minimaps off")
+    func legacyPreferences() throws {
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(AppConfig.defaults)) as? [String: Any])
+        var code = try #require(object["code"] as? [String: Any])
+        var harness = try #require(object["harness"] as? [String: Any])
+        code.removeValue(forKey: "showMinimap")
+        harness.removeValue(forKey: "acpShowMinimap")
+        object["code"] = code
+        object["harness"] = harness
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: JSONSerialization.data(withJSONObject: object))
+        #expect(!decoded.code.showMinimap)
+        #expect(!decoded.harness.acpShowMinimap)
+    }
+
+    @Test("Transcript code blocks reuse syntax colors and user bubbles retain their alignment")
+    @MainActor func transcriptColors() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let code = ACPTranscriptMinimap.preview(.agent(id: UUID(), StreamingText("```swift\nlet value = 42\n```")), theme: theme)
+        let keyword = NSColor(theme.color("syntax-keyword"))
+        let number = NSColor(theme.color("mod"))
+        #expect(code.marks.contains { $0.color == keyword })
+        #expect(code.marks.contains { $0.color == number })
+        let user = ACPTranscriptMinimap.preview(.user(id: UUID(), text: "hello", attachments: []), theme: theme)
+        #expect(user.marks.allSatisfy { $0.rect.minX >= 24 })
+        #expect(user.marks.contains { $0.color == NSColor(theme.color("accent")).withAlphaComponent(0.26) })
+    }
+
+    @Test("Transcript previews update for streaming and never carry content between sessions")
+    @MainActor func transcriptInvalidation() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let transcript = ACPTranscript()
+        let buffer = StreamingText("a")
+        transcript.messages = [.agent(id: UUID(), buffer)]
+        let renderer = ACPTranscriptMinimap()
+        let before = renderer.drawing(transcript: transcript, theme: theme)
+        #expect(!renderer.needsUpdate(transcript: transcript, theme: theme))
+        buffer.append("bc")
+        transcript.streamingTick &+= 1
+        let after = renderer.drawing(transcript: transcript, theme: theme)
+        #expect(after.marks.count > before.marks.count)
+        let second = ACPTranscript()
+        second.messages = [.systemNotice(id: UUID(), text: "different session")]
+        second.streamingTick = transcript.streamingTick
+        #expect(renderer.needsUpdate(transcript: second, theme: theme))
+        #expect(renderer.needsUpdate(transcript: transcript, theme: try Theme.loadBundled(id: "light")))
+    }
+
+    @Test("Character blocks preserve indentation, gaps, and attributed syntax colors")
+    func syntaxBlocks() {
+        let text = NSMutableAttributedString(string: "  let x\n\t42\n", attributes: [.foregroundColor: NSColor.white])
+        text.addAttribute(.foregroundColor, value: NSColor.systemPink, range: NSRange(location: 2, length: 3))
+        let drawing = MinimapDrawing.text(text, columns: 80, tabWidth: 4)
+        #expect(drawing.height == 9)
+        #expect(drawing.marks.first?.rect.minX == 2)
+        #expect(drawing.marks.first?.color == NSColor.systemPink)
+        #expect(!drawing.marks.contains { $0.rect.contains(CGPoint(x: 5.5, y: 1)) })
+        #expect(drawing.marks.contains { $0.rect.minX == 4 && $0.rect.minY == 3 })
+    }
+
+    @Test("CRLF and composed characters retain line and column positions")
+    func unicodeBlocks() {
+        let drawing = MinimapDrawing.text(NSAttributedString(string: "e\u{301}x\r\ny"), columns: 80)
+        #expect(drawing.height == 6)
+        #expect(drawing.marks.map(\.rect.minX) == [0, 1, 0])
+        #expect(drawing.marks.map(\.rect.minY) == [0, 0, 3])
+    }
+
+    @Test("The viewport thumb stays usable for long documents and empty tracks")
+    func thumbGeometry() {
+        let geometry = MinimapGeometry(height: 400, proportion: 0.001, value: 0.5)
+        #expect(geometry.thumb.minY == 192)
+        #expect(geometry.thumb.height == 16)
+        #expect(MinimapGeometry(height: 0, proportion: 1, value: 1).thumb == CGRect(x: 0, y: 0, width: 96, height: 0))
+    }
+
+    @Test("Minimap reserves space without covering the document or scrollbars")
+    @MainActor func layout() {
+        let scroll = MinimapScrollView(frame: NSRect(x: 0, y: 0, width: 500, height: 300))
+        scroll.hasVerticalScroller = true
+        scroll.hasHorizontalScroller = true
+        scroll.scrollerStyle = .legacy
+        scroll.documentView = NSView(frame: NSRect(x: 0, y: 0, width: 1000, height: 1000))
+        scroll.tile()
+        let originalWidth = scroll.contentView.frame.width
+        scroll.showsMinimap = true
+        scroll.tile()
+        #expect(scroll.contentView.frame.width == originalWidth - MinimapView.width)
+        #expect(scroll.verticalScroller!.frame.maxX <= scroll.minimap.frame.minX)
+        scroll.tile()
+        #expect(scroll.contentView.frame.width == originalWidth - MinimapView.width)
+        scroll.showsMinimap = false
+        scroll.tile()
+        #expect(scroll.contentView.frame.width == originalWidth)
+    }
+
+    @Test("Transcript minimap collapses when the chat pane is too narrow")
+    @MainActor func transcriptResponsiveVisibility() {
+        #expect(!ACPTranscriptScrollerView.shouldShowMinimap(preferred: true, availableWidth: 719))
+        #expect(ACPTranscriptScrollerView.shouldShowMinimap(preferred: true, availableWidth: 720))
+        #expect(!ACPTranscriptScrollerView.shouldShowMinimap(preferred: false, availableWidth: 1_200))
+
+        let scroller = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 719, height: 400))
+        scroller.minimapPreferred = true
+        scroller.layoutSubtreeIfNeeded()
+        #expect(!scroller.showsMinimap)
+        scroller.setFrameSize(NSSize(width: 720, height: 400))
+        scroller.layoutSubtreeIfNeeded()
+        #expect(scroller.showsMinimap)
+    }
+
+    @Test("Editor and transcript visibility survive independent config round trips")
+    func visibilityPersistence() throws {
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(AppConfig.defaults)) as? [String: Any])
+        for (section, key) in [("code", "showMinimap"), ("harness", "acpShowMinimap")] {
+            var settings = try #require(object[section] as? [String: Any])
+            settings[key] = true
+            object[section] = settings
+        }
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: JSONSerialization.data(withJSONObject: object))
+        let saved = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(decoded)) as? [String: Any])
+        #expect((saved["code"] as? [String: Any])?["showMinimap"] as? Bool == true)
+        #expect((saved["harness"] as? [String: Any])?["acpShowMinimap"] as? Bool == true)
+    }
+}

--- a/AlasTests/MinimapTests.swift
+++ b/AlasTests/MinimapTests.swift
@@ -160,6 +160,17 @@ struct MinimapTests {
         #expect(renderer.needsUpdate(transcript: transcript, theme: try Theme.loadBundled(id: "light")))
     }
 
+    @Test("Long transcript previews keep fallback marks bounded")
+    @MainActor func transcriptPreviewBounded() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let transcript = ACPTranscript()
+        transcript.messages = (0..<10_000).map { _ in
+            .systemNotice(id: UUID(), text: "message")
+        }
+        let drawing = ACPTranscriptMinimap().drawing(transcript: transcript, theme: theme)
+        #expect(drawing.marks.count < 3_000)
+    }
+
     @Test("Character blocks preserve indentation, gaps, and attributed syntax colors")
     func syntaxBlocks() {
         let text = NSMutableAttributedString(string: "  let x\n\t42\n", attributes: [.foregroundColor: NSColor.white])


### PR DESCRIPTION
## Summary
- add optional syntax-aware minimaps to the file editor and ACP transcript
- persist independent minimap preferences and add compact toolbar controls
- hide the transcript minimap below 720pt while preserving the preference

## Verification
- xcodegen
- build-for-testing (macOS)
- focused minimap and transcript navigation tests (25 passing)