### PR TITLE
feat(attention): gate sidebar UI behind debug flag

### DIFF
--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -53,6 +53,9 @@ struct AppConfig: Codable, Equatable {
     /// Preview gate for the right pane icon rail. This remains off until the
     /// rail presentation has completed preview testing.
     var rightPaneRailEnabled: Bool = false
+    /// Preview gate for the Needs Attention inbox and project affordances.
+    /// Events continue collecting while its presentation is disabled.
+    var needsAttentionEnabled: Bool = false
     var recentProjectIds: [String] = []
     var recentWorktreeIdsByProject: [String: [String]] = [:]
     var recentWorktreeRefs: [RepoSelectorRecents.RecentWorktreeRef] = []
@@ -522,6 +525,7 @@ struct AppConfig: Codable, Equatable {
         runTabEnabled: false,
         agentTabEnabled: false,
         rightPaneRailEnabled: false,
+        needsAttentionEnabled: false,
         recentProjectIds: [],
         recentWorktreeIdsByProject: [:],
         recentWorktreeRefs: [],
@@ -617,6 +621,7 @@ extension AppConfig {
              runTabEnabled,
              agentTabEnabled,
              rightPaneRailEnabled,
+             needsAttentionEnabled,
              recentProjectIds, recentWorktreeIdsByProject, recentWorktreeRefs,
              collapsedProjectIds,
              sidebarChromeOverrides,
@@ -860,6 +865,8 @@ extension AppConfig {
         // continue to load without exposing the sidebar rollup.
         agentTabEnabled = (try? c.decode(Bool.self, forKey: .agentTabEnabled)) ?? false
         rightPaneRailEnabled = (try? c.decode(Bool.self, forKey: .rightPaneRailEnabled)) ?? false
+        // Needs Attention remains opt-in while its entry points are in preview.
+        needsAttentionEnabled = (try? c.decode(Bool.self, forKey: .needsAttentionEnabled)) ?? false
         recentProjectIds = (try? c.decode([String].self, forKey: .recentProjectIds)) ?? []
         recentWorktreeIdsByProject =
             (try? c.decode([String: [String]].self, forKey: .recentWorktreeIdsByProject)) ?? [:]

--- a/Alas/Sources/Settings/AdvancedPane.swift
+++ b/Alas/Sources/Settings/AdvancedPane.swift
@@ -65,6 +65,21 @@ struct AdvancedPane: View {
                             }
                         ))
                     }
+                    SettingsRow(
+                        name: "Needs attention",
+                        desc: "Shows the attention inbox and repository attention counts."
+                    ) {
+                        AlasToggle(on: Binding(
+                            get: { state.config.needsAttentionEnabled },
+                            set: { enabled in
+                                state.config.needsAttentionEnabled = enabled
+                                if !enabled {
+                                    state.isAttentionInboxOpen = false
+                                }
+                                state.saveConfig()
+                            }
+                        ))
+                    }
                     if let recovery = state.workspaceRecoveryError {
                         VStack(alignment: .leading, spacing: 8) {
                             Text("Workspace recovery required: \(recovery.message)")

--- a/Alas/Sources/Sidebar/SidebarHeaderView.swift
+++ b/Alas/Sources/Sidebar/SidebarHeaderView.swift
@@ -9,6 +9,7 @@ struct SidebarHeaderView: View {
     let onHideSidebar: () -> Void
     var onNewWorkspace: (() -> Void)? = nil
     var attentionCount: Int = 0
+    var showsAttentionInbox = true
     @Binding var attentionInboxOpen: Bool
     var attentionAggregation: AttentionAggregation = AttentionAggregation(items: [], history: [], unresolvedCount: 0, unresolvedCountByProject: [:])
     var attentionLoadError: String? = nil
@@ -24,6 +25,7 @@ struct SidebarHeaderView: View {
          onHideSidebar: @escaping () -> Void,
          onNewWorkspace: (() -> Void)? = nil,
          attentionCount: Int = 0,
+         showsAttentionInbox: Bool = true,
          attentionInboxOpen: Binding<Bool> = .constant(false),
          attentionAggregation: AttentionAggregation = AttentionAggregation(items: [], history: [], unresolvedCount: 0, unresolvedCountByProject: [:]),
          attentionLoadError: String? = nil,
@@ -39,6 +41,7 @@ struct SidebarHeaderView: View {
         self.onHideSidebar = onHideSidebar
         self.onNewWorkspace = onNewWorkspace
         self.attentionCount = attentionCount
+        self.showsAttentionInbox = showsAttentionInbox
         self._attentionInboxOpen = attentionInboxOpen
         self.attentionAggregation = attentionAggregation
         self.attentionLoadError = attentionLoadError
@@ -94,7 +97,9 @@ struct SidebarHeaderView: View {
                     headerHovered: hovering
                 )
                 ToolbarBtn(icon: "search", tooltip: "Search", action: onSearch)
-                attentionToolbarButton
+                if showsAttentionInbox {
+                    attentionToolbarButton
+                }
                 if let onNewWorkspace {
                     Menu {
                         Button("Add repository...", systemImage: "folder.badge.plus", action: onAddProject)
@@ -127,7 +132,9 @@ struct SidebarHeaderView: View {
             Spacer(minLength: 0)
             HStack(spacing: 2) {
                 ToolbarBtn(icon: "search", tooltip: "Search", action: onSearch)
-                attentionToolbarButton
+                if showsAttentionInbox {
+                    attentionToolbarButton
+                }
                 Menu {
                     Menu("Sort worktrees") {
                         ForEach(WorktreeSortPresentation.modes, id: \.self) { mode in

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -1,6 +1,22 @@
 import SwiftUI
 import AppKit
 
+struct SidebarAttentionPresentation {
+    let showsInbox: Bool
+    let count: Int
+    private let countsByProject: [String: Int]
+
+    init(enabled: Bool, aggregation: AttentionAggregation) {
+        showsInbox = enabled
+        count = enabled ? aggregation.unresolvedCount : 0
+        countsByProject = enabled ? aggregation.unresolvedCountByProject : [:]
+    }
+
+    func count(for projectID: String) -> Int {
+        countsByProject[projectID, default: 0]
+    }
+}
+
 struct SidebarView: View {
     @Bindable var state: AppState
     @Binding var collapsedProjects: Set<String>
@@ -19,6 +35,10 @@ struct SidebarView: View {
     var body: some View {
         let override = state.config.sidebarChromeOverride(forThemeId: state.themeStore.current.id)
         let attentionAggregation = state.attentionAggregation
+        let attentionPresentation = SidebarAttentionPresentation(
+            enabled: state.config.needsAttentionEnabled,
+            aggregation: attentionAggregation
+        )
         ZStack {
             SidebarMaterialBackground(
                 choice: state.config.sidebarMaterial,
@@ -35,7 +55,8 @@ struct SidebarView: View {
                     },
                     onHideSidebar: onHideSidebar,
                     onNewWorkspace: state.config.workspacesEnabled ? { showingNewWorkspace = true } : nil,
-                    attentionCount: attentionAggregation.unresolvedCount,
+                    attentionCount: attentionPresentation.count,
+                    showsAttentionInbox: attentionPresentation.showsInbox,
                     attentionInboxOpen: $state.isAttentionInboxOpen,
                     attentionAggregation: attentionAggregation,
                     attentionLoadError: state.attentionStore.loadError?.localizedDescription,
@@ -184,7 +205,7 @@ struct SidebarView: View {
                                     )
                                     state.saveSpaces()
                                 },
-                                attentionCount: attentionAggregation.unresolvedCountByProject[project.id, default: 0]
+                                attentionCount: attentionPresentation.count(for: project.id)
                             )
                         }
                         Color.clear

--- a/AlasTests/AppConfigTests.swift
+++ b/AlasTests/AppConfigTests.swift
@@ -33,6 +33,7 @@ struct AppConfigTests {
         #expect(cfg.agentTabEnabled == false)
         #expect(cfg.runTabEnabled == false)
         #expect(cfg.rightPaneRailEnabled == false)
+        #expect(cfg.needsAttentionEnabled == false)
     }
 
     @Test func decodeOldConfigDefaultsWorkspacesDisabled() throws {
@@ -77,6 +78,17 @@ struct AppConfigTests {
         let decoded = try JSONDecoder().decode(AppConfig.self, from: oldConfig)
 
         #expect(decoded.rightPaneRailEnabled == false)
+    }
+
+    @Test func decodeOldConfigDefaultsNeedsAttentionDisabled() throws {
+        let data = try JSONEncoder().encode(AppConfig.defaults)
+        var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        object.removeValue(forKey: "needsAttentionEnabled")
+
+        let oldConfig = try JSONSerialization.data(withJSONObject: object)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: oldConfig)
+
+        #expect(decoded.needsAttentionEnabled == false)
     }
 
     @Test func decodeOldHarnessConfigDefaultsAwaitingPingOn() throws {

--- a/AlasTests/Attention/AttentionInboxViewTests.swift
+++ b/AlasTests/Attention/AttentionInboxViewTests.swift
@@ -6,6 +6,20 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct AttentionInboxViewTests {
+    @Test func sidebarPresentationHidesAttentionWhenFeatureIsDisabled() {
+        let aggregation = aggregation(items: [makeItem()])
+
+        let disabled = SidebarAttentionPresentation(enabled: false, aggregation: aggregation)
+        #expect(disabled.showsInbox == false)
+        #expect(disabled.count == 0)
+        #expect(disabled.count(for: "p1") == 0)
+
+        let enabled = SidebarAttentionPresentation(enabled: true, aggregation: aggregation)
+        #expect(enabled.showsInbox == true)
+        #expect(enabled.count == 1)
+        #expect(enabled.count(for: "p1") == 1)
+    }
+
     @Test func headerAccessibilityIncludesCountAndZeroHidesBadge() {
         #expect(SidebarHeaderView.attentionAccessibilityLabel(count: 4) == "Open attention inbox, 4 items")
         #expect(SidebarHeaderView.attentionAccessibilityLabel(count: 1) == "Open attention inbox, 1 item")

--- a/docs/superpowers/plans/2026-09-13-needs-attention-feature-flag.md
+++ b/docs/superpowers/plans/2026-09-13-needs-attention-feature-flag.md
@@ -1,0 +1,84 @@
+# Needs attention feature flag implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hide Needs Attention until a user enables its debug feature flag, without stopping event collection.
+
+**Architecture:** Persist `needsAttentionEnabled` in `AppConfig`, expose a Debug toggle, and project the flag in `SidebarView`. Sidebar presentation receives real attention state only when enabled; the attention store and producers remain unchanged.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Swift Testing, XcodeGen.
+
+---
+
+### Task 1: Persist the feature flag
+
+**Files:**
+- Modify: `Alas/Sources/Persistence/AppConfig.swift`
+- Test: `AlasTests/AppConfigTests.swift`
+
+- [ ] **Step 1: Write failing tests for the default and legacy decode behavior**
+
+```swift
+#expect(AppConfig.defaults.needsAttentionEnabled == false)
+// Remove "needsAttentionEnabled" from an encoded config, decode it, then:
+#expect(decoded.needsAttentionEnabled == false)
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail because the property is absent**
+
+Run: `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppConfigTests`
+
+- [ ] **Step 3: Add `needsAttentionEnabled` to `AppConfig`**
+
+Add the Boolean with a `false` property default, initialize it as `false` in `AppConfig.defaults`, include its coding key, and decode absent keys as `false`.
+
+- [ ] **Step 4: Run the focused tests and verify they pass**
+
+Run: `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppConfigTests`
+
+### Task 2: Gate sidebar presentation and add the Debug control
+
+**Files:**
+- Modify: `Alas/Sources/Settings/AdvancedPane.swift`
+- Modify: `Alas/Sources/Sidebar/SidebarView.swift`
+- Modify: `Alas/Sources/Sidebar/SidebarHeaderView.swift`
+- Test: `AlasTests/Attention/AttentionInboxViewTests.swift`
+
+- [ ] **Step 1: Write a failing test for sidebar presentation**
+
+Extract a small, pure `SidebarAttentionPresentation` value from `SidebarView`. It receives the enabled flag and aggregation, and exposes whether to show the inbox plus the global and per-project counts. Assert disabled presentation hides the inbox and returns zero counts. Assert enabled presentation preserves the aggregation values.
+
+- [ ] **Step 2: Run the focused attention tests and verify the new test fails**
+
+Run: `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AttentionInboxViewTests`
+
+- [ ] **Step 3: Implement the smallest presentation gate**
+
+Add the `Needs attention` Settings > Debug > Experimental toggle using `state.config.needsAttentionEnabled` and `state.saveConfig()`. Add `showsAttentionInbox` to `SidebarHeaderView` and use it to omit the toolbar button from both header variants. In `SidebarView`, use `SidebarAttentionPresentation` for the header and project counts. When disabling, set `state.isAttentionInboxOpen` to `false`, covered by the focused test.
+
+- [ ] **Step 4: Run focused attention tests and verify they pass**
+
+Run: `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AttentionInboxViewTests`
+
+### Task 3: Regenerate, verify, review, and publish
+
+**Files:**
+- Modify: `Alas.xcodeproj/project.pbxproj` only if `xcodegen` changes it
+
+- [ ] **Step 1: Regenerate the Xcode project**
+
+Run: `rtk xcodegen`
+
+- [ ] **Step 2: Run required verification**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+rtk git diff --check
+```
+
+- [ ] **Step 3: Commit and request review**
+
+Commit the implementation and tests, push the branch, open a pull request, then address every actionable review finding and failing CI check.

--- a/docs/superpowers/specs/2026-09-13-needs-attention-feature-flag-design.md
+++ b/docs/superpowers/specs/2026-09-13-needs-attention-feature-flag-design.md
@@ -1,0 +1,41 @@
+# Needs attention feature flag
+
+**Date:** 2026-09-13  
+**Status:** Approved in conversation
+
+## Goal
+
+Keep Needs Attention experimental by hiding its sidebar entry point and project-level counts until a user enables it in Settings > Debug. The feature is off by default.
+
+## Behavior
+
+`AppConfig` gains a persisted `needsAttentionEnabled` Boolean. New configurations and configurations written before this key existed decode it as `false`.
+
+Settings > Debug > Experimental gains a `Needs attention` toggle. It saves the flag through the existing app configuration flow.
+
+When disabled, the sidebar header does not show the attention inbox button and project rows do not show their unresolved-item counts. If the inbox is open when the user disables the setting, the app closes it.
+
+Attention signals, persistence, aggregation, history, and navigation continue to run while disabled. Re-enabling the setting immediately reveals the current unresolved count and stored history.
+
+## Implementation
+
+`SidebarView` owns the presentation decision because it already derives the aggregation and supplies both affected sidebar views. It will conditionally construct the header entry point and pass zero project attention counts while the flag is off.
+
+No producer, store, aggregation, or navigation code changes. The existing `SidebarHeaderView` and `RepoGroupView` APIs stay intact, keeping the flag outside the attention domain model.
+
+## Testing
+
+- Assert the flag defaults to disabled in `AppConfig.defaults`.
+- Assert an older encoded configuration without the key decodes with the flag disabled.
+- Cover the sidebar presentation decision so a disabled flag removes the header entry point and project counts, while enabled preserves the aggregated values.
+
+## Verification
+
+Run focused Swift Testing coverage while developing. Before opening the pull request, run:
+
+```bash
+rtk xcodegen
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+rtk git diff --check
+```

--- a/docs/superpowers/specs/2026-09-13-needs-attention-feature-flag-design.md
+++ b/docs/superpowers/specs/2026-09-13-needs-attention-feature-flag-design.md
@@ -19,9 +19,9 @@ Attention signals, persistence, aggregation, history, and navigation continue to
 
 ## Implementation
 
-`SidebarView` owns the presentation decision because it already derives the aggregation and supplies both affected sidebar views. It will conditionally construct the header entry point and pass zero project attention counts while the flag is off.
+`SidebarView` owns the presentation decision because it already derives the aggregation and supplies both affected sidebar views. It passes `needsAttentionEnabled` to `SidebarHeaderView`, which conditionally builds the inbox button in both of its width variants. It passes zero project attention counts while the flag is off.
 
-No producer, store, aggregation, or navigation code changes. The existing `SidebarHeaderView` and `RepoGroupView` APIs stay intact, keeping the flag outside the attention domain model.
+No producer, store, aggregation, or navigation code changes. `SidebarHeaderView` gains only the presentation Boolean; `RepoGroupView` keeps its existing API. The flag stays outside the attention domain model.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

- Add an opt-in Needs Attention flag in Settings > Debug.
- Hide the sidebar inbox entry point and project counts until enabled.
- Keep attention collection and history active while hidden.

## Testing

- Not run locally: Xcode build service stalled before test execution.