### PR TITLE
fix(minimap): layout crash in transcript and editor

### DIFF
--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -57,13 +57,13 @@ struct ACPTranscriptScroller: NSViewRepresentable {
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
-    func makeNSView(context: Context) -> ACPTranscriptScrollerView {
+    func makeNSView(context: Context) -> MinimapContainerView<ACPTranscriptScrollerView> {
         let scroller = ACPTranscriptScrollerView(frame: .zero)
         context.coordinator.attach(scroller: scroller, host: self)
-        return scroller
+        return MinimapContainerView(scrollView: scroller)
     }
 
-    func updateNSView(_ nsView: ACPTranscriptScrollerView, context: Context) {
+    func updateNSView(_ nsView: MinimapContainerView<ACPTranscriptScrollerView>, context: Context) {
         context.coordinator.update(host: self)
     }
 

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScrollerView.swift
@@ -68,7 +68,7 @@ final class ACPTranscriptScrollerView: MinimapScrollView {
     var onContentWidthChange: (() -> Void)?
     private var lastReportedContentWidth: CGFloat?
     var minimapPreferred = false {
-        didSet { updateMinimapVisibility() }
+        didSet { updateMinimapVisibility(availableWidth: superview?.bounds.width ?? bounds.width) }
     }
 
     /// Fired from `layout()` whenever `contentView.bounds.height` differs
@@ -229,7 +229,6 @@ final class ACPTranscriptScrollerView: MinimapScrollView {
     }
 
     override func layout() {
-        updateMinimapVisibility()
         super.layout()
         // `super.layout()` runs AppKit's own scroll-view tiling first, so
         // `contentView.bounds` already reflects any scroller-visibility
@@ -254,10 +253,10 @@ final class ACPTranscriptScrollerView: MinimapScrollView {
         applyLogicalScrollerMetrics()
     }
 
-    private func updateMinimapVisibility() {
+    override func updateMinimapVisibility(availableWidth: CGFloat) {
         showsMinimap = Self.shouldShowMinimap(
             preferred: minimapPreferred,
-            availableWidth: bounds.width
+            availableWidth: availableWidth
         )
     }
 

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -138,7 +138,7 @@ struct CodeEditorView: NSViewRepresentable {
         CodeEditorCoordinator(appState: appState)
     }
 
-    func makeNSView(context: Context) -> NSScrollView {
+    func makeNSView(context: Context) -> MinimapContainerView<CodeEditorScrollView> {
         let scroll = CodeEditorScrollView()
         scroll.hasVerticalScroller = true
         scroll.hasHorizontalScroller = true
@@ -231,10 +231,11 @@ struct CodeEditorView: NSViewRepresentable {
             externalEditable: externalEditable
         )
         scroll.configureMinimap(shown: showMinimap, theme: theme)
-        return scroll
+        return MinimapContainerView(scrollView: scroll)
     }
 
-    func updateNSView(_ nsView: NSScrollView, context: Context) {
+    func updateNSView(_ container: MinimapContainerView<CodeEditorScrollView>, context: Context) {
+        let nsView = container.scrollView
         configureLifecycleCallbacks(on: context.coordinator)
         context.coordinator.updateIfNeeded(
             worktreeId: worktreeId,
@@ -260,10 +261,10 @@ struct CodeEditorView: NSViewRepresentable {
                 rendersTextDecorations: !context.coordinator.currentBufferReadOnly
             )
         }
-        (nsView as? CodeEditorScrollView)?.configureMinimap(shown: showMinimap, theme: theme)
+        nsView.configureMinimap(shown: showMinimap, theme: theme)
     }
 
-    static func dismantleNSView(_ nsView: NSScrollView, coordinator: CodeEditorCoordinator) {
+    static func dismantleNSView(_ nsView: MinimapContainerView<CodeEditorScrollView>, coordinator: CodeEditorCoordinator) {
         // Detach the coordinator from the text view, but DO NOT close the
         // buffer's LSP document or watcher — the buffer outlives this view.
         coordinator.detach()

--- a/Alas/Sources/Shared/MinimapView.swift
+++ b/Alas/Sources/Shared/MinimapView.swift
@@ -119,6 +119,7 @@ final class MinimapView: NSView {
     var onNavigate: ((Double) -> Void)?
     var onNavigationStart: (() -> Void)?
     var onNavigationEnd: (() -> Void)?
+    var onScrollWheel: ((NSEvent) -> Void)?
     var value: Double = 0 { didSet { needsDisplay = true } }
     var proportion: CGFloat = 1 { didSet { needsDisplay = true } }
     var backgroundColor = NSColor.textBackgroundColor { didSet { needsDisplay = true } }
@@ -217,6 +218,10 @@ final class MinimapView: NSView {
         CGRect(x: 0, y: 0, width: 0.5, height: bounds.height).fill()
     }
 
+    override func scrollWheel(with event: NSEvent) {
+        if let onScrollWheel { onScrollWheel(event) } else { super.scrollWheel(with: event) }
+    }
+
     override func mouseDown(with event: NSEvent) {
         onNavigationStart?()
         let y = convert(event.locationInWindow, from: nil).y
@@ -278,29 +283,44 @@ class MinimapScrollView: NSScrollView {
     var showsMinimap = false {
         didSet {
             guard showsMinimap != oldValue else { return }
-            if showsMinimap { addSubview(minimap) } else { minimap.removeFromSuperview() }
-            tile()
-            needsLayout = true
+            superview?.needsLayout = true
         }
     }
 
-    override func tile() {
-        super.tile()
-        guard showsMinimap else { return }
-        let width = min(MinimapView.width, max(0, bounds.width / 3))
-        var clip = contentView.frame
-        clip.size.width = max(0, clip.width - width)
-        contentView.frame = clip
-        if let verticalScroller {
-            var frame = verticalScroller.frame
-            frame.origin.x -= width
-            verticalScroller.frame = frame
+    func updateMinimapVisibility(availableWidth: CGFloat) {}
+}
+
+/// Keep the minimap outside AppKit's tiling area so repeated layout passes
+/// never expand and shrink the clip view around hosted document content.
+final class MinimapContainerView<ScrollView: MinimapScrollView>: NSView {
+    let scrollView: ScrollView
+
+    init(scrollView: ScrollView) {
+        self.scrollView = scrollView
+        super.init(frame: scrollView.frame)
+        addSubview(scrollView)
+        addSubview(scrollView.minimap)
+        scrollView.minimap.onScrollWheel = { [weak scrollView] event in
+            scrollView?.scrollWheel(with: event)
         }
-        if let horizontalScroller {
-            var frame = horizontalScroller.frame
-            frame.size.width = max(0, frame.width - width)
-            horizontalScroller.frame = frame
-        }
-        minimap.frame = CGRect(x: bounds.maxX - width, y: 0, width: width, height: bounds.height)
+        needsLayout = true
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        needsLayout = true
+    }
+
+    override func layout() {
+        scrollView.updateMinimapVisibility(availableWidth: bounds.width)
+        let width = scrollView.showsMinimap ? min(MinimapView.width, max(0, bounds.width / 3)) : 0
+        scrollView.minimap.isHidden = !scrollView.showsMinimap
+        let scrollFrame = CGRect(x: bounds.minX, y: bounds.minY, width: max(0, bounds.width - width), height: bounds.height)
+        if scrollView.frame != scrollFrame { scrollView.frame = scrollFrame }
+        let minimapFrame = CGRect(x: bounds.maxX - width, y: bounds.minY, width: width, height: bounds.height)
+        if scrollView.minimap.frame != minimapFrame { scrollView.minimap.frame = minimapFrame }
+        super.layout()
     }
 }

--- a/AlasTests/MinimapTests.swift
+++ b/AlasTests/MinimapTests.swift
@@ -1,7 +1,24 @@
 import AppKit
+import SwiftUI
 import Testing
 
 @testable import Alas
+
+@MainActor
+private final class MinimapTrackingClipView: NSClipView {
+    var widthChanges = 0
+
+    override func setFrameSize(_ newSize: NSSize) {
+        if newSize.width != frame.width { widthChanges += 1 }
+        super.setFrameSize(newSize)
+    }
+}
+
+@MainActor
+private final class MinimapWheelScrollView: MinimapScrollView {
+    var wheelEvent: NSEvent?
+    override func scrollWheel(with event: NSEvent) { wheelEvent = event }
+}
 
 @MainActor
 private final class MinimapColorReferenceView: NSView {
@@ -19,6 +36,18 @@ private final class MinimapColorReferenceView: NSView {
 
 @Suite("Minimap")
 struct MinimapTests {
+    @Test("Wheel events over the minimap reach its document scroll view")
+    @MainActor func wheelForwarding() throws {
+        let scroll = MinimapWheelScrollView(frame: NSRect(x: 0, y: 0, width: 500, height: 300))
+        let container = MinimapContainerView(scrollView: scroll)
+        scroll.showsMinimap = true
+        container.layoutSubtreeIfNeeded()
+        let cgEvent = try #require(CGEvent(scrollWheelEvent2Source: nil, units: .pixel, wheelCount: 1, wheel1: 20, wheel2: 0, wheel3: 0))
+        let event = try #require(NSEvent(cgEvent: cgEvent))
+        scroll.minimap.scrollWheel(with: event)
+        #expect(scroll.wheelEvent === event)
+    }
+
     @Test("Drag release does not navigate twice when the viewport changes")
     @MainActor func dragRelease() throws {
         let view = MinimapView(frame: CGRect(x: 0, y: 0, width: 96, height: 600))
@@ -206,17 +235,48 @@ struct MinimapTests {
         scroll.hasHorizontalScroller = true
         scroll.scrollerStyle = .legacy
         scroll.documentView = NSView(frame: NSRect(x: 0, y: 0, width: 1000, height: 1000))
+        let container = MinimapContainerView(scrollView: scroll)
+        container.layoutSubtreeIfNeeded()
         scroll.tile()
         let originalWidth = scroll.contentView.frame.width
         scroll.showsMinimap = true
+        container.layoutSubtreeIfNeeded()
         scroll.tile()
         #expect(scroll.contentView.frame.width == originalWidth - MinimapView.width)
         #expect(scroll.verticalScroller!.frame.maxX <= scroll.minimap.frame.minX)
         scroll.tile()
         #expect(scroll.contentView.frame.width == originalWidth - MinimapView.width)
         scroll.showsMinimap = false
+        container.layoutSubtreeIfNeeded()
         scroll.tile()
         #expect(scroll.contentView.frame.width == originalWidth)
+    }
+
+    @Test("Repeated minimap tiling leaves hosted document width unchanged", arguments: [NSScroller.Style.legacy, .overlay])
+    @MainActor func stableLayout(style: NSScroller.Style) {
+        let scroll = MinimapScrollView(frame: NSRect(x: 0, y: 0, width: 500, height: 300))
+        let clip = MinimapTrackingClipView()
+        scroll.contentView = clip
+        scroll.hasVerticalScroller = true
+        scroll.hasHorizontalScroller = true
+        scroll.scrollerStyle = style
+        let document = NSHostingView(rootView: Text("Transcript").frame(width: 1000, height: 1000))
+        document.frame = NSRect(x: 0, y: 0, width: 1000, height: 1000)
+        scroll.documentView = document
+        let container = MinimapContainerView(scrollView: scroll)
+        scroll.showsMinimap = true
+        container.layoutSubtreeIfNeeded()
+        scroll.tile()
+        clip.widthChanges = 0
+        for _ in 0..<10 {
+            container.needsLayout = true
+            container.layoutSubtreeIfNeeded()
+            scroll.tile()
+        }
+        #expect(clip.widthChanges == 0)
+        #expect(scroll.frame.maxX == scroll.minimap.frame.minX)
+        #expect(scroll.minimap.superview === container)
+        #expect(!scroll.minimap.isHidden)
     }
 
     @Test("Transcript minimap collapses when the chat pane is too narrow")
@@ -226,12 +286,23 @@ struct MinimapTests {
         #expect(!ACPTranscriptScrollerView.shouldShowMinimap(preferred: false, availableWidth: 1_200))
 
         let scroller = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 719, height: 400))
+        let container = MinimapContainerView(scrollView: scroller)
         scroller.minimapPreferred = true
-        scroller.layoutSubtreeIfNeeded()
+        container.layoutSubtreeIfNeeded()
         #expect(!scroller.showsMinimap)
-        scroller.setFrameSize(NSSize(width: 720, height: 400))
-        scroller.layoutSubtreeIfNeeded()
+        container.setFrameSize(NSSize(width: 720, height: 400))
+        container.layoutSubtreeIfNeeded()
         #expect(scroller.showsMinimap)
+        #expect(scroller.frame.width == 720 - MinimapView.width)
+        for _ in 0..<10 {
+            container.needsLayout = true
+            container.layoutSubtreeIfNeeded()
+            #expect(scroller.showsMinimap)
+        }
+        container.setFrameSize(NSSize(width: 719, height: 400))
+        container.layoutSubtreeIfNeeded()
+        #expect(!scroller.showsMinimap)
+        #expect(scroller.frame.width == 719)
     }
 
     @Test("Editor and transcript visibility survive independent config round trips")


### PR DESCRIPTION
## Summary

Fix a minimap layout loop that crashes the transcript while AppKit updates hosted SwiftUI rows. Each unchanged scroll-view tile pass previously expanded and then shrank the clip view, repeatedly invalidating layout.

Place the minimap beside the native scroll view in a shared container used by the transcript and editor. Preserve wheel forwarding, document navigation, and responsive visibility based on the full pane width.

## Validation

- App build and SwiftFormat lint passed.
- All 16 minimap tests passed before rebasing; rerunning on the rebased commit.
- Direct AppKit checks with hosted SwiftUI content and an NSWindow confirmed zero clip-width changes across repeated layout passes for legacy and overlay scrollers; the original implementation produced 20 changes across 10 passes.
- Regression coverage includes stable layout, reserved space, responsive visibility, wheel forwarding, rendering, and navigation.
- The local full suite reported failures in attention, worktree, and session tests outside the minimap suite, then stalled and was interrupted. CI results are pending.
