### PR TITLE
feat(acp): simplify transcript minimap into conversation blocks

### DIFF
--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptMinimap.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptMinimap.swift
@@ -1,189 +1,126 @@
 import AppKit
 
+/// Conversation turns have their own scale, independent of text and tool output length.
+struct ACPTranscriptMinimapLayout {
+    enum Role {
+        case user, assistant, notice, history
+    }
+
+    struct Block {
+        let role: Role
+        var messages: Range<Int>
+        let y: CGFloat
+        let height: CGFloat
+    }
+
+    private(set) var blocks: [Block] = []
+    private(set) var height: CGFloat = 0
+
+    init(messages: [ACPMessage], offset: Int) {
+        if offset > 0 {
+            append(role: .history, messages: 0..<offset)
+        }
+        for (index, message) in messages.enumerated() {
+            let role: Role
+            switch message {
+            case .user: role = .user
+            case .systemNotice: role = .notice
+            case .agent, .thought, .toolCall, .fileEdit, .plan: role = .assistant
+            }
+            let globalIndex = offset + index
+            if role != .user, let last = blocks.last, last.role == role {
+                blocks[blocks.count - 1].messages = last.messages.lowerBound..<(globalIndex + 1)
+            } else {
+                append(role: role, messages: globalIndex..<(globalIndex + 1))
+            }
+        }
+    }
+
+    private mutating func append(role: Role, messages: Range<Int>) {
+        let extent: CGFloat = role == .user || role == .notice ? 24 : 48
+        blocks.append(Block(role: role, messages: messages, y: height, height: extent))
+        height += extent
+    }
+
+    /// Convert a fractional global message index to a fraction of the turn map.
+    func fraction(at messagePosition: CGFloat) -> CGFloat {
+        guard height > 0, !blocks.isEmpty else { return 0 }
+        let index = blockIndex { CGFloat($0.messages.upperBound) <= messagePosition }
+        let block = blocks[index]
+        let progress = min(1, max(0, (messagePosition - CGFloat(block.messages.lowerBound)) / CGFloat(block.messages.count)))
+        return (block.y + progress * block.height) / height
+    }
+
+    func messagePosition(at fraction: CGFloat) -> CGFloat {
+        guard height > 0, !blocks.isEmpty else { return 0 }
+        let y = min(1, max(0, fraction)) * height
+        let index = blockIndex { $0.y + $0.height <= y }
+        let block = blocks[index]
+        let progress = min(1, max(0, (y - block.y) / block.height))
+        return CGFloat(block.messages.lowerBound) + progress * CGFloat(block.messages.count)
+    }
+
+    private func blockIndex(before position: (Block) -> Bool) -> Int {
+        var low = 0
+        var high = blocks.count
+        while low < high {
+            let middle = (low + high) / 2
+            if position(blocks[middle]) { low = middle + 1 } else { high = middle }
+        }
+        return min(low, blocks.count - 1)
+    }
+}
+
 @MainActor
 final class ACPTranscriptMinimap {
-    private struct Entry {
-        let message: ACPMessage
-        let revision: UInt64
-        let drawing: MinimapDrawing
-    }
-    private var entries: [ACPMessage.StableIdentityKey: Entry] = [:]
     private var theme: Theme?
     private var generation: UInt64?
-    private var tick: UInt32?
     private var offset: Int?
     private var transcriptID: ObjectIdentifier?
     private var cachedDrawing = MinimapDrawing()
+    private(set) var layout = ACPTranscriptMinimapLayout(messages: [], offset: 0)
 
     func needsUpdate(transcript: ACPTranscript, theme: Theme) -> Bool {
         self.theme != theme || generation != transcript.messagesGeneration
-            || tick != transcript.streamingTick || offset != transcript.messageIndexOffset
+            || offset != transcript.messageIndexOffset
             || transcriptID != ObjectIdentifier(transcript)
     }
 
     func drawing(transcript: ACPTranscript, theme: Theme) -> MinimapDrawing {
         guard needsUpdate(transcript: transcript, theme: theme) else { return cachedDrawing }
-        if self.theme != theme || transcriptID != ObjectIdentifier(transcript) { entries.removeAll() }
         transcriptID = ObjectIdentifier(transcript)
         self.theme = theme
         generation = transcript.messagesGeneration
-        tick = transcript.streamingTick
         offset = transcript.messageIndexOffset
-        let count = transcript.logicalMessageCount
-        let slot: CGFloat = max(24, 360 / CGFloat(max(1, count)))
-        var result = MinimapDrawing(height: CGFloat(max(1, count)) * slot)
-        if transcript.messageIndexOffset > 0 {
-            result.marks.append(.init(
-                rect: CGRect(x: 0, y: 0, width: 88, height: CGFloat(transcript.messageIndexOffset) * slot),
-                color: NSColor(theme.color("fg-faint")).withAlphaComponent(0.12)
+        layout = ACPTranscriptMinimapLayout(messages: transcript.messages, offset: transcript.messageIndexOffset)
+        let userColor = NSColor(theme.color("accent")).withAlphaComponent(0.65)
+        let assistantColor = NSColor(theme.color("fg-muted")).withAlphaComponent(0.38)
+        let noticeColor = NSColor(theme.color("fg-faint")).withAlphaComponent(0.2)
+        var drawing = MinimapDrawing(height: layout.height)
+        for block in layout.blocks {
+            let x: CGFloat
+            let width: CGFloat
+            let color: NSColor
+            switch block.role {
+            case .user:
+                x = 24
+                width = 64
+                color = userColor
+            case .assistant:
+                x = 0
+                width = 64
+                color = assistantColor
+            case .notice, .history:
+                x = 0
+                width = 88
+                color = noticeColor
+            }
+            drawing.marks.append(.init(
+                rect: CGRect(x: x, y: block.y + 2, width: width, height: block.height - 4),
+                color: color
             ))
         }
-        // Bound preview generation independently of history length. Each sample
-        // keeps its global position; a hidden render window never changes the map.
-        var sampleStride = 1
-        while count / sampleStride > 382 { sampleStride *= 2 }
-        let firstGlobal = ((transcript.messageIndexOffset + sampleStride - 1) / sampleStride) * sampleStride
-        var indices = Set(stride(from: firstGlobal - transcript.messageIndexOffset, to: transcript.messages.count, by: sampleStride))
-        if !transcript.messages.isEmpty {
-            indices.insert(0)
-            indices.insert(transcript.messages.count - 1)
-        }
-        let promptColor = NSColor(theme.color("accent")).withAlphaComponent(0.26)
-        let cardColor = NSColor(theme.color("bg-2"))
-        let textColor = NSColor(theme.color("fg-faint")).withAlphaComponent(0.6)
-        for start in stride(from: 0, to: transcript.messages.count, by: sampleStride) {
-            let end = min(transcript.messages.count, start + sampleStride)
-            let messages = transcript.messages[start..<end]
-            guard let message = messages.first(where: {
-                if case .user = $0 { return true }
-                return false
-            }) ?? messages.first(where: {
-                if case .toolCall = $0 { return true }
-                if case .fileEdit = $0 { return true }
-                return false
-            }) ?? messages.first(where: {
-                if case .plan = $0 { return false }
-                return true
-            }) else { continue }
-            let y = CGFloat(transcript.messageIndexOffset + start) * slot
-            let height = CGFloat(end - start) * slot
-            let rect: CGRect
-            let color: NSColor
-            switch message {
-            case .user:
-                rect = CGRect(x: 24, y: y, width: 64, height: max(2, height))
-                color = promptColor.withAlphaComponent(promptColor.alphaComponent * 0.45)
-            case .toolCall, .fileEdit:
-                rect = CGRect(x: 0, y: y, width: 88, height: max(2, min(8, height)))
-                color = cardColor
-            case .plan:
-                continue
-            default:
-                rect = CGRect(x: 0, y: y, width: 60, height: max(1, min(2, height)))
-                color = textColor
-            }
-            result.marks.append(.init(rect: rect, color: color))
-        }
-        var retained: [ACPMessage.StableIdentityKey: Entry] = [:]
-        for index in indices.sorted() {
-            let message = transcript.messages[index]
-            let revision: UInt64
-            switch message {
-            case .agent(_, _, let text), .thought(_, _, let text): revision = text.revision
-            default: revision = 0
-            }
-            let key = message.stableIdentityKey
-            let entry: Entry
-            if let cached = entries[key], cached.message == message, cached.revision == revision {
-                entry = cached
-            } else {
-                entry = Entry(message: message, revision: revision, drawing: Self.preview(message, theme: theme))
-            }
-            retained[key] = entry
-            let y = CGFloat(transcript.messageIndexOffset + index) * slot
-            let scale = min(1, (slot - 4) / max(1, entry.drawing.height))
-            result.marks.append(contentsOf: entry.drawing.marks.map {
-                .init(rect: CGRect(x: $0.rect.minX, y: y + $0.rect.minY * scale,
-                                   width: $0.rect.width, height: $0.rect.height * scale), color: $0.color)
-            })
-        }
-        entries = retained
-        cachedDrawing = result
-        return result
-    }
-
-    static func preview(_ message: ACPMessage, theme: Theme) -> MinimapDrawing {
-        let fg = NSColor(theme.color("fg"))
-        let muted = NSColor(theme.color("fg-faint"))
-        let accent = NSColor(theme.color("accent"))
-        var drawing: MinimapDrawing
-        switch message {
-        case .user(_, _, let text, let attachments, _):
-            drawing = markdown(text, theme: theme, columns: 60)
-            var bubble = MinimapDrawing(height: drawing.height + 6)
-            bubble.marks.append(.init(rect: CGRect(x: 24, y: 0, width: 64, height: bubble.height),
-                                      color: accent.withAlphaComponent(0.26)))
-            bubble.append(drawing, x: 26, y: 3)
-            for index in attachments.prefix(4).indices {
-                bubble.marks.append(.init(rect: CGRect(x: 26 + index * 10, y: 0, width: 8, height: 4), color: accent))
-            }
-            return bubble
-        case .agent(_, _, let text):
-            return markdown(text.value, theme: theme, columns: 84)
-        case .thought(_, _, let text):
-            drawing = MinimapDrawing.text(NSAttributedString(string: String(text.value.prefix(1024)), attributes: [.foregroundColor: muted]), columns: 80, wraps: true)
-            drawing.marks.insert(.init(rect: CGRect(x: 0, y: 0, width: 1, height: drawing.height), color: NSColor(theme.color("bg-4"))), at: 0)
-        case .toolCall(let tool):
-            drawing = MinimapDrawing.text(NSAttributedString(string: String(tool.title.prefix(80)), attributes: [.foregroundColor: fg]), columns: 76)
-            var card = MinimapDrawing(height: 8)
-            card.marks.append(.init(rect: CGRect(x: 0, y: 0, width: 88, height: 8), color: NSColor(theme.color("bg-2"))))
-            let status = tool.status == "failed" ? "del" : tool.status == "completed" ? "add" : "accent"
-            card.marks.append(.init(rect: CGRect(x: 2, y: 2, width: 3, height: 3), color: NSColor(theme.color(status))))
-            card.append(drawing, x: 8, y: 2)
-            return card
-        case .fileEdit(_, let edit):
-            drawing = MinimapDrawing.text(NSAttributedString(string: String(edit.path.prefix(80)), attributes: [.foregroundColor: accent]))
-            drawing.marks.append(.init(rect: CGRect(x: 0, y: 4, width: CGFloat(min(40, edit.added)), height: 2), color: NSColor(theme.color("add"))))
-            drawing.marks.append(.init(rect: CGRect(x: 44, y: 4, width: CGFloat(min(40, edit.removed)), height: 2), color: NSColor(theme.color("del"))))
-            drawing.height = 8
-        case .systemNotice(_, let text):
-            drawing = MinimapDrawing.text(NSAttributedString(string: String(text.prefix(160)), attributes: [.foregroundColor: muted]), wraps: true)
-        case .plan:
-            drawing = MinimapDrawing(height: 3)
-        }
+        cachedDrawing = drawing
         return drawing
-    }
-
-    private static func markdown(_ text: String, theme: Theme, columns: Int) -> MinimapDrawing {
-        var result = MinimapDrawing()
-        for block in ACPMarkdownText.parse(String(text.prefix(4096))) {
-            let attributed: NSAttributedString
-            var background: NSColor?
-            switch block {
-            case .code(let language, let body), .streamingCode(let language, let body):
-                attributed = ACPCodeBlockHighlighter.attributedString(code: String(body.prefix(2048)), language: language, theme: theme)
-                background = NSColor(theme.color("bg-2"))
-            case .heading(let level, let text):
-                attributed = ACPMarkdownInlineRenderer.makeAttributedString(source: text, theme: theme, typography: .default, role: .heading(level: level))
-            case .paragraph(let text):
-                attributed = ACPMarkdownInlineRenderer.makeAttributedString(source: text, theme: theme, typography: .default, role: .body)
-            case .quote(let text):
-                attributed = ACPMarkdownInlineRenderer.makeAttributedString(source: text, theme: theme, typography: .default, role: .quote)
-            case .taskList(let items):
-                attributed = NSAttributedString(string: items.map { $0.text }.joined(separator: "\n"), attributes: [.foregroundColor: NSColor(theme.color("fg"))])
-            case .table(let header, let rows):
-                attributed = NSAttributedString(string: ([header] + rows).map { $0.joined(separator: "  ") }.joined(separator: "\n"), attributes: [.foregroundColor: NSColor(theme.color("fg"))])
-            case .mermaid(let source):
-                attributed = NSAttributedString(string: String(source.prefix(1024)), attributes: [.foregroundColor: NSColor(theme.color("accent"))])
-            }
-            let drawing = MinimapDrawing.text(attributed, columns: columns, wraps: background == nil)
-            let y = result.height
-            if let background {
-                result.marks.append(.init(rect: CGRect(x: 0, y: y, width: CGFloat(columns), height: drawing.height), color: background))
-            }
-            result.append(drawing, y: y)
-            result.height += 3
-        }
-        return result
     }
 }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptMinimap.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptMinimap.swift
@@ -97,28 +97,37 @@ final class ACPTranscriptMinimap {
         let assistantColor = NSColor(theme.color("fg-muted")).withAlphaComponent(0.38)
         let noticeColor = NSColor(theme.color("fg-faint")).withAlphaComponent(0.2)
         var drawing = MinimapDrawing(height: layout.height)
-        for block in layout.blocks {
-            let x: CGFloat
-            let width: CGFloat
-            let color: NSColor
-            switch block.role {
-            case .user:
-                x = 24
-                width = 64
-                color = userColor
-            case .assistant:
-                x = 0
-                width = 64
-                color = assistantColor
-            case .notice, .history:
-                x = 0
-                width = 88
-                color = noticeColor
+        // Dense histories share drawing buckets while navigation retains every turn.
+        // Keep both speaker lanes instead of sampling away short user prompts.
+        let bucketSize = max(1, Int(ceil(Double(layout.blocks.count) / 512)))
+        let roles: [ACPTranscriptMinimapLayout.Role] = [.history, .notice, .assistant, .user]
+        for start in stride(from: 0, to: layout.blocks.count, by: bucketSize) {
+            let bucket = layout.blocks[start..<min(layout.blocks.count, start + bucketSize)]
+            for role in roles {
+                guard let first = bucket.first(where: { $0.role == role }),
+                      let last = bucket.last(where: { $0.role == role }) else { continue }
+                let x: CGFloat
+                let width: CGFloat
+                let color: NSColor
+                switch role {
+                case .user:
+                    x = bucketSize > 1 ? 48 : 24
+                    width = bucketSize > 1 ? 40 : 64
+                    color = userColor
+                case .assistant:
+                    x = 0
+                    width = bucketSize > 1 ? 40 : 64
+                    color = assistantColor
+                case .notice, .history:
+                    x = 0
+                    width = 88
+                    color = noticeColor
+                }
+                drawing.marks.append(.init(
+                    rect: CGRect(x: x, y: first.y + 2, width: width, height: last.y + last.height - first.y - 4),
+                    color: color
+                ))
             }
-            drawing.marks.append(.init(
-                rect: CGRect(x: x, y: block.y + 2, width: width, height: block.height - 4),
-                color: color
-            ))
         }
         cachedDrawing = drawing
         return drawing

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -98,7 +98,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         /// has been reconciled into the AppKit tiling map.
         private var pendingLogicalTargetId: String?
         private var pendingMinimapRowFraction: CGFloat = 0
-        private var minimapGestureRange: (count: Int, proportion: CGFloat)?
+        private var minimapGestureRange: (count: Int, proportion: CGFloat, layout: ACPTranscriptMinimapLayout?)?
         private var isPendingLogicalResolutionScheduled = false
         private let scrollSettleTimer: DebounceTimer
         /// Memoizes the window-sliced row list + its id → message-index
@@ -111,7 +111,6 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         /// scrolling must stay smooth.
         private let visibleRowsCache = ACPVisibleRowsCache()
         private var minimapRenderer: ACPTranscriptMinimap?
-        private var pendingMinimapUpdate: DispatchWorkItem?
 
         static let composerSpacerHeight: CGFloat = 220
 
@@ -150,10 +149,13 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             }
             scroller.minimap.onNavigationStart = { [weak self] in
                 guard let self, let host = self.host, let scroller = self.scroller else { return }
-                self.minimapGestureRange = (host.transcript.logicalMessageCount, scroller.minimap.proportion)
+                self.minimapGestureRange = (host.transcript.logicalMessageCount, scroller.minimap.proportion, self.minimapRenderer?.layout)
             }
             scroller.minimap.onNavigationEnd = { [weak self] in
-                self?.minimapGestureRange = nil
+                guard let self else { return }
+                self.minimapGestureRange = nil
+                self.updateMinimap()
+                self.syncMinimapViewport()
             }
             update(host: host)
         }
@@ -297,27 +299,20 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             guard let host, let scroller else { return }
             guard host.showMinimap, scroller.showsMinimap else {
                 minimapGestureRange = nil
-                pendingMinimapUpdate?.cancel()
-                pendingMinimapUpdate = nil
                 minimapRenderer = nil
                 scroller.minimap.update(drawing: MinimapDrawing())
                 return
             }
             scroller.minimap.backgroundColor = NSColor(host.theme.color("bg-1"))
             scroller.minimap.indicatorColor = NSColor(host.theme.color("fg-muted"))
+            // Keep the drawing and its navigation scale fixed throughout a drag.
+            guard minimapGestureRange == nil else { return }
             if let minimapRenderer, !minimapRenderer.needsUpdate(transcript: host.transcript, theme: host.theme) { return }
-            guard pendingMinimapUpdate == nil else { return }
-            let work = DispatchWorkItem { [weak self] in
-                guard let self else { return }
-                self.pendingMinimapUpdate = nil
-                guard let host = self.host, host.showMinimap, let scroller = self.scroller, scroller.showsMinimap else { return }
-                if self.minimapRenderer == nil { self.minimapRenderer = ACPTranscriptMinimap() }
-                if let drawing = self.minimapRenderer?.drawing(transcript: host.transcript, theme: host.theme) {
-                    scroller.minimap.update(drawing: drawing)
-                }
+            if minimapRenderer == nil { minimapRenderer = ACPTranscriptMinimap() }
+            if let drawing = minimapRenderer?.drawing(transcript: host.transcript, theme: host.theme) {
+                scroller.minimap.update(drawing: drawing)
             }
-            pendingMinimapUpdate = work
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: work)
+            syncMinimapViewport()
         }
 
         /// Wraps a row's content with the layout and environment values that
@@ -936,9 +931,10 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             host.transcript.freezeVisibleTail()
             let count = host.transcript.logicalMessageCount
             // Keep the drag's mapping stable while rows of different heights enter the viewport.
-            let range = minimapGestureRange ?? (count: count, proportion: scroller.minimap.proportion)
+            let range = minimapGestureRange ?? (count: count, proportion: scroller.minimap.proportion, layout: minimapRenderer?.layout)
+            let fraction = CGFloat(value) * (1 - range.proportion)
             let position = min(CGFloat(count) - 0.000_001,
-                               max(0, CGFloat(value) * (1 - range.proportion) * CGFloat(range.count)))
+                               max(0, range.layout?.messagePosition(at: fraction) ?? fraction * CGFloat(range.count)))
             pendingLogicalTargetGlobalIndex = Int(position)
             pendingMinimapRowFraction = position - floor(position)
             if resolvePendingLogicalTargetIfPossible() { update(host: host) }
@@ -1041,9 +1037,12 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             let count = CGFloat(host.transcript.logicalMessageCount)
             let top = globalMessagePosition(at: scroller.scrollY) ?? 0
             let bottom = globalMessagePosition(at: scroller.scrollY + scroller.viewportHeight) ?? count
-            let proportion = min(1, max(0.000_001, (bottom - top) / count))
+            let layout = minimapGestureRange?.layout ?? minimapRenderer?.layout
+            let topFraction = layout?.fraction(at: top) ?? top / count
+            let bottomFraction = layout?.fraction(at: bottom) ?? bottom / count
+            let proportion = min(1, max(0.000_001, bottomFraction - topFraction))
             scroller.minimap.proportion = proportion
-            scroller.minimap.value = host.session.followsTranscriptTail ? 1 : Double(min(1, top / max(0.000_001, count * (1 - proportion))))
+            scroller.minimap.value = host.session.followsTranscriptTail ? 1 : Double(min(1, topFraction / max(0.000_001, 1 - proportion)))
         }
 
         private func currentTopGlobalMessageIndex() -> Int? {

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -111,6 +111,7 @@ struct ACPTranscriptScroller: NSViewRepresentable {
         /// scrolling must stay smooth.
         private let visibleRowsCache = ACPVisibleRowsCache()
         private var minimapRenderer: ACPTranscriptMinimap?
+        private var pendingMinimapUpdate: DispatchWorkItem?
 
         static let composerSpacerHeight: CGFloat = 220
 
@@ -299,6 +300,8 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             guard let host, let scroller else { return }
             guard host.showMinimap, scroller.showsMinimap else {
                 minimapGestureRange = nil
+                pendingMinimapUpdate?.cancel()
+                pendingMinimapUpdate = nil
                 minimapRenderer = nil
                 scroller.minimap.update(drawing: MinimapDrawing())
                 return
@@ -307,6 +310,26 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             scroller.minimap.indicatorColor = NSColor(host.theme.color("fg-muted"))
             // Keep the drawing and its navigation scale fixed throughout a drag.
             guard minimapGestureRange == nil else { return }
+            if let minimapRenderer, !minimapRenderer.needsUpdate(transcript: host.transcript, theme: host.theme) { return }
+            if minimapRenderer == nil {
+                refreshMinimapDrawing()
+                return
+            }
+            // Tool content replacements bump messagesGeneration too. Coalesce these
+            // bursts so a running tool cannot rebuild the map on every update.
+            guard pendingMinimapUpdate == nil else { return }
+            let work = DispatchWorkItem { [weak self] in
+                guard let self else { return }
+                self.pendingMinimapUpdate = nil
+                self.refreshMinimapDrawing()
+            }
+            pendingMinimapUpdate = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.12, execute: work)
+        }
+
+        private func refreshMinimapDrawing() {
+            guard let host, host.showMinimap, let scroller, scroller.showsMinimap,
+                  minimapGestureRange == nil else { return }
             if let minimapRenderer, !minimapRenderer.needsUpdate(transcript: host.transcript, theme: host.theme) { return }
             if minimapRenderer == nil { minimapRenderer = ACPTranscriptMinimap() }
             if let drawing = minimapRenderer?.drawing(transcript: host.transcript, theme: host.theme) {

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -754,6 +754,39 @@ struct ACPTranscriptScrollerLogicalNavigationTests {
         scroller.minimap.onNavigationEnd?()
     }
 
+    @Test("Minimap drag mapping stays stable while earlier history is loaded")
+    func minimapDragDuringBackfill() {
+        let session = ACPSession(id: "backfill-minimap", agentId: "claude", worktreeId: "w", title: "t")
+        let tall = ACPMessage.agent(id: UUID(), StreamingText(String(repeating: "Long reply.\n\n", count: 100)))
+        session.replaceTranscriptMessages([
+            .user(id: UUID(), text: "prompt", attachments: []), tall,
+            .user(id: UUID(), text: "next", attachments: [])
+        ], messageIndexOffset: 100)
+        session.followsTranscriptTail = true
+        var host = makeHost(session: session)
+        host.showMinimap = true
+        let scroller = ACPTranscriptScrollerView(frame: NSRect(x: 0, y: 0, width: 800, height: 400))
+        let coordinator = ACPTranscriptScroller.Coordinator()
+        coordinator.attach(scroller: scroller, host: host)
+        scroller.layoutSubtreeIfNeeded()
+        let layout = ACPTranscriptMinimapLayout(messages: session.transcript.messages, offset: 100)
+        let destination = Double(layout.fraction(at: 101.5) / (1 - scroller.minimap.proportion))
+        #expect(destination < 1)
+        scroller.minimap.onNavigationStart?()
+        scroller.minimap.onNavigate?(destination)
+        #expect(coordinator.topVisibleMessageIdForTesting == tall.stableId)
+        session.transcript.prependMessages((0..<100).map { _ in
+            .user(id: UUID(), text: "older prompt", attachments: [])
+        })
+        coordinator.update(host: host)
+        scroller.minimap.onNavigate?(destination)
+        #expect(coordinator.topVisibleMessageIdForTesting == tall.stableId)
+        let position = scroller.scrollY
+        scroller.minimap.onNavigationEnd?()
+        #expect(abs(scroller.scrollY - position) < 1)
+        #expect(!session.followsTranscriptTail)
+    }
+
     @Test("Minimap targets skip plan entries that have no transcript row")
     func minimapSkipsHiddenPlans() {
         let session = ACPSession(id: "plan-minimap", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
+++ b/AlasTests/ACP/UI/ACPTranscriptScrollerPolicyTests.swift
@@ -747,6 +747,8 @@ struct ACPTranscriptScrollerLogicalNavigationTests {
         let position = scroller.scrollY
         #expect(coordinator.topVisibleMessageIdForTesting == tall.stableId)
         #expect(abs(scroller.minimap.proportion - initialProportion) > 0.01)
+        session.transcript.messages.append(.user(id: UUID(), text: "new prompt during drag", attachments: []))
+        coordinator.update(host: host)
         scroller.minimap.onNavigate?(destination)
         #expect(abs(scroller.scrollY - position) < 1)
         scroller.minimap.onNavigationEnd?()

--- a/AlasTests/MinimapTests.swift
+++ b/AlasTests/MinimapTests.swift
@@ -127,20 +127,30 @@ struct MinimapTests {
         #expect(!decoded.harness.acpShowMinimap)
     }
 
-    @Test("Transcript code blocks reuse syntax colors and user bubbles retain their alignment")
+    @Test("Transcript blocks distinguish speakers and group assistant activity without text detail")
     @MainActor func transcriptColors() throws {
         let theme = try Theme.loadBundled(id: "cool-slate")
-        let code = ACPTranscriptMinimap.preview(.agent(id: UUID(), StreamingText("```swift\nlet value = 42\n```")), theme: theme)
-        let keyword = NSColor(theme.color("syntax-keyword"))
-        let number = NSColor(theme.color("mod"))
-        #expect(code.marks.contains { $0.color == keyword })
-        #expect(code.marks.contains { $0.color == number })
-        let user = ACPTranscriptMinimap.preview(.user(id: UUID(), text: "hello", attachments: []), theme: theme)
-        #expect(user.marks.allSatisfy { $0.rect.minX >= 24 })
-        #expect(user.marks.contains { $0.color == NSColor(theme.color("accent")).withAlphaComponent(0.26) })
+        let transcript = ACPTranscript()
+        transcript.messages = [
+            .user(id: UUID(), text: "hello", attachments: []),
+            .thought(id: UUID(), StreamingText("thinking")),
+            .toolCall(.init(toolCallId: "tool", title: "Read file", status: "completed")),
+            .fileEdit(id: UUID(), .init(path: "file.swift", added: 2, removed: 1)),
+            .plan(id: UUID(), []),
+            .agent(id: UUID(), StreamingText("```swift\nlet value = 42\n```")),
+            .user(id: UUID(), text: "next", attachments: []),
+            .agent(id: UUID(), StreamingText(String(repeating: "reply ", count: 10_000)))
+        ]
+        let drawing = ACPTranscriptMinimap().drawing(transcript: transcript, theme: theme)
+        #expect(drawing.marks.count == 4)
+        guard drawing.marks.count == 4 else { return }
+        #expect(drawing.marks[0].rect.minX > drawing.marks[1].rect.minX)
+        #expect(drawing.marks[0].color != drawing.marks[1].color)
+        #expect(drawing.marks[0].rect.height >= 20)
+        #expect(drawing.marks[1].rect.height == drawing.marks[3].rect.height)
     }
 
-    @Test("Transcript previews update for streaming and never carry content between sessions")
+    @Test("Transcript blocks ignore streamed text and never carry content between sessions")
     @MainActor func transcriptInvalidation() throws {
         let theme = try Theme.loadBundled(id: "cool-slate")
         let transcript = ACPTranscript()
@@ -151,8 +161,11 @@ struct MinimapTests {
         #expect(!renderer.needsUpdate(transcript: transcript, theme: theme))
         buffer.append("bc")
         transcript.streamingTick &+= 1
+        #expect(!renderer.needsUpdate(transcript: transcript, theme: theme))
         let after = renderer.drawing(transcript: transcript, theme: theme)
-        #expect(after.marks.count > before.marks.count)
+        #expect(after.marks.map(\.rect) == before.marks.map(\.rect))
+        transcript.messages.append(.user(id: UUID(), text: "next", attachments: []))
+        #expect(renderer.needsUpdate(transcript: transcript, theme: theme))
         let second = ACPTranscript()
         second.messages = [.systemNotice(id: UUID(), text: "different session")]
         second.streamingTick = transcript.streamingTick
@@ -169,6 +182,53 @@ struct MinimapTests {
         }
         let drawing = ACPTranscriptMinimap().drawing(transcript: transcript, theme: theme)
         #expect(drawing.marks.count < 3_000)
+    }
+
+    @Test("Transcript blocks preserve consecutive prompts and reserve unloaded history")
+    @MainActor func transcriptHistoryBlocks() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let transcript = ACPTranscript()
+        let renderer = ACPTranscriptMinimap()
+        #expect(renderer.drawing(transcript: transcript, theme: theme).marks.isEmpty)
+        transcript.replaceMessages(with: [
+            .user(id: UUID(), text: "first", attachments: []),
+            .user(id: UUID(), text: "also", attachments: [])
+        ], messageIndexOffset: 1_000)
+        let drawing = renderer.drawing(transcript: transcript, theme: theme)
+        #expect(drawing.marks.count == 3)
+        guard drawing.marks.count == 3 else { return }
+        #expect(drawing.marks[0].rect.maxY <= drawing.marks[1].rect.minY)
+        #expect(drawing.marks[1].rect.maxY < drawing.marks[2].rect.minY)
+        #expect(drawing.marks[0].rect.height < drawing.marks[1].rect.height * 3)
+    }
+
+    @Test("Turn navigation maps compressed assistant activity back to global messages")
+    @MainActor func transcriptTurnNavigation() {
+        let layout = ACPTranscriptMinimapLayout(messages: [
+            .user(id: UUID(), text: "first", attachments: []),
+            .thought(id: UUID(), StreamingText("thinking")),
+            .agent(id: UUID(), StreamingText("reply")),
+            .user(id: UUID(), text: "next", attachments: []),
+            .agent(id: UUID(), StreamingText("reply"))
+        ], offset: 0)
+        #expect(layout.fraction(at: 3) == 0.5)
+        #expect(layout.messagePosition(at: 0.5) == 3)
+        #expect(layout.messagePosition(at: 0.25) == 1.5)
+        #expect(layout.fraction(at: -1) == 0)
+        #expect(layout.fraction(at: 99) == 1)
+        #expect(layout.messagePosition(at: -1) == 0)
+        #expect(layout.messagePosition(at: 2) == 5)
+        for position in stride(from: CGFloat(0), through: 5, by: 0.25) {
+            #expect(abs(layout.messagePosition(at: layout.fraction(at: position)) - position) < 0.000_001)
+        }
+        let history = ACPTranscriptMinimapLayout(messages: [
+            .user(id: UUID(), text: "recent", attachments: [])
+        ], offset: 1_000)
+        #expect(history.fraction(at: 1_000) == CGFloat(2) / 3)
+        #expect(history.messagePosition(at: CGFloat(1) / 3) == 500)
+        let empty = ACPTranscriptMinimapLayout(messages: [], offset: 0)
+        #expect(empty.fraction(at: 1) == 0)
+        #expect(empty.messagePosition(at: 1) == 0)
     }
 
     @Test("Character blocks preserve indentation, gaps, and attributed syntax colors")

--- a/AlasTests/MinimapTests.swift
+++ b/AlasTests/MinimapTests.swift
@@ -173,15 +173,19 @@ struct MinimapTests {
         #expect(renderer.needsUpdate(transcript: transcript, theme: try Theme.loadBundled(id: "light")))
     }
 
-    @Test("Long transcript previews keep fallback marks bounded")
+    @Test("Long alternating conversations keep drawing marks bounded without hiding either speaker")
     @MainActor func transcriptPreviewBounded() throws {
         let theme = try Theme.loadBundled(id: "cool-slate")
         let transcript = ACPTranscript()
-        transcript.messages = (0..<10_000).map { _ in
-            .systemNotice(id: UUID(), text: "message")
+        transcript.messages = (0..<10_000).map { index in
+            index.isMultiple(of: 2)
+                ? .user(id: UUID(), text: "prompt", attachments: [])
+                : .agent(id: UUID(), StreamingText("reply"))
         }
         let drawing = ACPTranscriptMinimap().drawing(transcript: transcript, theme: theme)
-        #expect(drawing.marks.count < 3_000)
+        #expect(drawing.marks.count <= 2_048)
+        #expect(drawing.marks.contains { $0.rect.minX == 0 })
+        #expect(drawing.marks.contains { $0.rect.minX >= 24 })
     }
 
     @Test("Transcript blocks preserve consecutive prompts and reserve unloaded history")


### PR DESCRIPTION
Replace the ACP transcript's detailed text previews with larger conversation blocks. Prompts stay right-aligned in the accent color, while consecutive assistant replies, reasoning, tool calls, and file edits share a muted block on the left. Block height no longer depends on text length, and text-only streaming updates reuse the drawing.

Coalesce changes to an existing map over 120 ms so bursts of tool-content replacements cannot rebuild it on every rendered update. The first map is rendered immediately so navigation is available when the pane opens.

Map clicks and the viewport indicator through the compressed turn layout, keeping the mapping stable during a drag, including when earlier history arrives. Dense histories aggregate drawing marks into bounded buckets while preserving both speaker lanes and every turn's navigation range. The code editor minimap and shared minimap view are unchanged.

Validation:
- macOS build passed and the built app was launched with `open -n`.
- All 29 focused minimap and ACP navigation tests passed, including 10,000 alternating messages and history loading during a drag.
- Formatting and `git diff --check` passed.
- The local full suite reported failures outside this change, including an attention fingerprint expectation that disagrees with unchanged production code and session/worktree timeouts. The run was stopped after stalling in `AppStateWorktreeCleanupBatchTests.oneFailingItemDoesNotAbortTheBatch`.
