### PR TITLE
feat(right-pane): default the icon rail on

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1304,6 +1304,7 @@
 		C245B74D0083CE00B6CD392C /* ACPAdapterVersionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15630570F849AC577CA0D379 /* ACPAdapterVersionChecker.swift */; };
 		C245DDADA1D81810E9302134 /* VerdictSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2942AD875C0E7AB71E8E3CAD /* VerdictSheet.swift */; };
 		C25405D2F1A57B8BC0E5D3EC /* WorkspaceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2AECB6C5521CD59E44929A /* WorkspaceStore.swift */; };
+		C26411F69CD7E575AD8B398B /* AppStateRightPaneRailAcceptanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1B7E0CE0F8F4EA812311B7 /* AppStateRightPaneRailAcceptanceTests.swift */; };
 		C2CE2E3DE88344FDDE67D66A /* LSPTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */; };
 		C2EDB6A5E6149758C4A0051E /* ConflictMarkerParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2392A88D394E21DAB8C6EF33 /* ConflictMarkerParser.swift */; };
 		C31DBE249E28F1C82421537C /* ACPComposerCodeBlockStylingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2ABBFA4FB2E5FC2D38C5D3 /* ACPComposerCodeBlockStylingTests.swift */; };
@@ -2475,6 +2476,7 @@
 		6EC184A7BDBFF2156FD2AD44 /* ACPOrchestrationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPOrchestrationModels.swift; sourceTree = "<group>"; };
 		6ED105A2C41B953A4DC9B8F6 /* MarkdownCodeBoxSurfaceOptInTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCodeBoxSurfaceOptInTests.swift; sourceTree = "<group>"; };
 		6F0AE27D70E34430C71AAF84 /* ProviderReviewMutationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderReviewMutationController.swift; sourceTree = "<group>"; };
+		6F1B7E0CE0F8F4EA812311B7 /* AppStateRightPaneRailAcceptanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateRightPaneRailAcceptanceTests.swift; sourceTree = "<group>"; };
 		6F4D0EAA4C7CB45617BDD3FE /* ReadonlyTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadonlyTextView.swift; sourceTree = "<group>"; };
 		6F88DEFC78E8D8AF65CB740A /* PairedReviewComposerSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairedReviewComposerSurfaceTests.swift; sourceTree = "<group>"; };
 		6FD359E5712BE30FF37251EE /* PaneDragMathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDragMathTests.swift; sourceTree = "<group>"; };
@@ -3768,6 +3770,7 @@
 				69FCCEC91C40EBC896CF9089 /* AppStateOverlayTests.swift */,
 				8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */,
 				FED0AAD3FE0E143D409A3E8B /* AppStateRemoteWorktreePathTests.swift */,
+				6F1B7E0CE0F8F4EA812311B7 /* AppStateRightPaneRailAcceptanceTests.swift */,
 				89441B078E6782A1395A34CB /* AppStateRunRecordTests.swift */,
 				23190FA641E518CAFA0A8177 /* AppStateRunScriptCreationTests.swift */,
 				EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */,
@@ -7743,6 +7746,7 @@
 				51E0500756DC8DD5238F4D19 /* AppStateOverlayTests.swift in Sources */,
 				25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */,
 				996B67B45E7247CDED5F98EF /* AppStateRemoteWorktreePathTests.swift in Sources */,
