### PR TITLE
refine(acp): transcript minimap density

### DIFF
--- a/Alas/Sources/ACP/UI/ACPTranscriptVisibleRow.swift
+++ b/Alas/Sources/ACP/UI/ACPTranscriptVisibleRow.swift
@@ -19,11 +19,18 @@ struct ACPTranscriptVisibleRow: Identifiable, Equatable {
     ) -> [ACPTranscriptVisibleRow] {
         let head = min(visibleHead, messages.count)
         let tail = max(head, min(visibleTail, messages.count))
-        return (head..<tail).compactMap { index in
+        // Replayed history can contain several snapshots of the same message.
+        // Match the lookup's last-snapshot policy so the tiler receives one row
+        // per identity, without changing the stored transcript.
+        var seen = Set<String>()
+        let rows: [ACPTranscriptVisibleRow] = (head..<tail).reversed().compactMap { index in
             let message = messages[index]
             if case .plan = message { return nil }
-            return ACPTranscriptVisibleRow(index: index, stableId: stableId(message))
+            let id = stableId(message)
+            guard seen.insert(id).inserted else { return nil }
+            return ACPTranscriptVisibleRow(index: index, stableId: id)
         }
+        return rows.reversed()
     }
 }
 

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptMinimap.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptMinimap.swift
@@ -53,7 +53,7 @@ struct ACPTranscriptMinimapLayout {
     private func bandCount(for message: ACPMessage) -> Int {
         switch message {
         case .agent(_, _, let text):
-            switch text.value.utf8.count {
+            switch text.utf8Length {
             case 0..<320: return 1
             case 320..<1_600: return 2
             case 1_600..<6_400: return 3
@@ -108,6 +108,7 @@ struct ACPTranscriptMinimapLayout {
 final class ACPTranscriptMinimap {
     private var theme: Theme?
     private var generation: UInt64?
+    private var streamingState: ACPSession.StreamingState?
     private var offset: Int?
     private var transcriptID: ObjectIdentifier?
     private var cachedDrawing = MinimapDrawing()
@@ -115,6 +116,7 @@ final class ACPTranscriptMinimap {
 
     func needsUpdate(transcript: ACPTranscript, theme: Theme) -> Bool {
         self.theme != theme || generation != transcript.messagesGeneration
+            || streamingState != transcript.streamingState
             || offset != transcript.messageIndexOffset
             || transcriptID != ObjectIdentifier(transcript)
     }
@@ -124,6 +126,7 @@ final class ACPTranscriptMinimap {
         transcriptID = ObjectIdentifier(transcript)
         self.theme = theme
         generation = transcript.messagesGeneration
+        streamingState = transcript.streamingState
         offset = transcript.messageIndexOffset
         layout = ACPTranscriptMinimapLayout(messages: transcript.messages, offset: transcript.messageIndexOffset)
         let userColor = NSColor(theme.color("accent")).withAlphaComponent(0.65)

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptMinimap.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptMinimap.swift
@@ -61,7 +61,13 @@ struct ACPTranscriptMinimapLayout {
             }
         case .thought, .toolCall, .fileEdit, .plan:
             return 1
-        case .user, .systemNotice:
+        case .user(_, _, let text, _, _):
+            switch text.utf8.count {
+            case 0..<80: return 1
+            case 80..<400: return 2
+            default: return 3
+            }
+        case .systemNotice:
             return 0
         }
     }
@@ -70,7 +76,13 @@ struct ACPTranscriptMinimapLayout {
         switch role {
         case .assistant:
             return CGFloat(max(1, bandCount) * 5 - 2)
-        case .user, .notice, .history:
+        case .user:
+            switch bandCount {
+            case 1: return 5
+            case 2: return 7
+            default: return 10
+            }
+        case .notice, .history:
             return 10
         }
     }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptMinimap.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptMinimap.swift
@@ -10,12 +10,14 @@ struct ACPTranscriptMinimapLayout {
         let role: Role
         var messages: Range<Int>
         let y: CGFloat
-        let height: CGFloat
+        var height: CGFloat
+        var bandCount: Int
     }
 
     private(set) var blocks: [Block] = []
     private(set) var height: CGFloat = 0
 
+    @MainActor
     init(messages: [ACPMessage], offset: Int) {
         if offset > 0 {
             append(role: .history, messages: 0..<offset)
@@ -29,17 +31,48 @@ struct ACPTranscriptMinimapLayout {
             }
             let globalIndex = offset + index
             if role != .user, let last = blocks.last, last.role == role {
+                let count = min(4, last.bandCount + bandCount(for: message))
                 blocks[blocks.count - 1].messages = last.messages.lowerBound..<(globalIndex + 1)
+                blocks[blocks.count - 1].bandCount = count
+                let newHeight = extent(for: role, bandCount: count)
+                height += newHeight - last.height
+                blocks[blocks.count - 1].height = newHeight
             } else {
-                append(role: role, messages: globalIndex..<(globalIndex + 1))
+                append(role: role, messages: globalIndex..<(globalIndex + 1), bandCount: bandCount(for: message))
             }
         }
     }
 
-    private mutating func append(role: Role, messages: Range<Int>) {
-        let extent: CGFloat = role == .user || role == .notice ? 24 : 48
-        blocks.append(Block(role: role, messages: messages, y: height, height: extent))
-        height += extent
+    private mutating func append(role: Role, messages: Range<Int>, bandCount: Int = 0) {
+        let blockHeight = extent(for: role, bandCount: bandCount)
+        blocks.append(Block(role: role, messages: messages, y: height, height: blockHeight, bandCount: bandCount))
+        height += blockHeight
+    }
+
+    @MainActor
+    private func bandCount(for message: ACPMessage) -> Int {
+        switch message {
+        case .agent(_, _, let text):
+            switch text.value.utf8.count {
+            case 0..<320: return 1
+            case 320..<1_600: return 2
+            case 1_600..<6_400: return 3
+            default: return 4
+            }
+        case .thought, .toolCall, .fileEdit, .plan:
+            return 1
+        case .user, .systemNotice:
+            return 0
+        }
+    }
+
+    private func extent(for role: Role, bandCount: Int) -> CGFloat {
+        switch role {
+        case .assistant:
+            return CGFloat(max(1, bandCount) * 5 - 2)
+        case .user, .notice, .history:
+            return 10
+        }
     }
 
     /// Convert a fractional global message index to a fraction of the turn map.
@@ -98,11 +131,19 @@ final class ACPTranscriptMinimap {
         let noticeColor = NSColor(theme.color("fg-faint")).withAlphaComponent(0.2)
         var drawing = MinimapDrawing(height: layout.height)
         // Dense histories share drawing buckets while navigation retains every turn.
-        // Keep both speaker lanes instead of sampling away short user prompts.
         let bucketSize = max(1, Int(ceil(Double(layout.blocks.count) / 512)))
         let roles: [ACPTranscriptMinimapLayout.Role] = [.history, .notice, .assistant, .user]
         for start in stride(from: 0, to: layout.blocks.count, by: bucketSize) {
             let bucket = layout.blocks[start..<min(layout.blocks.count, start + bucketSize)]
+            if bucketSize == 1, let block = bucket.first, block.role == .assistant {
+                for band in 0..<block.bandCount {
+                    drawing.marks.append(.init(
+                        rect: CGRect(x: 0, y: block.y + CGFloat(band * 5), width: 64, height: 3),
+                        color: assistantColor
+                    ))
+                }
+                continue
+            }
             for role in roles {
                 guard let first = bucket.first(where: { $0.role == role }),
                       let last = bucket.last(where: { $0.role == role }) else { continue }
@@ -111,20 +152,21 @@ final class ACPTranscriptMinimap {
                 let color: NSColor
                 switch role {
                 case .user:
-                    x = bucketSize > 1 ? 48 : 24
-                    width = bucketSize > 1 ? 40 : 64
+                    x = bucketSize > 1 ? 56 : 64
+                    width = bucketSize > 1 ? 32 : 24
                     color = userColor
                 case .assistant:
                     x = 0
-                    width = bucketSize > 1 ? 40 : 64
+                    width = bucketSize > 1 ? 48 : 64
                     color = assistantColor
                 case .notice, .history:
                     x = 0
                     width = 88
                     color = noticeColor
                 }
+                let inset: CGFloat = role == .assistant ? 0 : 1
                 drawing.marks.append(.init(
-                    rect: CGRect(x: x, y: first.y + 2, width: width, height: last.y + last.height - first.y - 4),
+                    rect: CGRect(x: x, y: first.y + inset, width: width, height: last.y + last.height - first.y - (inset * 2)),
                     color: color
                 ))
             }

--- a/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
+++ b/Alas/Sources/ACP/UI/Scroller/ACPTranscriptScroller.swift
@@ -331,6 +331,12 @@ struct ACPTranscriptScroller: NSViewRepresentable {
             guard let host, host.showMinimap, let scroller, scroller.showsMinimap,
                   minimapGestureRange == nil else { return }
             if let minimapRenderer, !minimapRenderer.needsUpdate(transcript: host.transcript, theme: host.theme) { return }
+            // Keep the cached map during a scroll gesture, including momentum.
+            // Its viewport indicator still updates on every scroll tick.
+            if minimapRenderer != nil, scroller.isUserScrollActive {
+                updateMinimap()
+                return
+            }
             if minimapRenderer == nil { minimapRenderer = ACPTranscriptMinimap() }
             if let drawing = minimapRenderer?.drawing(transcript: host.transcript, theme: host.theme) {
                 scroller.minimap.update(drawing: drawing)

--- a/AlasTests/MinimapTests.swift
+++ b/AlasTests/MinimapTests.swift
@@ -175,9 +175,9 @@ struct MinimapTests {
         guard drawing.marks.count == 10 else { return }
         #expect(drawing.marks[0].rect.minX > drawing.marks[1].rect.minX)
         #expect(drawing.marks[0].color != drawing.marks[1].color)
-        #expect(drawing.marks[0].rect.height == 8)
+        #expect(drawing.marks[0].rect.height == 3)
         #expect(drawing.marks[1...4].allSatisfy { $0.rect.height == 3 && $0.rect.minX == 0 })
-        #expect(drawing.marks[5].rect.height == 8)
+        #expect(drawing.marks[5].rect.height == 3)
         #expect(drawing.marks[6...9].allSatisfy { $0.rect.height == 3 && $0.rect.minX == 0 })
     }
 
@@ -202,6 +202,19 @@ struct MinimapTests {
         second.streamingTick = transcript.streamingTick
         #expect(renderer.needsUpdate(transcript: second, theme: theme))
         #expect(renderer.needsUpdate(transcript: transcript, theme: try Theme.loadBundled(id: "light")))
+    }
+
+    @Test("User prompt bars grow modestly with message size")
+    @MainActor func promptBarSizes() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let transcript = ACPTranscript()
+        transcript.messages = [
+            .user(id: UUID(), text: "Short", attachments: []),
+            .user(id: UUID(), text: String(repeating: "medium ", count: 20), attachments: []),
+            .user(id: UUID(), text: String(repeating: "long ", count: 200), attachments: [])
+        ]
+        let drawing = ACPTranscriptMinimap().drawing(transcript: transcript, theme: theme)
+        #expect(drawing.marks.map(\.rect.height) == [3, 5, 8])
     }
 
     @Test("Navigation windows tile only the latest snapshot of a replayed message")
@@ -292,8 +305,8 @@ struct MinimapTests {
         let history = ACPTranscriptMinimapLayout(messages: [
             .user(id: UUID(), text: "recent", attachments: [])
         ], offset: 1_000)
-        #expect(history.fraction(at: 1_000) == 0.5)
-        #expect(history.messagePosition(at: 0.25) == 500)
+        #expect(history.fraction(at: 1_000) == CGFloat(2) / 3)
+        #expect(history.messagePosition(at: 0.25) == 375)
         let empty = ACPTranscriptMinimapLayout(messages: [], offset: 0)
         #expect(empty.fraction(at: 1) == 0)
         #expect(empty.messagePosition(at: 1) == 0)

--- a/AlasTests/MinimapTests.swift
+++ b/AlasTests/MinimapTests.swift
@@ -204,6 +204,21 @@ struct MinimapTests {
         #expect(renderer.needsUpdate(transcript: transcript, theme: try Theme.loadBundled(id: "light")))
     }
 
+    @Test("Navigation windows tile only the latest snapshot of a replayed message")
+    @MainActor func replayedMessageNavigation() {
+        let first = ACPMessage.agent(id: UUID(), messageId: "replayed", StreamingText("partial"))
+        let prompt = ACPMessage.user(id: UUID(), text: "Next", attachments: [])
+        let latest = ACPMessage.agent(id: UUID(), messageId: "replayed", StreamingText("complete"))
+        let messages = [first, prompt, latest]
+        let rows = ACPTranscriptVisibleRow.rows(
+            messages: messages, visibleHead: 0, visibleTail: 3, stableId: { $0.stableId }
+        )
+        #expect(rows.map(\.index) == [1, 2])
+        #expect(Set(rows.map(\.stableId)).count == rows.count)
+        let lookup = ACPTranscriptVisibleRowLookup(rows: rows.map { ($0.index, $0.stableId) })
+        #expect(lookup.transcriptIndex(for: latest.stableId) == 2)
+    }
+
     @Test("Completed responses refresh their bands without rebuilding on every chunk")
     @MainActor func completedResponseBands() throws {
         let theme = try Theme.loadBundled(id: "cool-slate")

--- a/AlasTests/MinimapTests.swift
+++ b/AlasTests/MinimapTests.swift
@@ -204,6 +204,24 @@ struct MinimapTests {
         #expect(renderer.needsUpdate(transcript: transcript, theme: try Theme.loadBundled(id: "light")))
     }
 
+    @Test("Completed responses refresh their bands without rebuilding on every chunk")
+    @MainActor func completedResponseBands() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let transcript = ACPTranscript()
+        let buffer = StreamingText("Hello")
+        transcript.messages = [.agent(id: UUID(), buffer)]
+        transcript.streamingState = .streaming
+        let renderer = ACPTranscriptMinimap()
+        #expect(renderer.drawing(transcript: transcript, theme: theme).marks.count == 1)
+        buffer.append(String(repeating: "response ", count: 1_000))
+        transcript.streamingTick &+= 1
+        #expect(!renderer.needsUpdate(transcript: transcript, theme: theme))
+        transcript.streamingState = .idle
+        #expect(renderer.needsUpdate(transcript: transcript, theme: theme))
+        #expect(renderer.drawing(transcript: transcript, theme: theme).marks.count == 4)
+        #expect(!renderer.needsUpdate(transcript: transcript, theme: theme))
+    }
+
     @Test("Long alternating conversations keep drawing marks bounded without hiding either speaker")
     @MainActor func transcriptPreviewBounded() throws {
         let theme = try Theme.loadBundled(id: "cool-slate")
@@ -259,8 +277,8 @@ struct MinimapTests {
         let history = ACPTranscriptMinimapLayout(messages: [
             .user(id: UUID(), text: "recent", attachments: [])
         ], offset: 1_000)
-        #expect(history.fraction(at: 1_000) > 0)
-        #expect(history.messagePosition(at: 0.5) < 1_000)
+        #expect(history.fraction(at: 1_000) == 0.5)
+        #expect(history.messagePosition(at: 0.25) == 500)
         let empty = ACPTranscriptMinimapLayout(messages: [], offset: 0)
         #expect(empty.fraction(at: 1) == 0)
         #expect(empty.messagePosition(at: 1) == 0)

--- a/AlasTests/MinimapTests.swift
+++ b/AlasTests/MinimapTests.swift
@@ -156,7 +156,7 @@ struct MinimapTests {
         #expect(!decoded.harness.acpShowMinimap)
     }
 
-    @Test("Transcript blocks distinguish speakers and group assistant activity without text detail")
+    @Test("Transcript minimap uses compact prompt bars and response bands")
     @MainActor func transcriptColors() throws {
         let theme = try Theme.loadBundled(id: "cool-slate")
         let transcript = ACPTranscript()
@@ -171,12 +171,14 @@ struct MinimapTests {
             .agent(id: UUID(), StreamingText(String(repeating: "reply ", count: 10_000)))
         ]
         let drawing = ACPTranscriptMinimap().drawing(transcript: transcript, theme: theme)
-        #expect(drawing.marks.count == 4)
-        guard drawing.marks.count == 4 else { return }
+        #expect(drawing.marks.count == 10)
+        guard drawing.marks.count == 10 else { return }
         #expect(drawing.marks[0].rect.minX > drawing.marks[1].rect.minX)
         #expect(drawing.marks[0].color != drawing.marks[1].color)
-        #expect(drawing.marks[0].rect.height >= 20)
-        #expect(drawing.marks[1].rect.height == drawing.marks[3].rect.height)
+        #expect(drawing.marks[0].rect.height == 8)
+        #expect(drawing.marks[1...4].allSatisfy { $0.rect.height == 3 && $0.rect.minX == 0 })
+        #expect(drawing.marks[5].rect.height == 8)
+        #expect(drawing.marks[6...9].allSatisfy { $0.rect.height == 3 && $0.rect.minX == 0 })
     }
 
     @Test("Transcript blocks ignore streamed text and never carry content between sessions")
@@ -244,9 +246,9 @@ struct MinimapTests {
             .user(id: UUID(), text: "next", attachments: []),
             .agent(id: UUID(), StreamingText("reply"))
         ], offset: 0)
-        #expect(layout.fraction(at: 3) == 0.5)
-        #expect(layout.messagePosition(at: 0.5) == 3)
-        #expect(layout.messagePosition(at: 0.25) == 1.5)
+        #expect(layout.fraction(at: 3) > layout.fraction(at: 2))
+        #expect(layout.messagePosition(at: layout.fraction(at: 3)) == 3)
+        #expect(layout.messagePosition(at: 0.25) > 0)
         #expect(layout.fraction(at: -1) == 0)
         #expect(layout.fraction(at: 99) == 1)
         #expect(layout.messagePosition(at: -1) == 0)
@@ -257,8 +259,8 @@ struct MinimapTests {
         let history = ACPTranscriptMinimapLayout(messages: [
             .user(id: UUID(), text: "recent", attachments: [])
         ], offset: 1_000)
-        #expect(history.fraction(at: 1_000) == CGFloat(2) / 3)
-        #expect(history.messagePosition(at: CGFloat(1) / 3) == 500)
+        #expect(history.fraction(at: 1_000) > 0)
+        #expect(history.messagePosition(at: 0.5) < 1_000)
         let empty = ACPTranscriptMinimapLayout(messages: [], offset: 0)
         #expect(empty.fraction(at: 1) == 0)
         #expect(empty.messagePosition(at: 1) == 0)


### PR DESCRIPTION
The ACP transcript minimap uses compact prompt bars that grow modestly with prompt size (3, 5, or 8 points) and one to four thin response bands, with reasoning and tool activity grouped into each assistant turn. The code editor minimap is unchanged.

Response sizing uses cached byte lengths. Map rebuilds wait until scrolling and momentum settle, while the viewport indicator continues updating. Finished replies refresh their bands without rebuilding for every streamed chunk.

Navigation windows also render only the latest snapshot of a repeated message identity, preventing a duplicate-row assertion when jumping through replayed history. Stored messages are unchanged.

Validation: app build and all 21 focused minimap tests pass, including prompt sizing, streaming completion, and repeated-message navigation. The full local suite reported failures in session recovery, terminal cleanup, and sidebar tests, then stalled in `AppStateWorktreeCleanupBatchTests.oneFailingItemDoesNotAbortTheBatch`; that run was stopped. CI is still running.
