### PR TITLE
fix(attention): use a bell icon for the notification inbox

### DIFF
--- a/Alas/Sources/Attention/AttentionInboxView.swift
+++ b/Alas/Sources/Attention/AttentionInboxView.swift
@@ -85,7 +85,7 @@ struct AttentionInboxView: View {
             )
             VStack(spacing: 0) {
                 HStack(spacing: 9) {
-                    Image(systemName: "exclamationmark.triangle")
+                    Image(systemName: "bell")
                         .font(.system(size: 12))
                         .foregroundStyle(theme.color("warn"))
                         .accessibilityHidden(true)

--- a/Alas/Sources/Sidebar/SidebarHeaderView.swift
+++ b/Alas/Sources/Sidebar/SidebarHeaderView.swift
@@ -175,9 +175,9 @@ private struct AttentionToolbarButton<Content: View>: View {
         Button {
             isOpen.toggle()
         } label: {
-            Image(systemName: "exclamationmark.triangle")
+            Image(systemName: "bell")
                 .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(theme.color(count > 0 ? "warn" : (hovering ? "fg" : "fg-muted")))
+                .foregroundStyle(theme.color(hovering || isOpen ? "fg" : "fg-muted"))
                 .frame(width: 26, height: 22)
                 .contentShape(Rectangle())
                 .background(theme.color("bg-3").opacity(hovering || isOpen ? 1 : 0))


### PR DESCRIPTION
The notification inbox affordance in the sidebar header used a warning triangle that turned orange whenever the unread count was non-zero. For an inbox that is mostly informational, that reads as an alert and keeps pulling the eye away from the rest of the header.

- Swap the glyph for `bell`, both on the toolbar button and in the popover header, so the panel matches the button that opens it.
- Tint the toolbar button like every other button up there: `fg-muted` at rest, `fg` on hover or while the popover is open.
- The unread badge is unchanged — still the orange (`warn`) capsule, so the count itself still stands out.

Verified with a local `xcodebuild build` and `AlasTests/AttentionInboxViewTests` (8/8 pass, including the toolbar layout and three-digit badge height checks).