+				C26411F69CD7E575AD8B398B /* AppStateRightPaneRailAcceptanceTests.swift in Sources */,
 				0A2377A64E08F89400F08E68 /* AppStateRunRecordTests.swift in Sources */,
 				F8C643420F6CF51D3B74164D /* AppStateRunScriptCreationTests.swift in Sources */,
 				07385C7266A0694AB7F4E872 /* AppStateSpacesTests.swift in Sources */,

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -51,6 +51,13 @@ struct AppConfig: Codable, Equatable {
     /// fallback switch so a user can revert to the legacy tab bar; it is not
     /// gating an in-progress feature the way the flags above are.
     var rightPaneRailEnabled: Bool = true
+    /// One-time migration marker for `rightPaneRailEnabled` graduating from
+    /// preview to default. A config saved during #1200's preview window
+    /// already has an explicit `false` on disk from the old default, which
+    /// is indistinguishable from a deliberate opt-out — this flag lets the
+    /// decoder force the new default exactly once, then respect whatever the
+    /// user sets afterward. See `init(from:)`.
+    var rightPaneRailDefaultApplied: Bool = true
     var recentProjectIds: [String] = []
     var recentWorktreeIdsByProject: [String: [String]] = [:]
     var recentWorktreeRefs: [RepoSelectorRecents.RecentWorktreeRef] = []
@@ -519,6 +526,7 @@ struct AppConfig: Codable, Equatable {
         workspacesEnabled: false,
         runTabEnabled: false,
         rightPaneRailEnabled: true,
+        rightPaneRailDefaultApplied: true,
         recentProjectIds: [],
         recentWorktreeIdsByProject: [:],
         recentWorktreeRefs: [],
@@ -613,6 +621,7 @@ extension AppConfig {
              workspacesEnabled,
              runTabEnabled,
              rightPaneRailEnabled,
+             rightPaneRailDefaultApplied,
              recentProjectIds, recentWorktreeIdsByProject, recentWorktreeRefs,
              collapsedProjectIds,
              sidebarChromeOverrides,
@@ -852,10 +861,21 @@ extension AppConfig {
         // The Run tab preview is opt-in. Configs written before it existed
         // continue to load without exposing unfinished command controls.
         runTabEnabled = (try? c.decode(Bool.self, forKey: .runTabEnabled)) ?? false
-        // The rail is on by default now, so a config written before it
-        // existed — or before it graduated from preview — must decode with
-        // it enabled rather than falling back to the legacy tab bar.
-        rightPaneRailEnabled = (try? c.decode(Bool.self, forKey: .rightPaneRailEnabled)) ?? true
+        // The rail is on by default now. A config saved during #1200's
+        // preview window has an explicit `rightPaneRailEnabled: false` on
+        // disk from the old default — indistinguishable, on its own, from a
+        // deliberate opt-out. `rightPaneRailDefaultApplied` disambiguates:
+        // its absence means this config predates the migration, so force the
+        // new default once and record that the migration ran. Once present,
+        // later loads respect whatever the user has set.
+        let hasMigratedRailDefault =
+            (try? c.decode(Bool.self, forKey: .rightPaneRailDefaultApplied)) ?? false
+        if hasMigratedRailDefault {
+            rightPaneRailEnabled = (try? c.decode(Bool.self, forKey: .rightPaneRailEnabled)) ?? true
+        } else {
+            rightPaneRailEnabled = true
+        }
+        rightPaneRailDefaultApplied = true
         recentProjectIds = (try? c.decode([String].self, forKey: .recentProjectIds)) ?? []
         recentWorktreeIdsByProject =
             (try? c.decode([String: [String]].self, forKey: .recentWorktreeIdsByProject)) ?? [:]

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -47,9 +47,10 @@ struct AppConfig: Codable, Equatable {
     /// Preview gate for the worktree Run tab. This remains off until the
     /// command lifecycle UI has completed preview testing.
     var runTabEnabled: Bool = false
-    /// Preview gate for the right pane icon rail. This remains off until the
-    /// rail presentation has completed preview testing.
-    var rightPaneRailEnabled: Bool = false
+    /// The right pane icon rail is the default presentation. This stays as a
+    /// fallback switch so a user can revert to the legacy tab bar; it is not
+    /// gating an in-progress feature the way the flags above are.
+    var rightPaneRailEnabled: Bool = true
     var recentProjectIds: [String] = []
     var recentWorktreeIdsByProject: [String: [String]] = [:]
     var recentWorktreeRefs: [RepoSelectorRecents.RecentWorktreeRef] = []
@@ -517,7 +518,7 @@ struct AppConfig: Codable, Equatable {
         files: Files(showIgnored: true),
         workspacesEnabled: false,
         runTabEnabled: false,
-        rightPaneRailEnabled: false,
+        rightPaneRailEnabled: true,
         recentProjectIds: [],
         recentWorktreeIdsByProject: [:],
         recentWorktreeRefs: [],
@@ -851,7 +852,10 @@ extension AppConfig {
         // The Run tab preview is opt-in. Configs written before it existed
         // continue to load without exposing unfinished command controls.
         runTabEnabled = (try? c.decode(Bool.self, forKey: .runTabEnabled)) ?? false
-        rightPaneRailEnabled = (try? c.decode(Bool.self, forKey: .rightPaneRailEnabled)) ?? false
+        // The rail is on by default now, so a config written before it
+        // existed — or before it graduated from preview — must decode with
+        // it enabled rather than falling back to the legacy tab bar.
+        rightPaneRailEnabled = (try? c.decode(Bool.self, forKey: .rightPaneRailEnabled)) ?? true
         recentProjectIds = (try? c.decode([String].self, forKey: .recentProjectIds)) ?? []
         recentWorktreeIdsByProject =
             (try? c.decode([String: [String]].self, forKey: .recentWorktreeIdsByProject)) ?? [:]

--- a/Alas/Sources/Settings/AdvancedPane.swift
+++ b/Alas/Sources/Settings/AdvancedPane.swift
@@ -43,7 +43,7 @@ struct AdvancedPane: View {
                     }
                     SettingsRow(
                         name: "Right pane icon rail",
-                        desc: "Replaces the right pane tab bar with a vertical icon rail (preview)."
+                        desc: "Uses a vertical icon rail for the right pane. Turn off to use the classic tab bar."
                     ) {
                         AlasToggle(on: Binding(
                             get: { state.config.rightPaneRailEnabled },

--- a/AlasTests/AppConfigTests.swift
+++ b/AlasTests/AppConfigTests.swift
@@ -32,6 +32,7 @@ struct AppConfigTests {
         #expect(cfg.workspacesEnabled == false)
         #expect(cfg.runTabEnabled == false)
         #expect(cfg.rightPaneRailEnabled == true)
+        #expect(cfg.rightPaneRailDefaultApplied == true)
     }
 
     @Test func decodeOldConfigDefaultsWorkspacesDisabled() throws {
@@ -56,30 +57,52 @@ struct AppConfigTests {
         #expect(decoded.runTabEnabled == false)
     }
 
-    @Test func decodeOldConfigDefaultsRightPaneRailEnabled() throws {
-        // A config written before the rail shipped has no opinion on it, so
-        // it must decode with the rail on — the feature is on by default now,
-        // not opt-in.
+    @Test func decodeConfigPredatingTheRailMigratesToEnabled() throws {
+        // A config written before the rail existed has no opinion on it and
+        // predates the migration marker too — it must decode with the rail
+        // on and come out the other side marked as migrated.
         let data = try JSONEncoder().encode(AppConfig.defaults)
         var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
         object.removeValue(forKey: "rightPaneRailEnabled")
+        object.removeValue(forKey: "rightPaneRailDefaultApplied")
 
         let oldConfig = try JSONSerialization.data(withJSONObject: object)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: oldConfig)
 
         #expect(decoded.rightPaneRailEnabled == true)
+        #expect(decoded.rightPaneRailDefaultApplied == true)
     }
 
-    @Test func decodeConfigWithRailExplicitlyDisabledStaysDisabled() throws {
-        // A user who opted out while it was a preview (or turned off the
-        // fallback toggle) must keep seeing the legacy tab bar after upgrade.
+    @Test func decodePreviewEraConfigWithRailOffMigratesToEnabled() throws {
+        // A config saved during #1200's preview window has an explicit
+        // `rightPaneRailEnabled: false` — written by the old default, not by
+        // a deliberate opt-out — and predates the migration marker. The
+        // one-time migration must override that stale false rather than
+        // reading it as an intentional choice.
+        let data = try JSONEncoder().encode(AppConfig.defaults)
+        var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        object["rightPaneRailEnabled"] = false
+        object.removeValue(forKey: "rightPaneRailDefaultApplied")
+
+        let oldConfig = try JSONSerialization.data(withJSONObject: object)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: oldConfig)
+
+        #expect(decoded.rightPaneRailEnabled == true)
+        #expect(decoded.rightPaneRailDefaultApplied == true)
+    }
+
+    @Test func decodeConfigWithRailExplicitlyDisabledAfterMigrationStaysDisabled() throws {
+        // Once the migration has run once (marker present), a `false` is a
+        // deliberate opt-out via the fallback toggle and must stick.
         var cfg = AppConfig.defaults
         cfg.rightPaneRailEnabled = false
+        cfg.rightPaneRailDefaultApplied = true
 
         let data = try JSONEncoder().encode(cfg)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
 
         #expect(decoded.rightPaneRailEnabled == false)
+        #expect(decoded.rightPaneRailDefaultApplied == true)
     }
 
     @Test func decodeOldHarnessConfigDefaultsAwaitingPingOn() throws {

--- a/AlasTests/AppConfigTests.swift
+++ b/AlasTests/AppConfigTests.swift
@@ -31,7 +31,7 @@ struct AppConfigTests {
         #expect(cfg.worktrees.branchPrefix == "feature/")
         #expect(cfg.workspacesEnabled == false)
         #expect(cfg.runTabEnabled == false)
-        #expect(cfg.rightPaneRailEnabled == false)
+        #expect(cfg.rightPaneRailEnabled == true)
     }
 
     @Test func decodeOldConfigDefaultsWorkspacesDisabled() throws {
@@ -56,13 +56,28 @@ struct AppConfigTests {
         #expect(decoded.runTabEnabled == false)
     }
 
-    @Test func decodeOldConfigDefaultsRightPaneRailDisabled() throws {
+    @Test func decodeOldConfigDefaultsRightPaneRailEnabled() throws {
+        // A config written before the rail shipped has no opinion on it, so
+        // it must decode with the rail on — the feature is on by default now,
+        // not opt-in.
         let data = try JSONEncoder().encode(AppConfig.defaults)
         var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
         object.removeValue(forKey: "rightPaneRailEnabled")
 
         let oldConfig = try JSONSerialization.data(withJSONObject: object)
         let decoded = try JSONDecoder().decode(AppConfig.self, from: oldConfig)
+
+        #expect(decoded.rightPaneRailEnabled == true)
+    }
+
+    @Test func decodeConfigWithRailExplicitlyDisabledStaysDisabled() throws {
+        // A user who opted out while it was a preview (or turned off the
+        // fallback toggle) must keep seeing the legacy tab bar after upgrade.
+        var cfg = AppConfig.defaults
+        cfg.rightPaneRailEnabled = false
+
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
 
         #expect(decoded.rightPaneRailEnabled == false)
     }

--- a/AlasTests/AppStateRightPaneRailAcceptanceTests.swift
+++ b/AlasTests/AppStateRightPaneRailAcceptanceTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import Alas
+
+/// `AppState.acceptsRightPaneTabShortcut` is the gate the ⌘⌃1-4 rail
+/// shortcuts and the "Right Sidebar: ..." menu items both check before
+/// acting. The rail's pure reducer is covered elsewhere (see
+/// `RightPaneTabShortcutTests`); this pins the flag gate itself, which had
+/// no direct coverage — only the flag-off default was exercised indirectly.
+@MainActor
+struct AppStateRightPaneRailAcceptanceTests {
+    @Test func shortcutsAreLiveWhenTheRailIsEnabled() {
+        let state = AppState()
+        state.config.rightPaneRailEnabled = true
+
+        #expect(state.acceptsRightPaneTabShortcut(.changes))
+        #expect(state.acceptsRightPaneTabShortcut(.files))
+    }
+
+    @Test func shortcutsAreInertWhenTheRailIsDisabled() {
+        // With the rail off, a hidden pane has no mounted `RightPaneState`
+        // to target, and mounting one resets the active tab — so the
+        // shortcut must be a no-op rather than acting on a pane the user
+        // can't see change.
+        let state = AppState()
+        state.config.rightPaneRailEnabled = false
+
+        #expect(!state.acceptsRightPaneTabShortcut(.changes))
+        #expect(!state.acceptsRightPaneTabShortcut(.files))
+    }
+
+    @Test func shortcutsRespectTheRunTabPreviewFlagWhenTheRailIsEnabled() {
+        let state = AppState()
+        state.config.rightPaneRailEnabled = true
+        state.config.runTabEnabled = false
+
+        #expect(state.acceptsRightPaneTabShortcut(.agent))
+        #expect(!state.acceptsRightPaneTabShortcut(.run))
+
+        state.config.runTabEnabled = true
+
+        #expect(state.acceptsRightPaneTabShortcut(.run))
+    }
+}


### PR DESCRIPTION
## Summary

Stage 1 of productionizing the right pane icon rail from #1200: flip `rightPaneRailEnabled` to default `true`, so the rail is what everyone sees without touching Settings. The flag stays as a fallback switch (Advanced → Experimental, reworded to drop the "preview" framing) so anyone who prefers the legacy tab bar can revert.

## Why now

#1200 shipped the rail behind an opt-in preview flag with two open gaps called out in that PR: nobody had manually clicked through the flag live, and there was no automated coverage for the flag actually flipping behavior (only the pure reducer/model logic underneath it was tested). Both are closed here:

- Manually verified the rail end to end before flipping the default: tab switching, collapse/expand, window drag from the toolbar, narrow-window resize.
- Added `AppStateRightPaneRailAcceptanceTests` covering `AppState.acceptsRightPaneTabShortcut` with the flag on and off, plus interaction with the per-tab Agent/Run preview flags — previously untested directly.
- Updated `AppConfigTests` for the new default and old-config decode behavior (missing key now decodes to rail-on; an explicit `false` is still honored, so anyone who opted out keeps the tab bar after upgrading).

## Not in this PR

The legacy `RightPaneTabBar` and every flag-off branch (`RightPaneView`, `RightPaneTransitionalView`, `AlasApp` menu gating, `AppState.acceptsRightPaneTabShortcut`, `CenterPaneView.rightSidebarHidden`) are untouched — removing them is a follow-up once this has baked in production as the default.

## Testing

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' build` — 0 errors
- Focused suites: `AppConfigTests`, `AppStateRightPaneRailAcceptanceTests`, `RightPaneTabShortcutTests`, `RightRailSizingTests`, `RightPaneRailModelTests`, `RightPaneRailReducerTests`, `RightPaneToolbarModelTests`, `AppStateTabAvailabilityTests` — all green
- Manual click-through of the running app