### PR TITLE
feat(agent-tab): enable the Agent tab by default

### DIFF
--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -283,7 +283,7 @@ struct AlasApp: App {
                                                 object: RightPaneTab.agent.rawValue)
             }
             .keyboardShortcut(state.shortcut(for: .rightPaneAgentTab))
-            .disabled(!state.config.rightPaneRailEnabled || !state.config.agentTabEnabled)
+            .disabled(!state.config.rightPaneRailEnabled)
             Button("Right Sidebar: Run") {
                 NotificationCenter.default.post(name: .alasSelectRightPaneTab,
                                                 object: RightPaneTab.run.rawValue)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1042,10 +1042,7 @@ final class AppState {
     /// made `ThreePaneSizing` auto-collapse the pane.
     func acceptsRightPaneTabShortcut(_ tab: RightPaneTab) -> Bool {
         config.rightPaneRailEnabled
-            && RightPaneTab.available(
-                agentTabEnabled: config.agentTabEnabled,
-                runTabEnabled: config.runTabEnabled
-            ).contains(tab)
+            && RightPaneTab.available(runTabEnabled: config.runTabEnabled).contains(tab)
     }
 
     func toggleSidebarVisibility() {

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -47,9 +47,6 @@ struct AppConfig: Codable, Equatable {
     /// Preview gate for the worktree Run tab. This remains off until the
     /// command lifecycle UI has completed preview testing.
     var runTabEnabled: Bool = false
-    /// Preview gate for the worktree Agent tab. This remains off until the
-    /// per-worktree rollup has completed preview testing.
-    var agentTabEnabled: Bool = false
     /// Preview gate for the right pane icon rail. This remains off until the
     /// rail presentation has completed preview testing.
     var rightPaneRailEnabled: Bool = false
@@ -520,7 +517,6 @@ struct AppConfig: Codable, Equatable {
         files: Files(showIgnored: true),
         workspacesEnabled: false,
         runTabEnabled: false,
-        agentTabEnabled: false,
         rightPaneRailEnabled: false,
         recentProjectIds: [],
         recentWorktreeIdsByProject: [:],
@@ -615,7 +611,6 @@ extension AppConfig {
              remote,
              workspacesEnabled,
              runTabEnabled,
-             agentTabEnabled,
              rightPaneRailEnabled,
              recentProjectIds, recentWorktreeIdsByProject, recentWorktreeRefs,
              collapsedProjectIds,
@@ -856,9 +851,6 @@ extension AppConfig {
         // The Run tab preview is opt-in. Configs written before it existed
         // continue to load without exposing unfinished command controls.
         runTabEnabled = (try? c.decode(Bool.self, forKey: .runTabEnabled)) ?? false
-        // The Agent tab preview is opt-in. Configs written before it existed
-        // continue to load without exposing the sidebar rollup.
-        agentTabEnabled = (try? c.decode(Bool.self, forKey: .agentTabEnabled)) ?? false
         rightPaneRailEnabled = (try? c.decode(Bool.self, forKey: .rightPaneRailEnabled)) ?? false
         recentProjectIds = (try? c.decode([String].self, forKey: .recentProjectIds)) ?? []
         recentWorktreeIdsByProject =

--- a/Alas/Sources/Right/RightPaneRail.swift
+++ b/Alas/Sources/Right/RightPaneRail.swift
@@ -11,14 +11,13 @@ struct RightPaneRail: View {
     let changesCount: Int
     var activeAgentCount: Int = 0
     var activeRunCount: Int = 0
-    var showAgentTab: Bool = false
     var showRunTab: Bool = false
     let onAction: (RightPaneRailAction) -> Void
 
     @Environment(\.theme) private var theme
 
     private var tabs: [RightPaneTab] {
-        RightPaneTab.available(agentTabEnabled: showAgentTab, runTabEnabled: showRunTab)
+        RightPaneTab.available(runTabEnabled: showRunTab)
     }
 
     var body: some View {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -6,15 +6,14 @@ import os
 enum RightPaneTab: String {
     case changes, files, agent, run
 
-    static func available(agentTabEnabled: Bool, runTabEnabled: Bool) -> [Self] {
-        var tabs: [Self] = [.changes, .files]
-        if agentTabEnabled { tabs.append(.agent) }
+    static func available(runTabEnabled: Bool) -> [Self] {
+        var tabs: [Self] = [.changes, .files, .agent]
         if runTabEnabled { tabs.append(.run) }
         return tabs
     }
 
-    static func visible(_ tab: Self, agentTabEnabled: Bool, runTabEnabled: Bool) -> Self {
-        available(agentTabEnabled: agentTabEnabled, runTabEnabled: runTabEnabled).contains(tab) ? tab : .changes
+    static func visible(_ tab: Self, runTabEnabled: Bool) -> Self {
+        available(runTabEnabled: runTabEnabled).contains(tab) ? tab : .changes
     }
 }
 

--- a/Alas/Sources/Right/RightPaneTabBar.swift
+++ b/Alas/Sources/Right/RightPaneTabBar.swift
@@ -29,7 +29,6 @@ struct RightPaneTabBar: View {
     let onHidePane: () -> Void
     let showIgnored: Bool
     let onToggleShowIgnored: () -> Void
-    var showAgentTab: Bool = false
     var showRunTab: Bool = false
     /// Number of commands currently starting or running in this worktree.
     var activeRunCount: Int = 0
@@ -69,16 +68,14 @@ struct RightPaneTabBar: View {
                         set: { _ in onToggleShowIgnored() }
                     ))
                 }
-            if RightPaneTab.available(agentTabEnabled: showAgentTab, runTabEnabled: showRunTab).contains(.agent) {
-                segment(
-                    .agent,
-                    icon: "person.crop.circle",
-                    label: "Agent",
-                    count: activeAgentCount > 0 ? activeAgentCount : nil,
-                    layout: layout
-                )
-            }
-            if RightPaneTab.available(agentTabEnabled: showAgentTab, runTabEnabled: showRunTab).contains(.run) {
+            segment(
+                .agent,
+                icon: "person.crop.circle",
+                label: "Agent",
+                count: activeAgentCount > 0 ? activeAgentCount : nil,
+                layout: layout
+            )
+            if RightPaneTab.available(runTabEnabled: showRunTab).contains(.run) {
                 segment(
                     .run,
                     icon: "play",

--- a/Alas/Sources/Right/RightPaneTransitionalView.swift
+++ b/Alas/Sources/Right/RightPaneTransitionalView.swift
@@ -55,7 +55,6 @@ struct RightPaneTransitionalView: View {
                             collapsed: collapsed,
                             changesCount: 0,
                             activeAgentCount: state.agentSidebarRollup(for: worktree).active.count,
-                            showAgentTab: state.config.agentTabEnabled,
                             showRunTab: state.config.runTabEnabled,
                             onAction: { handle($0) }
                         )
@@ -70,7 +69,6 @@ struct RightPaneTransitionalView: View {
                             onHidePane: {},
                             showIgnored: state.config.files.showIgnored,
                             onToggleShowIgnored: {},
-                            showAgentTab: state.config.agentTabEnabled,
                             showRunTab: state.config.runTabEnabled,
                             activeAgentCount: state.agentSidebarRollup(for: worktree).active.count
                         )

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -39,7 +39,6 @@ struct RightPaneView: View {
         let initialState = state.rightPaneStore.activeState(worktreeId: worktree.id)
         initialState?.activeTab = RightPaneTab.visible(
             initialState?.activeTab ?? .changes,
-            agentTabEnabled: state.config.agentTabEnabled,
             runTabEnabled: state.config.runTabEnabled
         )
         _rps = State(initialValue: initialState)
@@ -72,14 +71,6 @@ struct RightPaneView: View {
                 .onChange(of: state.config.runTabEnabled) {
                     rps.activeTab = RightPaneTab.visible(
                         rps.activeTab,
-                        agentTabEnabled: state.config.agentTabEnabled,
-                        runTabEnabled: state.config.runTabEnabled
-                    )
-                }
-                .onChange(of: state.config.agentTabEnabled) {
-                    rps.activeTab = RightPaneTab.visible(
-                        rps.activeTab,
-                        agentTabEnabled: state.config.agentTabEnabled,
                         runTabEnabled: state.config.runTabEnabled
                     )
                 }
@@ -201,7 +192,7 @@ struct RightPaneView: View {
 
     @ViewBuilder
     private func tabContent(rps: RightPaneState) -> some View {
-        if rps.hasLoadedSnapshot || (rps.activeTab == .agent && state.config.agentTabEnabled) {
+        if rps.hasLoadedSnapshot || rps.activeTab == .agent {
             switch rps.activeTab {
             case .changes:
                 ChangesTabView(
@@ -298,7 +289,6 @@ struct RightPaneView: View {
                     changesCount: rps.displayChanges.count,
                     activeAgentCount: agentRollup.active.count,
                     activeRunCount: runningScriptNames.count,
-                    showAgentTab: state.config.agentTabEnabled,
                     showRunTab: state.config.runTabEnabled,
                     onAction: { action in handle(action, rps: rps) }
                 )
@@ -322,7 +312,6 @@ struct RightPaneView: View {
                         state.config.files.showIgnored.toggle()
                         state.saveConfig()
                     },
-                    showAgentTab: state.config.agentTabEnabled,
                     showRunTab: state.config.runTabEnabled,
                     activeRunCount: state.runRecords
                         .records(worktreeID: worktree.id)

--- a/Alas/Sources/Settings/AdvancedPane.swift
+++ b/Alas/Sources/Settings/AdvancedPane.swift
@@ -30,18 +30,6 @@ struct AdvancedPane: View {
                         ))
                     }
                     SettingsRow(
-                        name: "Agent tab preview",
-                        desc: "Shows the worktree Agent tab for preview testing."
-                    ) {
-                        AlasToggle(on: Binding(
-                            get: { state.config.agentTabEnabled },
-                            set: { enabled in
-                                state.config.agentTabEnabled = enabled
-                                state.saveConfig()
-                            }
-                        ))
-                    }
-                    SettingsRow(
                         name: "Run tab preview",
                         desc: "Shows the worktree Run tab for preview testing."
                     ) {

--- a/AlasTests/AppConfigTests.swift
+++ b/AlasTests/AppConfigTests.swift
@@ -30,7 +30,6 @@ struct AppConfigTests {
         #expect(cfg.worktrees.rootPath == "~/.alas/worktrees")
         #expect(cfg.worktrees.branchPrefix == "feature/")
         #expect(cfg.workspacesEnabled == false)
-        #expect(cfg.agentTabEnabled == false)
         #expect(cfg.runTabEnabled == false)
         #expect(cfg.rightPaneRailEnabled == false)
     }
@@ -55,17 +54,6 @@ struct AppConfigTests {
         let decoded = try JSONDecoder().decode(AppConfig.self, from: oldConfig)
 
         #expect(decoded.runTabEnabled == false)
-    }
-
-    @Test func decodeOldConfigDefaultsAgentTabDisabled() throws {
-        let data = try JSONEncoder().encode(AppConfig.defaults)
-        var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
-        object.removeValue(forKey: "agentTabEnabled")
-
-        let oldConfig = try JSONSerialization.data(withJSONObject: object)
-        let decoded = try JSONDecoder().decode(AppConfig.self, from: oldConfig)
-
-        #expect(decoded.agentTabEnabled == false)
     }
 
     @Test func decodeOldConfigDefaultsRightPaneRailDisabled() throws {

--- a/AlasTests/RightPaneTabTests.swift
+++ b/AlasTests/RightPaneTabTests.swift
@@ -2,14 +2,12 @@ import Testing
 @testable import Alas
 
 struct RightPaneTabTests {
-    @Test func agentTabRequiresPreviewFlag() {
-        #expect(RightPaneTab.available(agentTabEnabled: false, runTabEnabled: false) == [.changes, .files])
-        #expect(RightPaneTab.available(agentTabEnabled: true, runTabEnabled: false) == [.changes, .files, .agent])
-        #expect(RightPaneTab.visible(.agent, agentTabEnabled: false, runTabEnabled: false) == .changes)
-        #expect(RightPaneTab.visible(.agent, agentTabEnabled: true, runTabEnabled: false) == .agent)
+    @Test func agentTabIsAlwaysAvailable() {
+        #expect(RightPaneTab.available(runTabEnabled: false) == [.changes, .files, .agent])
+        #expect(RightPaneTab.visible(.agent, runTabEnabled: false) == .agent)
     }
 
     @Test func disablingRunOnlyFallsBackFromRun() {
-        #expect(RightPaneTab.visible(.run, agentTabEnabled: true, runTabEnabled: false) == .changes)
+        #expect(RightPaneTab.visible(.run, runTabEnabled: false) == .changes)
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### 🎨 Changed
+
+- Enable the Agent tab by default, removing its preview gate.
+
 ## [0.17.0] - 2026-09-12
 
 ### ✨ Features


### PR DESCRIPTION
## Summary

Removes the `agentTabEnabled` preview flag now that the worktree Agent tab (rollup, delegation tree, follow-up composer, interrupt/delegate actions) has shipped through several iterations (#1176, #1184, #1191). The tab becomes an unconditional part of the right pane instead of an opt-in preview.

## Changes

- Delete `AppConfig.agentTabEnabled` (property, default, `CodingKeys` case, custom decode line).
- `RightPaneTab.available`/`.visible` drop the `agentTabEnabled` parameter; `.agent` is always in the tab set.
- Update all call sites: `RightPaneRail`, `RightPaneTabBar`, `RightPaneView`, `RightPaneTransitionalView`, `AppState.acceptsRightPaneTabShortcut`.
- Drop the `agentTabEnabled` clause from the `AlasApp.swift` menu-shortcut disable check (still gated by `rightPaneRailEnabled`, untouched).
- Remove the "Agent tab preview" toggle from the Advanced settings pane.
- Remove tests that existed solely for the flag; update remaining ones to the new signatures/behavior.

Out of scope: `rightPaneRailEnabled` (icon-rail redesign) and `runTabEnabled` stay as their own preview flags, untouched.

## Testing

- `xcodebuild build` (arm64, local)
- Focused suites (arm64, local): `RightPaneTabTests`, `AppConfigTests`, `RightPaneRailModelTests`, `RightPaneRailReducerTests`, `RightPaneTabBarLayoutTests`, `RightPaneTabShortcutTests`, `AgentSidebarRollupTests` — 66/66 passed
- Full suite deferred to CI