### PR TITLE
fix(changes): hide checkpoints section when empty

### DIFF
--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -381,7 +381,7 @@ struct ChangesTabView: View {
 
         rows.append(appKitRow(
             id: "working-tree-header",
-            token: "\(workingGroupsSignature)-\(rps.workingTreeExpanded)-\(rps.mergeOp.current != nil)-\(rps.stashOperationInFlight)",
+            token: "\(workingGroupsSignature)-\(rps.workingTreeExpanded)-\(rps.mergeOp.current != nil)-\(rps.stashOperationInFlight)-\(rps.checkpointMutationsDisabled)-\(String(reflecting: rps.checkpointLoadError))",
             estimatedHeight: 32,
             retention: .sticky
         ) { workingTree.headerRow })
@@ -425,8 +425,31 @@ struct ChangesTabView: View {
         return AppKitDiffRowPlan(rows: rows)
     }
 
+    static func shouldShowCheckpointsSection(
+        summaryCount: Int,
+        nonterminalJournalCount: Int,
+        lastStatus: String?,
+        operationInFlight: CheckpointOperationKind?,
+        hasVisibleLoadError: Bool
+    ) -> Bool {
+        summaryCount > 0
+            || nonterminalJournalCount > 0
+            || lastStatus != nil
+            || operationInFlight != nil
+            || hasVisibleLoadError
+    }
+
     private func appendCheckpointRows(to rows: inout [AppKitDiffRowSpec]) {
         let summaries = rps.checkpointSummaries
+        let hasVisibleLoadError = rps.checkpointLoadError != nil && !rps.worktree.path.isRemoteAlasPath
+        guard Self.shouldShowCheckpointsSection(
+            summaryCount: summaries.count,
+            nonterminalJournalCount: rps.nonterminalCheckpointJournals.count,
+            lastStatus: rps.lastCheckpointStatus,
+            operationInFlight: rps.checkpointOperationInFlight,
+            hasVisibleLoadError: hasVisibleLoadError
+        ) else { return }
+
         rows.append(appKitRow(
             id: "checkpoints-header",
             token: "\(String(reflecting: summaries))\(rps.checkpointsExpanded)\(rps.checkpointMutationsDisabled)\(String(reflecting: rps.checkpointLoadError))\(String(reflecting: rps.nonterminalCheckpointJournals))\(String(reflecting: rps.lastCheckpointStatus))",
@@ -841,6 +864,8 @@ struct ChangesTabView: View {
             onDiscardFile: { rps.requestDiscardFile(path: $0.path) },
             onStashChanges: { rps.requestStashChanges() },
             stashChangesDisabled: rps.mergeOp.current != nil || rps.stashOperationInFlight,
+            onCreateCheckpoint: { rps.requestCheckpointCreation() },
+            createCheckpointDisabled: rps.checkpointMutationsDisabled || rps.checkpointLoadError != nil,
             isOpenFileEnabled: { file in
                 DiffOpenFileAvailability.isAvailable(
                     worktreePath: rps.worktree.path,

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -50,6 +50,8 @@ struct WorkingTreeSectionView: View {
     var onDiscardFile:     ((ChangedFile) -> Void)? = nil
     var onStashChanges:     (() -> Void)? = nil
     var stashChangesDisabled: Bool = false
+    var onCreateCheckpoint: (() -> Void)? = nil
+    var createCheckpointDisabled: Bool = false
     var isOpenFileEnabled: ((ChangedFile) -> Bool)? = nil
     var dragPayload: ((ChangedFile) -> DragOutPayload?)? = nil
 
@@ -111,8 +113,12 @@ struct WorkingTreeSectionView: View {
                         onStashChanges?()
                     }
                     .disabled(stashChangesDisabled || changes.isEmpty || onStashChanges == nil)
-                    Divider()
                 }
+                Button("Create Checkpoint…") {
+                    onCreateCheckpoint?()
+                }
+                .disabled(createCheckpointDisabled || onCreateCheckpoint == nil)
+                Divider()
                 Button("Discard all working tree changes…", role: .destructive) {
                     onDiscardAll?()
                 }

--- a/AlasTests/ChangesTabViewTests.swift
+++ b/AlasTests/ChangesTabViewTests.swift
@@ -132,6 +132,63 @@ struct ChangesTabViewTests {
         #expect(enabled != nowUnavailable)
     }
 
+    @Test func checkpointsSectionHiddenWhenThereIsNothingToShow() {
+        #expect(!ChangesTabView.shouldShowCheckpointsSection(
+            summaryCount: 0,
+            nonterminalJournalCount: 0,
+            lastStatus: nil,
+            operationInFlight: nil,
+            hasVisibleLoadError: false
+        ))
+    }
+
+    @Test func checkpointsSectionVisibleWithSummaries() {
+        #expect(ChangesTabView.shouldShowCheckpointsSection(
+            summaryCount: 1,
+            nonterminalJournalCount: 0,
+            lastStatus: nil,
+            operationInFlight: nil,
+            hasVisibleLoadError: false
+        ))
+    }
+
+    @Test func checkpointsSectionVisibleForRecoveryJournalWithNoSummaries() {
+        #expect(ChangesTabView.shouldShowCheckpointsSection(
+            summaryCount: 0,
+            nonterminalJournalCount: 1,
+            lastStatus: nil,
+            operationInFlight: nil,
+            hasVisibleLoadError: false
+        ))
+    }
+
+    @Test func checkpointsSectionVisibleForInFlightStatusOrOperation() {
+        #expect(ChangesTabView.shouldShowCheckpointsSection(
+            summaryCount: 0,
+            nonterminalJournalCount: 0,
+            lastStatus: "Checkpoint created",
+            operationInFlight: nil,
+            hasVisibleLoadError: false
+        ))
+        #expect(ChangesTabView.shouldShowCheckpointsSection(
+            summaryCount: 0,
+            nonterminalJournalCount: 0,
+            lastStatus: nil,
+            operationInFlight: .capture,
+            hasVisibleLoadError: false
+        ))
+    }
+
+    @Test func checkpointsSectionVisibleForVisibleLoadError() {
+        #expect(ChangesTabView.shouldShowCheckpointsSection(
+            summaryCount: 0,
+            nonterminalJournalCount: 0,
+            lastStatus: nil,
+            operationInFlight: nil,
+            hasVisibleLoadError: true
+        ))
+    }
+
     @Test func appKitCommitRowsTrackPrimaryRemote() {
         let primaryRemote = CodeHostRemote(
             kind: .github,


### PR DESCRIPTION
## Summary
The Changes-tab Checkpoints section always rendered (header, "no checkpoints" row, storage footer) even when there were zero checkpoints. The only way to create one was the `+` in that section's header, so simply hiding the section would have removed the feature's only entry point.

## Changes
- Added a "Create Checkpoint…" action to the Working tree section's header context menu, next to "Stash Changes…", so checkpoints stay reachable when the section is hidden.
- The Checkpoints section now only renders when there's something to show: existing summaries, a nonterminal recovery journal, an in-flight operation/status, or a genuine (non-remote) load error.
- Extracted `ChangesTabView.shouldShowCheckpointsSection(...)` as a static predicate (matching the existing pattern used by `shouldShowChangesPreparationCard`/`shouldShowGGDrawer`) for testability.

## Testing
- Added 5 Swift Testing cases covering each branch of `shouldShowCheckpointsSection`.
- Ran the focused `AlasTests/ChangesTabViewTests` suite locally — all tests pass.